### PR TITLE
Release: BDHLNDR-4, BDHLNDR-5, BDHLNDR-6 (build config fixes + concurrent worker crash fix)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -20,6 +20,9 @@ asarUnpack:
   - node_modules/sodium-native/**/*
   - node_modules/tree-sitter/**/*
   - node_modules/tree-sitter-*/**/*
+  # Required by tree-sitter's native loader to resolve the prebuilt .node file.
+  # Without this, tree-sitter falls back to a non-native parser in packaged builds.
+  - node_modules/node-gyp-build/**/*
   - node_modules/sqlite-vec/**/*
   - node_modules/sqlite-vec-*/**/*
   - node_modules/@huggingface/**/*
@@ -37,7 +40,7 @@ extraResources:
 publish:
   provider: github
   owner: Software-Development-LLC
-  repo: bodhilander
+  repo: Bodhilander
 
 # macOS configuration
 mac:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -969,13 +969,13 @@ safeHandle('vector-search:search-symbols', (directoryPath: string, name: string,
   return getVectorSearchManager().searchSymbols(directoryPath, name, symbolType as any, limit);
 });
 
-safeHandle('vector-search:cancel-indexing', (indexId: string) => {
-  getVectorSearchManager().cancelIndexing(indexId);
+safeHandle('vector-search:cancel-indexing', async (indexId: string) => {
+  await getVectorSearchManager().cancelIndexing(indexId);
   return { success: true };
 });
 
-safeHandle('vector-search:delete-index', (directoryPath: string) => {
-  getVectorSearchManager().deleteIndex(directoryPath);
+safeHandle('vector-search:delete-index', async (directoryPath: string) => {
+  await getVectorSearchManager().deleteIndex(directoryPath);
   return { success: true };
 });
 

--- a/src/main/vector-search/index.ts
+++ b/src/main/vector-search/index.ts
@@ -181,8 +181,16 @@ export class VectorSearchManager extends EventEmitter {
   async startIndexing(directoryPath: string): Promise<void> {
     const index = await this.getOrCreateIndex(directoryPath);
 
-    // Cancel any existing indexing for this directory
-    this.cancelIndexing(index.id);
+    // If a worker is already running for this index, don't spawn another one.
+    // Multiple renderer consumers (IndexStatus, CodeSearchModal) each mount
+    // their own useCodeSearch hook, and on session switch each fires its own
+    // auto-index effect — without this guard, concurrent workers race on
+    // native module initialization (tree-sitter / onnxruntime-node) and
+    // crash the process. (BDHLNDR-6 / root cause of BDHLNDR-3.)
+    if (this.workers.has(index.id)) {
+      console.log('[VectorSearch] Indexing already in progress for:', directoryPath);
+      return;
+    }
 
     // Clear the cancelled flag since we're starting fresh
     this.cancelledIndexes.delete(index.id);
@@ -282,7 +290,9 @@ export class VectorSearchManager extends EventEmitter {
       if (this.workers.has(index.id)) {
         const errorMsg = 'Worker timed out during initialization (model download may have failed)';
         console.error('[VectorSearch]', errorMsg);
-        this.cancelIndexing(index.id);
+        // Fire-and-forget — the timeout handler isn't async. Termination
+        // races are bounded here since we just update DB/emit after.
+        void this.cancelIndexing(index.id);
         codeSearchRepo.updateIndexStatus(index.id, 'error', errorMsg);
         this.emit('indexing-error', {
           indexId: index.id,
@@ -311,16 +321,24 @@ export class VectorSearchManager extends EventEmitter {
     }
   }
 
-  cancelIndexing(indexId: string): void {
+  async cancelIndexing(indexId: string): Promise<void> {
     // Mark as cancelled so worker knows to stop
     this.cancelledIndexes.add(indexId);
     this.clearWorkerTimeout(indexId);
 
     const worker = this.workers.get(indexId);
     if (worker) {
-      worker.postMessage({ type: 'cancel' });
-      worker.terminate();
+      // Remove from the map synchronously so any concurrent startIndexing
+      // correctly observes "no running worker" for this index.
       this.workers.delete(indexId);
+      worker.postMessage({ type: 'cancel' });
+      // Await termination so callers that immediately restart indexing
+      // don't race with native-module init in the dying worker.
+      try {
+        await worker.terminate();
+      } catch (err) {
+        console.error('[VectorSearch] Error terminating worker:', err);
+      }
     }
   }
 
@@ -561,11 +579,13 @@ export class VectorSearchManager extends EventEmitter {
     return codeSearchRepo.getAllIndexes();
   }
 
-  deleteIndex(directoryPath: string): void {
+  async deleteIndex(directoryPath: string): Promise<void> {
     const index = codeSearchRepo.getIndexByDirectory(directoryPath);
     if (index) {
       this.stopWatching(index.id);
-      this.cancelIndexing(index.id);
+      // Await termination before deleting the DB row so any in-flight
+      // writes from the dying worker don't resurrect a deleted index.
+      await this.cancelIndexing(index.id);
       codeSearchRepo.deleteIndex(index.id);
     }
   }


### PR DESCRIPTION
Development → production release PR.

## What ships

| Ticket | Type | What |
|---|---|---|
| [BDHLNDR-4](https://gobodhi.atlassian.net/browse/BDHLNDR-4) | Bug | Unpack `node-gyp-build` so tree-sitter's native parser loads in packaged builds (instead of silently falling back) |
| [BDHLNDR-5](https://gobodhi.atlassian.net/browse/BDHLNDR-5) | Bug | Fix lowercase `repo: bodhilander` → `Bodhilander` in `electron-builder.yml`; auto-updater no longer 404s |
| [BDHLNDR-6](https://gobodhi.atlassian.net/browse/BDHLNDR-6) | Bug | Prevent concurrent VectorSearch workers on session activity — root-cause fix for [BDHLNDR-3](https://gobodhi.atlassian.net/browse/BDHLNDR-3) (Windows crash on session return) |

BDHLNDR-1, BDHLNDR-2, and BDHLNDR-7 were shipped in the previous release via PR #5.

## Commits

- `d9c8c64` Merge PR #7 (BDHLNDR-6)
- `c438451` fix(BDHLNDR-6): prevent concurrent VectorSearch workers on session activity
- `ac5b8f4` Merge PR #6 (BDHLNDR-4/5)
- `55d517c` fix: unpack node-gyp-build (BDHLNDR-4) and fix updater repo casing (BDHLNDR-5)

## Post-merge checklist

After this PR merges, **bump the version on `production` to trigger the Build and Release workflow**, per `CLAUDE.md`:

```bash
git checkout production
git pull
npm version patch   # or minor/major depending on severity
git push            # DO NOT use --tags
```

The `release.yml` workflow will create the tag and ship the build to GitHub Releases.

## User-facing validation after the new build ships

- [ ] **BDHLNDR-4**: `%APPDATA%\bodhilander\logs\main.log` no longer shows `[Parser] tree-sitter not available`. Re-index any directory and confirm symbol counts are populated (they were previously zero because the fallback parser was a no-op for symbol extraction).
- [ ] **BDHLNDR-5**: No more `HttpError: 404 ... releases.atom` stack traces at startup. Auto-updater should fetch the feed successfully.
- [ ] **BDHLNDR-6 / BDHLNDR-3**: Reproduce the crash repro — start a session, switch away, come back. If the crash is gone, close BDHLNDR-3 as resolved. If it still reproduces, remaining suspect is terminal remount / xterm WebGL on session re-focus (separate investigation, would need a new ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-4]: https://gobodhi.atlassian.net/browse/BDHLNDR-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-5]: https://gobodhi.atlassian.net/browse/BDHLNDR-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-6]: https://gobodhi.atlassian.net/browse/BDHLNDR-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-3]: https://gobodhi.atlassian.net/browse/BDHLNDR-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ