### PR TITLE
fix(BDHLNDR-12): propagate PTY resize when a session becomes active

### DIFF
--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -35,6 +35,18 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({ visible: false, x: 0, y: 0, hasSelection: false });
   const [error, setError] = useState<string | null>(null);
 
+  // Fit the xterm renderer to the current container size AND propagate the new
+  // cols/rows to the PTY (BDHLNDR-12). Kept as a single source of truth so the
+  // ResizeObserver, the window resize listener, and the session-activation
+  // effect all go through the same path.
+  const handleResize = useCallback(() => {
+    if (fitAddonRef.current && xtermRef.current) {
+      fitAddonRef.current.fit();
+      const { cols, rows } = xtermRef.current;
+      window.electronAPI.resizeSession(sessionId, cols, rows);
+    }
+  }, [sessionId]);
+
   // Sync isStopped prop changes to isRunning state (fixes stop button)
   useEffect(() => {
     setIsRunning(!isStopped);
@@ -70,16 +82,20 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     return () => window.removeEventListener('focus-terminal', handleFocusTerminal);
   }, [isActive]);
 
-  // Scroll to bottom when terminal becomes active (session switch)
+  // Refit and scroll to bottom when terminal becomes active (session switch).
+  // Critically, this must also resize the PTY (via handleResize) — the
+  // previously active layout may have changed while this session was hidden
+  // with `display: none` (App.tsx:1293). Without a PTY resize here, the shell
+  // keeps emitting at the stale column count and the visible output appears
+  // hard-wrapped to a narrow width (BDHLNDR-12).
   useEffect(() => {
     if (isActive && xtermRef.current && fitAddonRef.current) {
-      // Fit first to ensure dimensions are correct, then scroll to bottom
       requestAnimationFrame(() => {
-        fitAddonRef.current?.fit();
+        handleResize();
         xtermRef.current?.scrollToBottom();
       });
     }
-  }, [isActive]);
+  }, [isActive, handleResize]);
 
   // Copy text from terminal selection
   const handleCopy = useCallback(() => {
@@ -310,14 +326,8 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       window.electronAPI.writeToSession(sessionId, data);
     });
 
-    // Handle resize with ResizeObserver for reliable sizing
-    const handleResize = () => {
-      if (fitAddonRef.current && xtermRef.current) {
-        fitAddonRef.current.fit();
-        const { cols, rows } = xtermRef.current;
-        window.electronAPI.resizeSession(sessionId, cols, rows);
-      }
-    };
+    // Use the hoisted handleResize (BDHLNDR-12) so the ResizeObserver, window
+    // resize listener, and session-activation effect all share one fit+PTY-resize path.
 
     // Use ResizeObserver to detect when container actually has dimensions
     const resizeObserver = new ResizeObserver((entries) => {
@@ -367,7 +377,7 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
         console.warn('Terminal dispose error (non-fatal):', e);
       }
     };
-  }, [sessionId, cwd, launchClaude, isRunning]);
+  }, [sessionId, cwd, launchClaude, isRunning, handleResize]);
 
   const handleStart = () => {
     setError(null);


### PR DESCRIPTION
## Summary

Fixes [BDHLNDR-12](https://gobodhi.atlassian.net/browse/BDHLNDR-12) — when a user switches away from and back to a session, the terminal's text can appear hard-wrapped at the old (narrow) column count inside the now-wider container (the "squished to the left" visual). Only a manual window resize would fix it.

## Root cause

Two cooperating pieces of code produce the bug:

1. **Inactive sessions are hidden with `display: none`** in `App.tsx:1293`:
   ```tsx
   style={{ display: session.id === activeSessionId ? 'flex' : 'none' }}
   ```
   While hidden, the terminal container's `contentRect` is 0×0. ResizeObserver entries are filtered by a `width > 0 && height > 0` guard, and window `resize` events that reach the inactive terminal's `handleResize` read 0×0 from the hidden container, so no meaningful PTY resize propagates.

2. **The `isActive` effect only called `fit()`**, never `resizeSession()`:
   ```tsx
   useEffect(() => {
     if (isActive && xtermRef.current && fitAddonRef.current) {
       requestAnimationFrame(() => {
         fitAddonRef.current?.fit();        // updates xterm.js local cols/rows
         xtermRef.current?.scrollToBottom();
         // ← no PTY resize — stale cols stay stale
       });
     }
   }, [isActive]);
   ```

When the layout changed (window resize, sidebar toggle, etc.) while a session was hidden, the PTY's cols stayed at whatever value was current at spawn time. On activation, xterm fit itself to the new width but the PTY kept emitting with the old narrow width — producing hard-wrapped lines inside a wider canvas.

## Fix

Hoisted `handleResize` out of the main effect into a component-level `useCallback([sessionId])`, then call it from:

- The existing `ResizeObserver` (unchanged behavior)
- The existing `window.addEventListener('resize', ...)` (unchanged behavior)
- **The `isActive` effect (new — closes the gap)**

One source of truth for fit + PTY resize. SIGWINCH now fires on session activation, so Claude Code / bash / zsh redraw their buffers at the new width — this matches the manual-resize workaround without requiring user action. Old squished output naturally gets re-emitted at the correct width.

Also added `handleResize` (which depends on `sessionId`) to both effects' dependency arrays, closing a latent `exhaustive-deps` gap.

## Diff

1 file, +23/−13 in `src/renderer/components/Terminal.tsx`.

## Verification

- [x] `bunx tsc --noEmit -p tsconfig.json` clean
- [x] No ResizeObserver / window-resize behavior changes (same `handleResize` semantics, just hoisted)
- [ ] Manual smoke test (needs packaged/dev build): repro steps below

## Test plan / repro

1. Open Bodhilander and create at least two sessions.
2. Make Session A active, let it emit output.
3. Resize the window (or toggle the sidebar) to change the terminal area width.
4. Switch to Session B, then back to Session A.
5. **Expected before fix:** Session A's content appears squished to the left, hard-wrapped at a narrow column.
6. **Expected after fix:** Session A renders at the correct width; the shell redraws at the new size on activation.
7. Regression check: create/restart sessions, resize window while a session is active — everything still works as before.

## Related

- BDHLNDR-8 (recent WebGL dispose fix) touched `Terminal.tsx` but not the resize path — independent.
- Reporter flagged a sibling issue about limited/missing scrollback history during the same session; that will be filed separately after investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-12]: https://gobodhi.atlassian.net/browse/BDHLNDR-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ