### PR TITLE
fix(BDHLNDR-6): prevent concurrent VectorSearch workers on session activity

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -969,13 +969,13 @@ safeHandle('vector-search:search-symbols', (directoryPath: string, name: string,
   return getVectorSearchManager().searchSymbols(directoryPath, name, symbolType as any, limit);
 });
 
-safeHandle('vector-search:cancel-indexing', (indexId: string) => {
-  getVectorSearchManager().cancelIndexing(indexId);
+safeHandle('vector-search:cancel-indexing', async (indexId: string) => {
+  await getVectorSearchManager().cancelIndexing(indexId);
   return { success: true };
 });
 
-safeHandle('vector-search:delete-index', (directoryPath: string) => {
-  getVectorSearchManager().deleteIndex(directoryPath);
+safeHandle('vector-search:delete-index', async (directoryPath: string) => {
+  await getVectorSearchManager().deleteIndex(directoryPath);
   return { success: true };
 });
 

--- a/src/main/vector-search/index.ts
+++ b/src/main/vector-search/index.ts
@@ -181,8 +181,16 @@ export class VectorSearchManager extends EventEmitter {
   async startIndexing(directoryPath: string): Promise<void> {
     const index = await this.getOrCreateIndex(directoryPath);
 
-    // Cancel any existing indexing for this directory
-    this.cancelIndexing(index.id);
+    // If a worker is already running for this index, don't spawn another one.
+    // Multiple renderer consumers (IndexStatus, CodeSearchModal) each mount
+    // their own useCodeSearch hook, and on session switch each fires its own
+    // auto-index effect — without this guard, concurrent workers race on
+    // native module initialization (tree-sitter / onnxruntime-node) and
+    // crash the process. (BDHLNDR-6 / root cause of BDHLNDR-3.)
+    if (this.workers.has(index.id)) {
+      console.log('[VectorSearch] Indexing already in progress for:', directoryPath);
+      return;
+    }
 
     // Clear the cancelled flag since we're starting fresh
     this.cancelledIndexes.delete(index.id);
@@ -282,7 +290,9 @@ export class VectorSearchManager extends EventEmitter {
       if (this.workers.has(index.id)) {
         const errorMsg = 'Worker timed out during initialization (model download may have failed)';
         console.error('[VectorSearch]', errorMsg);
-        this.cancelIndexing(index.id);
+        // Fire-and-forget — the timeout handler isn't async. Termination
+        // races are bounded here since we just update DB/emit after.
+        void this.cancelIndexing(index.id);
         codeSearchRepo.updateIndexStatus(index.id, 'error', errorMsg);
         this.emit('indexing-error', {
           indexId: index.id,
@@ -311,16 +321,24 @@ export class VectorSearchManager extends EventEmitter {
     }
   }
 
-  cancelIndexing(indexId: string): void {
+  async cancelIndexing(indexId: string): Promise<void> {
     // Mark as cancelled so worker knows to stop
     this.cancelledIndexes.add(indexId);
     this.clearWorkerTimeout(indexId);
 
     const worker = this.workers.get(indexId);
     if (worker) {
-      worker.postMessage({ type: 'cancel' });
-      worker.terminate();
+      // Remove from the map synchronously so any concurrent startIndexing
+      // correctly observes "no running worker" for this index.
       this.workers.delete(indexId);
+      worker.postMessage({ type: 'cancel' });
+      // Await termination so callers that immediately restart indexing
+      // don't race with native-module init in the dying worker.
+      try {
+        await worker.terminate();
+      } catch (err) {
+        console.error('[VectorSearch] Error terminating worker:', err);
+      }
     }
   }
 
@@ -561,11 +579,13 @@ export class VectorSearchManager extends EventEmitter {
     return codeSearchRepo.getAllIndexes();
   }
 
-  deleteIndex(directoryPath: string): void {
+  async deleteIndex(directoryPath: string): Promise<void> {
     const index = codeSearchRepo.getIndexByDirectory(directoryPath);
     if (index) {
       this.stopWatching(index.id);
-      this.cancelIndexing(index.id);
+      // Await termination before deleting the DB row so any in-flight
+      // writes from the dying worker don't resurrect a deleted index.
+      await this.cancelIndexing(index.id);
       codeSearchRepo.deleteIndex(index.id);
     }
   }


### PR DESCRIPTION
## Summary

Root cause of [BDHLNDR-3](https://gobodhi.atlassian.net/browse/BDHLNDR-3) (Windows crash when leaving and returning to a session). Evidence from a user `main.log`:

```
10:30:50.251 [VectorSearch] Starting indexing for: C:\work\repos\bodhi-service-ai-engine
10:30:55.410 [VectorSearch] Starting indexing for: C:\work\repos\bodhi-service-ai-engine  ← same dir, 5s later
```

Two `[VectorSearch Worker] Starting worker thread...` blocks, each re-initializing `@huggingface/transformers` and tree-sitter against the same cache directory. The log ends mid-flow without a JS trace — a native crash during double-initialization.

## The two bugs

### 1. `startIndexing` always cancelled-and-restarted

`useCodeSearch` auto-fires on `directoryPath` changes from multiple consumers (`IndexStatus.tsx:16`, `CodeSearchModal.tsx:35`). Each session switch → N simultaneous `startIndexing` IPC calls for the same path. The old top-of-function `this.cancelIndexing(index.id)` meant each call would tear down and respawn the worker, on top of whatever previous calls were already doing.

**Fix**: if a worker is already running for this index, log and return. This is the primary deduplication point — N concurrent IPC calls collapse to one worker.

### 2. `cancelIndexing` didn't await `worker.terminate()`

`Worker.terminate()` returns a Promise. It was called and immediately followed by `new Worker(...)` in the old startIndexing flow, so the dying worker was still unloading native modules (onnxruntime-node, tree-sitter, better-sqlite3) while the new worker was loading them.

**Fix**: `cancelIndexing` is now `async` and `await`s termination. The worker is removed from `this.workers` synchronously *before* `terminate()` is called, so any concurrent `startIndexing` correctly observes "no running worker".

## Caller updates

- `deleteIndex(directoryPath)` → `async`, awaits cancel (otherwise DB delete could race with in-flight worker writes).
- `vector-search:cancel-indexing` IPC handler → awaits cancel.
- `vector-search:delete-index` IPC handler → awaits delete.
- Worker-init timeout callback → uses `void this.cancelIndexing(...)` since it's inside a `setTimeout` and only updates DB/emits after (no concurrent-spawn risk).

## What this doesn't touch

- `useCodeSearch` renderer-side deduplication — left alone. Multiple consumer components still each fire their own auto-index effect, but the main-process guard catches them all. Renderer-level dedup would be cleaner code but is not required for correctness.

## Depends on / related

- **Depends on [BDHLNDR-4](https://gobodhi.atlassian.net/browse/BDHLNDR-4)** (tree-sitter/node-gyp-build packaging) — under the fallback parser the concurrent workers may be exercising additional unsafe paths. BDHLNDR-4 should ship in the same release.
- **Resolves [BDHLNDR-3](https://gobodhi.atlassian.net/browse/BDHLNDR-3)** pending post-release verification on Windows.

## Test plan

- [ ] Install a build containing this + BDHLNDR-4. Open multiple sessions with the same cwd. Switch between them repeatedly. Leave one session and return. Confirm the app no longer crashes and that `main.log` shows at most one `[VectorSearch] Starting indexing for:` event per directory per launch.
- [ ] Trigger a Re-index from `CodeSearchModal` (delete + start flow). Confirm the old worker is gone before the new one spawns (no overlap in worker log output).
- [ ] Force an init timeout (e.g. by interrupting network during first-run model download) and confirm the error path still reports the error and doesn't hang.
- [ ] `bun run build:main` — tsc passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-3]: https://gobodhi.atlassian.net/browse/BDHLNDR-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-4]: https://gobodhi.atlassian.net/browse/BDHLNDR-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ