### PR TITLE
feat(BDHLNDR-20): session history export (CSV/JSON)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import * as sessionsRepo from './repositories/sessions';
 import * as prefsRepo from './repositories/preferences';
 import * as memoriesRepo from './repositories/memories';
 import * as sessionEventsRepo from './repositories/session-events';
+import { exportSessions, ExportFormat } from './session-export';
 import { StateMonitor } from './state-monitor';
 import { createApplicationMenu } from './menu';
 import { initAutoUpdater, checkForUpdatesManual, downloadUpdate } from './auto-updater';
@@ -672,6 +673,11 @@ safeHandle('db:sessionEvents:getGlobalStats', (since?: string) =>
 
 safeHandle('db:sessionEvents:getToolUseCounts', (sessionId?: string) =>
   sessionEventsRepo.getToolUseCounts(sessionId)
+);
+
+// Session Export IPC Handlers (BDHLNDR-20)
+safeHandle('export:sessions', (format: ExportFormat, since?: string) =>
+  exportSessions({ format, since })
 );
 
 // Preferences IPC Handlers

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -160,6 +160,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getToolUseCounts: (sessionId?: string): Promise<Record<string, number>> =>
     ipcRenderer.invoke('db:sessionEvents:getToolUseCounts', sessionId),
 
+  // Session Export (BDHLNDR-20)
+  exportSessions: (format: 'csv' | 'json', since?: string): Promise<{ success: boolean; filePath?: string; error?: string; sessionCount?: number; eventCount?: number }> =>
+    ipcRenderer.invoke('export:sessions', format, since),
+
   // Preferences
   getPreference: (key: string): Promise<string | null> =>
     ipcRenderer.invoke('prefs:get', key),

--- a/src/main/session-export.ts
+++ b/src/main/session-export.ts
@@ -1,0 +1,209 @@
+/**
+ * Session Export — BDHLNDR-20
+ *
+ * Formats session data as CSV or JSON and writes to a user-selected file.
+ */
+
+import { dialog, app } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as sessionsRepo from './repositories/sessions';
+import * as sessionEventsRepo from './repositories/session-events';
+import * as groupsRepo from './repositories/groups';
+import log from 'electron-log';
+
+export type ExportFormat = 'csv' | 'json';
+
+interface ExportOptions {
+  format: ExportFormat;
+  since?: string; // ISO date string
+}
+
+interface ExportResult {
+  success: boolean;
+  filePath?: string;
+  error?: string;
+  sessionCount?: number;
+  eventCount?: number;
+}
+
+function escapeCSV(value: string | number | null | undefined): string {
+  if (value == null) return '';
+  const str = String(value);
+  if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function formatDuration(seconds: number): string {
+  if (!seconds || seconds < 1) return '0s';
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+
+function buildCSV(since?: string): { content: string; sessionCount: number } {
+  const sessions = sessionsRepo.getAllSessions();
+  const groups = groupsRepo.getAllGroups();
+  const groupMap = new Map(groups.map(g => [g.id, g.name]));
+
+  // Filter by date if specified
+  const filtered = since
+    ? sessions.filter(s => new Date(s.createdAt).toISOString() >= since)
+    : sessions;
+
+  const headers = [
+    'Session Name',
+    'Group',
+    'State',
+    'Working Directory',
+    'Created At',
+    'Last Activity',
+    'Ended At',
+    'Duration',
+    'Duration (seconds)',
+    'Total Events',
+    'Tool Calls',
+    'Top Tools',
+  ];
+
+  const rows: string[] = [headers.map(escapeCSV).join(',')];
+
+  for (const session of filtered) {
+    const stats = sessionEventsRepo.getSessionStats(session.id);
+    const toolEntries = Object.entries(stats.toolUseCounts);
+    const totalTools = toolEntries.reduce((sum, [, count]) => sum + count, 0);
+    const topTools = toolEntries
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([name, count]) => `${name}(${count})`)
+      .join('; ');
+
+    rows.push([
+      escapeCSV(session.name),
+      escapeCSV(groupMap.get(session.groupId) ?? 'Unknown'),
+      escapeCSV(session.state),
+      escapeCSV(session.workingDir),
+      escapeCSV(session.createdAt instanceof Date ? session.createdAt.toISOString() : String(session.createdAt)),
+      escapeCSV(session.lastActivityAt instanceof Date ? session.lastActivityAt.toISOString() : String(session.lastActivityAt)),
+      escapeCSV(session.endedAt instanceof Date ? session.endedAt.toISOString() : ''),
+      escapeCSV(formatDuration(session.durationSeconds)),
+      escapeCSV(Math.round(session.durationSeconds)),
+      escapeCSV(stats.totalEvents),
+      escapeCSV(totalTools),
+      escapeCSV(topTools),
+    ].join(','));
+  }
+
+  // BOM for Excel UTF-8 compatibility
+  return { content: '\uFEFF' + rows.join('\r\n'), sessionCount: filtered.length };
+}
+
+function buildJSON(since?: string): { content: string; sessionCount: number; eventCount: number } {
+  const sessions = sessionsRepo.getAllSessions();
+  const groups = groupsRepo.getAllGroups();
+  const groupMap = new Map(groups.map(g => [g.id, g.name]));
+
+  const filtered = since
+    ? sessions.filter(s => new Date(s.createdAt).toISOString() >= since)
+    : sessions;
+
+  let totalEvents = 0;
+  const exportData = filtered.map(session => {
+    const stats = sessionEventsRepo.getSessionStats(session.id);
+    const events = sessionEventsRepo.getEventsBySession(session.id, 10000);
+    totalEvents += events.length;
+
+    return {
+      session: {
+        id: session.id,
+        name: session.name,
+        group: groupMap.get(session.groupId) ?? 'Unknown',
+        groupId: session.groupId,
+        state: session.state,
+        workingDir: session.workingDir,
+        createdAt: session.createdAt instanceof Date ? session.createdAt.toISOString() : session.createdAt,
+        lastActivityAt: session.lastActivityAt instanceof Date ? session.lastActivityAt.toISOString() : session.lastActivityAt,
+        endedAt: session.endedAt instanceof Date ? session.endedAt.toISOString() : session.endedAt,
+        durationSeconds: session.durationSeconds,
+      },
+      stats: {
+        totalEvents: stats.totalEvents,
+        totalDurationSeconds: stats.totalDurationSeconds,
+        toolUseCounts: stats.toolUseCounts,
+        stateBreakdown: stats.stateBreakdown,
+      },
+      events: events.map(e => ({
+        id: e.id,
+        eventType: e.eventType,
+        eventData: e.eventData,
+        createdAt: e.createdAt instanceof Date ? e.createdAt.toISOString() : e.createdAt,
+      })),
+    };
+  });
+
+  const output = {
+    exportedAt: new Date().toISOString(),
+    appVersion: app.getVersion(),
+    sessionCount: filtered.length,
+    totalEvents,
+    sessions: exportData,
+  };
+
+  return {
+    content: JSON.stringify(output, null, 2),
+    sessionCount: filtered.length,
+    eventCount: totalEvents,
+  };
+}
+
+export async function exportSessions(options: ExportOptions): Promise<ExportResult> {
+  try {
+    const defaultName = `bodhilander-sessions-${new Date().toISOString().slice(0, 10)}`;
+    const ext = options.format === 'csv' ? 'csv' : 'json';
+
+    const result = await dialog.showSaveDialog({
+      title: `Export Sessions (${options.format.toUpperCase()})`,
+      defaultPath: path.join(app.getPath('documents'), `${defaultName}.${ext}`),
+      filters: options.format === 'csv'
+        ? [{ name: 'CSV Files', extensions: ['csv'] }]
+        : [{ name: 'JSON Files', extensions: ['json'] }],
+    });
+
+    if (result.canceled || !result.filePath) {
+      return { success: false, error: 'Export cancelled' };
+    }
+
+    let content: string;
+    let sessionCount: number;
+    let eventCount = 0;
+
+    if (options.format === 'csv') {
+      const csv = buildCSV(options.since);
+      content = csv.content;
+      sessionCount = csv.sessionCount;
+    } else {
+      const json = buildJSON(options.since);
+      content = json.content;
+      sessionCount = json.sessionCount;
+      eventCount = json.eventCount;
+    }
+
+    fs.writeFileSync(result.filePath, content, 'utf-8');
+    log.info(`[Export] Exported ${sessionCount} sessions to ${result.filePath}`);
+
+    return {
+      success: true,
+      filePath: result.filePath,
+      sessionCount,
+      eventCount,
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    log.error('[Export] Failed to export sessions:', msg);
+    return { success: false, error: msg };
+  }
+}

--- a/src/renderer/components/panels/AnalyticsPanel.css
+++ b/src/renderer/components/panels/AnalyticsPanel.css
@@ -26,6 +26,19 @@
   color: #d4d4d4;
 }
 
+.export-buttons {
+  display: flex;
+  gap: 4px;
+}
+
+.export-buttons .icon-button {
+  font-size: 10px;
+  width: auto;
+  padding: 2px 8px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
 .analytics-header-actions {
   display: flex;
   align-items: center;

--- a/src/renderer/components/panels/AnalyticsPanel.tsx
+++ b/src/renderer/components/panels/AnalyticsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
   PieChart, Pie, Cell, ResponsiveContainer, Legend,
@@ -289,6 +289,50 @@ function RecentActivityFeed({ events }: { events: SessionEvent[] }) {
   );
 }
 
+// --- Export ---
+
+function ExportButtons({ timeRange }: { timeRange: TimeRange }) {
+  const [exporting, setExporting] = useState(false);
+
+  const handleExport = useCallback(async (format: 'csv' | 'json') => {
+    setExporting(true);
+    try {
+      const since = timeRange === 'all' ? undefined : (() => {
+        const now = new Date();
+        switch (timeRange) {
+          case 'today': now.setHours(0, 0, 0, 0); return now.toISOString();
+          case '7d': now.setDate(now.getDate() - 7); return now.toISOString();
+          case '30d': now.setDate(now.getDate() - 30); return now.toISOString();
+        }
+      })();
+      await window.electronAPI.exportSessions(format, since);
+    } finally {
+      setExporting(false);
+    }
+  }, [timeRange]);
+
+  return (
+    <div className="export-buttons">
+      <button
+        className="icon-button"
+        onClick={() => handleExport('csv')}
+        disabled={exporting}
+        title="Export as CSV"
+      >
+        {exporting ? '...' : 'CSV'}
+      </button>
+      <button
+        className="icon-button"
+        onClick={() => handleExport('json')}
+        disabled={exporting}
+        title="Export as JSON"
+      >
+        {exporting ? '...' : 'JSON'}
+      </button>
+    </div>
+  );
+}
+
 // --- Main Component ---
 
 interface AnalyticsPanelProps {
@@ -335,6 +379,7 @@ export default function AnalyticsPanel({ onClose }: AnalyticsPanelProps) {
         <h2>Analytics</h2>
         <div className="analytics-header-actions">
           <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          <ExportButtons timeRange={timeRange} />
           <button className="icon-button" onClick={refresh} title="Refresh">↻</button>
           <button className="icon-button" onClick={onClose} title="Close">×</button>
         </div>

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -67,6 +67,9 @@ interface ElectronAPI {
   getGlobalStats: (since?: string) => Promise<GlobalStats>;
   getToolUseCounts: (sessionId?: string) => Promise<Record<string, number>>;
 
+  // Session Export (BDHLNDR-20)
+  exportSessions: (format: 'csv' | 'json', since?: string) => Promise<{ success: boolean; filePath?: string; error?: string; sessionCount?: number; eventCount?: number }>;
+
   // Preferences
   getPreference: (key: string) => Promise<string | null>;
   setPreference: (key: string, value: string) => Promise<void>;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -89,6 +89,9 @@ export interface ElectronAPI {
   getGlobalStats: (since?: string) => Promise<GlobalStats>;
   getToolUseCounts: (sessionId?: string) => Promise<Record<string, number>>;
 
+  // Session Export (BDHLNDR-20)
+  exportSessions: (format: 'csv' | 'json', since?: string) => Promise<{ success: boolean; filePath?: string; error?: string; sessionCount?: number; eventCount?: number }>;
+
   // Preferences
   getPreference: (key: string) => Promise<string | null>;
   setPreference: (key: string, value: string) => Promise<void>;


### PR DESCRIPTION
## Summary

- CSV export with session name, group, state, timestamps, duration, tool counts, top tools
- JSON export with full session metadata, stats, and all events with event_data
- Export buttons in analytics dashboard header (CSV and JSON)
- Date range filtering matches current time range selector
- File save dialog defaults to Documents folder
- BOM prefix for Excel UTF-8 compatibility

### New Files
- `src/main/session-export.ts` — export formatting, file save dialog, CSV/JSON builders

### Modified Files
- `src/main/index.ts` — IPC handler for `export:sessions`
- `src/main/preload.ts` — `exportSessions()` bridge method
- `src/renderer/components/panels/AnalyticsPanel.tsx` — export buttons
- `src/renderer/components/panels/AnalyticsPanel.css` — export button styles
- Both `electron.d.ts` files — type declarations

## Test plan

- [ ] Click CSV in analytics header → save dialog opens, defaults to Documents
- [ ] Save CSV → opens in Excel/Google Sheets with correct columns and data
- [ ] Click JSON → save dialog opens, save file is valid JSON
- [ ] JSON contains session metadata, stats, and events array
- [ ] Time range filter applies to export (7d exports only last 7 days)
- [ ] Export with 0 sessions → saves empty CSV/JSON without crashing
- [ ] `bunx tsc --noEmit` clean
- [ ] `bun run build` clean

**Jira:** [BDHLNDR-20](https://gobodhi.atlassian.net/browse/BDHLNDR-20)
**Parent Epic:** [BDHLNDR-14 — Session Analytics Dashboard](https://gobodhi.atlassian.net/browse/BDHLNDR-14)
**Depends on:** PR #17, #18, #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-20]: https://gobodhi.atlassian.net/browse/BDHLNDR-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ