### PR TITLE
Release v3.2.0 — Session Analytics Dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "qrcode": "^1.5.4",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
+        "recharts": "^3.8.1",
         "socket.io-client": "^4.8.3",
         "sodium-native": "^5.0.10",
         "sqlite-vec": "^0.1.6",
@@ -240,9 +241,15 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
 
@@ -255,6 +262,24 @@
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
@@ -303,6 +328,8 @@
     "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
 
     "@types/sodium-native": ["@types/sodium-native@2.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-jZIg5ltGH1okmnH3FrLQsgwjcjOVozMSHwSiEm1/LpMekhOMHbQqp21P4H24mizh1BjwI6Q8qmphmD/HJuAqWg=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
 
@@ -492,6 +519,8 @@
 
     "clone-response": ["clone-response@1.0.3", "", { "dependencies": { "mimic-response": "^1.0.0" } }, "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA=="],
 
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -536,9 +565,33 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 
@@ -642,6 +695,8 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
+    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
+
     "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
     "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
@@ -659,6 +714,8 @@
     "estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
@@ -798,6 +855,8 @@
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "import-local": ["import-local@3.2.0", "", { "dependencies": { "pkg-dir": "^4.2.0", "resolve-cwd": "^3.0.0" }, "bin": { "import-local-fixture": "fixtures/cli.js" } }, "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
@@ -807,6 +866,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "interpret": ["interpret@3.1.1", "", {}, "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ=="],
 
@@ -1092,13 +1153,23 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-is": ["react-is@19.2.4", "", {}, "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="],
+
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "read-binary-file-arch": ["read-binary-file-arch@1.0.6", "", { "dependencies": { "debug": "^4.3.4" }, "bin": { "read-binary-file-arch": "cli.js" } }, "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
     "rechoir": ["rechoir@0.8.0", "", { "dependencies": { "resolve": "^1.20.0" } }, "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "relateurl": ["relateurl@0.2.7", "", {}, "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="],
 
@@ -1113,6 +1184,8 @@
     "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
 
     "resedit": ["resedit@1.7.2", "", { "dependencies": { "pe-library": "^0.4.1" } }, "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -1272,6 +1345,8 @@
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tiny-typed-emitter": ["tiny-typed-emitter@2.1.0", "", {}, "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
@@ -1322,6 +1397,8 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "utf8-byte-length": ["utf8-byte-length@1.0.5", "", {}, "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
@@ -1331,6 +1408,8 @@
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "verror": ["verror@1.10.1", "", { "dependencies": { "assert-plus": "^1.0.0", "core-util-is": "1.0.2", "extsprintf": "^1.2.0" } }, "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg=="],
+
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
     "watchpack": ["watchpack@2.5.1", "", { "dependencies": { "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.1.2" } }, "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg=="],
 
@@ -1419,6 +1498,8 @@
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "node-pty": "^1.1.0",
     "qrcode": "^1.5.4",
     "react": "^19.2.3",
+    "recharts": "^3.8.1",
     "react-dom": "^19.2.3",
     "socket.io-client": "^4.8.3",
     "sodium-native": "^5.0.10",

--- a/src/hooks/bodhilander-hook.ts
+++ b/src/hooks/bodhilander-hook.ts
@@ -185,7 +185,8 @@ function parseArgs(): { hookType: string; groupId?: string; sessionId?: string }
   const args = process.argv.slice(2);
   let hookType = 'PostToolUse';
   let groupId: string | undefined;
-  let sessionId: string | undefined;
+  // Use BODHILANDER_SESSION_ID env var (set by claude-launcher.ts) as default
+  let sessionId: string | undefined = process.env.BODHILANDER_SESSION_ID;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--group-id' && args[i + 1]) {

--- a/src/main/api/routes/hooks.ts
+++ b/src/main/api/routes/hooks.ts
@@ -7,8 +7,25 @@
 
 import { Router, Request, Response } from 'express';
 import * as memoriesRepo from '../../repositories/memories';
-import * as groupsRepo from '../../repositories/groups';
+import * as sessionEventsRepo from '../../repositories/session-events';
+import * as sessionsRepo from '../../repositories/sessions';
+import { SessionEventType } from '../../../shared/types';
 import log from 'electron-log';
+
+/**
+ * Try to log a session event. Only writes if session_id references a valid session.
+ */
+function tryLogEvent(sessionId: string | undefined, eventType: SessionEventType, eventData?: Record<string, unknown> | null): void {
+  if (!sessionId) return;
+  try {
+    // Verify the session exists before writing (foreign key constraint)
+    const sessions = sessionsRepo.getAllSessions();
+    if (!sessions.some(s => s.id === sessionId)) return;
+    sessionEventsRepo.createEvent(sessionId, eventType, eventData);
+  } catch (error) {
+    log.error(`[HooksAPI] Failed to log ${eventType} event:`, error);
+  }
+}
 
 /**
  * Middleware to restrict to localhost only
@@ -115,10 +132,14 @@ export function createHooksRouter(): Router {
           });
 
           log.info(`[HooksAPI] Saved git commit as memory: ${memory.id}`);
+          tryLogEvent(session_id, 'tool_use', { tool_name });
           res.json({ saved: true, memory_id: memory.id, type: 'git_commit' });
           return;
         }
       }
+
+      // Log tool use event regardless of memory creation (BDHLNDR-17)
+      tryLogEvent(session_id, 'tool_use', { tool_name });
 
       // For other significant tool uses, just acknowledge
       res.json({ saved: false, reason: 'not_actionable' });
@@ -144,6 +165,13 @@ export function createHooksRouter(): Router {
       } = req.body;
 
       log.info(`[HooksAPI] Stop: session=${session_id}, reason=${stop_reason}, tools=${tool_uses_count}`);
+
+      // Log stop event regardless of significance (BDHLNDR-17)
+      tryLogEvent(session_id, 'session_stop', {
+        stop_reason,
+        tool_uses_count,
+        files_edited,
+      });
 
       // Only process if there was significant activity
       const isSignificant = (tool_uses_count && tool_uses_count > 3) ||
@@ -188,6 +216,13 @@ export function createHooksRouter(): Router {
       const { session_id, group_id, notification_type, message } = req.body;
 
       log.info(`[HooksAPI] Notification: ${notification_type}`);
+
+      // Log notification event (BDHLNDR-17)
+      if (notification_type === 'error') {
+        tryLogEvent(session_id, 'error', { message });
+      } else {
+        tryLogEvent(session_id, 'notification', { type: notification_type, message });
+      }
 
       // Could capture error notifications as error_fix memories
       if (notification_type === 'error' && message && group_id) {

--- a/src/main/api/routes/hooks.ts
+++ b/src/main/api/routes/hooks.ts
@@ -18,13 +18,17 @@ import log from 'electron-log';
 function tryLogEvent(sessionId: string | undefined, eventType: SessionEventType, eventData?: Record<string, unknown> | null): void {
   if (!sessionId) return;
   try {
-    // Verify the session exists before writing (foreign key constraint)
-    const sessions = sessionsRepo.getAllSessions();
-    if (!sessions.some(s => s.id === sessionId)) return;
+    if (!sessionsRepo.sessionExists(sessionId)) return;
     sessionEventsRepo.createEvent(sessionId, eventType, eventData);
   } catch (error) {
     log.error(`[HooksAPI] Failed to log ${eventType} event:`, error);
   }
+}
+
+/** Sanitize a value for safe logging (strip control characters, truncate). */
+function sanitizeLogValue(val: unknown, maxLen = 100): string {
+  const str = String(val ?? '').replace(/[\x00-\x1f\x7f]/g, '');
+  return str.length > maxLen ? str.slice(0, maxLen) + '...' : str;
 }
 
 /**
@@ -97,7 +101,7 @@ export function createHooksRouter(): Router {
     try {
       const { tool_name, tool_input, tool_output, session_id, group_id } = req.body;
 
-      log.info(`[HooksAPI] PostToolUse: ${tool_name}`);
+      log.info(`[HooksAPI] PostToolUse: ${sanitizeLogValue(tool_name)}`);
 
       // Handle git commits specially
       if (tool_name === 'Bash') {
@@ -164,10 +168,10 @@ export function createHooksRouter(): Router {
         summary_hint
       } = req.body;
 
-      log.info(`[HooksAPI] Stop: session=${session_id}, reason=${stop_reason}, tools=${tool_uses_count}`);
+      log.info(`[HooksAPI] Stop: session=${sanitizeLogValue(session_id)}, reason=${sanitizeLogValue(stop_reason)}, tools=${sanitizeLogValue(tool_uses_count)}`);
 
-      // Log stop event regardless of significance (BDHLNDR-17)
-      tryLogEvent(session_id, 'session_stop', {
+      // Log turn completion event (distinct from session_stop which means PTY exited) (BDHLNDR-17)
+      tryLogEvent(session_id, 'turn_complete', {
         stop_reason,
         tool_uses_count,
         files_edited,
@@ -215,7 +219,7 @@ export function createHooksRouter(): Router {
     try {
       const { session_id, group_id, notification_type, message } = req.body;
 
-      log.info(`[HooksAPI] Notification: ${notification_type}`);
+      log.info(`[HooksAPI] Notification: ${sanitizeLogValue(notification_type)}`);
 
       // Log notification event (BDHLNDR-17)
       if (notification_type === 'error') {

--- a/src/main/api/routes/sessions.ts
+++ b/src/main/api/routes/sessions.ts
@@ -80,6 +80,8 @@ export function createSessionsRouter(): Router {
           createdAt: now,
           lastActivityAt: now,
           claudeSessionId: null,
+          endedAt: null,
+          durationSeconds: 0,
         };
 
         sessionsRepo.createSession(session);

--- a/src/main/api/routes/sessions.ts
+++ b/src/main/api/routes/sessions.ts
@@ -7,6 +7,7 @@
 import { Router, Request, Response } from 'express';
 import log from 'electron-log';
 import * as sessionsRepo from '../../repositories/sessions';
+import * as sessionEventsRepo from '../../repositories/session-events';
 import { ptyManager } from '../../pty-manager';
 import { requireControlPermission, requireModifyPermission } from '../middleware/auth';
 import {
@@ -85,6 +86,13 @@ export function createSessionsRouter(): Router {
         };
 
         sessionsRepo.createSession(session);
+
+        // Log session start event (BDHLNDR-17)
+        try {
+          sessionEventsRepo.createEvent(session.id, 'session_start', null);
+        } catch (error) {
+          log.error('Failed to log session_start event:', error);
+        }
 
         // Start PTY if requested
         if (launchClaude) {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -106,6 +106,39 @@ function initializeTables(database: Database.Database): void {
     database.exec("ALTER TABLE sessions ADD COLUMN claude_session_id TEXT DEFAULT NULL");
   }
 
+  // Migration: Add ended_at and duration_seconds columns to sessions (BDHLNDR-17)
+  const sessionColsBdhlndr17 = sessionColumns.map(c => c.name);
+  if (!sessionColsBdhlndr17.includes('ended_at')) {
+    database.exec("ALTER TABLE sessions ADD COLUMN ended_at TEXT DEFAULT NULL");
+  }
+  if (!sessionColsBdhlndr17.includes('duration_seconds')) {
+    database.exec("ALTER TABLE sessions ADD COLUMN duration_seconds REAL DEFAULT 0");
+  }
+
+  // Migration: Create session_events table (BDHLNDR-17)
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS session_events (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      event_type TEXT NOT NULL CHECK(event_type IN (
+        'session_start', 'session_stop', 'state_change', 'tool_use', 'error', 'notification'
+      )),
+      event_data TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE INDEX IF NOT EXISTS idx_session_events_session_id ON session_events(session_id);
+    CREATE INDEX IF NOT EXISTS idx_session_events_type ON session_events(event_type);
+    CREATE INDEX IF NOT EXISTS idx_session_events_created ON session_events(created_at);
+  `);
+
+  // Backfill duration_seconds for existing stopped sessions (rough estimate from wall clock)
+  database.exec(`
+    UPDATE sessions
+    SET duration_seconds = (julianday(last_activity_at) - julianday(created_at)) * 86400
+    WHERE duration_seconds = 0 AND state = 'stopped'
+      AND last_activity_at IS NOT NULL AND created_at IS NOT NULL
+  `);
+
   // Migration: Create memories table if it doesn't exist
   database.exec(`
     CREATE TABLE IF NOT EXISTS memories (

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -108,11 +108,13 @@ function initializeTables(database: Database.Database): void {
 
   // Migration: Add ended_at and duration_seconds columns to sessions (BDHLNDR-17)
   const sessionColsBdhlndr17 = sessionColumns.map(c => c.name);
+  let durationColumnJustAdded = false;
   if (!sessionColsBdhlndr17.includes('ended_at')) {
     database.exec("ALTER TABLE sessions ADD COLUMN ended_at TEXT DEFAULT NULL");
   }
   if (!sessionColsBdhlndr17.includes('duration_seconds')) {
     database.exec("ALTER TABLE sessions ADD COLUMN duration_seconds REAL DEFAULT 0");
+    durationColumnJustAdded = true;
   }
 
   // Migration: Create session_events table (BDHLNDR-17)
@@ -121,23 +123,24 @@ function initializeTables(database: Database.Database): void {
       id TEXT PRIMARY KEY,
       session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
       event_type TEXT NOT NULL CHECK(event_type IN (
-        'session_start', 'session_stop', 'state_change', 'tool_use', 'error', 'notification'
+        'session_start', 'session_stop', 'state_change', 'tool_use', 'turn_complete', 'error', 'notification'
       )),
       event_data TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
     );
-    CREATE INDEX IF NOT EXISTS idx_session_events_session_id ON session_events(session_id);
-    CREATE INDEX IF NOT EXISTS idx_session_events_type ON session_events(event_type);
+    CREATE INDEX IF NOT EXISTS idx_session_events_session_type_time ON session_events(session_id, event_type, created_at);
     CREATE INDEX IF NOT EXISTS idx_session_events_created ON session_events(created_at);
   `);
 
-  // Backfill duration_seconds for existing stopped sessions (rough estimate from wall clock)
-  database.exec(`
-    UPDATE sessions
-    SET duration_seconds = (julianday(last_activity_at) - julianday(created_at)) * 86400
-    WHERE duration_seconds = 0 AND state = 'stopped'
-      AND last_activity_at IS NOT NULL AND created_at IS NOT NULL
-  `);
+  // Backfill duration_seconds for existing stopped sessions (one-time, rough wall-clock estimate)
+  if (durationColumnJustAdded) {
+    database.exec(`
+      UPDATE sessions
+      SET duration_seconds = (julianday(last_activity_at) - julianday(created_at)) * 86400
+      WHERE duration_seconds = 0 AND state = 'stopped'
+        AND last_activity_at IS NOT NULL AND created_at IS NOT NULL
+    `);
+  }
 
   // Migration: Create memories table if it doesn't exist
   database.exec(`

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -137,6 +137,44 @@ soundManager.setSessionStateLookup((sessionId: string) => {
   return sessionStates.get(sessionId)?.state;
 });
 
+// Track which sessions have already had their state logged in this tick,
+// to deduplicate when both stateMonitor and ptyManager fire for the same transition.
+const recentlyLoggedStates: Map<string, { state: string; timestamp: number }> = new Map();
+
+/**
+ * Shared handler for session state change event logging (BDHLNDR-17).
+ * Called from both stateMonitor and ptyManager handlers.
+ * Deduplicates: if the same session+state was logged within the last 2 seconds, skips.
+ */
+function logSessionStateEvent(sessionId: string, newState: SessionState): void {
+  // Dedup guard: skip if same session+state was logged within 2 seconds
+  const recent = recentlyLoggedStates.get(sessionId);
+  const now = Date.now();
+  if (recent && recent.state === newState && (now - recent.timestamp) < 2000) {
+    return;
+  }
+  recentlyLoggedStates.set(sessionId, { state: newState, timestamp: now });
+
+  try {
+    const previousState = sessionStates.get(sessionId)?.state ?? 'unknown';
+    sessionEventsRepo.createEvent(sessionId, 'state_change', {
+      from: previousState,
+      to: newState,
+    });
+    if (newState === 'stopped') {
+      sessionEventsRepo.createEvent(sessionId, 'session_stop', null);
+      const breakdown = sessionEventsRepo.getStateBreakdown(sessionId);
+      const activeSeconds = (breakdown['working'] || 0) + (breakdown['waiting'] || 0);
+      sessionsRepo.updateSession(sessionId, {
+        endedAt: new Date(),
+        durationSeconds: activeSeconds,
+      });
+    }
+  } catch (error) {
+    log.error('Failed to log session event:', error);
+  }
+}
+
 const SPLASH_DURATION = 2500; // 2.5 seconds
 
 function updateTrayWithWaitingSessions(): void {
@@ -281,8 +319,6 @@ function createWindow(): void {
 
   stateMonitor.on('stateChange', (event) => {
     mainWindow?.webContents.send('state:change', event);
-    // Track previous state for event logging
-    const previousState = sessionStates.get(event.sessionId)?.state as SessionState | undefined;
     // Update database with error handling
     try {
       sessionsRepo.updateSession(event.sessionId, {
@@ -292,24 +328,8 @@ function createWindow(): void {
     } catch (error) {
       console.error('Failed to update session state in database:', error);
     }
-    // Log session event (BDHLNDR-17)
-    try {
-      sessionEventsRepo.createEvent(event.sessionId, 'state_change', {
-        from: previousState ?? 'unknown',
-        to: event.state,
-      });
-      if (event.state === 'stopped') {
-        sessionEventsRepo.createEvent(event.sessionId, 'session_stop', null);
-        const breakdown = sessionEventsRepo.getStateBreakdown(event.sessionId);
-        const activeSeconds = (breakdown['working'] || 0) + (breakdown['waiting'] || 0);
-        sessionsRepo.updateSession(event.sessionId, {
-          endedAt: new Date(),
-          durationSeconds: activeSeconds,
-        });
-      }
-    } catch (error) {
-      log.error('Failed to log session event:', error);
-    }
+    // Log session event with dedup (BDHLNDR-17)
+    logSessionStateEvent(event.sessionId, event.state);
     // Handle notifications and tray updates
     handleStateChange(event.sessionId, event.state);
   });
@@ -416,8 +436,6 @@ function createWindow(): void {
   // PTY state detection forwarding
   ptyManager.on('stateChange', (event) => {
     mainWindow?.webContents.send('state:change', event);
-    // Track previous state for event logging
-    const previousState = sessionStates.get(event.sessionId)?.state as SessionState | undefined;
     // Update database
     try {
       sessionsRepo.updateSession(event.sessionId, {
@@ -427,24 +445,8 @@ function createWindow(): void {
     } catch (error) {
       console.error('Failed to update session state in database:', error);
     }
-    // Log session event (BDHLNDR-17)
-    try {
-      sessionEventsRepo.createEvent(event.sessionId, 'state_change', {
-        from: previousState ?? 'unknown',
-        to: event.state,
-      });
-      if (event.state === 'stopped') {
-        sessionEventsRepo.createEvent(event.sessionId, 'session_stop', null);
-        const breakdown = sessionEventsRepo.getStateBreakdown(event.sessionId);
-        const activeSeconds = (breakdown['working'] || 0) + (breakdown['waiting'] || 0);
-        sessionsRepo.updateSession(event.sessionId, {
-          endedAt: new Date(),
-          durationSeconds: activeSeconds,
-        });
-      }
-    } catch (error) {
-      log.error('Failed to log session event:', error);
-    }
+    // Log session event with dedup (BDHLNDR-17)
+    logSessionStateEvent(event.sessionId, event.state);
     // Handle notifications and tray updates
     handleStateChange(event.sessionId, event.state);
     // Broadcast to mobile clients
@@ -670,10 +672,6 @@ safeHandle('db:sessionEvents:getGlobalStats', (since?: string) =>
 
 safeHandle('db:sessionEvents:getToolUseCounts', (sessionId?: string) =>
   sessionEventsRepo.getToolUseCounts(sessionId)
-);
-
-safeHandle('db:sessionEvents:getEventsSince', (since: string, sessionId?: string) =>
-  sessionEventsRepo.getEventsSince(new Date(since), sessionId)
 );
 
 // Preferences IPC Handlers

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import * as sessionsRepo from './repositories/sessions';
 import * as prefsRepo from './repositories/preferences';
 import * as memoriesRepo from './repositories/memories';
 import * as sessionEventsRepo from './repositories/session-events';
+import { exportSessions, ExportFormat } from './session-export';
 import { StateMonitor } from './state-monitor';
 import { createApplicationMenu } from './menu';
 import { initAutoUpdater, checkForUpdatesManual, downloadUpdate } from './auto-updater';
@@ -672,6 +673,11 @@ safeHandle('db:sessionEvents:getGlobalStats', (since?: string) =>
 
 safeHandle('db:sessionEvents:getToolUseCounts', (sessionId?: string) =>
   sessionEventsRepo.getToolUseCounts(sessionId)
+);
+
+// Session Export IPC Handlers (BDHLNDR-20)
+safeHandle('export:sessions', (format: ExportFormat, since?: string) =>
+  exportSessions({ format, since })
 );
 
 // Preferences IPC Handlers

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,13 +6,14 @@ import * as groupsRepo from './repositories/groups';
 import * as sessionsRepo from './repositories/sessions';
 import * as prefsRepo from './repositories/preferences';
 import * as memoriesRepo from './repositories/memories';
+import * as sessionEventsRepo from './repositories/session-events';
 import { StateMonitor } from './state-monitor';
 import { createApplicationMenu } from './menu';
 import { initAutoUpdater, checkForUpdatesManual, downloadUpdate } from './auto-updater';
 import { notificationManager } from './notification-manager';
 import { trayManager } from './tray-manager';
 import { soundManager, SoundEvent } from './sound-manager';
-import { Group, Session, MemoryCreateInput, MemoryUpdateInput } from '../shared/types';
+import { Group, Session, SessionState, MemoryCreateInput, MemoryUpdateInput } from '../shared/types';
 import { authService } from './sharing/auth';
 import { shareManager } from './sharing/share-manager';
 import { teamsAuthService } from './teams/teams-auth';
@@ -264,12 +265,24 @@ function createWindow(): void {
   // Mark all sessions as stopped on startup (PTY processes don't survive restarts)
   sessionsRepo.markAllSessionsStopped();
 
+  // Prune session events older than 90 days (BDHLNDR-17)
+  try {
+    const pruned = sessionEventsRepo.pruneEvents(new Date(Date.now() - 90 * 24 * 60 * 60 * 1000));
+    if (pruned > 0) {
+      log.info(`[SessionEvents] Pruned ${pruned} events older than 90 days`);
+    }
+  } catch (error) {
+    log.error('Failed to prune session events:', error);
+  }
+
   // Start state monitor
   stateMonitor = new StateMonitor(ptyManager.getSocketPath());
   stateMonitor.start();
 
   stateMonitor.on('stateChange', (event) => {
     mainWindow?.webContents.send('state:change', event);
+    // Track previous state for event logging
+    const previousState = sessionStates.get(event.sessionId)?.state as SessionState | undefined;
     // Update database with error handling
     try {
       sessionsRepo.updateSession(event.sessionId, {
@@ -278,6 +291,24 @@ function createWindow(): void {
       });
     } catch (error) {
       console.error('Failed to update session state in database:', error);
+    }
+    // Log session event (BDHLNDR-17)
+    try {
+      sessionEventsRepo.createEvent(event.sessionId, 'state_change', {
+        from: previousState ?? 'unknown',
+        to: event.state,
+      });
+      if (event.state === 'stopped') {
+        sessionEventsRepo.createEvent(event.sessionId, 'session_stop', null);
+        const breakdown = sessionEventsRepo.getStateBreakdown(event.sessionId);
+        const activeSeconds = (breakdown['working'] || 0) + (breakdown['waiting'] || 0);
+        sessionsRepo.updateSession(event.sessionId, {
+          endedAt: new Date(),
+          durationSeconds: activeSeconds,
+        });
+      }
+    } catch (error) {
+      log.error('Failed to log session event:', error);
     }
     // Handle notifications and tray updates
     handleStateChange(event.sessionId, event.state);
@@ -385,6 +416,8 @@ function createWindow(): void {
   // PTY state detection forwarding
   ptyManager.on('stateChange', (event) => {
     mainWindow?.webContents.send('state:change', event);
+    // Track previous state for event logging
+    const previousState = sessionStates.get(event.sessionId)?.state as SessionState | undefined;
     // Update database
     try {
       sessionsRepo.updateSession(event.sessionId, {
@@ -393,6 +426,24 @@ function createWindow(): void {
       });
     } catch (error) {
       console.error('Failed to update session state in database:', error);
+    }
+    // Log session event (BDHLNDR-17)
+    try {
+      sessionEventsRepo.createEvent(event.sessionId, 'state_change', {
+        from: previousState ?? 'unknown',
+        to: event.state,
+      });
+      if (event.state === 'stopped') {
+        sessionEventsRepo.createEvent(event.sessionId, 'session_stop', null);
+        const breakdown = sessionEventsRepo.getStateBreakdown(event.sessionId);
+        const activeSeconds = (breakdown['working'] || 0) + (breakdown['waiting'] || 0);
+        sessionsRepo.updateSession(event.sessionId, {
+          endedAt: new Date(),
+          durationSeconds: activeSeconds,
+        });
+      }
+    } catch (error) {
+      log.error('Failed to log session event:', error);
     }
     // Handle notifications and tray updates
     handleStateChange(event.sessionId, event.state);
@@ -538,6 +589,12 @@ safeHandle('db:sessions:getAll', () => {
 
 safeHandle('db:sessions:create', (session: Session) => {
   sessionsRepo.createSession(session);
+  // Log session start event (BDHLNDR-17)
+  try {
+    sessionEventsRepo.createEvent(session.id, 'session_start', null);
+  } catch (error) {
+    log.error('Failed to log session_start event:', error);
+  }
   getApiServer().broadcastSessionsUpdated();
 });
 
@@ -597,6 +654,27 @@ safeHandle('db:memories:getById', (id: string) => {
 safeHandle('db:memories:getGlobal', () => {
   return memoriesRepo.getGlobalContextMemories();
 });
+
+// Database IPC Handlers - Session Events (BDHLNDR-17)
+safeHandle('db:sessionEvents:getBySession', (sessionId: string, limit?: number) =>
+  sessionEventsRepo.getEventsBySession(sessionId, limit)
+);
+
+safeHandle('db:sessionEvents:getSessionStats', (sessionId: string) =>
+  sessionEventsRepo.getSessionStats(sessionId)
+);
+
+safeHandle('db:sessionEvents:getGlobalStats', (since?: string) =>
+  sessionEventsRepo.getGlobalStats(since ? new Date(since) : undefined)
+);
+
+safeHandle('db:sessionEvents:getToolUseCounts', (sessionId?: string) =>
+  sessionEventsRepo.getToolUseCounts(sessionId)
+);
+
+safeHandle('db:sessionEvents:getEventsSince', (since: string, sessionId?: string) =>
+  sessionEventsRepo.getEventsSince(new Date(since), sessionId)
+);
 
 // Preferences IPC Handlers
 safeHandle('prefs:get', (key: string) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -149,6 +149,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('memory:extracted', listener);
     return () => ipcRenderer.removeListener('memory:extracted', listener);
   },
+
+  // Database - Session Events (BDHLNDR-17)
+  getSessionEvents: (sessionId: string, limit?: number): Promise<SessionEvent[]> =>
+    ipcRenderer.invoke('db:sessionEvents:getBySession', sessionId, limit),
+  getSessionStats: (sessionId: string): Promise<SessionStats> =>
+    ipcRenderer.invoke('db:sessionEvents:getSessionStats', sessionId),
+  getGlobalStats: (since?: string): Promise<GlobalStats> =>
+    ipcRenderer.invoke('db:sessionEvents:getGlobalStats', since),
+  getToolUseCounts: (sessionId?: string): Promise<Record<string, number>> =>
+    ipcRenderer.invoke('db:sessionEvents:getToolUseCounts', sessionId),
 
   // Preferences
   getPreference: (key: string): Promise<string | null> =>

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -160,6 +160,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getToolUseCounts: (sessionId?: string): Promise<Record<string, number>> =>
     ipcRenderer.invoke('db:sessionEvents:getToolUseCounts', sessionId),
 
+  // Session Export (BDHLNDR-20)
+  exportSessions: (format: 'csv' | 'json', since?: string): Promise<{ success: boolean; filePath?: string; error?: string; sessionCount?: number; eventCount?: number }> =>
+    ipcRenderer.invoke('export:sessions', format, since),
+
   // Preferences
   getPreference: (key: string): Promise<string | null> =>
     ipcRenderer.invoke('prefs:get', key),

--- a/src/main/repositories/session-events.ts
+++ b/src/main/repositories/session-events.ts
@@ -1,0 +1,243 @@
+import { getDatabase } from '../database';
+import { SessionEvent, SessionEventType, SessionStats, GlobalStats } from '../../shared/types';
+
+interface SessionEventRow {
+  id: string;
+  session_id: string;
+  event_type: string;
+  event_data: string | null;
+  created_at: string;
+}
+
+function rowToSessionEvent(row: SessionEventRow): SessionEvent {
+  return {
+    id: row.id,
+    sessionId: row.session_id,
+    eventType: row.event_type as SessionEventType,
+    eventData: row.event_data ? JSON.parse(row.event_data) : null,
+    createdAt: new Date(row.created_at),
+  };
+}
+
+export function createEvent(
+  sessionId: string,
+  eventType: SessionEventType,
+  eventData?: Record<string, unknown> | null
+): SessionEvent {
+  const db = getDatabase();
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const data = eventData ? JSON.stringify(eventData) : null;
+
+  db.prepare(`
+    INSERT INTO session_events (id, session_id, event_type, event_data, created_at)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(id, sessionId, eventType, data, now);
+
+  return {
+    id,
+    sessionId,
+    eventType,
+    eventData: eventData ?? null,
+    createdAt: new Date(now),
+  };
+}
+
+export function getEventsBySession(sessionId: string, limit: number = 500): SessionEvent[] {
+  const db = getDatabase();
+  const rows = db.prepare(
+    'SELECT * FROM session_events WHERE session_id = ? ORDER BY created_at DESC LIMIT ?'
+  ).all(sessionId, limit) as SessionEventRow[];
+  return rows.map(rowToSessionEvent);
+}
+
+export function getEventsByType(eventType: SessionEventType, limit: number = 500): SessionEvent[] {
+  const db = getDatabase();
+  const rows = db.prepare(
+    'SELECT * FROM session_events WHERE event_type = ? ORDER BY created_at DESC LIMIT ?'
+  ).all(eventType, limit) as SessionEventRow[];
+  return rows.map(rowToSessionEvent);
+}
+
+export function getEventsSince(since: Date, sessionId?: string): SessionEvent[] {
+  const db = getDatabase();
+  const sinceStr = since.toISOString();
+  let rows: SessionEventRow[];
+
+  if (sessionId) {
+    rows = db.prepare(
+      'SELECT * FROM session_events WHERE created_at >= ? AND session_id = ? ORDER BY created_at ASC'
+    ).all(sinceStr, sessionId) as SessionEventRow[];
+  } else {
+    rows = db.prepare(
+      'SELECT * FROM session_events WHERE created_at >= ? ORDER BY created_at ASC'
+    ).all(sinceStr) as SessionEventRow[];
+  }
+
+  return rows.map(rowToSessionEvent);
+}
+
+export function getLastEvent(sessionId: string): SessionEvent | null {
+  const db = getDatabase();
+  const row = db.prepare(
+    'SELECT * FROM session_events WHERE session_id = ? ORDER BY created_at DESC LIMIT 1'
+  ).get(sessionId) as SessionEventRow | undefined;
+  return row ? rowToSessionEvent(row) : null;
+}
+
+export function getToolUseCounts(sessionId?: string): Record<string, number> {
+  const db = getDatabase();
+  let rows: { tool: string; count: number }[];
+
+  if (sessionId) {
+    rows = db.prepare(`
+      SELECT json_extract(event_data, '$.tool_name') as tool, COUNT(*) as count
+      FROM session_events
+      WHERE event_type = 'tool_use' AND session_id = ?
+      GROUP BY tool
+      ORDER BY count DESC
+    `).all(sessionId) as { tool: string; count: number }[];
+  } else {
+    rows = db.prepare(`
+      SELECT json_extract(event_data, '$.tool_name') as tool, COUNT(*) as count
+      FROM session_events
+      WHERE event_type = 'tool_use'
+      GROUP BY tool
+      ORDER BY count DESC
+    `).all() as { tool: string; count: number }[];
+  }
+
+  const counts: Record<string, number> = {};
+  for (const row of rows) {
+    if (row.tool) {
+      counts[row.tool] = row.count;
+    }
+  }
+  return counts;
+}
+
+export function getStateBreakdown(sessionId: string): Record<string, number> {
+  const db = getDatabase();
+
+  // Get all state-related events in chronological order
+  const rows = db.prepare(`
+    SELECT event_type, event_data, created_at
+    FROM session_events
+    WHERE session_id = ? AND event_type IN ('state_change', 'session_start', 'session_stop')
+    ORDER BY created_at ASC
+  `).all(sessionId) as { event_type: string; event_data: string | null; created_at: string }[];
+
+  const breakdown: Record<string, number> = {};
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    const nextRow = rows[i + 1];
+
+    if (row.event_type === 'state_change' && row.event_data && nextRow) {
+      const data = JSON.parse(row.event_data);
+      const toState = data.to as string;
+      const currentTime = new Date(row.created_at).getTime();
+      const nextTime = new Date(nextRow.created_at).getTime();
+      const seconds = (nextTime - currentTime) / 1000;
+
+      breakdown[toState] = (breakdown[toState] || 0) + seconds;
+    }
+  }
+
+  return breakdown;
+}
+
+export function getSessionStats(sessionId: string): SessionStats {
+  const db = getDatabase();
+
+  const countRow = db.prepare(
+    'SELECT COUNT(*) as count FROM session_events WHERE session_id = ?'
+  ).get(sessionId) as { count: number };
+
+  const durationRow = db.prepare(
+    'SELECT duration_seconds FROM sessions WHERE id = ?'
+  ).get(sessionId) as { duration_seconds: number } | undefined;
+
+  return {
+    totalEvents: countRow.count,
+    totalDurationSeconds: durationRow?.duration_seconds ?? 0,
+    toolUseCounts: getToolUseCounts(sessionId),
+    stateBreakdown: getStateBreakdown(sessionId),
+  };
+}
+
+export function getGlobalStats(since?: Date): GlobalStats {
+  const db = getDatabase();
+  const sinceStr = since?.toISOString();
+
+  // Total sessions
+  let totalSessions: number;
+  if (sinceStr) {
+    totalSessions = (db.prepare(
+      'SELECT COUNT(DISTINCT session_id) as count FROM session_events WHERE created_at >= ?'
+    ).get(sinceStr) as { count: number }).count;
+  } else {
+    totalSessions = (db.prepare(
+      'SELECT COUNT(DISTINCT session_id) as count FROM session_events'
+    ).get() as { count: number }).count;
+  }
+
+  // Total events
+  let totalEvents: number;
+  if (sinceStr) {
+    totalEvents = (db.prepare(
+      'SELECT COUNT(*) as count FROM session_events WHERE created_at >= ?'
+    ).get(sinceStr) as { count: number }).count;
+  } else {
+    totalEvents = (db.prepare(
+      'SELECT COUNT(*) as count FROM session_events'
+    ).get() as { count: number }).count;
+  }
+
+  // Total duration
+  let totalDurationSeconds: number;
+  if (sinceStr) {
+    totalDurationSeconds = (db.prepare(
+      'SELECT COALESCE(SUM(duration_seconds), 0) as total FROM sessions WHERE created_at >= ?'
+    ).get(sinceStr) as { total: number }).total;
+  } else {
+    totalDurationSeconds = (db.prepare(
+      'SELECT COALESCE(SUM(duration_seconds), 0) as total FROM sessions'
+    ).get() as { total: number }).total;
+  }
+
+  // Events per day
+  let eventsPerDay: { date: string; count: number }[];
+  if (sinceStr) {
+    eventsPerDay = db.prepare(`
+      SELECT date(created_at) as date, COUNT(*) as count
+      FROM session_events
+      WHERE created_at >= ?
+      GROUP BY date(created_at)
+      ORDER BY date ASC
+    `).all(sinceStr) as { date: string; count: number }[];
+  } else {
+    eventsPerDay = db.prepare(`
+      SELECT date(created_at) as date, COUNT(*) as count
+      FROM session_events
+      GROUP BY date(created_at)
+      ORDER BY date ASC
+    `).all() as { date: string; count: number }[];
+  }
+
+  return {
+    totalSessions,
+    totalEvents,
+    totalDurationSeconds,
+    eventsPerDay,
+    toolUseCounts: getToolUseCounts(),
+  };
+}
+
+export function pruneEvents(olderThan: Date): number {
+  const db = getDatabase();
+  const result = db.prepare(
+    'DELETE FROM session_events WHERE created_at < ?'
+  ).run(olderThan.toISOString());
+  return result.changes;
+}

--- a/src/main/repositories/session-events.ts
+++ b/src/main/repositories/session-events.ts
@@ -9,12 +9,21 @@ interface SessionEventRow {
   created_at: string;
 }
 
+function safeJsonParse(json: string | null): Record<string, unknown> | null {
+  if (!json) return null;
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
 function rowToSessionEvent(row: SessionEventRow): SessionEvent {
   return {
     id: row.id,
     sessionId: row.session_id,
     eventType: row.event_type as SessionEventType,
-    eventData: row.event_data ? JSON.parse(row.event_data) : null,
+    eventData: safeJsonParse(row.event_data),
     createdAt: new Date(row.created_at),
   };
 }
@@ -59,19 +68,19 @@ export function getEventsByType(eventType: SessionEventType, limit: number = 500
   return rows.map(rowToSessionEvent);
 }
 
-export function getEventsSince(since: Date, sessionId?: string): SessionEvent[] {
+export function getEventsSince(since: Date, sessionId?: string, limit: number = 10000): SessionEvent[] {
   const db = getDatabase();
   const sinceStr = since.toISOString();
   let rows: SessionEventRow[];
 
   if (sessionId) {
     rows = db.prepare(
-      'SELECT * FROM session_events WHERE created_at >= ? AND session_id = ? ORDER BY created_at ASC'
-    ).all(sinceStr, sessionId) as SessionEventRow[];
+      'SELECT * FROM session_events WHERE created_at >= ? AND session_id = ? ORDER BY created_at ASC LIMIT ?'
+    ).all(sinceStr, sessionId, limit) as SessionEventRow[];
   } else {
     rows = db.prepare(
-      'SELECT * FROM session_events WHERE created_at >= ? ORDER BY created_at ASC'
-    ).all(sinceStr) as SessionEventRow[];
+      'SELECT * FROM session_events WHERE created_at >= ? ORDER BY created_at ASC LIMIT ?'
+    ).all(sinceStr, limit) as SessionEventRow[];
   }
 
   return rows.map(rowToSessionEvent);
@@ -131,17 +140,20 @@ export function getStateBreakdown(sessionId: string): Record<string, number> {
 
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
+    if (row.event_type !== 'state_change' || !row.event_data) continue;
+
+    const data = safeJsonParse(row.event_data);
+    if (!data?.to) continue;
+
+    const toState = data.to as string;
+    const currentTime = new Date(row.created_at).getTime();
+
+    // Use next event's time as boundary, or current time for open-ended final interval
     const nextRow = rows[i + 1];
+    const nextTime = nextRow ? new Date(nextRow.created_at).getTime() : Date.now();
+    const seconds = (nextTime - currentTime) / 1000;
 
-    if (row.event_type === 'state_change' && row.event_data && nextRow) {
-      const data = JSON.parse(row.event_data);
-      const toState = data.to as string;
-      const currentTime = new Date(row.created_at).getTime();
-      const nextTime = new Date(nextRow.created_at).getTime();
-      const seconds = (nextTime - currentTime) / 1000;
-
-      breakdown[toState] = (breakdown[toState] || 0) + seconds;
-    }
+    breakdown[toState] = (breakdown[toState] || 0) + seconds;
   }
 
   return breakdown;

--- a/src/main/repositories/sessions.ts
+++ b/src/main/repositories/sessions.ts
@@ -1,6 +1,12 @@
 import { getDatabase } from '../database';
 import { Session, SessionState } from '../../shared/types';
 
+export function sessionExists(id: string): boolean {
+  const db = getDatabase();
+  const row = db.prepare('SELECT 1 FROM sessions WHERE id = ? LIMIT 1').get(id);
+  return !!row;
+}
+
 export function getAllSessions(): Session[] {
   const db = getDatabase();
   const rows = db.prepare('SELECT * FROM sessions ORDER BY "order"').all() as any[];

--- a/src/main/repositories/sessions.ts
+++ b/src/main/repositories/sessions.ts
@@ -16,14 +16,16 @@ export function getAllSessions(): Session[] {
     createdAt: new Date(row.created_at),
     lastActivityAt: new Date(row.last_activity_at),
     claudeSessionId: row.claude_session_id ?? null,
+    endedAt: row.ended_at ? new Date(row.ended_at) : null,
+    durationSeconds: row.duration_seconds ?? 0,
   }));
 }
 
 export function createSession(session: Session): void {
   const db = getDatabase();
   db.prepare(`
-    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at, claude_session_id)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at, claude_session_id, ended_at, duration_seconds)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     session.id,
     session.groupId,
@@ -34,7 +36,9 @@ export function createSession(session: Session): void {
     session.order,
     session.createdAt.toISOString(),
     session.lastActivityAt.toISOString(),
-    session.claudeSessionId ?? null
+    session.claudeSessionId ?? null,
+    session.endedAt ? session.endedAt.toISOString() : null,
+    session.durationSeconds ?? 0
   );
 }
 
@@ -91,6 +95,14 @@ export function updateSession(id: string, updates: Partial<Session>): void {
   if (updates.lastActivityAt !== undefined) {
     fields.push('last_activity_at = ?');
     values.push(updates.lastActivityAt.toISOString());
+  }
+  if (updates.endedAt !== undefined) {
+    fields.push('ended_at = ?');
+    values.push(updates.endedAt ? updates.endedAt.toISOString() : null);
+  }
+  if (updates.durationSeconds !== undefined) {
+    fields.push('duration_seconds = ?');
+    values.push(updates.durationSeconds);
   }
 
   if (fields.length > 0) {

--- a/src/main/session-export.ts
+++ b/src/main/session-export.ts
@@ -1,0 +1,209 @@
+/**
+ * Session Export — BDHLNDR-20
+ *
+ * Formats session data as CSV or JSON and writes to a user-selected file.
+ */
+
+import { dialog, app } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as sessionsRepo from './repositories/sessions';
+import * as sessionEventsRepo from './repositories/session-events';
+import * as groupsRepo from './repositories/groups';
+import log from 'electron-log';
+
+export type ExportFormat = 'csv' | 'json';
+
+interface ExportOptions {
+  format: ExportFormat;
+  since?: string; // ISO date string
+}
+
+interface ExportResult {
+  success: boolean;
+  filePath?: string;
+  error?: string;
+  sessionCount?: number;
+  eventCount?: number;
+}
+
+function escapeCSV(value: string | number | null | undefined): string {
+  if (value == null) return '';
+  const str = String(value);
+  if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function formatDuration(seconds: number): string {
+  if (!seconds || seconds < 1) return '0s';
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+
+function buildCSV(since?: string): { content: string; sessionCount: number } {
+  const sessions = sessionsRepo.getAllSessions();
+  const groups = groupsRepo.getAllGroups();
+  const groupMap = new Map(groups.map(g => [g.id, g.name]));
+
+  // Filter by date if specified
+  const filtered = since
+    ? sessions.filter(s => new Date(s.createdAt).toISOString() >= since)
+    : sessions;
+
+  const headers = [
+    'Session Name',
+    'Group',
+    'State',
+    'Working Directory',
+    'Created At',
+    'Last Activity',
+    'Ended At',
+    'Duration',
+    'Duration (seconds)',
+    'Total Events',
+    'Tool Calls',
+    'Top Tools',
+  ];
+
+  const rows: string[] = [headers.map(escapeCSV).join(',')];
+
+  for (const session of filtered) {
+    const stats = sessionEventsRepo.getSessionStats(session.id);
+    const toolEntries = Object.entries(stats.toolUseCounts);
+    const totalTools = toolEntries.reduce((sum, [, count]) => sum + count, 0);
+    const topTools = toolEntries
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([name, count]) => `${name}(${count})`)
+      .join('; ');
+
+    rows.push([
+      escapeCSV(session.name),
+      escapeCSV(groupMap.get(session.groupId) ?? 'Unknown'),
+      escapeCSV(session.state),
+      escapeCSV(session.workingDir),
+      escapeCSV(session.createdAt instanceof Date ? session.createdAt.toISOString() : String(session.createdAt)),
+      escapeCSV(session.lastActivityAt instanceof Date ? session.lastActivityAt.toISOString() : String(session.lastActivityAt)),
+      escapeCSV(session.endedAt instanceof Date ? session.endedAt.toISOString() : ''),
+      escapeCSV(formatDuration(session.durationSeconds)),
+      escapeCSV(Math.round(session.durationSeconds)),
+      escapeCSV(stats.totalEvents),
+      escapeCSV(totalTools),
+      escapeCSV(topTools),
+    ].join(','));
+  }
+
+  // BOM for Excel UTF-8 compatibility
+  return { content: '\uFEFF' + rows.join('\r\n'), sessionCount: filtered.length };
+}
+
+function buildJSON(since?: string): { content: string; sessionCount: number; eventCount: number } {
+  const sessions = sessionsRepo.getAllSessions();
+  const groups = groupsRepo.getAllGroups();
+  const groupMap = new Map(groups.map(g => [g.id, g.name]));
+
+  const filtered = since
+    ? sessions.filter(s => new Date(s.createdAt).toISOString() >= since)
+    : sessions;
+
+  let totalEvents = 0;
+  const exportData = filtered.map(session => {
+    const stats = sessionEventsRepo.getSessionStats(session.id);
+    const events = sessionEventsRepo.getEventsBySession(session.id, 10000);
+    totalEvents += events.length;
+
+    return {
+      session: {
+        id: session.id,
+        name: session.name,
+        group: groupMap.get(session.groupId) ?? 'Unknown',
+        groupId: session.groupId,
+        state: session.state,
+        workingDir: session.workingDir,
+        createdAt: session.createdAt instanceof Date ? session.createdAt.toISOString() : session.createdAt,
+        lastActivityAt: session.lastActivityAt instanceof Date ? session.lastActivityAt.toISOString() : session.lastActivityAt,
+        endedAt: session.endedAt instanceof Date ? session.endedAt.toISOString() : session.endedAt,
+        durationSeconds: session.durationSeconds,
+      },
+      stats: {
+        totalEvents: stats.totalEvents,
+        totalDurationSeconds: stats.totalDurationSeconds,
+        toolUseCounts: stats.toolUseCounts,
+        stateBreakdown: stats.stateBreakdown,
+      },
+      events: events.map(e => ({
+        id: e.id,
+        eventType: e.eventType,
+        eventData: e.eventData,
+        createdAt: e.createdAt instanceof Date ? e.createdAt.toISOString() : e.createdAt,
+      })),
+    };
+  });
+
+  const output = {
+    exportedAt: new Date().toISOString(),
+    appVersion: app.getVersion(),
+    sessionCount: filtered.length,
+    totalEvents,
+    sessions: exportData,
+  };
+
+  return {
+    content: JSON.stringify(output, null, 2),
+    sessionCount: filtered.length,
+    eventCount: totalEvents,
+  };
+}
+
+export async function exportSessions(options: ExportOptions): Promise<ExportResult> {
+  try {
+    const defaultName = `bodhilander-sessions-${new Date().toISOString().slice(0, 10)}`;
+    const ext = options.format === 'csv' ? 'csv' : 'json';
+
+    const result = await dialog.showSaveDialog({
+      title: `Export Sessions (${options.format.toUpperCase()})`,
+      defaultPath: path.join(app.getPath('documents'), `${defaultName}.${ext}`),
+      filters: options.format === 'csv'
+        ? [{ name: 'CSV Files', extensions: ['csv'] }]
+        : [{ name: 'JSON Files', extensions: ['json'] }],
+    });
+
+    if (result.canceled || !result.filePath) {
+      return { success: false, error: 'Export cancelled' };
+    }
+
+    let content: string;
+    let sessionCount: number;
+    let eventCount = 0;
+
+    if (options.format === 'csv') {
+      const csv = buildCSV(options.since);
+      content = csv.content;
+      sessionCount = csv.sessionCount;
+    } else {
+      const json = buildJSON(options.since);
+      content = json.content;
+      sessionCount = json.sessionCount;
+      eventCount = json.eventCount;
+    }
+
+    fs.writeFileSync(result.filePath, content, 'utf-8');
+    log.info(`[Export] Exported ${sessionCount} sessions to ${result.filePath}`);
+
+    return {
+      success: true,
+      filePath: result.filePath,
+      sessionCount,
+      eventCount,
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    log.error('[Export] Failed to export sessions:', msg);
+    return { success: false, error: msg };
+  }
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { NamePromptModal } from './components/NamePromptModal';
 import { SettingsModal } from './components/SettingsModal';
 import { NewItemChoice } from './components/NewItemChoice';
 import { MemoryPanel } from './components/panels/MemoryPanel';
+import AnalyticsPanel from './components/panels/AnalyticsPanel';
 import { CodeSearchModal } from './components/CodeSearchModal';
 import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
@@ -92,6 +93,9 @@ const App: React.FC = () => {
 
   // Memory panel state
   const [memoryPanelOpen, setMemoryPanelOpen] = useState(false);
+
+  // Analytics view state (BDHLNDR-18)
+  const [analyticsViewOpen, setAnalyticsViewOpen] = useState(false);
 
   // Code search modal state
   const [codeSearchOpen, setCodeSearchOpen] = useState(false);
@@ -737,6 +741,7 @@ const App: React.FC = () => {
     onExpand: handleExpand,
     onSelect: handleSelect,
     onCodeSearch: handleCodeSearch,
+    onToggleAnalytics: () => setAnalyticsViewOpen(prev => !prev),
   }), [handleKeyboardNewSession, handleNextSession, handlePrevSession, handleNextWaiting, handleCloseSession, handleFocusSidebar, handleNewGroup, handleNewSubGroup, handleNavigateUp, handleNavigateDown, handleCollapse, handleExpand, handleSelect, handleCodeSearch]);
 
   useKeyboardShortcuts(shortcutHandlers);
@@ -837,6 +842,14 @@ const App: React.FC = () => {
               aria-label="Toggle Memory Panel"
             >
               *
+            </button>
+            <button
+              className={`icon-button ${analyticsViewOpen ? 'active' : ''}`}
+              onClick={() => setAnalyticsViewOpen(prev => !prev)}
+              title="Analytics Dashboard (Ctrl+Shift+A)"
+              aria-label="Analytics Dashboard"
+            >
+              📊
             </button>
             <button
               className="icon-button"
@@ -1285,6 +1298,9 @@ const App: React.FC = () => {
       </aside>
 
       <main className="main">
+        {analyticsViewOpen ? (
+          <AnalyticsPanel onClose={() => setAnalyticsViewOpen(false)} />
+        ) : (
         <div className="terminal-area">
           {sessions.map(session => (
             <div
@@ -1374,6 +1390,7 @@ const App: React.FC = () => {
             </div>
           )}
         </div>
+        )}
       </main>
 
       {/* Memory Panel */}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,6 +10,7 @@ import { SettingsModal } from './components/SettingsModal';
 import { NewItemChoice } from './components/NewItemChoice';
 import { MemoryPanel } from './components/panels/MemoryPanel';
 import AnalyticsPanel from './components/panels/AnalyticsPanel';
+import { SessionStatsBadge } from './components/SessionStatsBadge';
 import { CodeSearchModal } from './components/CodeSearchModal';
 import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
@@ -1038,6 +1039,7 @@ const App: React.FC = () => {
                           {session.name}
                         </span>
                       )}
+                      <SessionStatsBadge sessionId={session.id} />
                     </div>
                     {sharingSessions.has(session.id) && (
                       <span className="share-indicator" title="Sharing" draggable={false}>⇄</span>
@@ -1209,6 +1211,7 @@ const App: React.FC = () => {
                             {session.name}
                           </span>
                         )}
+                        <SessionStatsBadge sessionId={session.id} />
                       </div>
                       {sharingSessions.has(session.id) && (
                         <span className="share-indicator" title="Sharing">⇄</span>

--- a/src/renderer/components/SessionStatsBadge.tsx
+++ b/src/renderer/components/SessionStatsBadge.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useSessionStats, formatDuration, formatStatsTooltip } from '../store/session-stats';
+
+interface SessionStatsBadgeProps {
+  sessionId: string;
+}
+
+/**
+ * Compact stats badge for sidebar session entries (BDHLNDR-19).
+ * Shows duration and event count in a single line below the session name.
+ */
+export function SessionStatsBadge({ sessionId }: SessionStatsBadgeProps) {
+  const { stats } = useSessionStats(sessionId);
+
+  if (!stats || stats.totalEvents === 0) return null;
+
+  const duration = formatDuration(stats.totalDurationSeconds);
+  const totalTools = Object.values(stats.toolUseCounts).reduce((sum, c) => sum + c, 0);
+
+  const parts: string[] = [];
+  if (duration) parts.push(duration);
+  if (totalTools > 0) parts.push(`${totalTools} tools`);
+  if (parts.length === 0) parts.push(`${stats.totalEvents} events`);
+
+  return (
+    <span
+      className="session-stats-badge"
+      title={formatStatsTooltip(stats)}
+    >
+      {parts.join(' · ')}
+    </span>
+  );
+}

--- a/src/renderer/components/TerminalHeader.tsx
+++ b/src/renderer/components/TerminalHeader.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Session } from '../../shared/types';
+import { useSessionStats, formatDuration, formatStatsTooltip } from '../store/session-stats';
 
 interface TerminalHeaderProps {
   session: Session;
@@ -20,6 +21,7 @@ const TerminalHeader: React.FC<TerminalHeaderProps> = ({
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(session.name);
+  const { stats } = useSessionStats(session.id);
 
   const handleFinishEdit = () => {
     if (editName.trim() && editName !== session.name) {
@@ -74,6 +76,22 @@ const TerminalHeader: React.FC<TerminalHeaderProps> = ({
       <span className="header-path" title={session.workingDir}>
         {truncatePath(session.workingDir)}
       </span>
+
+      {stats && stats.totalEvents > 0 && (
+        <span className="header-stats" title={formatStatsTooltip(stats)}>
+          {formatDuration(stats.totalDurationSeconds) && (
+            <span className="header-stat">{formatDuration(stats.totalDurationSeconds)}</span>
+          )}
+          {stats.totalEvents > 0 && (
+            <span className="header-stat">{stats.totalEvents} events</span>
+          )}
+          {Object.values(stats.toolUseCounts).reduce((s, c) => s + c, 0) > 0 && (
+            <span className="header-stat">
+              {Object.values(stats.toolUseCounts).reduce((s, c) => s + c, 0)} tools
+            </span>
+          )}
+        </span>
+      )}
 
       <div className="header-actions">
         <button className="header-action" onClick={onRestart} title="Restart session" aria-label="Restart session">

--- a/src/renderer/components/panels/AnalyticsPanel.css
+++ b/src/renderer/components/panels/AnalyticsPanel.css
@@ -1,0 +1,269 @@
+/* AnalyticsPanel.css — BDHLNDR-18 */
+
+.analytics-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #1e1e1e;
+  overflow: hidden;
+}
+
+/* Header */
+.analytics-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid #3c3c3c;
+  background: #252526;
+  flex-shrink: 0;
+}
+
+.analytics-header h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #d4d4d4;
+}
+
+.analytics-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Time Range Selector */
+.time-range-selector {
+  display: flex;
+  gap: 2px;
+  background: #1e1e1e;
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.time-range-btn {
+  padding: 4px 10px;
+  font-size: 11px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: #888;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.time-range-btn:hover {
+  color: #d4d4d4;
+  background: #3c3c3c;
+}
+
+.time-range-btn.active {
+  background: #5a7aff;
+  color: #fff;
+}
+
+/* Body */
+.analytics-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Summary Stats Row */
+.analytics-summary {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.stat-card {
+  background: #252526;
+  border: 1px solid #3c3c3c;
+  border-radius: 8px;
+  padding: 16px;
+  text-align: center;
+}
+
+.stat-value {
+  font-size: 24px;
+  font-weight: 700;
+  color: #d4d4d4;
+  line-height: 1.2;
+}
+
+.stat-label {
+  font-size: 11px;
+  color: #888;
+  margin-top: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Charts Grid */
+.analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+/* Chart Card */
+.chart-card {
+  background: #252526;
+  border: 1px solid #3c3c3c;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.chart-card-title {
+  color: #d4d4d4;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+
+.chart-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 120px;
+  color: #666;
+  font-size: 13px;
+}
+
+/* Time Breakdown */
+.time-breakdown {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 120px;
+  gap: 8px;
+}
+
+.time-breakdown-total {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.time-breakdown-value {
+  font-size: 32px;
+  font-weight: 700;
+  color: #4ade80;
+}
+
+.time-breakdown-label {
+  font-size: 12px;
+  color: #888;
+}
+
+.time-breakdown-detail {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #888;
+}
+
+.time-breakdown-sep {
+  color: #555;
+}
+
+/* Activity Feed */
+.activity-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.activity-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  transition: background 0.1s;
+}
+
+.activity-item:hover {
+  background: #2a2a2a;
+}
+
+.activity-icon {
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #333;
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.activity-icon-session_start { color: #4ade80; }
+.activity-icon-session_stop { color: #888; }
+.activity-icon-state_change { color: #61afef; }
+.activity-icon-tool_use { color: #e5c07b; }
+.activity-icon-turn_complete { color: #5a7aff; }
+.activity-icon-error { color: #e06c75; }
+.activity-icon-notification { color: #c678dd; }
+
+.activity-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.activity-label {
+  font-size: 12px;
+  color: #d4d4d4;
+}
+
+.activity-detail {
+  font-size: 11px;
+  color: #888;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-time {
+  font-size: 11px;
+  color: #666;
+  flex-shrink: 0;
+}
+
+/* Loading & Error States */
+.analytics-loading,
+.analytics-error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #888;
+  font-size: 14px;
+}
+
+.analytics-error {
+  color: #e06c75;
+}
+
+/* Responsive: stack on narrow widths */
+@media (max-width: 700px) {
+  .analytics-summary {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .analytics-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/renderer/components/panels/AnalyticsPanel.css
+++ b/src/renderer/components/panels/AnalyticsPanel.css
@@ -26,6 +26,19 @@
   color: #d4d4d4;
 }
 
+.export-buttons {
+  display: flex;
+  gap: 4px;
+}
+
+.export-buttons .icon-button {
+  font-size: 10px;
+  width: auto;
+  padding: 2px 8px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
 .analytics-header-actions {
   display: flex;
   align-items: center;

--- a/src/renderer/components/panels/AnalyticsPanel.tsx
+++ b/src/renderer/components/panels/AnalyticsPanel.tsx
@@ -1,0 +1,378 @@
+import React, { useState } from 'react';
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
+  PieChart, Pie, Cell, ResponsiveContainer, Legend,
+} from 'recharts';
+import { useAnalytics, TimeRange } from '../../store/analytics';
+import { useSessions } from '../../store/sessions';
+import { SessionEvent, Session } from '../../../shared/types';
+import './AnalyticsPanel.css';
+
+// Theme colors matching existing dark theme
+const COLORS = {
+  primary: '#5a7aff',
+  working: '#4ade80',
+  waiting: '#e5c07b',
+  idle: '#61afef',
+  error: '#e06c75',
+  stopped: '#888',
+  purple: '#c678dd',
+  text: '#888',
+  textPrimary: '#d4d4d4',
+  grid: '#333',
+  cardBg: '#252526',
+  tooltipBg: '#1e1e1e',
+  border: '#3c3c3c',
+};
+
+const STATE_COLORS: Record<string, string> = {
+  working: COLORS.working,
+  waiting: COLORS.waiting,
+  idle: COLORS.idle,
+  error: COLORS.error,
+  stopped: COLORS.stopped,
+};
+
+const TOOLTIP_STYLE = {
+  backgroundColor: COLORS.tooltipBg,
+  border: `1px solid ${COLORS.border}`,
+  borderRadius: '6px',
+  color: COLORS.textPrimary,
+  fontSize: '12px',
+};
+
+// --- Utility functions ---
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+function formatEventTime(date: Date | string): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  const now = new Date();
+  const diff = now.getTime() - d.getTime();
+  if (diff < 60000) return 'just now';
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function eventTypeLabel(type: string): string {
+  switch (type) {
+    case 'session_start': return 'Session started';
+    case 'session_stop': return 'Session stopped';
+    case 'state_change': return 'State changed';
+    case 'tool_use': return 'Tool used';
+    case 'turn_complete': return 'Turn completed';
+    case 'error': return 'Error';
+    case 'notification': return 'Notification';
+    default: return type;
+  }
+}
+
+function eventTypeIcon(type: string): string {
+  switch (type) {
+    case 'session_start': return '▶';
+    case 'session_stop': return '■';
+    case 'state_change': return '↻';
+    case 'tool_use': return '⚡';
+    case 'turn_complete': return '✓';
+    case 'error': return '✗';
+    case 'notification': return '🔔';
+    default: return '•';
+  }
+}
+
+// --- Sub-components ---
+
+function TimeRangeSelector({ value, onChange }: { value: TimeRange; onChange: (v: TimeRange) => void }) {
+  const ranges: { label: string; value: TimeRange }[] = [
+    { label: 'Today', value: 'today' },
+    { label: '7 days', value: '7d' },
+    { label: '30 days', value: '30d' },
+    { label: 'All time', value: 'all' },
+  ];
+  return (
+    <div className="time-range-selector">
+      {ranges.map(r => (
+        <button
+          key={r.value}
+          className={`time-range-btn ${value === r.value ? 'active' : ''}`}
+          onClick={() => onChange(r.value)}
+        >
+          {r.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="stat-card">
+      <div className="stat-value">{typeof value === 'number' ? formatNumber(value) : value}</div>
+      <div className="stat-label">{label}</div>
+    </div>
+  );
+}
+
+function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="chart-card">
+      <div className="chart-card-title">{title}</div>
+      {children}
+    </div>
+  );
+}
+
+function ActivityChart({ data }: { data: { date: string; count: number }[] }) {
+  if (!data || data.length === 0) {
+    return <div className="chart-empty">No activity data yet</div>;
+  }
+
+  const formatted = data.map(d => ({
+    date: new Date(d.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+    events: d.count,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <BarChart data={formatted} margin={{ top: 5, right: 5, bottom: 5, left: -10 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke={COLORS.grid} vertical={false} />
+        <XAxis dataKey="date" tick={{ fill: COLORS.text, fontSize: 11 }} axisLine={false} tickLine={false} />
+        <YAxis tick={{ fill: COLORS.text, fontSize: 11 }} axisLine={false} tickLine={false} allowDecimals={false} />
+        <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'rgba(90, 122, 255, 0.1)' }} />
+        <Bar dataKey="events" fill={COLORS.primary} radius={[3, 3, 0, 0]} maxBarSize={40} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function StateDistributionChart({ sessions }: { sessions: Session[] }) {
+  const counts: Record<string, number> = {};
+  for (const s of sessions) {
+    counts[s.state] = (counts[s.state] || 0) + 1;
+  }
+
+  const data = Object.entries(counts)
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value - a.value);
+
+  if (data.length === 0) {
+    return <div className="chart-empty">No sessions</div>;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <PieChart>
+        <Pie
+          data={data}
+          cx="50%"
+          cy="50%"
+          innerRadius={50}
+          outerRadius={80}
+          paddingAngle={2}
+          dataKey="value"
+          label={({ name, value }) => `${name} (${value})`}
+        >
+          {data.map((entry) => (
+            <Cell key={entry.name} fill={STATE_COLORS[entry.name] || COLORS.text} />
+          ))}
+        </Pie>
+        <Tooltip contentStyle={TOOLTIP_STYLE} />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}
+
+function ToolUsageChart({ data }: { data: Record<string, number> }) {
+  const entries = Object.entries(data)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([name, count]) => ({ name, count }));
+
+  if (entries.length === 0) {
+    return <div className="chart-empty">No tool usage data yet</div>;
+  }
+
+  const barColors = [COLORS.primary, COLORS.purple, COLORS.idle, COLORS.working, COLORS.waiting, COLORS.error, COLORS.stopped, COLORS.text];
+
+  return (
+    <ResponsiveContainer width="100%" height={Math.max(150, entries.length * 32)}>
+      <BarChart data={entries} layout="vertical" margin={{ top: 5, right: 5, bottom: 5, left: 50 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke={COLORS.grid} horizontal={false} />
+        <XAxis type="number" tick={{ fill: COLORS.text, fontSize: 11 }} axisLine={false} tickLine={false} allowDecimals={false} />
+        <YAxis type="category" dataKey="name" tick={{ fill: COLORS.text, fontSize: 11 }} axisLine={false} tickLine={false} width={60} />
+        <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'rgba(90, 122, 255, 0.1)' }} />
+        <Bar dataKey="count" radius={[0, 3, 3, 0]} maxBarSize={24}>
+          {entries.map((_, i) => (
+            <Cell key={i} fill={barColors[i % barColors.length]} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function TimeBreakdownChart({ sessions }: { sessions: Session[] }) {
+  // Aggregate duration across all sessions by computing from current state counts
+  // Use session durations for stopped sessions
+  const stoppedDuration = sessions
+    .filter(s => s.state === 'stopped')
+    .reduce((sum, s) => sum + (s.durationSeconds || 0), 0);
+
+  const data = [
+    { name: 'Active', seconds: stoppedDuration, fill: COLORS.working },
+  ];
+
+  // Count currently running sessions
+  const activeSessions = sessions.filter(s => s.state === 'working' || s.state === 'waiting' || s.state === 'idle');
+  if (activeSessions.length > 0) {
+    data.push({ name: 'In Progress', seconds: activeSessions.length, fill: COLORS.idle });
+  }
+
+  if (stoppedDuration === 0 && activeSessions.length === 0) {
+    return <div className="chart-empty">No duration data yet</div>;
+  }
+
+  return (
+    <div className="time-breakdown">
+      <div className="time-breakdown-total">
+        <span className="time-breakdown-value">{formatDuration(stoppedDuration)}</span>
+        <span className="time-breakdown-label">Total active time across all sessions</span>
+      </div>
+      <div className="time-breakdown-detail">
+        <span className="time-breakdown-count">{sessions.filter(s => s.state === 'stopped').length} completed</span>
+        <span className="time-breakdown-sep">·</span>
+        <span className="time-breakdown-count">{activeSessions.length} in progress</span>
+      </div>
+    </div>
+  );
+}
+
+function RecentActivityFeed({ events }: { events: SessionEvent[] }) {
+  if (events.length === 0) {
+    return <div className="chart-empty">No recent activity</div>;
+  }
+
+  return (
+    <div className="activity-feed">
+      {events.map(event => (
+        <div key={event.id} className="activity-item">
+          <span className={`activity-icon activity-icon-${event.eventType}`}>
+            {eventTypeIcon(event.eventType)}
+          </span>
+          <div className="activity-content">
+            <span className="activity-label">{eventTypeLabel(event.eventType)}</span>
+            {event.eventType === 'tool_use' && event.eventData?.tool_name != null && (
+              <span className="activity-detail">{String(event.eventData.tool_name)}</span>
+            )}
+            {event.eventType === 'state_change' && event.eventData?.from != null && (
+              <span className="activity-detail">
+                {String(event.eventData.from)} → {String(event.eventData.to)}
+              </span>
+            )}
+          </div>
+          <span className="activity-time">{formatEventTime(event.createdAt)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// --- Main Component ---
+
+interface AnalyticsPanelProps {
+  onClose: () => void;
+}
+
+export default function AnalyticsPanel({ onClose }: AnalyticsPanelProps) {
+  const [timeRange, setTimeRange] = useState<TimeRange>('7d');
+  const { globalStats, recentEvents, loading, error, refresh } = useAnalytics(timeRange);
+  const { sessions } = useSessions();
+
+  if (loading && !globalStats) {
+    return (
+      <div className="analytics-panel">
+        <div className="analytics-header">
+          <h2>Analytics</h2>
+          <div className="analytics-header-actions">
+            <button className="icon-button" onClick={onClose} title="Close">×</button>
+          </div>
+        </div>
+        <div className="analytics-loading">Loading analytics...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="analytics-panel">
+        <div className="analytics-header">
+          <h2>Analytics</h2>
+          <div className="analytics-header-actions">
+            <button className="icon-button" onClick={refresh} title="Retry">↻</button>
+            <button className="icon-button" onClick={onClose} title="Close">×</button>
+          </div>
+        </div>
+        <div className="analytics-error">Failed to load analytics: {error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="analytics-panel">
+      <div className="analytics-header">
+        <h2>Analytics</h2>
+        <div className="analytics-header-actions">
+          <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          <button className="icon-button" onClick={refresh} title="Refresh">↻</button>
+          <button className="icon-button" onClick={onClose} title="Close">×</button>
+        </div>
+      </div>
+
+      <div className="analytics-body">
+        {/* Summary stats row */}
+        <div className="analytics-summary">
+          <StatCard label="Sessions" value={globalStats?.totalSessions ?? 0} />
+          <StatCard label="Events" value={globalStats?.totalEvents ?? 0} />
+          <StatCard label="Active Time" value={formatDuration(globalStats?.totalDurationSeconds ?? 0)} />
+          <StatCard label="Tools Used" value={Object.keys(globalStats?.toolUseCounts ?? {}).length} />
+        </div>
+
+        {/* Charts grid */}
+        <div className="analytics-grid">
+          <ChartCard title="Session Activity">
+            <ActivityChart data={globalStats?.eventsPerDay ?? []} />
+          </ChartCard>
+
+          <ChartCard title="Session States">
+            <StateDistributionChart sessions={sessions} />
+          </ChartCard>
+
+          <ChartCard title="Top Tools">
+            <ToolUsageChart data={globalStats?.toolUseCounts ?? {}} />
+          </ChartCard>
+
+          <ChartCard title="Time Summary">
+            <TimeBreakdownChart sessions={sessions} />
+          </ChartCard>
+        </div>
+
+        {/* Recent activity */}
+        <ChartCard title="Recent Activity">
+          <RecentActivityFeed events={recentEvents} />
+        </ChartCard>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/panels/AnalyticsPanel.tsx
+++ b/src/renderer/components/panels/AnalyticsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
   PieChart, Pie, Cell, ResponsiveContainer, Legend,
@@ -289,6 +289,50 @@ function RecentActivityFeed({ events }: { events: SessionEvent[] }) {
   );
 }
 
+// --- Export ---
+
+function ExportButtons({ timeRange }: { timeRange: TimeRange }) {
+  const [exporting, setExporting] = useState(false);
+
+  const handleExport = useCallback(async (format: 'csv' | 'json') => {
+    setExporting(true);
+    try {
+      const since = timeRange === 'all' ? undefined : (() => {
+        const now = new Date();
+        switch (timeRange) {
+          case 'today': now.setHours(0, 0, 0, 0); return now.toISOString();
+          case '7d': now.setDate(now.getDate() - 7); return now.toISOString();
+          case '30d': now.setDate(now.getDate() - 30); return now.toISOString();
+        }
+      })();
+      await window.electronAPI.exportSessions(format, since);
+    } finally {
+      setExporting(false);
+    }
+  }, [timeRange]);
+
+  return (
+    <div className="export-buttons">
+      <button
+        className="icon-button"
+        onClick={() => handleExport('csv')}
+        disabled={exporting}
+        title="Export as CSV"
+      >
+        {exporting ? '...' : 'CSV'}
+      </button>
+      <button
+        className="icon-button"
+        onClick={() => handleExport('json')}
+        disabled={exporting}
+        title="Export as JSON"
+      >
+        {exporting ? '...' : 'JSON'}
+      </button>
+    </div>
+  );
+}
+
 // --- Main Component ---
 
 interface AnalyticsPanelProps {
@@ -335,6 +379,7 @@ export default function AnalyticsPanel({ onClose }: AnalyticsPanelProps) {
         <h2>Analytics</h2>
         <div className="analytics-header-actions">
           <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          <ExportButtons timeRange={timeRange} />
           <button className="icon-button" onClick={refresh} title="Refresh">↻</button>
           <button className="icon-button" onClick={onClose} title="Close">×</button>
         </div>

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -60,6 +60,12 @@ interface ElectronAPI {
   getMemoryById: (id: string) => Promise<Memory | null>;
   getGlobalContextMemories: () => Promise<Memory[]>;
   onMemoryExtracted: (callback: (memory: Memory) => void) => () => void;
+
+  // Session Events (BDHLNDR-17)
+  getSessionEvents: (sessionId: string, limit?: number) => Promise<SessionEvent[]>;
+  getSessionStats: (sessionId: string) => Promise<SessionStats>;
+  getGlobalStats: (since?: string) => Promise<GlobalStats>;
+  getToolUseCounts: (sessionId?: string) => Promise<Record<string, number>>;
 
   // Preferences
   getPreference: (key: string) => Promise<string | null>;

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -67,6 +67,9 @@ interface ElectronAPI {
   getGlobalStats: (since?: string) => Promise<GlobalStats>;
   getToolUseCounts: (sessionId?: string) => Promise<Record<string, number>>;
 
+  // Session Export (BDHLNDR-20)
+  exportSessions: (format: 'csv' | 'json', since?: string) => Promise<{ success: boolean; filePath?: string; error?: string; sessionCount?: number; eventCount?: number }>;
+
   // Preferences
   getPreference: (key: string) => Promise<string | null>;
   setPreference: (key: string, value: string) => Promise<void>;

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -15,6 +15,7 @@ interface ShortcutHandlers {
   onExpand?: () => void;
   onSelect?: () => void;
   onCodeSearch?: () => void;
+  onToggleAnalytics?: () => void;
 }
 
 export function useKeyboardShortcuts(handlers: ShortcutHandlers) {
@@ -88,6 +89,12 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers) {
     if (isMod && e.shiftKey && key === 'f') {
       e.preventDefault();
       handlers.onCodeSearch?.();
+    }
+
+    // Ctrl+Shift+A = Analytics dashboard
+    if (isMod && e.shiftKey && key === 'a') {
+      e.preventDefault();
+      handlers.onToggleAnalytics?.();
     }
   }, [handlers]);
 

--- a/src/renderer/store/analytics.ts
+++ b/src/renderer/store/analytics.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useCallback } from 'react';
+import { GlobalStats, SessionEvent } from '../../shared/types';
+
+export type TimeRange = 'today' | '7d' | '30d' | 'all';
+
+function timeRangeToSince(range: TimeRange): string | undefined {
+  if (range === 'all') return undefined;
+  const now = new Date();
+  switch (range) {
+    case 'today':
+      now.setHours(0, 0, 0, 0);
+      return now.toISOString();
+    case '7d':
+      now.setDate(now.getDate() - 7);
+      return now.toISOString();
+    case '30d':
+      now.setDate(now.getDate() - 30);
+      return now.toISOString();
+  }
+}
+
+interface UseAnalyticsResult {
+  globalStats: GlobalStats | null;
+  recentEvents: SessionEvent[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+export function useAnalytics(timeRange: TimeRange): UseAnalyticsResult {
+  const [globalStats, setGlobalStats] = useState<GlobalStats | null>(null);
+  const [recentEvents, setRecentEvents] = useState<SessionEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadStats = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const since = timeRangeToSince(timeRange);
+      const stats = await window.electronAPI.getGlobalStats(since);
+      setGlobalStats(stats);
+
+      // Load recent events (last 30 across all sessions)
+      const allSessions = await window.electronAPI.getAllSessions();
+      const allEvents: SessionEvent[] = [];
+      // Fetch last few events per session, then sort globally
+      for (const session of allSessions.slice(0, 20)) {
+        const events = await window.electronAPI.getSessionEvents(session.id, 10);
+        allEvents.push(...events);
+      }
+      allEvents.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      setRecentEvents(allEvents.slice(0, 30));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load analytics');
+    } finally {
+      setLoading(false);
+    }
+  }, [timeRange]);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
+  return { globalStats, recentEvents, loading, error, refresh: loadStats };
+}

--- a/src/renderer/store/session-stats.ts
+++ b/src/renderer/store/session-stats.ts
@@ -1,0 +1,75 @@
+import { useState, useEffect, useCallback } from 'react';
+import { SessionStats } from '../../shared/types';
+
+interface UseSessionStatsResult {
+  stats: SessionStats | null;
+  loading: boolean;
+}
+
+export function useSessionStats(sessionId: string | null): UseSessionStatsResult {
+  const [stats, setStats] = useState<SessionStats | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const loadStats = useCallback(async () => {
+    if (!sessionId) {
+      setStats(null);
+      return;
+    }
+    try {
+      setLoading(true);
+      const result = await window.electronAPI.getSessionStats(sessionId);
+      setStats(result);
+    } catch {
+      setStats(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
+  // Refresh stats periodically while session is active (every 30s)
+  useEffect(() => {
+    if (!sessionId) return;
+    const interval = setInterval(loadStats, 30000);
+    return () => clearInterval(interval);
+  }, [sessionId, loadStats]);
+
+  return { stats, loading };
+}
+
+export function formatDuration(seconds: number): string {
+  if (!seconds || seconds < 1) return '';
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+export function formatStatsTooltip(stats: SessionStats): string {
+  const lines: string[] = [];
+  if (stats.totalDurationSeconds > 0) {
+    lines.push(`Duration: ${formatDuration(stats.totalDurationSeconds)}`);
+  }
+  lines.push(`Events: ${stats.totalEvents}`);
+  const toolEntries = Object.entries(stats.toolUseCounts);
+  if (toolEntries.length > 0) {
+    const totalTools = toolEntries.reduce((sum, [, count]) => sum + count, 0);
+    lines.push(`Tool calls: ${totalTools}`);
+    for (const [name, count] of toolEntries.slice(0, 5)) {
+      lines.push(`  ${name}: ${count}`);
+    }
+  }
+  const stateEntries = Object.entries(stats.stateBreakdown);
+  if (stateEntries.length > 0) {
+    lines.push('Time breakdown:');
+    for (const [state, secs] of stateEntries) {
+      const dur = formatDuration(secs);
+      if (dur) lines.push(`  ${state}: ${dur}`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/src/renderer/store/sessions.ts
+++ b/src/renderer/store/sessions.ts
@@ -60,6 +60,8 @@ export function useSessions() {
           createdAt: new Date(),
           lastActivityAt: new Date(),
           claudeSessionId: null,
+          endedAt: null,
+          durationSeconds: 0,
         };
 
         // Persist asynchronously

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -372,14 +372,29 @@ body {
   flex: 1;
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
 }
 
 .session-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.session-stats-badge {
+  font-size: 10px;
+  color: #666;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.2;
+  cursor: help;
+}
+
+.session.active .session-stats-badge {
+  color: #888;
 }
 
 .session-name-input {
@@ -640,6 +655,25 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.header-stats {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+  cursor: help;
+}
+
+.header-stat {
+  font-size: 11px;
+  color: #666;
+  white-space: nowrap;
+}
+
+.header-stat + .header-stat::before {
+  content: '·';
+  margin-right: 8px;
+  color: #555;
 }
 
 .header-actions {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -89,6 +89,9 @@ export interface ElectronAPI {
   getGlobalStats: (since?: string) => Promise<GlobalStats>;
   getToolUseCounts: (sessionId?: string) => Promise<Record<string, number>>;
 
+  // Session Export (BDHLNDR-20)
+  exportSessions: (format: 'csv' | 'json', since?: string) => Promise<{ success: boolean; filePath?: string; error?: string; sessionCount?: number; eventCount?: number }>;
+
   // Preferences
   getPreference: (key: string) => Promise<string | null>;
   setPreference: (key: string, value: string) => Promise<void>;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -19,6 +19,9 @@ import {
   SymbolSearchResult,
   IndexProgress,
   SymbolType,
+  SessionEvent,
+  SessionStats,
+  GlobalStats,
 } from '../../shared/types';
 
 interface StateChangeEvent {
@@ -79,6 +82,12 @@ export interface ElectronAPI {
   getMemoryById: (id: string) => Promise<Memory | null>;
   getGlobalContextMemories: () => Promise<Memory[]>;
   onMemoryExtracted: (callback: (memory: Memory) => void) => () => void;
+
+  // Session Events (BDHLNDR-17)
+  getSessionEvents: (sessionId: string, limit?: number) => Promise<SessionEvent[]>;
+  getSessionStats: (sessionId: string) => Promise<SessionStats>;
+  getGlobalStats: (since?: string) => Promise<GlobalStats>;
+  getToolUseCounts: (sessionId?: string) => Promise<Record<string, number>>;
 
   // Preferences
   getPreference: (key: string) => Promise<string | null>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -15,6 +15,10 @@ export interface Session {
    * Null for non-Claude sessions or Claude sessions that have not been launched yet.
    */
   claudeSessionId: string | null;
+  /** When the session was stopped/ended (BDHLNDR-17). Null if still active. */
+  endedAt: Date | null;
+  /** Active time in seconds (working + waiting states), not wall clock (BDHLNDR-17). */
+  durationSeconds: number;
 }
 
 export interface Group {
@@ -201,6 +205,37 @@ export interface MemoryEvent {
     source: 'claude';
   };
   timestamp: number;
+}
+
+// =============================================================================
+// Session Event Types (BDHLNDR-17)
+// =============================================================================
+// Types for session event tracking and analytics
+// =============================================================================
+
+export type SessionEventType = 'session_start' | 'session_stop' | 'state_change' | 'tool_use' | 'error' | 'notification';
+
+export interface SessionEvent {
+  id: string;
+  sessionId: string;
+  eventType: SessionEventType;
+  eventData: Record<string, unknown> | null;
+  createdAt: Date;
+}
+
+export interface SessionStats {
+  totalEvents: number;
+  totalDurationSeconds: number;
+  toolUseCounts: Record<string, number>;
+  stateBreakdown: Record<string, number>; // state name → seconds
+}
+
+export interface GlobalStats {
+  totalSessions: number;
+  totalEvents: number;
+  totalDurationSeconds: number;
+  eventsPerDay: { date: string; count: number }[];
+  toolUseCounts: Record<string, number>;
 }
 
 // =============================================================================

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -213,7 +213,7 @@ export interface MemoryEvent {
 // Types for session event tracking and analytics
 // =============================================================================
 
-export type SessionEventType = 'session_start' | 'session_stop' | 'state_change' | 'tool_use' | 'error' | 'notification';
+export type SessionEventType = 'session_start' | 'session_stop' | 'state_change' | 'tool_use' | 'turn_complete' | 'error' | 'notification';
 
 export interface SessionEvent {
   id: string;


### PR DESCRIPTION
## Release v3.2.0

### Session Analytics Dashboard (Epic BDHLNDR-14)

**New features:**

- **Session event tracking** (BDHLNDR-17) — Every session state change, tool use, and Claude turn is logged with timestamps. Sessions track active duration (working + waiting time). Events auto-prune after 90 days.

- **Analytics dashboard** (BDHLNDR-18) — New dashboard accessible from sidebar (📊) or Ctrl+Shift+A. Shows session activity over time, state distribution, top tools, time summary, and recent activity feed. Time range filtering (today/7d/30d/all). Built with Recharts.

- **Per-session stats** (BDHLNDR-19) — Session duration and tool count visible at a glance in the sidebar and terminal header. Hover tooltip shows full breakdown. Auto-refreshes every 30 seconds.

- **Session export** (BDHLNDR-20) — Export session history as CSV or JSON from the analytics dashboard. CSV opens in Excel/Google Sheets. JSON includes full event data. Date range filtering applies to exports.

### Dependencies added
- `recharts ^3.8.1` (React charting library)

### PRs included
- #17 — feat(BDHLNDR-17): session events table and duration/state tracking
- #18 — feat(BDHLNDR-18): analytics dashboard with charts and activity feed
- #19 — feat(BDHLNDR-19): per-session stats in sidebar and terminal header
- #20 — feat(BDHLNDR-20): session history export (CSV/JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)