### PR TITLE
Release: BDHLNDR-8 (WebGL dispose fix) + BDHLNDR-9 (Claude session resume)

### DIFF
--- a/src/main/api/routes/sessions.ts
+++ b/src/main/api/routes/sessions.ts
@@ -79,6 +79,7 @@ export function createSessionsRouter(): Router {
           order: getNextOrder(),
           createdAt: now,
           lastActivityAt: now,
+          claudeSessionId: null,
         };
 
         sessionsRepo.createSession(session);

--- a/src/main/claude-launcher.ts
+++ b/src/main/claude-launcher.ts
@@ -1,12 +1,31 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import * as crypto from 'crypto';
 import { app } from 'electron';
+
+/**
+ * Which Claude CLI flag to use for the stored session UUID (BDHLNDR-9).
+ * - `new`    → `--session-id <uuid>` (first launch, set the session's ID)
+ * - `resume` → `--resume <uuid>` (subsequent launches, restore prior conversation)
+ */
+export type ClaudeSessionMode = 'new' | 'resume';
+
+export interface ClaudeSessionLaunch {
+  id: string;
+  mode: ClaudeSessionMode;
+}
 
 export interface ClaudeLaunchConfig {
   sessionId: string;
   projectDir: string;
   socketPath: string;
+  /**
+   * Claude session UUID + mode. When provided, the returned args include
+   * `--session-id <uuid>` or `--resume <uuid>`. Omit for the legacy fresh-launch
+   * behavior (no flag), which is only used if resume infrastructure is disabled.
+   */
+  claudeSession?: ClaudeSessionLaunch;
 }
 
 export function getClaudeCommand(config: ClaudeLaunchConfig): { command: string; args: string[]; env: NodeJS.ProcessEnv } {
@@ -25,11 +44,28 @@ export function getClaudeCommand(config: ClaudeLaunchConfig): { command: string;
     ENABLE_EXPERIMENTAL_MCP_CLI: 'true',
   };
 
+  // Build args for the Claude session UUID (BDHLNDR-9).
+  // UUIDs are alphanumeric + hyphens, so they are safe to inline into shell
+  // command strings without escaping.
+  const args: string[] = [];
+  if (config.claudeSession) {
+    const flag = config.claudeSession.mode === 'resume' ? '--resume' : '--session-id';
+    args.push(flag, config.claudeSession.id);
+  }
+
   return {
     command: 'claude',
-    args: [],
+    args,
     env,
   };
+}
+
+/**
+ * Generate a new Claude session UUID for first-launch use (BDHLNDR-9).
+ * Format matches Claude CLI's `--session-id` requirement (standard v4 UUID).
+ */
+export function generateClaudeSessionId(): string {
+  return crypto.randomUUID();
 }
 
 function getHookScriptPath(): string {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -99,6 +99,13 @@ function initializeTables(database: Database.Database): void {
     database.exec("ALTER TABLE groups ADD COLUMN collapsed INTEGER DEFAULT 0");
   }
 
+  // Migration: Add claude_session_id column to sessions if it doesn't exist (BDHLNDR-9)
+  // Stores the Claude Code session UUID so we can resume conversation on restart.
+  const sessionColumns = database.prepare("PRAGMA table_info(sessions)").all() as { name: string }[];
+  if (!sessionColumns.some(col => col.name === 'claude_session_id')) {
+    database.exec("ALTER TABLE sessions ADD COLUMN claude_session_id TEXT DEFAULT NULL");
+  }
+
   // Migration: Create memories table if it doesn't exist
   database.exec(`
     CREATE TABLE IF NOT EXISTS memories (

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -2,9 +2,14 @@ import * as pty from 'node-pty';
 import * as fs from 'fs';
 import { execFile } from 'child_process';
 import { EventEmitter } from 'events';
-import { getClaudeCommand, getSocketPath } from './claude-launcher';
+import { getClaudeCommand, getSocketPath, generateClaudeSessionId, ClaudeSessionMode } from './claude-launcher';
 import { detectShell, ShellInfo } from './shell-detector';
 import { getPreference } from './repositories/preferences';
+import {
+  getClaudeSessionId as getStoredClaudeSessionId,
+  setClaudeSessionId as storeClaudeSessionId,
+  clearClaudeSessionId as clearStoredClaudeSessionId,
+} from './repositories/sessions';
 import { writeMemoryFile, getMemoryInjectionContent } from './memory/injector';
 import log from 'electron-log';
 
@@ -32,7 +37,20 @@ interface PtySession {
   workingDebounce: NodeJS.Timeout | null;
   recentOutputBytes: number;
   lastOutputTime: number;
+  /** UUID passed to `claude --session-id` / `--resume` (BDHLNDR-9). Null for shell-only sessions. */
+  claudeSessionId: string | null;
+  /** Whether this spawn used `--resume`. Used to detect resume failure on early exit. */
+  claudeResumeAttempted: boolean;
+  /** Wall-clock spawn time (ms) for early-exit detection. */
+  spawnedAt: number;
 }
+
+/**
+ * If a Claude session launched with `--resume` exits non-zero within this
+ * window, we treat it as a resume failure and transparently respawn with a
+ * fresh `--session-id` (BDHLNDR-9).
+ */
+const RESUME_FAILURE_WINDOW_MS = 5000;
 
 // Max scrollback buffer size (100KB should be plenty for recent terminal history)
 const MAX_SCROLLBACK_SIZE = 100 * 1024;
@@ -119,16 +137,42 @@ class PtyManager extends EventEmitter {
       throw new Error(errorMsg);
     }
 
+    // Track Claude resume state for early-exit fallback (BDHLNDR-9)
+    let claudeSessionId: string | null = null;
+    let claudeSessionMode: ClaudeSessionMode | null = null;
+
     if (launchClaude) {
+      // Resolve the Claude session UUID + mode (BDHLNDR-9).
+      // If we have a stored ID, we're restarting and should resume. Otherwise
+      // generate a fresh UUID, pass it via --session-id, and persist it so the
+      // NEXT launch can resume.
+      const storedClaudeSessionId = getStoredClaudeSessionId(id);
+      if (storedClaudeSessionId) {
+        claudeSessionId = storedClaudeSessionId;
+        claudeSessionMode = 'resume';
+      } else {
+        claudeSessionId = generateClaudeSessionId();
+        claudeSessionMode = 'new';
+        storeClaudeSessionId(id, claudeSessionId);
+      }
+
       const claudeConfig = getClaudeCommand({
         sessionId: id,
         projectDir: cwd,
         socketPath: this.socketPath,
+        claudeSession: { id: claudeSessionId, mode: claudeSessionMode },
       });
+
+      // Suffix appended to every shell's claude command. UUIDs are alphanumeric
+      // + hyphens, so they are safe to inline without escaping.
+      // e.g. ' --resume 7a3f...' or ' --session-id 7a3f...'
+      const claudeSessionFlag = claudeConfig.args.length > 0
+        ? ' ' + claudeConfig.args.join(' ')
+        : '';
 
       // Get memory content for system prompt injection
       // Pass via environment variable to avoid shell escaping issues with newlines
-      let claudeCmd = 'claude';
+      let claudeCmd = `claude${claudeSessionFlag}`;
       let processEnv = { ...env, ...claudeConfig.env } as { [key: string]: string };
 
       if (groupId) {
@@ -142,7 +186,7 @@ class PtyManager extends EventEmitter {
         // Launch Claude inside WSL
         shell = 'wsl.exe';
         if (processEnv.BODHILANDER_SYSTEM_PROMPT) {
-          claudeCmd = 'claude --append-system-prompt "$BODHILANDER_SYSTEM_PROMPT"';
+          claudeCmd = `claude --append-system-prompt "$BODHILANDER_SYSTEM_PROMPT"${claudeSessionFlag}`;
         }
         args = [...shellInfo.args, '--', 'bash', '-c', claudeCmd];
         env = processEnv;
@@ -151,18 +195,18 @@ class PtyManager extends EventEmitter {
         shell = shellInfo.shell;
         if (shellInfo.shell.toLowerCase().includes('powershell')) {
           if (processEnv.BODHILANDER_SYSTEM_PROMPT) {
-            claudeCmd = 'claude --append-system-prompt $env:BODHILANDER_SYSTEM_PROMPT';
+            claudeCmd = `claude --append-system-prompt $env:BODHILANDER_SYSTEM_PROMPT${claudeSessionFlag}`;
           }
           args = ['-NoLogo', '-Command', claudeCmd];
         } else if (shellInfo.shell.toLowerCase().includes('cmd')) {
           if (processEnv.BODHILANDER_SYSTEM_PROMPT) {
-            claudeCmd = 'claude --append-system-prompt "%BODHILANDER_SYSTEM_PROMPT%"';
+            claudeCmd = `claude --append-system-prompt "%BODHILANDER_SYSTEM_PROMPT%"${claudeSessionFlag}`;
           }
           args = ['/c', claudeCmd];
         } else {
           // Assume bash-like shell (Git Bash, etc.)
           if (processEnv.BODHILANDER_SYSTEM_PROMPT) {
-            claudeCmd = 'claude --append-system-prompt "$BODHILANDER_SYSTEM_PROMPT"';
+            claudeCmd = `claude --append-system-prompt "$BODHILANDER_SYSTEM_PROMPT"${claudeSessionFlag}`;
           }
           args = ['-c', claudeCmd];
         }
@@ -171,7 +215,7 @@ class PtyManager extends EventEmitter {
         // macOS/Linux: run Claude through interactive login shell
         shell = shellInfo.shell;
         if (processEnv.BODHILANDER_SYSTEM_PROMPT) {
-          claudeCmd = 'claude --append-system-prompt "$BODHILANDER_SYSTEM_PROMPT"';
+          claudeCmd = `claude --append-system-prompt "$BODHILANDER_SYSTEM_PROMPT"${claudeSessionFlag}`;
         }
         args = ['-l', '-i', '-c', claudeCmd];
         env = processEnv;
@@ -227,6 +271,40 @@ class PtyManager extends EventEmitter {
     });
 
     ptyProcess.onExit(({ exitCode }) => {
+      // Resume-failure fallback (BDHLNDR-9): if we launched Claude with --resume
+      // and it exited non-zero within the failure window, treat that as a dead
+      // session and transparently respawn with a fresh UUID. The renderer never
+      // sees an 'exit' event for this path — it just sees new output from the
+      // replacement pty.
+      const session = this.sessions.get(id);
+      const isResumeFailure = session
+        && session.isClaudeSession
+        && session.claudeResumeAttempted
+        && exitCode !== 0
+        && (Date.now() - session.spawnedAt) < RESUME_FAILURE_WINDOW_MS;
+
+      if (isResumeFailure) {
+        log.warn(
+          `[PTY] Claude resume failed for session ${id} (exitCode=${exitCode}, ` +
+          `age=${Date.now() - session!.spawnedAt}ms). Clearing stored session ID ` +
+          `and retrying with a fresh Claude session.`
+        );
+        try {
+          clearStoredClaudeSessionId(id);
+        } catch (e) {
+          log.error(`[PTY] Failed to clear claude_session_id for ${id}:`, e);
+        }
+        // Remove the dead entry so createSession can re-insert a fresh one.
+        this.sessions.delete(id);
+        try {
+          this.createSession(id, cwd, true, groupId);
+          return; // Successful retry — suppress the exit emission.
+        } catch (e) {
+          log.error(`[PTY] Resume-failure retry spawn failed for ${id}:`, e);
+          // Fall through to emit the original exit so the UI recovers.
+        }
+      }
+
       this.emit('exit', { id, exitCode });
       this.sessions.delete(id);
     });
@@ -250,6 +328,9 @@ class PtyManager extends EventEmitter {
       workingDebounce: null,
       recentOutputBytes: 0,
       lastOutputTime: 0,
+      claudeSessionId,
+      claudeResumeAttempted: claudeSessionMode === 'resume',
+      spawnedAt: Date.now(),
     });
 
   }

--- a/src/main/repositories/sessions.ts
+++ b/src/main/repositories/sessions.ts
@@ -15,14 +15,15 @@ export function getAllSessions(): Session[] {
     order: row.order,
     createdAt: new Date(row.created_at),
     lastActivityAt: new Date(row.last_activity_at),
+    claudeSessionId: row.claude_session_id ?? null,
   }));
 }
 
 export function createSession(session: Session): void {
   const db = getDatabase();
   db.prepare(`
-    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at, claude_session_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     session.id,
     session.groupId,
@@ -32,8 +33,38 @@ export function createSession(session: Session): void {
     session.shellType,
     session.order,
     session.createdAt.toISOString(),
-    session.lastActivityAt.toISOString()
+    session.lastActivityAt.toISOString(),
+    session.claudeSessionId ?? null
   );
+}
+
+/**
+ * Get the stored Claude session UUID for a Bodhilander session (BDHLNDR-9).
+ * Returns null if no Claude session has been launched yet for this session.
+ */
+export function getClaudeSessionId(id: string): string | null {
+  const db = getDatabase();
+  const row = db.prepare('SELECT claude_session_id FROM sessions WHERE id = ?').get(id) as
+    | { claude_session_id: string | null }
+    | undefined;
+  return row?.claude_session_id ?? null;
+}
+
+/**
+ * Store the Claude session UUID so we can pass it to `claude --resume` on restart (BDHLNDR-9).
+ */
+export function setClaudeSessionId(id: string, claudeSessionId: string): void {
+  const db = getDatabase();
+  db.prepare('UPDATE sessions SET claude_session_id = ? WHERE id = ?').run(claudeSessionId, id);
+}
+
+/**
+ * Clear the stored Claude session UUID (e.g. after a failed resume) so the next
+ * launch starts fresh (BDHLNDR-9).
+ */
+export function clearClaudeSessionId(id: string): void {
+  const db = getDatabase();
+  db.prepare('UPDATE sessions SET claude_session_id = NULL WHERE id = ?').run(id);
 }
 
 export function updateSession(id: string, updates: Partial<Session>): void {

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -29,6 +29,7 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  const webglAddonRef = useRef<WebglAddon | null>(null);
   const lastPasteTimeRef = useRef<number>(0);
   const [isRunning, setIsRunning] = useState(!isStopped);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({ visible: false, x: 0, y: 0, hasSelection: false });
@@ -181,6 +182,8 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   useEffect(() => {
     if (!terminalRef.current || !isRunning) return;
 
+    let mounted = true;
+
     const term = new XTerm({
       theme: {
         background: '#1e1e1e',
@@ -201,12 +204,16 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     term.open(terminalRef.current);
     fitAddon.fit();
 
-    // Load WebGL renderer after terminal is fully rendered for better performance
+    // Load WebGL renderer after terminal is fully rendered for better performance.
+    // Guard with `mounted` so the addon is not attached after effect cleanup —
+    // otherwise its dispose cascades through a torn-down RenderService and crashes.
     requestAnimationFrame(() => {
+      if (!mounted) return;
       try {
         const webglAddon = new WebglAddon();
         webglAddon.onContextLoss(() => { webglAddon.dispose(); });
         term.loadAddon(webglAddon);
+        webglAddonRef.current = webglAddon;
       } catch (e) {
         console.warn('WebGL addon failed to load, using canvas renderer:', e);
       }
@@ -334,11 +341,31 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     });
 
     return () => {
+      mounted = false;
       window.removeEventListener('resize', handleResize);
       resizeObserver.disconnect();
       cleanupPtyData();
       window.electronAPI.killSession(sessionId);
-      term.dispose();
+
+      // Dispose the WebGL addon explicitly before term.dispose() so its internal
+      // RenderService is still valid. Letting term.dispose() cascade into the
+      // addon can throw "Cannot read properties of undefined (reading 'onRequestRedraw')"
+      // when the addon was loaded async and is being torn down in the same tick.
+      if (webglAddonRef.current) {
+        try {
+          webglAddonRef.current.dispose();
+        } catch (e) {
+          console.warn('WebGL addon dispose error (non-fatal):', e);
+        }
+        webglAddonRef.current = null;
+      }
+
+      // Safety net: never let a terminal/addon dispose error escape to the React tree.
+      try {
+        term.dispose();
+      } catch (e) {
+        console.warn('Terminal dispose error (non-fatal):', e);
+      }
     };
   }, [sessionId, cwd, launchClaude, isRunning]);
 

--- a/src/renderer/store/sessions.ts
+++ b/src/renderer/store/sessions.ts
@@ -59,6 +59,7 @@ export function useSessions() {
           order: prev.filter(s => s.groupId === groupId).length,
           createdAt: new Date(),
           lastActivityAt: new Date(),
+          claudeSessionId: null,
         };
 
         // Persist asynchronously

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -10,6 +10,11 @@ export interface Session {
   order: number;
   createdAt: Date;
   lastActivityAt: Date;
+  /**
+   * Claude Code session UUID for conversation resume across restarts (BDHLNDR-9).
+   * Null for non-Claude sessions or Claude sessions that have not been launched yet.
+   */
+  claudeSessionId: string | null;
 }
 
 export interface Group {


### PR DESCRIPTION
## Release summary

Merges `development` → `production` to cut a new release with two tickets:

### BDHLNDR-8 — WebGL addon disposal crash (Bug, Medium)

Stopping a Claude session was throwing `TypeError: Cannot read properties of undefined (reading 'onRequestRedraw')` from `xterm-addon-webgl` up to the React ErrorBoundary. Fix tracks the addon in a ref, guards the async rAF load with a mounted flag, and disposes the addon explicitly in a try/catch before `term.dispose()`. Merged via #9.

### BDHLNDR-9 — Resume Claude session on restart (Story, Medium)

Stopping and restarting a Claude session now preserves the conversation. Bodhilander generates a UUID up front and passes it to Claude via `--session-id <uuid>` on first launch and `--resume <uuid>` on restart — sidesteps the hook-capture/correlation problem. Includes a transparent respawn fallback if `--resume` fails. Schema migration adds a nullable `claude_session_id` column to `sessions`. Merged via #10.

## Test plan

Both tickets have already been merged to `development` and smoke-tested:
- [x] BDHLNDR-8: stop/restart/unmount no longer crashes
- [x] BDHLNDR-9: `--session-id` → `--resume` preserves context (manual smoke test confirmed by reporter)

## Next steps after merge

1. Bump version on `production` (proposing **minor: 3.0.2 → 3.1.0** since BDHLNDR-9 is a new user-facing feature)
2. `git push` **without** `--tags` — the release workflow creates the tag itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)