### PR TITLE
fix(BDHLNDR-13): raise xterm.js scrollback from 1000 to 10000 lines

### DIFF
--- a/src/renderer/components/RemoteTerminal.tsx
+++ b/src/renderer/components/RemoteTerminal.tsx
@@ -43,6 +43,8 @@ const RemoteTerminal: React.FC<RemoteTerminalProps> = ({ code, permission, isAct
       fontSize: 14,
       cursorBlink: permission === 'control',
       disableStdin: permission === 'read',
+      // BDHLNDR-13: match primary Terminal component — default 1000 is too small.
+      scrollback: 10000,
     });
 
     const fitAddon = new FitAddon();

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -196,6 +196,9 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       fontSize: 14,
       cursorBlink: true,
       minimumContrastRatio: 4.5,
+      // BDHLNDR-13: xterm.js defaults to 1000 lines, which fills up quickly
+      // during Claude Code sessions. 10k lines ≈ 2MB/terminal — negligible.
+      scrollback: 10000,
     });
 
     const fitAddon = new FitAddon();


### PR DESCRIPTION
## Summary

Fixes [BDHLNDR-13](https://gobodhi.atlassian.net/browse/BDHLNDR-13) — terminal scroll history was limited to ~1000 lines (xterm.js default) and exhausted within a handful of Claude Code messages, causing older output to disappear from scroll-up.

## Root cause

Both `Terminal.tsx` and `RemoteTerminal.tsx` called `new XTerm({...})` without a `scrollback` option. xterm.js defaults to **1000 lines**, which fills up fast for a Claude Code session manager where individual exchanges frequently contain long responses, file contents, and diffs.

## Fix

Added `scrollback: 10000` to both XTerm constructors.

### Memory cost

At ~200 chars/line average, 10,000 lines ≈ 2 MB per terminal. For 10 concurrent sessions, ~20 MB total — negligible on any modern machine.

### Why 10,000 specifically

Balance between comfortably covering long Claude conversations and keeping memory sane. 50,000 would also be acceptable if we hear complaints, but 10x the current limit is a meaningful jump and the right starting point. A user-configurable preference can follow as a future enhancement.

## Diff

2 files, +5/−0 total.

## Unrelated to main-process scrollback buffer

For clarity in case of confusion: `pty-manager.ts` has a separate `MAX_SCROLLBACK_SIZE = 100 * 1024` byte buffer used by the mobile API (`/api/v1/terminal/:id/buffer`). That is **not** the xterm.js scrollback and does not affect what the user sees when scrolling in the desktop view. This PR does not touch it.

## Test plan

- [x] `bunx tsc --noEmit -p tsconfig.json` clean
- [ ] Manual smoke test: open a Claude session, have a long exchange, scroll back — should see substantially more history than before
- [ ] Check renderer memory usage in dev tools with a couple of long-running sessions — expect no dramatic increase

## Related

- Independent from PR #14 (BDHLNDR-12 — squished text on session switch). Both touch `Terminal.tsx` but at different locations; no conflict expected.
- Reporter filed both issues simultaneously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-13]: https://gobodhi.atlassian.net/browse/BDHLNDR-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ