### PR TITLE
fix(BDHLNDR-4,BDHLNDR-5): unpack node-gyp-build and fix updater repo casing

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -20,6 +20,9 @@ asarUnpack:
   - node_modules/sodium-native/**/*
   - node_modules/tree-sitter/**/*
   - node_modules/tree-sitter-*/**/*
+  # Required by tree-sitter's native loader to resolve the prebuilt .node file.
+  # Without this, tree-sitter falls back to a non-native parser in packaged builds.
+  - node_modules/node-gyp-build/**/*
   - node_modules/sqlite-vec/**/*
   - node_modules/sqlite-vec-*/**/*
   - node_modules/@huggingface/**/*
@@ -37,7 +40,7 @@ extraResources:
 publish:
   provider: github
   owner: Software-Development-LLC
-  repo: bodhilander
+  repo: Bodhilander
 
 # macOS configuration
 mac:


### PR DESCRIPTION
## Summary

Two small electron-builder.yml config fixes:

- **[BDHLNDR-4](https://gobodhi.atlassian.net/browse/BDHLNDR-4)** — tree-sitter's native loader requires `node-gyp-build` at runtime to resolve the prebuilt `.node` binary. It was not in `asarUnpack`, so the unpacked tree-sitter module's `require('node-gyp-build')` failed (module still packed inside `app.asar`, unreachable from an unpacked entrypoint). Tree-sitter silently fell back to a non-native parser, logged on every worker spawn:
  ```
  [VectorSearch Worker Error] [Parser] tree-sitter not available, using fallback parser: Cannot find module 'node-gyp-build'
  ```
  Added `node_modules/node-gyp-build/**/*` to `asarUnpack` alongside the existing tree-sitter entries.

- **[BDHLNDR-5](https://gobodhi.atlassian.net/browse/BDHLNDR-5)** — `publish.repo` was lowercase `bodhilander`. GitHub's `releases.atom` endpoint enforces casing, so every update check failed with `HttpError: 404`. Fixed to `Bodhilander`.

## Test plan

- [ ] Build a packaged version locally or via the release workflow.
- [ ] Launch the packaged app, open DevTools / tail `%APPDATA%\bodhilander\logs\main.log`.
- [ ] Confirm no "tree-sitter not available" warnings — parser loads natively.
- [ ] Confirm the auto-updater fetches `releases.atom` successfully (200 response, no 404 stack traces at startup).
- [ ] Re-index a directory and confirm symbol counts are populated (tree-sitter was previously no-op'ing symbol extraction via fallback).

## Notes

Both fixes are config-only (1 file, 4 inserts, 1 delete). No runtime code changes. BDHLNDR-4 is a prerequisite for fully resolving BDHLNDR-6 (worker race) — under the fallback parser, concurrent workers may be exercising unsafe code paths that worsen the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-4]: https://gobodhi.atlassian.net/browse/BDHLNDR-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-5]: https://gobodhi.atlassian.net/browse/BDHLNDR-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ