### PR TITLE
feat(BDHLNDR-17): session events table and duration/state tracking

### DIFF
--- a/src/hooks/bodhilander-hook.ts
+++ b/src/hooks/bodhilander-hook.ts
@@ -185,7 +185,8 @@ function parseArgs(): { hookType: string; groupId?: string; sessionId?: string }
   const args = process.argv.slice(2);
   let hookType = 'PostToolUse';
   let groupId: string | undefined;
-  let sessionId: string | undefined;
+  // Use BODHILANDER_SESSION_ID env var (set by claude-launcher.ts) as default
+  let sessionId: string | undefined = process.env.BODHILANDER_SESSION_ID;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--group-id' && args[i + 1]) {

--- a/src/main/api/routes/hooks.ts
+++ b/src/main/api/routes/hooks.ts
@@ -7,8 +7,25 @@
 
 import { Router, Request, Response } from 'express';
 import * as memoriesRepo from '../../repositories/memories';
-import * as groupsRepo from '../../repositories/groups';
+import * as sessionEventsRepo from '../../repositories/session-events';
+import * as sessionsRepo from '../../repositories/sessions';
+import { SessionEventType } from '../../../shared/types';
 import log from 'electron-log';
+
+/**
+ * Try to log a session event. Only writes if session_id references a valid session.
+ */
+function tryLogEvent(sessionId: string | undefined, eventType: SessionEventType, eventData?: Record<string, unknown> | null): void {
+  if (!sessionId) return;
+  try {
+    // Verify the session exists before writing (foreign key constraint)
+    const sessions = sessionsRepo.getAllSessions();
+    if (!sessions.some(s => s.id === sessionId)) return;
+    sessionEventsRepo.createEvent(sessionId, eventType, eventData);
+  } catch (error) {
+    log.error(`[HooksAPI] Failed to log ${eventType} event:`, error);
+  }
+}
 
 /**
  * Middleware to restrict to localhost only
@@ -115,10 +132,14 @@ export function createHooksRouter(): Router {
           });
 
           log.info(`[HooksAPI] Saved git commit as memory: ${memory.id}`);
+          tryLogEvent(session_id, 'tool_use', { tool_name });
           res.json({ saved: true, memory_id: memory.id, type: 'git_commit' });
           return;
         }
       }
+
+      // Log tool use event regardless of memory creation (BDHLNDR-17)
+      tryLogEvent(session_id, 'tool_use', { tool_name });
 
       // For other significant tool uses, just acknowledge
       res.json({ saved: false, reason: 'not_actionable' });
@@ -144,6 +165,13 @@ export function createHooksRouter(): Router {
       } = req.body;
 
       log.info(`[HooksAPI] Stop: session=${session_id}, reason=${stop_reason}, tools=${tool_uses_count}`);
+
+      // Log stop event regardless of significance (BDHLNDR-17)
+      tryLogEvent(session_id, 'session_stop', {
+        stop_reason,
+        tool_uses_count,
+        files_edited,
+      });
 
       // Only process if there was significant activity
       const isSignificant = (tool_uses_count && tool_uses_count > 3) ||
@@ -188,6 +216,13 @@ export function createHooksRouter(): Router {
       const { session_id, group_id, notification_type, message } = req.body;
 
       log.info(`[HooksAPI] Notification: ${notification_type}`);
+
+      // Log notification event (BDHLNDR-17)
+      if (notification_type === 'error') {
+        tryLogEvent(session_id, 'error', { message });
+      } else {
+        tryLogEvent(session_id, 'notification', { type: notification_type, message });
+      }
 
       // Could capture error notifications as error_fix memories
       if (notification_type === 'error' && message && group_id) {

--- a/src/main/api/routes/hooks.ts
+++ b/src/main/api/routes/hooks.ts
@@ -18,13 +18,17 @@ import log from 'electron-log';
 function tryLogEvent(sessionId: string | undefined, eventType: SessionEventType, eventData?: Record<string, unknown> | null): void {
   if (!sessionId) return;
   try {
-    // Verify the session exists before writing (foreign key constraint)
-    const sessions = sessionsRepo.getAllSessions();
-    if (!sessions.some(s => s.id === sessionId)) return;
+    if (!sessionsRepo.sessionExists(sessionId)) return;
     sessionEventsRepo.createEvent(sessionId, eventType, eventData);
   } catch (error) {
     log.error(`[HooksAPI] Failed to log ${eventType} event:`, error);
   }
+}
+
+/** Sanitize a value for safe logging (strip control characters, truncate). */
+function sanitizeLogValue(val: unknown, maxLen = 100): string {
+  const str = String(val ?? '').replace(/[\x00-\x1f\x7f]/g, '');
+  return str.length > maxLen ? str.slice(0, maxLen) + '...' : str;
 }
 
 /**
@@ -97,7 +101,7 @@ export function createHooksRouter(): Router {
     try {
       const { tool_name, tool_input, tool_output, session_id, group_id } = req.body;
 
-      log.info(`[HooksAPI] PostToolUse: ${tool_name}`);
+      log.info(`[HooksAPI] PostToolUse: ${sanitizeLogValue(tool_name)}`);
 
       // Handle git commits specially
       if (tool_name === 'Bash') {
@@ -164,10 +168,10 @@ export function createHooksRouter(): Router {
         summary_hint
       } = req.body;
 
-      log.info(`[HooksAPI] Stop: session=${session_id}, reason=${stop_reason}, tools=${tool_uses_count}`);
+      log.info(`[HooksAPI] Stop: session=${sanitizeLogValue(session_id)}, reason=${sanitizeLogValue(stop_reason)}, tools=${sanitizeLogValue(tool_uses_count)}`);
 
-      // Log stop event regardless of significance (BDHLNDR-17)
-      tryLogEvent(session_id, 'session_stop', {
+      // Log turn completion event (distinct from session_stop which means PTY exited) (BDHLNDR-17)
+      tryLogEvent(session_id, 'turn_complete', {
         stop_reason,
         tool_uses_count,
         files_edited,
@@ -215,7 +219,7 @@ export function createHooksRouter(): Router {
     try {
       const { session_id, group_id, notification_type, message } = req.body;
 
-      log.info(`[HooksAPI] Notification: ${notification_type}`);
+      log.info(`[HooksAPI] Notification: ${sanitizeLogValue(notification_type)}`);
 
       // Log notification event (BDHLNDR-17)
       if (notification_type === 'error') {

--- a/src/main/api/routes/sessions.ts
+++ b/src/main/api/routes/sessions.ts
@@ -80,6 +80,8 @@ export function createSessionsRouter(): Router {
           createdAt: now,
           lastActivityAt: now,
           claudeSessionId: null,
+          endedAt: null,
+          durationSeconds: 0,
         };
 
         sessionsRepo.createSession(session);

--- a/src/main/api/routes/sessions.ts
+++ b/src/main/api/routes/sessions.ts
@@ -7,6 +7,7 @@
 import { Router, Request, Response } from 'express';
 import log from 'electron-log';
 import * as sessionsRepo from '../../repositories/sessions';
+import * as sessionEventsRepo from '../../repositories/session-events';
 import { ptyManager } from '../../pty-manager';
 import { requireControlPermission, requireModifyPermission } from '../middleware/auth';
 import {
@@ -85,6 +86,13 @@ export function createSessionsRouter(): Router {
         };
 
         sessionsRepo.createSession(session);
+
+        // Log session start event (BDHLNDR-17)
+        try {
+          sessionEventsRepo.createEvent(session.id, 'session_start', null);
+        } catch (error) {
+          log.error('Failed to log session_start event:', error);
+        }
 
         // Start PTY if requested
         if (launchClaude) {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -106,6 +106,39 @@ function initializeTables(database: Database.Database): void {
     database.exec("ALTER TABLE sessions ADD COLUMN claude_session_id TEXT DEFAULT NULL");
   }
 
+  // Migration: Add ended_at and duration_seconds columns to sessions (BDHLNDR-17)
+  const sessionColsBdhlndr17 = sessionColumns.map(c => c.name);
+  if (!sessionColsBdhlndr17.includes('ended_at')) {
+    database.exec("ALTER TABLE sessions ADD COLUMN ended_at TEXT DEFAULT NULL");
+  }
+  if (!sessionColsBdhlndr17.includes('duration_seconds')) {
+    database.exec("ALTER TABLE sessions ADD COLUMN duration_seconds REAL DEFAULT 0");
+  }
+
+  // Migration: Create session_events table (BDHLNDR-17)
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS session_events (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      event_type TEXT NOT NULL CHECK(event_type IN (
+        'session_start', 'session_stop', 'state_change', 'tool_use', 'error', 'notification'
+      )),
+      event_data TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE INDEX IF NOT EXISTS idx_session_events_session_id ON session_events(session_id);
+    CREATE INDEX IF NOT EXISTS idx_session_events_type ON session_events(event_type);
+    CREATE INDEX IF NOT EXISTS idx_session_events_created ON session_events(created_at);
+  `);
+
+  // Backfill duration_seconds for existing stopped sessions (rough estimate from wall clock)
+  database.exec(`
+    UPDATE sessions
+    SET duration_seconds = (julianday(last_activity_at) - julianday(created_at)) * 86400
+    WHERE duration_seconds = 0 AND state = 'stopped'
+      AND last_activity_at IS NOT NULL AND created_at IS NOT NULL
+  `);
+
   // Migration: Create memories table if it doesn't exist
   database.exec(`
     CREATE TABLE IF NOT EXISTS memories (

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -108,11 +108,13 @@ function initializeTables(database: Database.Database): void {
 
   // Migration: Add ended_at and duration_seconds columns to sessions (BDHLNDR-17)
   const sessionColsBdhlndr17 = sessionColumns.map(c => c.name);
+  let durationColumnJustAdded = false;
   if (!sessionColsBdhlndr17.includes('ended_at')) {
     database.exec("ALTER TABLE sessions ADD COLUMN ended_at TEXT DEFAULT NULL");
   }
   if (!sessionColsBdhlndr17.includes('duration_seconds')) {
     database.exec("ALTER TABLE sessions ADD COLUMN duration_seconds REAL DEFAULT 0");
+    durationColumnJustAdded = true;
   }
 
   // Migration: Create session_events table (BDHLNDR-17)
@@ -121,23 +123,24 @@ function initializeTables(database: Database.Database): void {
       id TEXT PRIMARY KEY,
       session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
       event_type TEXT NOT NULL CHECK(event_type IN (
-        'session_start', 'session_stop', 'state_change', 'tool_use', 'error', 'notification'
+        'session_start', 'session_stop', 'state_change', 'tool_use', 'turn_complete', 'error', 'notification'
       )),
       event_data TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
     );
-    CREATE INDEX IF NOT EXISTS idx_session_events_session_id ON session_events(session_id);
-    CREATE INDEX IF NOT EXISTS idx_session_events_type ON session_events(event_type);
+    CREATE INDEX IF NOT EXISTS idx_session_events_session_type_time ON session_events(session_id, event_type, created_at);
     CREATE INDEX IF NOT EXISTS idx_session_events_created ON session_events(created_at);
   `);
 
-  // Backfill duration_seconds for existing stopped sessions (rough estimate from wall clock)
-  database.exec(`
-    UPDATE sessions
-    SET duration_seconds = (julianday(last_activity_at) - julianday(created_at)) * 86400
-    WHERE duration_seconds = 0 AND state = 'stopped'
-      AND last_activity_at IS NOT NULL AND created_at IS NOT NULL
-  `);
+  // Backfill duration_seconds for existing stopped sessions (one-time, rough wall-clock estimate)
+  if (durationColumnJustAdded) {
+    database.exec(`
+      UPDATE sessions
+      SET duration_seconds = (julianday(last_activity_at) - julianday(created_at)) * 86400
+      WHERE duration_seconds = 0 AND state = 'stopped'
+        AND last_activity_at IS NOT NULL AND created_at IS NOT NULL
+    `);
+  }
 
   // Migration: Create memories table if it doesn't exist
   database.exec(`

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -137,6 +137,44 @@ soundManager.setSessionStateLookup((sessionId: string) => {
   return sessionStates.get(sessionId)?.state;
 });
 
+// Track which sessions have already had their state logged in this tick,
+// to deduplicate when both stateMonitor and ptyManager fire for the same transition.
+const recentlyLoggedStates: Map<string, { state: string; timestamp: number }> = new Map();
+
+/**
+ * Shared handler for session state change event logging (BDHLNDR-17).
+ * Called from both stateMonitor and ptyManager handlers.
+ * Deduplicates: if the same session+state was logged within the last 2 seconds, skips.
+ */
+function logSessionStateEvent(sessionId: string, newState: SessionState): void {
+  // Dedup guard: skip if same session+state was logged within 2 seconds
+  const recent = recentlyLoggedStates.get(sessionId);
+  const now = Date.now();
+  if (recent && recent.state === newState && (now - recent.timestamp) < 2000) {
+    return;
+  }
+  recentlyLoggedStates.set(sessionId, { state: newState, timestamp: now });
+
+  try {
+    const previousState = sessionStates.get(sessionId)?.state ?? 'unknown';
+    sessionEventsRepo.createEvent(sessionId, 'state_change', {
+      from: previousState,
+      to: newState,
+    });
+    if (newState === 'stopped') {
+      sessionEventsRepo.createEvent(sessionId, 'session_stop', null);
+      const breakdown = sessionEventsRepo.getStateBreakdown(sessionId);
+      const activeSeconds = (breakdown['working'] || 0) + (breakdown['waiting'] || 0);
+      sessionsRepo.updateSession(sessionId, {
+        endedAt: new Date(),
+        durationSeconds: activeSeconds,
+      });
+    }
+  } catch (error) {
+    log.error('Failed to log session event:', error);
+  }
+}
+
 const SPLASH_DURATION = 2500; // 2.5 seconds
 
 function updateTrayWithWaitingSessions(): void {
@@ -281,8 +319,6 @@ function createWindow(): void {
 
   stateMonitor.on('stateChange', (event) => {
     mainWindow?.webContents.send('state:change', event);
-    // Track previous state for event logging
-    const previousState = sessionStates.get(event.sessionId)?.state as SessionState | undefined;
     // Update database with error handling
     try {
       sessionsRepo.updateSession(event.sessionId, {
@@ -292,24 +328,8 @@ function createWindow(): void {
     } catch (error) {
       console.error('Failed to update session state in database:', error);
     }
-    // Log session event (BDHLNDR-17)
-    try {
-      sessionEventsRepo.createEvent(event.sessionId, 'state_change', {
-        from: previousState ?? 'unknown',
-        to: event.state,
-      });
-      if (event.state === 'stopped') {
-        sessionEventsRepo.createEvent(event.sessionId, 'session_stop', null);
-        const breakdown = sessionEventsRepo.getStateBreakdown(event.sessionId);
-        const activeSeconds = (breakdown['working'] || 0) + (breakdown['waiting'] || 0);
-        sessionsRepo.updateSession(event.sessionId, {
-          endedAt: new Date(),
-          durationSeconds: activeSeconds,
-        });
-      }
-    } catch (error) {
-      log.error('Failed to log session event:', error);
-    }
+    // Log session event with dedup (BDHLNDR-17)
+    logSessionStateEvent(event.sessionId, event.state);
     // Handle notifications and tray updates
     handleStateChange(event.sessionId, event.state);
   });
@@ -416,8 +436,6 @@ function createWindow(): void {
   // PTY state detection forwarding
   ptyManager.on('stateChange', (event) => {
     mainWindow?.webContents.send('state:change', event);
-    // Track previous state for event logging
-    const previousState = sessionStates.get(event.sessionId)?.state as SessionState | undefined;
     // Update database
     try {
       sessionsRepo.updateSession(event.sessionId, {
@@ -427,24 +445,8 @@ function createWindow(): void {
     } catch (error) {
       console.error('Failed to update session state in database:', error);
     }
-    // Log session event (BDHLNDR-17)
-    try {
-      sessionEventsRepo.createEvent(event.sessionId, 'state_change', {
-        from: previousState ?? 'unknown',
-        to: event.state,
-      });
-      if (event.state === 'stopped') {
-        sessionEventsRepo.createEvent(event.sessionId, 'session_stop', null);
-        const breakdown = sessionEventsRepo.getStateBreakdown(event.sessionId);
-        const activeSeconds = (breakdown['working'] || 0) + (breakdown['waiting'] || 0);
-        sessionsRepo.updateSession(event.sessionId, {
-          endedAt: new Date(),
-          durationSeconds: activeSeconds,
-        });
-      }
-    } catch (error) {
-      log.error('Failed to log session event:', error);
-    }
+    // Log session event with dedup (BDHLNDR-17)
+    logSessionStateEvent(event.sessionId, event.state);
     // Handle notifications and tray updates
     handleStateChange(event.sessionId, event.state);
     // Broadcast to mobile clients
@@ -670,10 +672,6 @@ safeHandle('db:sessionEvents:getGlobalStats', (since?: string) =>
 
 safeHandle('db:sessionEvents:getToolUseCounts', (sessionId?: string) =>
   sessionEventsRepo.getToolUseCounts(sessionId)
-);
-
-safeHandle('db:sessionEvents:getEventsSince', (since: string, sessionId?: string) =>
-  sessionEventsRepo.getEventsSince(new Date(since), sessionId)
 );
 
 // Preferences IPC Handlers

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,13 +6,14 @@ import * as groupsRepo from './repositories/groups';
 import * as sessionsRepo from './repositories/sessions';
 import * as prefsRepo from './repositories/preferences';
 import * as memoriesRepo from './repositories/memories';
+import * as sessionEventsRepo from './repositories/session-events';
 import { StateMonitor } from './state-monitor';
 import { createApplicationMenu } from './menu';
 import { initAutoUpdater, checkForUpdatesManual, downloadUpdate } from './auto-updater';
 import { notificationManager } from './notification-manager';
 import { trayManager } from './tray-manager';
 import { soundManager, SoundEvent } from './sound-manager';
-import { Group, Session, MemoryCreateInput, MemoryUpdateInput } from '../shared/types';
+import { Group, Session, SessionState, MemoryCreateInput, MemoryUpdateInput } from '../shared/types';
 import { authService } from './sharing/auth';
 import { shareManager } from './sharing/share-manager';
 import { teamsAuthService } from './teams/teams-auth';
@@ -264,12 +265,24 @@ function createWindow(): void {
   // Mark all sessions as stopped on startup (PTY processes don't survive restarts)
   sessionsRepo.markAllSessionsStopped();
 
+  // Prune session events older than 90 days (BDHLNDR-17)
+  try {
+    const pruned = sessionEventsRepo.pruneEvents(new Date(Date.now() - 90 * 24 * 60 * 60 * 1000));
+    if (pruned > 0) {
+      log.info(`[SessionEvents] Pruned ${pruned} events older than 90 days`);
+    }
+  } catch (error) {
+    log.error('Failed to prune session events:', error);
+  }
+
   // Start state monitor
   stateMonitor = new StateMonitor(ptyManager.getSocketPath());
   stateMonitor.start();
 
   stateMonitor.on('stateChange', (event) => {
     mainWindow?.webContents.send('state:change', event);
+    // Track previous state for event logging
+    const previousState = sessionStates.get(event.sessionId)?.state as SessionState | undefined;
     // Update database with error handling
     try {
       sessionsRepo.updateSession(event.sessionId, {
@@ -278,6 +291,24 @@ function createWindow(): void {
       });
     } catch (error) {
       console.error('Failed to update session state in database:', error);
+    }
+    // Log session event (BDHLNDR-17)
+    try {
+      sessionEventsRepo.createEvent(event.sessionId, 'state_change', {
+        from: previousState ?? 'unknown',
+        to: event.state,
+      });
+      if (event.state === 'stopped') {
+        sessionEventsRepo.createEvent(event.sessionId, 'session_stop', null);
+        const breakdown = sessionEventsRepo.getStateBreakdown(event.sessionId);
+        const activeSeconds = (breakdown['working'] || 0) + (breakdown['waiting'] || 0);
+        sessionsRepo.updateSession(event.sessionId, {
+          endedAt: new Date(),
+          durationSeconds: activeSeconds,
+        });
+      }
+    } catch (error) {
+      log.error('Failed to log session event:', error);
     }
     // Handle notifications and tray updates
     handleStateChange(event.sessionId, event.state);
@@ -385,6 +416,8 @@ function createWindow(): void {
   // PTY state detection forwarding
   ptyManager.on('stateChange', (event) => {
     mainWindow?.webContents.send('state:change', event);
+    // Track previous state for event logging
+    const previousState = sessionStates.get(event.sessionId)?.state as SessionState | undefined;
     // Update database
     try {
       sessionsRepo.updateSession(event.sessionId, {
@@ -393,6 +426,24 @@ function createWindow(): void {
       });
     } catch (error) {
       console.error('Failed to update session state in database:', error);
+    }
+    // Log session event (BDHLNDR-17)
+    try {
+      sessionEventsRepo.createEvent(event.sessionId, 'state_change', {
+        from: previousState ?? 'unknown',
+        to: event.state,
+      });
+      if (event.state === 'stopped') {
+        sessionEventsRepo.createEvent(event.sessionId, 'session_stop', null);
+        const breakdown = sessionEventsRepo.getStateBreakdown(event.sessionId);
+        const activeSeconds = (breakdown['working'] || 0) + (breakdown['waiting'] || 0);
+        sessionsRepo.updateSession(event.sessionId, {
+          endedAt: new Date(),
+          durationSeconds: activeSeconds,
+        });
+      }
+    } catch (error) {
+      log.error('Failed to log session event:', error);
     }
     // Handle notifications and tray updates
     handleStateChange(event.sessionId, event.state);
@@ -538,6 +589,12 @@ safeHandle('db:sessions:getAll', () => {
 
 safeHandle('db:sessions:create', (session: Session) => {
   sessionsRepo.createSession(session);
+  // Log session start event (BDHLNDR-17)
+  try {
+    sessionEventsRepo.createEvent(session.id, 'session_start', null);
+  } catch (error) {
+    log.error('Failed to log session_start event:', error);
+  }
   getApiServer().broadcastSessionsUpdated();
 });
 
@@ -597,6 +654,27 @@ safeHandle('db:memories:getById', (id: string) => {
 safeHandle('db:memories:getGlobal', () => {
   return memoriesRepo.getGlobalContextMemories();
 });
+
+// Database IPC Handlers - Session Events (BDHLNDR-17)
+safeHandle('db:sessionEvents:getBySession', (sessionId: string, limit?: number) =>
+  sessionEventsRepo.getEventsBySession(sessionId, limit)
+);
+
+safeHandle('db:sessionEvents:getSessionStats', (sessionId: string) =>
+  sessionEventsRepo.getSessionStats(sessionId)
+);
+
+safeHandle('db:sessionEvents:getGlobalStats', (since?: string) =>
+  sessionEventsRepo.getGlobalStats(since ? new Date(since) : undefined)
+);
+
+safeHandle('db:sessionEvents:getToolUseCounts', (sessionId?: string) =>
+  sessionEventsRepo.getToolUseCounts(sessionId)
+);
+
+safeHandle('db:sessionEvents:getEventsSince', (since: string, sessionId?: string) =>
+  sessionEventsRepo.getEventsSince(new Date(since), sessionId)
+);
 
 // Preferences IPC Handlers
 safeHandle('prefs:get', (key: string) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -149,6 +149,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('memory:extracted', listener);
     return () => ipcRenderer.removeListener('memory:extracted', listener);
   },
+
+  // Database - Session Events (BDHLNDR-17)
+  getSessionEvents: (sessionId: string, limit?: number): Promise<SessionEvent[]> =>
+    ipcRenderer.invoke('db:sessionEvents:getBySession', sessionId, limit),
+  getSessionStats: (sessionId: string): Promise<SessionStats> =>
+    ipcRenderer.invoke('db:sessionEvents:getSessionStats', sessionId),
+  getGlobalStats: (since?: string): Promise<GlobalStats> =>
+    ipcRenderer.invoke('db:sessionEvents:getGlobalStats', since),
+  getToolUseCounts: (sessionId?: string): Promise<Record<string, number>> =>
+    ipcRenderer.invoke('db:sessionEvents:getToolUseCounts', sessionId),
 
   // Preferences
   getPreference: (key: string): Promise<string | null> =>

--- a/src/main/repositories/session-events.ts
+++ b/src/main/repositories/session-events.ts
@@ -1,0 +1,243 @@
+import { getDatabase } from '../database';
+import { SessionEvent, SessionEventType, SessionStats, GlobalStats } from '../../shared/types';
+
+interface SessionEventRow {
+  id: string;
+  session_id: string;
+  event_type: string;
+  event_data: string | null;
+  created_at: string;
+}
+
+function rowToSessionEvent(row: SessionEventRow): SessionEvent {
+  return {
+    id: row.id,
+    sessionId: row.session_id,
+    eventType: row.event_type as SessionEventType,
+    eventData: row.event_data ? JSON.parse(row.event_data) : null,
+    createdAt: new Date(row.created_at),
+  };
+}
+
+export function createEvent(
+  sessionId: string,
+  eventType: SessionEventType,
+  eventData?: Record<string, unknown> | null
+): SessionEvent {
+  const db = getDatabase();
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const data = eventData ? JSON.stringify(eventData) : null;
+
+  db.prepare(`
+    INSERT INTO session_events (id, session_id, event_type, event_data, created_at)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(id, sessionId, eventType, data, now);
+
+  return {
+    id,
+    sessionId,
+    eventType,
+    eventData: eventData ?? null,
+    createdAt: new Date(now),
+  };
+}
+
+export function getEventsBySession(sessionId: string, limit: number = 500): SessionEvent[] {
+  const db = getDatabase();
+  const rows = db.prepare(
+    'SELECT * FROM session_events WHERE session_id = ? ORDER BY created_at DESC LIMIT ?'
+  ).all(sessionId, limit) as SessionEventRow[];
+  return rows.map(rowToSessionEvent);
+}
+
+export function getEventsByType(eventType: SessionEventType, limit: number = 500): SessionEvent[] {
+  const db = getDatabase();
+  const rows = db.prepare(
+    'SELECT * FROM session_events WHERE event_type = ? ORDER BY created_at DESC LIMIT ?'
+  ).all(eventType, limit) as SessionEventRow[];
+  return rows.map(rowToSessionEvent);
+}
+
+export function getEventsSince(since: Date, sessionId?: string): SessionEvent[] {
+  const db = getDatabase();
+  const sinceStr = since.toISOString();
+  let rows: SessionEventRow[];
+
+  if (sessionId) {
+    rows = db.prepare(
+      'SELECT * FROM session_events WHERE created_at >= ? AND session_id = ? ORDER BY created_at ASC'
+    ).all(sinceStr, sessionId) as SessionEventRow[];
+  } else {
+    rows = db.prepare(
+      'SELECT * FROM session_events WHERE created_at >= ? ORDER BY created_at ASC'
+    ).all(sinceStr) as SessionEventRow[];
+  }
+
+  return rows.map(rowToSessionEvent);
+}
+
+export function getLastEvent(sessionId: string): SessionEvent | null {
+  const db = getDatabase();
+  const row = db.prepare(
+    'SELECT * FROM session_events WHERE session_id = ? ORDER BY created_at DESC LIMIT 1'
+  ).get(sessionId) as SessionEventRow | undefined;
+  return row ? rowToSessionEvent(row) : null;
+}
+
+export function getToolUseCounts(sessionId?: string): Record<string, number> {
+  const db = getDatabase();
+  let rows: { tool: string; count: number }[];
+
+  if (sessionId) {
+    rows = db.prepare(`
+      SELECT json_extract(event_data, '$.tool_name') as tool, COUNT(*) as count
+      FROM session_events
+      WHERE event_type = 'tool_use' AND session_id = ?
+      GROUP BY tool
+      ORDER BY count DESC
+    `).all(sessionId) as { tool: string; count: number }[];
+  } else {
+    rows = db.prepare(`
+      SELECT json_extract(event_data, '$.tool_name') as tool, COUNT(*) as count
+      FROM session_events
+      WHERE event_type = 'tool_use'
+      GROUP BY tool
+      ORDER BY count DESC
+    `).all() as { tool: string; count: number }[];
+  }
+
+  const counts: Record<string, number> = {};
+  for (const row of rows) {
+    if (row.tool) {
+      counts[row.tool] = row.count;
+    }
+  }
+  return counts;
+}
+
+export function getStateBreakdown(sessionId: string): Record<string, number> {
+  const db = getDatabase();
+
+  // Get all state-related events in chronological order
+  const rows = db.prepare(`
+    SELECT event_type, event_data, created_at
+    FROM session_events
+    WHERE session_id = ? AND event_type IN ('state_change', 'session_start', 'session_stop')
+    ORDER BY created_at ASC
+  `).all(sessionId) as { event_type: string; event_data: string | null; created_at: string }[];
+
+  const breakdown: Record<string, number> = {};
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    const nextRow = rows[i + 1];
+
+    if (row.event_type === 'state_change' && row.event_data && nextRow) {
+      const data = JSON.parse(row.event_data);
+      const toState = data.to as string;
+      const currentTime = new Date(row.created_at).getTime();
+      const nextTime = new Date(nextRow.created_at).getTime();
+      const seconds = (nextTime - currentTime) / 1000;
+
+      breakdown[toState] = (breakdown[toState] || 0) + seconds;
+    }
+  }
+
+  return breakdown;
+}
+
+export function getSessionStats(sessionId: string): SessionStats {
+  const db = getDatabase();
+
+  const countRow = db.prepare(
+    'SELECT COUNT(*) as count FROM session_events WHERE session_id = ?'
+  ).get(sessionId) as { count: number };
+
+  const durationRow = db.prepare(
+    'SELECT duration_seconds FROM sessions WHERE id = ?'
+  ).get(sessionId) as { duration_seconds: number } | undefined;
+
+  return {
+    totalEvents: countRow.count,
+    totalDurationSeconds: durationRow?.duration_seconds ?? 0,
+    toolUseCounts: getToolUseCounts(sessionId),
+    stateBreakdown: getStateBreakdown(sessionId),
+  };
+}
+
+export function getGlobalStats(since?: Date): GlobalStats {
+  const db = getDatabase();
+  const sinceStr = since?.toISOString();
+
+  // Total sessions
+  let totalSessions: number;
+  if (sinceStr) {
+    totalSessions = (db.prepare(
+      'SELECT COUNT(DISTINCT session_id) as count FROM session_events WHERE created_at >= ?'
+    ).get(sinceStr) as { count: number }).count;
+  } else {
+    totalSessions = (db.prepare(
+      'SELECT COUNT(DISTINCT session_id) as count FROM session_events'
+    ).get() as { count: number }).count;
+  }
+
+  // Total events
+  let totalEvents: number;
+  if (sinceStr) {
+    totalEvents = (db.prepare(
+      'SELECT COUNT(*) as count FROM session_events WHERE created_at >= ?'
+    ).get(sinceStr) as { count: number }).count;
+  } else {
+    totalEvents = (db.prepare(
+      'SELECT COUNT(*) as count FROM session_events'
+    ).get() as { count: number }).count;
+  }
+
+  // Total duration
+  let totalDurationSeconds: number;
+  if (sinceStr) {
+    totalDurationSeconds = (db.prepare(
+      'SELECT COALESCE(SUM(duration_seconds), 0) as total FROM sessions WHERE created_at >= ?'
+    ).get(sinceStr) as { total: number }).total;
+  } else {
+    totalDurationSeconds = (db.prepare(
+      'SELECT COALESCE(SUM(duration_seconds), 0) as total FROM sessions'
+    ).get() as { total: number }).total;
+  }
+
+  // Events per day
+  let eventsPerDay: { date: string; count: number }[];
+  if (sinceStr) {
+    eventsPerDay = db.prepare(`
+      SELECT date(created_at) as date, COUNT(*) as count
+      FROM session_events
+      WHERE created_at >= ?
+      GROUP BY date(created_at)
+      ORDER BY date ASC
+    `).all(sinceStr) as { date: string; count: number }[];
+  } else {
+    eventsPerDay = db.prepare(`
+      SELECT date(created_at) as date, COUNT(*) as count
+      FROM session_events
+      GROUP BY date(created_at)
+      ORDER BY date ASC
+    `).all() as { date: string; count: number }[];
+  }
+
+  return {
+    totalSessions,
+    totalEvents,
+    totalDurationSeconds,
+    eventsPerDay,
+    toolUseCounts: getToolUseCounts(),
+  };
+}
+
+export function pruneEvents(olderThan: Date): number {
+  const db = getDatabase();
+  const result = db.prepare(
+    'DELETE FROM session_events WHERE created_at < ?'
+  ).run(olderThan.toISOString());
+  return result.changes;
+}

--- a/src/main/repositories/session-events.ts
+++ b/src/main/repositories/session-events.ts
@@ -9,12 +9,21 @@ interface SessionEventRow {
   created_at: string;
 }
 
+function safeJsonParse(json: string | null): Record<string, unknown> | null {
+  if (!json) return null;
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
 function rowToSessionEvent(row: SessionEventRow): SessionEvent {
   return {
     id: row.id,
     sessionId: row.session_id,
     eventType: row.event_type as SessionEventType,
-    eventData: row.event_data ? JSON.parse(row.event_data) : null,
+    eventData: safeJsonParse(row.event_data),
     createdAt: new Date(row.created_at),
   };
 }
@@ -59,19 +68,19 @@ export function getEventsByType(eventType: SessionEventType, limit: number = 500
   return rows.map(rowToSessionEvent);
 }
 
-export function getEventsSince(since: Date, sessionId?: string): SessionEvent[] {
+export function getEventsSince(since: Date, sessionId?: string, limit: number = 10000): SessionEvent[] {
   const db = getDatabase();
   const sinceStr = since.toISOString();
   let rows: SessionEventRow[];
 
   if (sessionId) {
     rows = db.prepare(
-      'SELECT * FROM session_events WHERE created_at >= ? AND session_id = ? ORDER BY created_at ASC'
-    ).all(sinceStr, sessionId) as SessionEventRow[];
+      'SELECT * FROM session_events WHERE created_at >= ? AND session_id = ? ORDER BY created_at ASC LIMIT ?'
+    ).all(sinceStr, sessionId, limit) as SessionEventRow[];
   } else {
     rows = db.prepare(
-      'SELECT * FROM session_events WHERE created_at >= ? ORDER BY created_at ASC'
-    ).all(sinceStr) as SessionEventRow[];
+      'SELECT * FROM session_events WHERE created_at >= ? ORDER BY created_at ASC LIMIT ?'
+    ).all(sinceStr, limit) as SessionEventRow[];
   }
 
   return rows.map(rowToSessionEvent);
@@ -131,17 +140,20 @@ export function getStateBreakdown(sessionId: string): Record<string, number> {
 
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
+    if (row.event_type !== 'state_change' || !row.event_data) continue;
+
+    const data = safeJsonParse(row.event_data);
+    if (!data?.to) continue;
+
+    const toState = data.to as string;
+    const currentTime = new Date(row.created_at).getTime();
+
+    // Use next event's time as boundary, or current time for open-ended final interval
     const nextRow = rows[i + 1];
+    const nextTime = nextRow ? new Date(nextRow.created_at).getTime() : Date.now();
+    const seconds = (nextTime - currentTime) / 1000;
 
-    if (row.event_type === 'state_change' && row.event_data && nextRow) {
-      const data = JSON.parse(row.event_data);
-      const toState = data.to as string;
-      const currentTime = new Date(row.created_at).getTime();
-      const nextTime = new Date(nextRow.created_at).getTime();
-      const seconds = (nextTime - currentTime) / 1000;
-
-      breakdown[toState] = (breakdown[toState] || 0) + seconds;
-    }
+    breakdown[toState] = (breakdown[toState] || 0) + seconds;
   }
 
   return breakdown;

--- a/src/main/repositories/sessions.ts
+++ b/src/main/repositories/sessions.ts
@@ -1,6 +1,12 @@
 import { getDatabase } from '../database';
 import { Session, SessionState } from '../../shared/types';
 
+export function sessionExists(id: string): boolean {
+  const db = getDatabase();
+  const row = db.prepare('SELECT 1 FROM sessions WHERE id = ? LIMIT 1').get(id);
+  return !!row;
+}
+
 export function getAllSessions(): Session[] {
   const db = getDatabase();
   const rows = db.prepare('SELECT * FROM sessions ORDER BY "order"').all() as any[];

--- a/src/main/repositories/sessions.ts
+++ b/src/main/repositories/sessions.ts
@@ -16,14 +16,16 @@ export function getAllSessions(): Session[] {
     createdAt: new Date(row.created_at),
     lastActivityAt: new Date(row.last_activity_at),
     claudeSessionId: row.claude_session_id ?? null,
+    endedAt: row.ended_at ? new Date(row.ended_at) : null,
+    durationSeconds: row.duration_seconds ?? 0,
   }));
 }
 
 export function createSession(session: Session): void {
   const db = getDatabase();
   db.prepare(`
-    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at, claude_session_id)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at, claude_session_id, ended_at, duration_seconds)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     session.id,
     session.groupId,
@@ -34,7 +36,9 @@ export function createSession(session: Session): void {
     session.order,
     session.createdAt.toISOString(),
     session.lastActivityAt.toISOString(),
-    session.claudeSessionId ?? null
+    session.claudeSessionId ?? null,
+    session.endedAt ? session.endedAt.toISOString() : null,
+    session.durationSeconds ?? 0
   );
 }
 
@@ -91,6 +95,14 @@ export function updateSession(id: string, updates: Partial<Session>): void {
   if (updates.lastActivityAt !== undefined) {
     fields.push('last_activity_at = ?');
     values.push(updates.lastActivityAt.toISOString());
+  }
+  if (updates.endedAt !== undefined) {
+    fields.push('ended_at = ?');
+    values.push(updates.endedAt ? updates.endedAt.toISOString() : null);
+  }
+  if (updates.durationSeconds !== undefined) {
+    fields.push('duration_seconds = ?');
+    values.push(updates.durationSeconds);
   }
 
   if (fields.length > 0) {

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -60,6 +60,12 @@ interface ElectronAPI {
   getMemoryById: (id: string) => Promise<Memory | null>;
   getGlobalContextMemories: () => Promise<Memory[]>;
   onMemoryExtracted: (callback: (memory: Memory) => void) => () => void;
+
+  // Session Events (BDHLNDR-17)
+  getSessionEvents: (sessionId: string, limit?: number) => Promise<SessionEvent[]>;
+  getSessionStats: (sessionId: string) => Promise<SessionStats>;
+  getGlobalStats: (since?: string) => Promise<GlobalStats>;
+  getToolUseCounts: (sessionId?: string) => Promise<Record<string, number>>;
 
   // Preferences
   getPreference: (key: string) => Promise<string | null>;

--- a/src/renderer/store/sessions.ts
+++ b/src/renderer/store/sessions.ts
@@ -60,6 +60,8 @@ export function useSessions() {
           createdAt: new Date(),
           lastActivityAt: new Date(),
           claudeSessionId: null,
+          endedAt: null,
+          durationSeconds: 0,
         };
 
         // Persist asynchronously

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -19,6 +19,9 @@ import {
   SymbolSearchResult,
   IndexProgress,
   SymbolType,
+  SessionEvent,
+  SessionStats,
+  GlobalStats,
 } from '../../shared/types';
 
 interface StateChangeEvent {
@@ -79,6 +82,12 @@ export interface ElectronAPI {
   getMemoryById: (id: string) => Promise<Memory | null>;
   getGlobalContextMemories: () => Promise<Memory[]>;
   onMemoryExtracted: (callback: (memory: Memory) => void) => () => void;
+
+  // Session Events (BDHLNDR-17)
+  getSessionEvents: (sessionId: string, limit?: number) => Promise<SessionEvent[]>;
+  getSessionStats: (sessionId: string) => Promise<SessionStats>;
+  getGlobalStats: (since?: string) => Promise<GlobalStats>;
+  getToolUseCounts: (sessionId?: string) => Promise<Record<string, number>>;
 
   // Preferences
   getPreference: (key: string) => Promise<string | null>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -15,6 +15,10 @@ export interface Session {
    * Null for non-Claude sessions or Claude sessions that have not been launched yet.
    */
   claudeSessionId: string | null;
+  /** When the session was stopped/ended (BDHLNDR-17). Null if still active. */
+  endedAt: Date | null;
+  /** Active time in seconds (working + waiting states), not wall clock (BDHLNDR-17). */
+  durationSeconds: number;
 }
 
 export interface Group {
@@ -201,6 +205,37 @@ export interface MemoryEvent {
     source: 'claude';
   };
   timestamp: number;
+}
+
+// =============================================================================
+// Session Event Types (BDHLNDR-17)
+// =============================================================================
+// Types for session event tracking and analytics
+// =============================================================================
+
+export type SessionEventType = 'session_start' | 'session_stop' | 'state_change' | 'tool_use' | 'error' | 'notification';
+
+export interface SessionEvent {
+  id: string;
+  sessionId: string;
+  eventType: SessionEventType;
+  eventData: Record<string, unknown> | null;
+  createdAt: Date;
+}
+
+export interface SessionStats {
+  totalEvents: number;
+  totalDurationSeconds: number;
+  toolUseCounts: Record<string, number>;
+  stateBreakdown: Record<string, number>; // state name → seconds
+}
+
+export interface GlobalStats {
+  totalSessions: number;
+  totalEvents: number;
+  totalDurationSeconds: number;
+  eventsPerDay: { date: string; count: number }[];
+  toolUseCounts: Record<string, number>;
 }
 
 // =============================================================================

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -213,7 +213,7 @@ export interface MemoryEvent {
 // Types for session event tracking and analytics
 // =============================================================================
 
-export type SessionEventType = 'session_start' | 'session_stop' | 'state_change' | 'tool_use' | 'error' | 'notification';
+export type SessionEventType = 'session_start' | 'session_stop' | 'state_change' | 'tool_use' | 'turn_complete' | 'error' | 'notification';
 
 export interface SessionEvent {
   id: string;


### PR DESCRIPTION
## Summary

- Add `session_events` SQLite table for capturing session lifecycle events (state changes, tool uses, stops, errors, notifications, turn completions)
- Add `ended_at` and `duration_seconds` columns to `sessions` table for quick duration lookups
- New `session-events` repository with CRUD + aggregation queries (tool use counts, state time breakdown, per-session and global stats)
- Wire event logging into state monitor, PTY manager, hook endpoints, and session creation (both IPC and REST API paths)
- Expose read-only event query APIs to renderer via IPC + preload bridge
- 90-day event pruning on startup

### Code Review Fixes (second commit)
- **Dedup guard**: extracted shared `logSessionStateEvent()` with 2-second dedup window to prevent duplicate events from stateMonitor + ptyManager
- **Performance**: replaced `getAllSessions()` full table scan with targeted `sessionExists()` PK lookup in hook event logging
- **Semantic fix**: hooks `/stop` now logs `turn_complete` (Claude finished responding) vs `session_stop` (PTY process ended)
- **Robustness**: safe JSON.parse with fallback, `getStateBreakdown` handles open-ended final intervals, `getEventsSince` capped at 10k rows
- **Indexes**: composite covering index `(session_id, event_type, created_at)` replaces 3 single-column indexes
- **Types**: new methods declared in both `ElectronAPI` `.d.ts` files
- **Security**: log output sanitized (control chars stripped, truncated)

## Test plan

- [ ] App launches cleanly on fresh install (migration creates new table + columns)
- [ ] App launches cleanly on existing install (migration adds columns, backfills duration)
- [ ] Create a session → verify `session_start` event in DB
- [ ] Run a Claude session through idle→working→waiting→idle→stopped → verify state_change events with correct from/to
- [ ] Verify `duration_seconds` on stopped session reflects working+waiting time only
- [ ] Delete a session → verify its events cascade-delete
- [ ] `bunx tsc --noEmit` clean
- [ ] `bun run build` clean

**Jira:** [BDHLNDR-17](https://gobodhi.atlassian.net/browse/BDHLNDR-17)
**Parent Epic:** [BDHLNDR-14 — Session Analytics Dashboard](https://gobodhi.atlassian.net/browse/BDHLNDR-14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-17]: https://gobodhi.atlassian.net/browse/BDHLNDR-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ