### PR TITLE
fix(BDHLNDR-8): prevent WebGL addon disposal crash on session stop

### DIFF
--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -29,6 +29,7 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  const webglAddonRef = useRef<WebglAddon | null>(null);
   const lastPasteTimeRef = useRef<number>(0);
   const [isRunning, setIsRunning] = useState(!isStopped);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({ visible: false, x: 0, y: 0, hasSelection: false });
@@ -181,6 +182,8 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   useEffect(() => {
     if (!terminalRef.current || !isRunning) return;
 
+    let mounted = true;
+
     const term = new XTerm({
       theme: {
         background: '#1e1e1e',
@@ -201,12 +204,16 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     term.open(terminalRef.current);
     fitAddon.fit();
 
-    // Load WebGL renderer after terminal is fully rendered for better performance
+    // Load WebGL renderer after terminal is fully rendered for better performance.
+    // Guard with `mounted` so the addon is not attached after effect cleanup —
+    // otherwise its dispose cascades through a torn-down RenderService and crashes.
     requestAnimationFrame(() => {
+      if (!mounted) return;
       try {
         const webglAddon = new WebglAddon();
         webglAddon.onContextLoss(() => { webglAddon.dispose(); });
         term.loadAddon(webglAddon);
+        webglAddonRef.current = webglAddon;
       } catch (e) {
         console.warn('WebGL addon failed to load, using canvas renderer:', e);
       }
@@ -334,11 +341,31 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     });
 
     return () => {
+      mounted = false;
       window.removeEventListener('resize', handleResize);
       resizeObserver.disconnect();
       cleanupPtyData();
       window.electronAPI.killSession(sessionId);
-      term.dispose();
+
+      // Dispose the WebGL addon explicitly before term.dispose() so its internal
+      // RenderService is still valid. Letting term.dispose() cascade into the
+      // addon can throw "Cannot read properties of undefined (reading 'onRequestRedraw')"
+      // when the addon was loaded async and is being torn down in the same tick.
+      if (webglAddonRef.current) {
+        try {
+          webglAddonRef.current.dispose();
+        } catch (e) {
+          console.warn('WebGL addon dispose error (non-fatal):', e);
+        }
+        webglAddonRef.current = null;
+      }
+
+      // Safety net: never let a terminal/addon dispose error escape to the React tree.
+      try {
+        term.dispose();
+      } catch (e) {
+        console.warn('Terminal dispose error (non-fatal):', e);
+      }
     };
   }, [sessionId, cwd, launchClaude, isRunning]);
 


### PR DESCRIPTION
## Summary

Fixes [BDHLNDR-8](https://gobodhi.atlassian.net/browse/BDHLNDR-8) — stopping a session was throwing `TypeError: Cannot read properties of undefined (reading 'onRequestRedraw')` from `xterm-addon-webgl` up to the React ErrorBoundary.

## Root cause

In `src/renderer/components/Terminal.tsx`, the `WebglAddon` was instantiated inside a `requestAnimationFrame` callback and never stored in a ref. When the effect tore down, `term.dispose()` cascaded through `AddonManager` into `webglAddon.dispose()` → `RenderService.setRenderer(...)`. If the render service was already torn down (or torn down in the same tick), `this._renderer` was undefined and the dispose crashed.

Known xterm.js lifecycle footgun when the addon is loaded async and disposal happens around the same time — triggered by stop, `restartKey` restart, or unmount.

## Fix

1. Track the addon in a new `webglAddonRef` so cleanup can reach it directly.
2. Declare a `mounted` flag at the top of the effect and guard the rAF body with `if (!mounted) return;` so the addon is never attached after teardown.
3. In the cleanup, dispose the WebGL addon explicitly **before** `term.dispose()`, inside a `try/catch`, so it cleans up while its internal state is still valid instead of via a late cascade.
4. Wrap `term.dispose()` in a `try/catch` as a last-resort safety net so no addon disposal error can escape to the React tree.

Canvas fallback path is unchanged (it's in the existing catch block that skips WebGL entirely).

## Diff

1 file, +29/−2 in `src/renderer/components/Terminal.tsx`.

## Test plan

- [ ] `bunx tsc --noEmit -p tsconfig.json` passes (verified locally, clean)
- [ ] Stop an active session — no ErrorBoundary, no console error
- [ ] Restart a session via the restart button (`restartKey` flow) — no crash
- [ ] Unmount a terminal (switch away) while it is still alive — no crash
- [ ] Force WebGL to fail (e.g. disable hardware acceleration) — canvas fallback still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-8]: https://gobodhi.atlassian.net/browse/BDHLNDR-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ