### PR TITLE
feat(BDHLNDR-19): per-session stats in sidebar and terminal header

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,6 +10,7 @@ import { SettingsModal } from './components/SettingsModal';
 import { NewItemChoice } from './components/NewItemChoice';
 import { MemoryPanel } from './components/panels/MemoryPanel';
 import AnalyticsPanel from './components/panels/AnalyticsPanel';
+import { SessionStatsBadge } from './components/SessionStatsBadge';
 import { CodeSearchModal } from './components/CodeSearchModal';
 import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
@@ -1038,6 +1039,7 @@ const App: React.FC = () => {
                           {session.name}
                         </span>
                       )}
+                      <SessionStatsBadge sessionId={session.id} />
                     </div>
                     {sharingSessions.has(session.id) && (
                       <span className="share-indicator" title="Sharing" draggable={false}>⇄</span>
@@ -1209,6 +1211,7 @@ const App: React.FC = () => {
                             {session.name}
                           </span>
                         )}
+                        <SessionStatsBadge sessionId={session.id} />
                       </div>
                       {sharingSessions.has(session.id) && (
                         <span className="share-indicator" title="Sharing">⇄</span>

--- a/src/renderer/components/SessionStatsBadge.tsx
+++ b/src/renderer/components/SessionStatsBadge.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useSessionStats, formatDuration, formatStatsTooltip } from '../store/session-stats';
+
+interface SessionStatsBadgeProps {
+  sessionId: string;
+}
+
+/**
+ * Compact stats badge for sidebar session entries (BDHLNDR-19).
+ * Shows duration and event count in a single line below the session name.
+ */
+export function SessionStatsBadge({ sessionId }: SessionStatsBadgeProps) {
+  const { stats } = useSessionStats(sessionId);
+
+  if (!stats || stats.totalEvents === 0) return null;
+
+  const duration = formatDuration(stats.totalDurationSeconds);
+  const totalTools = Object.values(stats.toolUseCounts).reduce((sum, c) => sum + c, 0);
+
+  const parts: string[] = [];
+  if (duration) parts.push(duration);
+  if (totalTools > 0) parts.push(`${totalTools} tools`);
+  if (parts.length === 0) parts.push(`${stats.totalEvents} events`);
+
+  return (
+    <span
+      className="session-stats-badge"
+      title={formatStatsTooltip(stats)}
+    >
+      {parts.join(' · ')}
+    </span>
+  );
+}

--- a/src/renderer/components/TerminalHeader.tsx
+++ b/src/renderer/components/TerminalHeader.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Session } from '../../shared/types';
+import { useSessionStats, formatDuration, formatStatsTooltip } from '../store/session-stats';
 
 interface TerminalHeaderProps {
   session: Session;
@@ -20,6 +21,7 @@ const TerminalHeader: React.FC<TerminalHeaderProps> = ({
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(session.name);
+  const { stats } = useSessionStats(session.id);
 
   const handleFinishEdit = () => {
     if (editName.trim() && editName !== session.name) {
@@ -74,6 +76,22 @@ const TerminalHeader: React.FC<TerminalHeaderProps> = ({
       <span className="header-path" title={session.workingDir}>
         {truncatePath(session.workingDir)}
       </span>
+
+      {stats && stats.totalEvents > 0 && (
+        <span className="header-stats" title={formatStatsTooltip(stats)}>
+          {formatDuration(stats.totalDurationSeconds) && (
+            <span className="header-stat">{formatDuration(stats.totalDurationSeconds)}</span>
+          )}
+          {stats.totalEvents > 0 && (
+            <span className="header-stat">{stats.totalEvents} events</span>
+          )}
+          {Object.values(stats.toolUseCounts).reduce((s, c) => s + c, 0) > 0 && (
+            <span className="header-stat">
+              {Object.values(stats.toolUseCounts).reduce((s, c) => s + c, 0)} tools
+            </span>
+          )}
+        </span>
+      )}
 
       <div className="header-actions">
         <button className="header-action" onClick={onRestart} title="Restart session" aria-label="Restart session">

--- a/src/renderer/store/session-stats.ts
+++ b/src/renderer/store/session-stats.ts
@@ -1,0 +1,75 @@
+import { useState, useEffect, useCallback } from 'react';
+import { SessionStats } from '../../shared/types';
+
+interface UseSessionStatsResult {
+  stats: SessionStats | null;
+  loading: boolean;
+}
+
+export function useSessionStats(sessionId: string | null): UseSessionStatsResult {
+  const [stats, setStats] = useState<SessionStats | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const loadStats = useCallback(async () => {
+    if (!sessionId) {
+      setStats(null);
+      return;
+    }
+    try {
+      setLoading(true);
+      const result = await window.electronAPI.getSessionStats(sessionId);
+      setStats(result);
+    } catch {
+      setStats(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
+  // Refresh stats periodically while session is active (every 30s)
+  useEffect(() => {
+    if (!sessionId) return;
+    const interval = setInterval(loadStats, 30000);
+    return () => clearInterval(interval);
+  }, [sessionId, loadStats]);
+
+  return { stats, loading };
+}
+
+export function formatDuration(seconds: number): string {
+  if (!seconds || seconds < 1) return '';
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+export function formatStatsTooltip(stats: SessionStats): string {
+  const lines: string[] = [];
+  if (stats.totalDurationSeconds > 0) {
+    lines.push(`Duration: ${formatDuration(stats.totalDurationSeconds)}`);
+  }
+  lines.push(`Events: ${stats.totalEvents}`);
+  const toolEntries = Object.entries(stats.toolUseCounts);
+  if (toolEntries.length > 0) {
+    const totalTools = toolEntries.reduce((sum, [, count]) => sum + count, 0);
+    lines.push(`Tool calls: ${totalTools}`);
+    for (const [name, count] of toolEntries.slice(0, 5)) {
+      lines.push(`  ${name}: ${count}`);
+    }
+  }
+  const stateEntries = Object.entries(stats.stateBreakdown);
+  if (stateEntries.length > 0) {
+    lines.push('Time breakdown:');
+    for (const [state, secs] of stateEntries) {
+      const dur = formatDuration(secs);
+      if (dur) lines.push(`  ${state}: ${dur}`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -372,14 +372,29 @@ body {
   flex: 1;
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
 }
 
 .session-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.session-stats-badge {
+  font-size: 10px;
+  color: #666;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.2;
+  cursor: help;
+}
+
+.session.active .session-stats-badge {
+  color: #888;
 }
 
 .session-name-input {
@@ -640,6 +655,25 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.header-stats {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+  cursor: help;
+}
+
+.header-stat {
+  font-size: 11px;
+  color: #666;
+  white-space: nowrap;
+}
+
+.header-stat + .header-stat::before {
+  content: '·';
+  margin-right: 8px;
+  color: #555;
 }
 
 .header-actions {


### PR DESCRIPTION
## Summary

- Sidebar session entries now show compact stats badge below the name (e.g., "2h 15m · 47 tools")
- Terminal header shows duration, event count, and tool call count between path and action buttons
- Hover tooltip on both shows full breakdown: duration, total events, per-tool counts, per-state time
- Stats auto-refresh every 30 seconds
- Hidden gracefully when session has no events yet

### New Files
- `src/renderer/store/session-stats.ts` — `useSessionStats()` hook + formatting utilities
- `src/renderer/components/SessionStatsBadge.tsx` — compact sidebar badge

### Modified Files
- `src/renderer/components/TerminalHeader.tsx` — added stats display
- `src/renderer/App.tsx` — imported and placed SessionStatsBadge in both session entry blocks
- `src/renderer/styles/global.css` — styles for badge and header stats

## Test plan

- [ ] Sidebar session entries show duration + tool count for sessions with events
- [ ] Sessions with no events show no badge (clean)
- [ ] Terminal header shows stats between path and action buttons
- [ ] Hover tooltip shows full breakdown
- [ ] Stats update after ~30 seconds without manual refresh
- [ ] Layout remains compact — no clutter
- [ ] `bunx tsc --noEmit` clean
- [ ] `bun run build` clean

**Jira:** [BDHLNDR-19](https://gobodhi.atlassian.net/browse/BDHLNDR-19)
**Parent Epic:** [BDHLNDR-14 — Session Analytics Dashboard](https://gobodhi.atlassian.net/browse/BDHLNDR-14)
**Depends on:** PR #17 (BDHLNDR-17), PR #18 (BDHLNDR-18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-19]: https://gobodhi.atlassian.net/browse/BDHLNDR-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ