### PR TITLE
feat(BDHLNDR-18): analytics dashboard with charts and activity feed

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "qrcode": "^1.5.4",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
+        "recharts": "^3.8.1",
         "socket.io-client": "^4.8.3",
         "sodium-native": "^5.0.10",
         "sqlite-vec": "^0.1.6",
@@ -240,9 +241,15 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
 
@@ -255,6 +262,24 @@
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
@@ -303,6 +328,8 @@
     "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
 
     "@types/sodium-native": ["@types/sodium-native@2.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-jZIg5ltGH1okmnH3FrLQsgwjcjOVozMSHwSiEm1/LpMekhOMHbQqp21P4H24mizh1BjwI6Q8qmphmD/HJuAqWg=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
 
@@ -492,6 +519,8 @@
 
     "clone-response": ["clone-response@1.0.3", "", { "dependencies": { "mimic-response": "^1.0.0" } }, "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA=="],
 
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -536,9 +565,33 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 
@@ -642,6 +695,8 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
+    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
+
     "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
     "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
@@ -659,6 +714,8 @@
     "estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
@@ -798,6 +855,8 @@
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "import-local": ["import-local@3.2.0", "", { "dependencies": { "pkg-dir": "^4.2.0", "resolve-cwd": "^3.0.0" }, "bin": { "import-local-fixture": "fixtures/cli.js" } }, "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
@@ -807,6 +866,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "interpret": ["interpret@3.1.1", "", {}, "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ=="],
 
@@ -1092,13 +1153,23 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-is": ["react-is@19.2.4", "", {}, "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="],
+
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "read-binary-file-arch": ["read-binary-file-arch@1.0.6", "", { "dependencies": { "debug": "^4.3.4" }, "bin": { "read-binary-file-arch": "cli.js" } }, "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
     "rechoir": ["rechoir@0.8.0", "", { "dependencies": { "resolve": "^1.20.0" } }, "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "relateurl": ["relateurl@0.2.7", "", {}, "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="],
 
@@ -1113,6 +1184,8 @@
     "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
 
     "resedit": ["resedit@1.7.2", "", { "dependencies": { "pe-library": "^0.4.1" } }, "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -1272,6 +1345,8 @@
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tiny-typed-emitter": ["tiny-typed-emitter@2.1.0", "", {}, "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
@@ -1322,6 +1397,8 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "utf8-byte-length": ["utf8-byte-length@1.0.5", "", {}, "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
@@ -1331,6 +1408,8 @@
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "verror": ["verror@1.10.1", "", { "dependencies": { "assert-plus": "^1.0.0", "core-util-is": "1.0.2", "extsprintf": "^1.2.0" } }, "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg=="],
+
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
     "watchpack": ["watchpack@2.5.1", "", { "dependencies": { "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.1.2" } }, "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg=="],
 
@@ -1419,6 +1498,8 @@
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "node-pty": "^1.1.0",
     "qrcode": "^1.5.4",
     "react": "^19.2.3",
+    "recharts": "^3.8.1",
     "react-dom": "^19.2.3",
     "socket.io-client": "^4.8.3",
     "sodium-native": "^5.0.10",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { NamePromptModal } from './components/NamePromptModal';
 import { SettingsModal } from './components/SettingsModal';
 import { NewItemChoice } from './components/NewItemChoice';
 import { MemoryPanel } from './components/panels/MemoryPanel';
+import AnalyticsPanel from './components/panels/AnalyticsPanel';
 import { CodeSearchModal } from './components/CodeSearchModal';
 import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
@@ -92,6 +93,9 @@ const App: React.FC = () => {
 
   // Memory panel state
   const [memoryPanelOpen, setMemoryPanelOpen] = useState(false);
+
+  // Analytics view state (BDHLNDR-18)
+  const [analyticsViewOpen, setAnalyticsViewOpen] = useState(false);
 
   // Code search modal state
   const [codeSearchOpen, setCodeSearchOpen] = useState(false);
@@ -737,6 +741,7 @@ const App: React.FC = () => {
     onExpand: handleExpand,
     onSelect: handleSelect,
     onCodeSearch: handleCodeSearch,
+    onToggleAnalytics: () => setAnalyticsViewOpen(prev => !prev),
   }), [handleKeyboardNewSession, handleNextSession, handlePrevSession, handleNextWaiting, handleCloseSession, handleFocusSidebar, handleNewGroup, handleNewSubGroup, handleNavigateUp, handleNavigateDown, handleCollapse, handleExpand, handleSelect, handleCodeSearch]);
 
   useKeyboardShortcuts(shortcutHandlers);
@@ -837,6 +842,14 @@ const App: React.FC = () => {
               aria-label="Toggle Memory Panel"
             >
               *
+            </button>
+            <button
+              className={`icon-button ${analyticsViewOpen ? 'active' : ''}`}
+              onClick={() => setAnalyticsViewOpen(prev => !prev)}
+              title="Analytics Dashboard (Ctrl+Shift+A)"
+              aria-label="Analytics Dashboard"
+            >
+              📊
             </button>
             <button
               className="icon-button"
@@ -1285,6 +1298,9 @@ const App: React.FC = () => {
       </aside>
 
       <main className="main">
+        {analyticsViewOpen ? (
+          <AnalyticsPanel onClose={() => setAnalyticsViewOpen(false)} />
+        ) : (
         <div className="terminal-area">
           {sessions.map(session => (
             <div
@@ -1374,6 +1390,7 @@ const App: React.FC = () => {
             </div>
           )}
         </div>
+        )}
       </main>
 
       {/* Memory Panel */}

--- a/src/renderer/components/panels/AnalyticsPanel.css
+++ b/src/renderer/components/panels/AnalyticsPanel.css
@@ -1,0 +1,269 @@
+/* AnalyticsPanel.css — BDHLNDR-18 */
+
+.analytics-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #1e1e1e;
+  overflow: hidden;
+}
+
+/* Header */
+.analytics-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid #3c3c3c;
+  background: #252526;
+  flex-shrink: 0;
+}
+
+.analytics-header h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #d4d4d4;
+}
+
+.analytics-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Time Range Selector */
+.time-range-selector {
+  display: flex;
+  gap: 2px;
+  background: #1e1e1e;
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.time-range-btn {
+  padding: 4px 10px;
+  font-size: 11px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: #888;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.time-range-btn:hover {
+  color: #d4d4d4;
+  background: #3c3c3c;
+}
+
+.time-range-btn.active {
+  background: #5a7aff;
+  color: #fff;
+}
+
+/* Body */
+.analytics-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Summary Stats Row */
+.analytics-summary {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.stat-card {
+  background: #252526;
+  border: 1px solid #3c3c3c;
+  border-radius: 8px;
+  padding: 16px;
+  text-align: center;
+}
+
+.stat-value {
+  font-size: 24px;
+  font-weight: 700;
+  color: #d4d4d4;
+  line-height: 1.2;
+}
+
+.stat-label {
+  font-size: 11px;
+  color: #888;
+  margin-top: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Charts Grid */
+.analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+/* Chart Card */
+.chart-card {
+  background: #252526;
+  border: 1px solid #3c3c3c;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.chart-card-title {
+  color: #d4d4d4;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+
+.chart-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 120px;
+  color: #666;
+  font-size: 13px;
+}
+
+/* Time Breakdown */
+.time-breakdown {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 120px;
+  gap: 8px;
+}
+
+.time-breakdown-total {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.time-breakdown-value {
+  font-size: 32px;
+  font-weight: 700;
+  color: #4ade80;
+}
+
+.time-breakdown-label {
+  font-size: 12px;
+  color: #888;
+}
+
+.time-breakdown-detail {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #888;
+}
+
+.time-breakdown-sep {
+  color: #555;
+}
+
+/* Activity Feed */
+.activity-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.activity-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  transition: background 0.1s;
+}
+
+.activity-item:hover {
+  background: #2a2a2a;
+}
+
+.activity-icon {
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #333;
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.activity-icon-session_start { color: #4ade80; }
+.activity-icon-session_stop { color: #888; }
+.activity-icon-state_change { color: #61afef; }
+.activity-icon-tool_use { color: #e5c07b; }
+.activity-icon-turn_complete { color: #5a7aff; }
+.activity-icon-error { color: #e06c75; }
+.activity-icon-notification { color: #c678dd; }
+
+.activity-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.activity-label {
+  font-size: 12px;
+  color: #d4d4d4;
+}
+
+.activity-detail {
+  font-size: 11px;
+  color: #888;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-time {
+  font-size: 11px;
+  color: #666;
+  flex-shrink: 0;
+}
+
+/* Loading & Error States */
+.analytics-loading,
+.analytics-error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #888;
+  font-size: 14px;
+}
+
+.analytics-error {
+  color: #e06c75;
+}
+
+/* Responsive: stack on narrow widths */
+@media (max-width: 700px) {
+  .analytics-summary {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .analytics-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/renderer/components/panels/AnalyticsPanel.tsx
+++ b/src/renderer/components/panels/AnalyticsPanel.tsx
@@ -1,0 +1,378 @@
+import React, { useState } from 'react';
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
+  PieChart, Pie, Cell, ResponsiveContainer, Legend,
+} from 'recharts';
+import { useAnalytics, TimeRange } from '../../store/analytics';
+import { useSessions } from '../../store/sessions';
+import { SessionEvent, Session } from '../../../shared/types';
+import './AnalyticsPanel.css';
+
+// Theme colors matching existing dark theme
+const COLORS = {
+  primary: '#5a7aff',
+  working: '#4ade80',
+  waiting: '#e5c07b',
+  idle: '#61afef',
+  error: '#e06c75',
+  stopped: '#888',
+  purple: '#c678dd',
+  text: '#888',
+  textPrimary: '#d4d4d4',
+  grid: '#333',
+  cardBg: '#252526',
+  tooltipBg: '#1e1e1e',
+  border: '#3c3c3c',
+};
+
+const STATE_COLORS: Record<string, string> = {
+  working: COLORS.working,
+  waiting: COLORS.waiting,
+  idle: COLORS.idle,
+  error: COLORS.error,
+  stopped: COLORS.stopped,
+};
+
+const TOOLTIP_STYLE = {
+  backgroundColor: COLORS.tooltipBg,
+  border: `1px solid ${COLORS.border}`,
+  borderRadius: '6px',
+  color: COLORS.textPrimary,
+  fontSize: '12px',
+};
+
+// --- Utility functions ---
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+function formatEventTime(date: Date | string): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  const now = new Date();
+  const diff = now.getTime() - d.getTime();
+  if (diff < 60000) return 'just now';
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function eventTypeLabel(type: string): string {
+  switch (type) {
+    case 'session_start': return 'Session started';
+    case 'session_stop': return 'Session stopped';
+    case 'state_change': return 'State changed';
+    case 'tool_use': return 'Tool used';
+    case 'turn_complete': return 'Turn completed';
+    case 'error': return 'Error';
+    case 'notification': return 'Notification';
+    default: return type;
+  }
+}
+
+function eventTypeIcon(type: string): string {
+  switch (type) {
+    case 'session_start': return '▶';
+    case 'session_stop': return '■';
+    case 'state_change': return '↻';
+    case 'tool_use': return '⚡';
+    case 'turn_complete': return '✓';
+    case 'error': return '✗';
+    case 'notification': return '🔔';
+    default: return '•';
+  }
+}
+
+// --- Sub-components ---
+
+function TimeRangeSelector({ value, onChange }: { value: TimeRange; onChange: (v: TimeRange) => void }) {
+  const ranges: { label: string; value: TimeRange }[] = [
+    { label: 'Today', value: 'today' },
+    { label: '7 days', value: '7d' },
+    { label: '30 days', value: '30d' },
+    { label: 'All time', value: 'all' },
+  ];
+  return (
+    <div className="time-range-selector">
+      {ranges.map(r => (
+        <button
+          key={r.value}
+          className={`time-range-btn ${value === r.value ? 'active' : ''}`}
+          onClick={() => onChange(r.value)}
+        >
+          {r.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="stat-card">
+      <div className="stat-value">{typeof value === 'number' ? formatNumber(value) : value}</div>
+      <div className="stat-label">{label}</div>
+    </div>
+  );
+}
+
+function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="chart-card">
+      <div className="chart-card-title">{title}</div>
+      {children}
+    </div>
+  );
+}
+
+function ActivityChart({ data }: { data: { date: string; count: number }[] }) {
+  if (!data || data.length === 0) {
+    return <div className="chart-empty">No activity data yet</div>;
+  }
+
+  const formatted = data.map(d => ({
+    date: new Date(d.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+    events: d.count,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <BarChart data={formatted} margin={{ top: 5, right: 5, bottom: 5, left: -10 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke={COLORS.grid} vertical={false} />
+        <XAxis dataKey="date" tick={{ fill: COLORS.text, fontSize: 11 }} axisLine={false} tickLine={false} />
+        <YAxis tick={{ fill: COLORS.text, fontSize: 11 }} axisLine={false} tickLine={false} allowDecimals={false} />
+        <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'rgba(90, 122, 255, 0.1)' }} />
+        <Bar dataKey="events" fill={COLORS.primary} radius={[3, 3, 0, 0]} maxBarSize={40} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function StateDistributionChart({ sessions }: { sessions: Session[] }) {
+  const counts: Record<string, number> = {};
+  for (const s of sessions) {
+    counts[s.state] = (counts[s.state] || 0) + 1;
+  }
+
+  const data = Object.entries(counts)
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value - a.value);
+
+  if (data.length === 0) {
+    return <div className="chart-empty">No sessions</div>;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <PieChart>
+        <Pie
+          data={data}
+          cx="50%"
+          cy="50%"
+          innerRadius={50}
+          outerRadius={80}
+          paddingAngle={2}
+          dataKey="value"
+          label={({ name, value }) => `${name} (${value})`}
+        >
+          {data.map((entry) => (
+            <Cell key={entry.name} fill={STATE_COLORS[entry.name] || COLORS.text} />
+          ))}
+        </Pie>
+        <Tooltip contentStyle={TOOLTIP_STYLE} />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}
+
+function ToolUsageChart({ data }: { data: Record<string, number> }) {
+  const entries = Object.entries(data)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([name, count]) => ({ name, count }));
+
+  if (entries.length === 0) {
+    return <div className="chart-empty">No tool usage data yet</div>;
+  }
+
+  const barColors = [COLORS.primary, COLORS.purple, COLORS.idle, COLORS.working, COLORS.waiting, COLORS.error, COLORS.stopped, COLORS.text];
+
+  return (
+    <ResponsiveContainer width="100%" height={Math.max(150, entries.length * 32)}>
+      <BarChart data={entries} layout="vertical" margin={{ top: 5, right: 5, bottom: 5, left: 50 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke={COLORS.grid} horizontal={false} />
+        <XAxis type="number" tick={{ fill: COLORS.text, fontSize: 11 }} axisLine={false} tickLine={false} allowDecimals={false} />
+        <YAxis type="category" dataKey="name" tick={{ fill: COLORS.text, fontSize: 11 }} axisLine={false} tickLine={false} width={60} />
+        <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'rgba(90, 122, 255, 0.1)' }} />
+        <Bar dataKey="count" radius={[0, 3, 3, 0]} maxBarSize={24}>
+          {entries.map((_, i) => (
+            <Cell key={i} fill={barColors[i % barColors.length]} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function TimeBreakdownChart({ sessions }: { sessions: Session[] }) {
+  // Aggregate duration across all sessions by computing from current state counts
+  // Use session durations for stopped sessions
+  const stoppedDuration = sessions
+    .filter(s => s.state === 'stopped')
+    .reduce((sum, s) => sum + (s.durationSeconds || 0), 0);
+
+  const data = [
+    { name: 'Active', seconds: stoppedDuration, fill: COLORS.working },
+  ];
+
+  // Count currently running sessions
+  const activeSessions = sessions.filter(s => s.state === 'working' || s.state === 'waiting' || s.state === 'idle');
+  if (activeSessions.length > 0) {
+    data.push({ name: 'In Progress', seconds: activeSessions.length, fill: COLORS.idle });
+  }
+
+  if (stoppedDuration === 0 && activeSessions.length === 0) {
+    return <div className="chart-empty">No duration data yet</div>;
+  }
+
+  return (
+    <div className="time-breakdown">
+      <div className="time-breakdown-total">
+        <span className="time-breakdown-value">{formatDuration(stoppedDuration)}</span>
+        <span className="time-breakdown-label">Total active time across all sessions</span>
+      </div>
+      <div className="time-breakdown-detail">
+        <span className="time-breakdown-count">{sessions.filter(s => s.state === 'stopped').length} completed</span>
+        <span className="time-breakdown-sep">·</span>
+        <span className="time-breakdown-count">{activeSessions.length} in progress</span>
+      </div>
+    </div>
+  );
+}
+
+function RecentActivityFeed({ events }: { events: SessionEvent[] }) {
+  if (events.length === 0) {
+    return <div className="chart-empty">No recent activity</div>;
+  }
+
+  return (
+    <div className="activity-feed">
+      {events.map(event => (
+        <div key={event.id} className="activity-item">
+          <span className={`activity-icon activity-icon-${event.eventType}`}>
+            {eventTypeIcon(event.eventType)}
+          </span>
+          <div className="activity-content">
+            <span className="activity-label">{eventTypeLabel(event.eventType)}</span>
+            {event.eventType === 'tool_use' && event.eventData?.tool_name != null && (
+              <span className="activity-detail">{String(event.eventData.tool_name)}</span>
+            )}
+            {event.eventType === 'state_change' && event.eventData?.from != null && (
+              <span className="activity-detail">
+                {String(event.eventData.from)} → {String(event.eventData.to)}
+              </span>
+            )}
+          </div>
+          <span className="activity-time">{formatEventTime(event.createdAt)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// --- Main Component ---
+
+interface AnalyticsPanelProps {
+  onClose: () => void;
+}
+
+export default function AnalyticsPanel({ onClose }: AnalyticsPanelProps) {
+  const [timeRange, setTimeRange] = useState<TimeRange>('7d');
+  const { globalStats, recentEvents, loading, error, refresh } = useAnalytics(timeRange);
+  const { sessions } = useSessions();
+
+  if (loading && !globalStats) {
+    return (
+      <div className="analytics-panel">
+        <div className="analytics-header">
+          <h2>Analytics</h2>
+          <div className="analytics-header-actions">
+            <button className="icon-button" onClick={onClose} title="Close">×</button>
+          </div>
+        </div>
+        <div className="analytics-loading">Loading analytics...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="analytics-panel">
+        <div className="analytics-header">
+          <h2>Analytics</h2>
+          <div className="analytics-header-actions">
+            <button className="icon-button" onClick={refresh} title="Retry">↻</button>
+            <button className="icon-button" onClick={onClose} title="Close">×</button>
+          </div>
+        </div>
+        <div className="analytics-error">Failed to load analytics: {error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="analytics-panel">
+      <div className="analytics-header">
+        <h2>Analytics</h2>
+        <div className="analytics-header-actions">
+          <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          <button className="icon-button" onClick={refresh} title="Refresh">↻</button>
+          <button className="icon-button" onClick={onClose} title="Close">×</button>
+        </div>
+      </div>
+
+      <div className="analytics-body">
+        {/* Summary stats row */}
+        <div className="analytics-summary">
+          <StatCard label="Sessions" value={globalStats?.totalSessions ?? 0} />
+          <StatCard label="Events" value={globalStats?.totalEvents ?? 0} />
+          <StatCard label="Active Time" value={formatDuration(globalStats?.totalDurationSeconds ?? 0)} />
+          <StatCard label="Tools Used" value={Object.keys(globalStats?.toolUseCounts ?? {}).length} />
+        </div>
+
+        {/* Charts grid */}
+        <div className="analytics-grid">
+          <ChartCard title="Session Activity">
+            <ActivityChart data={globalStats?.eventsPerDay ?? []} />
+          </ChartCard>
+
+          <ChartCard title="Session States">
+            <StateDistributionChart sessions={sessions} />
+          </ChartCard>
+
+          <ChartCard title="Top Tools">
+            <ToolUsageChart data={globalStats?.toolUseCounts ?? {}} />
+          </ChartCard>
+
+          <ChartCard title="Time Summary">
+            <TimeBreakdownChart sessions={sessions} />
+          </ChartCard>
+        </div>
+
+        {/* Recent activity */}
+        <ChartCard title="Recent Activity">
+          <RecentActivityFeed events={recentEvents} />
+        </ChartCard>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -15,6 +15,7 @@ interface ShortcutHandlers {
   onExpand?: () => void;
   onSelect?: () => void;
   onCodeSearch?: () => void;
+  onToggleAnalytics?: () => void;
 }
 
 export function useKeyboardShortcuts(handlers: ShortcutHandlers) {
@@ -88,6 +89,12 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers) {
     if (isMod && e.shiftKey && key === 'f') {
       e.preventDefault();
       handlers.onCodeSearch?.();
+    }
+
+    // Ctrl+Shift+A = Analytics dashboard
+    if (isMod && e.shiftKey && key === 'a') {
+      e.preventDefault();
+      handlers.onToggleAnalytics?.();
     }
   }, [handlers]);
 

--- a/src/renderer/store/analytics.ts
+++ b/src/renderer/store/analytics.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useCallback } from 'react';
+import { GlobalStats, SessionEvent } from '../../shared/types';
+
+export type TimeRange = 'today' | '7d' | '30d' | 'all';
+
+function timeRangeToSince(range: TimeRange): string | undefined {
+  if (range === 'all') return undefined;
+  const now = new Date();
+  switch (range) {
+    case 'today':
+      now.setHours(0, 0, 0, 0);
+      return now.toISOString();
+    case '7d':
+      now.setDate(now.getDate() - 7);
+      return now.toISOString();
+    case '30d':
+      now.setDate(now.getDate() - 30);
+      return now.toISOString();
+  }
+}
+
+interface UseAnalyticsResult {
+  globalStats: GlobalStats | null;
+  recentEvents: SessionEvent[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+export function useAnalytics(timeRange: TimeRange): UseAnalyticsResult {
+  const [globalStats, setGlobalStats] = useState<GlobalStats | null>(null);
+  const [recentEvents, setRecentEvents] = useState<SessionEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadStats = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const since = timeRangeToSince(timeRange);
+      const stats = await window.electronAPI.getGlobalStats(since);
+      setGlobalStats(stats);
+
+      // Load recent events (last 30 across all sessions)
+      const allSessions = await window.electronAPI.getAllSessions();
+      const allEvents: SessionEvent[] = [];
+      // Fetch last few events per session, then sort globally
+      for (const session of allSessions.slice(0, 20)) {
+        const events = await window.electronAPI.getSessionEvents(session.id, 10);
+        allEvents.push(...events);
+      }
+      allEvents.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      setRecentEvents(allEvents.slice(0, 30));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load analytics');
+    } finally {
+      setLoading(false);
+    }
+  }, [timeRange]);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
+  return { globalStats, recentEvents, loading, error, refresh: loadStats };
+}


### PR DESCRIPTION
## Summary

- New analytics dashboard accessible from sidebar (📊 icon) or **Ctrl+Shift+A**
- Renders in main content area (replaces terminal view when open)
- Summary stat cards: sessions, events, active time, tools used
- 4 chart panels: session activity (bar), state distribution (donut), top tools (horizontal bar), time summary
- Recent activity feed with event type icons and relative timestamps
- Time range selector: today, 7 days, 30 days, all time
- Dark theme matching existing UI, responsive 2-column grid layout
- `useAnalytics()` hook following existing `useMemories` pattern

### Dependencies
- Added `recharts ^3.8.1` (React charting library, ~45KB gzipped)
- Depends on BDHLNDR-17 (session events infrastructure) — branched from its feature branch

### New Files
- `src/renderer/components/panels/AnalyticsPanel.tsx` (300 lines)
- `src/renderer/components/panels/AnalyticsPanel.css` (200 lines)
- `src/renderer/store/analytics.ts` (65 lines)

## Test plan

- [ ] Click 📊 icon in sidebar → analytics dashboard opens in main area
- [ ] Click × or 📊 again → returns to terminal view
- [ ] Ctrl+Shift+A toggles the dashboard
- [ ] Time range buttons filter the data (today/7d/30d/all)
- [ ] Charts render with real session data (need sessions with events from BDHLNDR-17)
- [ ] Empty state shows "No activity data yet" messages gracefully
- [ ] Refresh button reloads data
- [ ] Dark theme colors match existing UI
- [ ] `bunx tsc --noEmit` clean
- [ ] `bun run build` clean

**Jira:** [BDHLNDR-18](https://gobodhi.atlassian.net/browse/BDHLNDR-18)
**Parent Epic:** [BDHLNDR-14 — Session Analytics Dashboard](https://gobodhi.atlassian.net/browse/BDHLNDR-14)
**Depends on:** PR #17 (BDHLNDR-17 — session events infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-18]: https://gobodhi.atlassian.net/browse/BDHLNDR-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ