### PR TITLE
Release 3.1.1: BDHLNDR-12 (squished text) + BDHLNDR-13 (scrollback)

### DIFF
--- a/src/renderer/components/RemoteTerminal.tsx
+++ b/src/renderer/components/RemoteTerminal.tsx
@@ -43,6 +43,8 @@ const RemoteTerminal: React.FC<RemoteTerminalProps> = ({ code, permission, isAct
       fontSize: 14,
       cursorBlink: permission === 'control',
       disableStdin: permission === 'read',
+      // BDHLNDR-13: match primary Terminal component — default 1000 is too small.
+      scrollback: 10000,
     });
 
     const fitAddon = new FitAddon();

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -35,6 +35,18 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({ visible: false, x: 0, y: 0, hasSelection: false });
   const [error, setError] = useState<string | null>(null);
 
+  // Fit the xterm renderer to the current container size AND propagate the new
+  // cols/rows to the PTY (BDHLNDR-12). Kept as a single source of truth so the
+  // ResizeObserver, the window resize listener, and the session-activation
+  // effect all go through the same path.
+  const handleResize = useCallback(() => {
+    if (fitAddonRef.current && xtermRef.current) {
+      fitAddonRef.current.fit();
+      const { cols, rows } = xtermRef.current;
+      window.electronAPI.resizeSession(sessionId, cols, rows);
+    }
+  }, [sessionId]);
+
   // Sync isStopped prop changes to isRunning state (fixes stop button)
   useEffect(() => {
     setIsRunning(!isStopped);
@@ -70,16 +82,20 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     return () => window.removeEventListener('focus-terminal', handleFocusTerminal);
   }, [isActive]);
 
-  // Scroll to bottom when terminal becomes active (session switch)
+  // Refit and scroll to bottom when terminal becomes active (session switch).
+  // Critically, this must also resize the PTY (via handleResize) — the
+  // previously active layout may have changed while this session was hidden
+  // with `display: none` (App.tsx:1293). Without a PTY resize here, the shell
+  // keeps emitting at the stale column count and the visible output appears
+  // hard-wrapped to a narrow width (BDHLNDR-12).
   useEffect(() => {
     if (isActive && xtermRef.current && fitAddonRef.current) {
-      // Fit first to ensure dimensions are correct, then scroll to bottom
       requestAnimationFrame(() => {
-        fitAddonRef.current?.fit();
+        handleResize();
         xtermRef.current?.scrollToBottom();
       });
     }
-  }, [isActive]);
+  }, [isActive, handleResize]);
 
   // Copy text from terminal selection
   const handleCopy = useCallback(() => {
@@ -310,14 +326,8 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       window.electronAPI.writeToSession(sessionId, data);
     });
 
-    // Handle resize with ResizeObserver for reliable sizing
-    const handleResize = () => {
-      if (fitAddonRef.current && xtermRef.current) {
-        fitAddonRef.current.fit();
-        const { cols, rows } = xtermRef.current;
-        window.electronAPI.resizeSession(sessionId, cols, rows);
-      }
-    };
+    // Use the hoisted handleResize (BDHLNDR-12) so the ResizeObserver, window
+    // resize listener, and session-activation effect all share one fit+PTY-resize path.
 
     // Use ResizeObserver to detect when container actually has dimensions
     const resizeObserver = new ResizeObserver((entries) => {
@@ -367,7 +377,7 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
         console.warn('Terminal dispose error (non-fatal):', e);
       }
     };
-  }, [sessionId, cwd, launchClaude, isRunning]);
+  }, [sessionId, cwd, launchClaude, isRunning, handleResize]);
 
   const handleStart = () => {
     setError(null);

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -196,6 +196,9 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       fontSize: 14,
       cursorBlink: true,
       minimumContrastRatio: 4.5,
+      // BDHLNDR-13: xterm.js defaults to 1000 lines, which fills up quickly
+      // during Claude Code sessions. 10k lines ≈ 2MB/terminal — negligible.
+      scrollback: 10000,
     });
 
     const fitAddon = new FitAddon();


### PR DESCRIPTION
## Release summary

Merges `development` → `production` to cut **v3.1.1**, a patch release with two bug fixes that came out of user reports today.

### BDHLNDR-12 — Squished text on session switch (Bug, Medium)

When users switched away from and back to a session, the terminal content rendered hard-wrapped at the old narrow column count inside the now-wider container. Root cause: the `isActive` effect in `Terminal.tsx` called `fit()` on the xterm.js renderer but never propagated the new size to the PTY, so the shell kept emitting at stale cols. Fix hoists `handleResize` into a component-level `useCallback` and routes the `isActive` effect through it, so SIGWINCH fires on activation and the shell redraws at the correct width. Merged via #14.

### BDHLNDR-13 — Scrollback limited to 1000 lines (Bug, Medium)

`Terminal.tsx` and `RemoteTerminal.tsx` constructed `new XTerm({...})` without a `scrollback` option, inheriting xterm.js's default of 1000 lines — exhausted within a handful of Claude Code messages. Fix sets `scrollback: 10000` in both constructors (~2 MB per terminal, negligible). Merged via #15.

## Test plan

Both fixes have been merged to `development` and smoke-tested:
- [x] BDHLNDR-12: session switch no longer produces squished output
- [x] BDHLNDR-13: scroll history now shows ~10× more content

## Next steps after merge

1. Bump version on `production` with **patch** (`npm version patch`, 3.1.0 → 3.1.1 — both tickets are bug fixes, no new features)
2. `git push` **without** `--tags` so the release workflow creates the tag itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)