### PR TITLE
fix: terminal width mismatch and scroll-to-bottom on idle/focus

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -32,6 +32,9 @@ interface PtySession {
   workingDebounce: NodeJS.Timeout | null;
   recentOutputBytes: number;
   lastOutputTime: number;
+  /** Last known column/row count — used to detect actual size changes. */
+  lastCols: number;
+  lastRows: number;
 }
 
 // Max scrollback buffer size (100KB should be plenty for recent terminal history)
@@ -250,6 +253,8 @@ class PtyManager extends EventEmitter {
       workingDebounce: null,
       recentOutputBytes: 0,
       lastOutputTime: 0,
+      lastCols: 80,
+      lastRows: 24,
     });
 
   }
@@ -263,9 +268,12 @@ class PtyManager extends EventEmitter {
 
   resize(id: string, cols: number, rows: number): void {
     const session = this.sessions.get(id);
-    if (session) {
-      session.pty.resize(cols, rows);
-    }
+    if (!session) return;
+    // Skip no-op resizes to avoid unnecessary ConPTY churn on Windows
+    if (session.lastCols === cols && session.lastRows === rows) return;
+    session.lastCols = cols;
+    session.lastRows = rows;
+    session.pty.resize(cols, rows);
   }
 
   kill(id: string): Promise<void> {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1308,6 +1308,7 @@ const App: React.FC = () => {
                   isStopped={session.state === 'stopped'}
                   restartKey={restartKeys[session.id] || 0}
                   isActive={session.id === activeSessionId}
+                  sessionState={session.state}
                   onStart={() => updateSession(session.id, { state: 'idle' })}
                   onError={() => updateSession(session.id, { state: 'error' })}
                 />

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -12,6 +12,7 @@ interface TerminalProps {
   isStopped?: boolean;
   restartKey?: number;
   isActive?: boolean;
+  sessionState?: string;
   onStart?: () => void;
   onError?: (error: string) => void;
 }
@@ -25,11 +26,12 @@ interface ContextMenuState {
 
 const PASTE_DEBOUNCE_MS = 300;
 
-const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true, isStopped = false, restartKey = 0, isActive = false, onStart, onError }) => {
+const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true, isStopped = false, restartKey = 0, isActive = false, sessionState, onStart, onError }) => {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const lastPasteTimeRef = useRef<number>(0);
+  const prevSessionStateRef = useRef<string | undefined>(sessionState);
   const [isRunning, setIsRunning] = useState(!isStopped);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({ visible: false, x: 0, y: 0, hasSelection: false });
   const [error, setError] = useState<string | null>(null);
@@ -69,16 +71,57 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     return () => window.removeEventListener('focus-terminal', handleFocusTerminal);
   }, [isActive]);
 
-  // Scroll to bottom when terminal becomes active (session switch)
+  // Refit and scroll to bottom when terminal becomes active (session switch).
+  // The display:none→flex transition means xterm may not have correct
+  // dimensions on the first animation frame. The multi-pass approach ensures
+  // the PTY gets the right column count and xterm reflows its buffer.
+  const fitAndSync = useCallback(() => {
+    if (fitAddonRef.current && xtermRef.current) {
+      fitAddonRef.current.fit();
+      const { cols, rows } = xtermRef.current;
+      window.electronAPI.resizeSession(sessionId, cols, rows);
+    }
+  }, [sessionId]);
+
   useEffect(() => {
     if (isActive && xtermRef.current && fitAddonRef.current) {
-      // Fit first to ensure dimensions are correct, then scroll to bottom
       requestAnimationFrame(() => {
-        fitAddonRef.current?.fit();
+        fitAndSync();
+        xtermRef.current?.scrollToBottom();
+        // Second pass: re-fit after the browser has flushed the display
+        // change, which triggers xterm buffer reflow to correct width.
+        requestAnimationFrame(() => {
+          fitAndSync();
+          xtermRef.current?.scrollToBottom();
+        });
+      });
+      // Third pass as a safety net for slower layout transitions.
+      const safetyTimer = setTimeout(() => {
+        if (fitAddonRef.current && xtermRef.current) {
+          fitAndSync();
+          xtermRef.current.scrollToBottom();
+        }
+      }, 150);
+      return () => clearTimeout(safetyTimer);
+    }
+  }, [isActive, fitAndSync]);
+
+  // Scroll to bottom when Claude transitions to idle or waiting (i.e. it
+  // finished a burst of work). This keeps the latest output visible without
+  // the user having to manually scroll down after every task.
+  useEffect(() => {
+    const prev = prevSessionStateRef.current;
+    prevSessionStateRef.current = sessionState;
+
+    if (!xtermRef.current || !isActive) return;
+
+    const scrollTargets = ['idle', 'waiting'];
+    if (sessionState && scrollTargets.includes(sessionState) && prev && prev !== sessionState) {
+      requestAnimationFrame(() => {
         xtermRef.current?.scrollToBottom();
       });
     }
-  }, [isActive]);
+  }, [sessionState, isActive]);
 
   // Copy text from terminal selection
   const handleCopy = useCallback(() => {


### PR DESCRIPTION
## Summary
- **Width mismatch fix**: Multi-pass fit+resize on session activation (double-rAF + 150ms safety timer) ensures xterm measures the container *after* the `display:none→flex` reflow completes, which triggers xterm's internal buffer reflow to the correct column width — fixing past entries that were hard-wrapped at the wrong width
- **Scroll to bottom on state change**: Terminal now receives `sessionState` prop and auto-scrolls to bottom when Claude transitions to `idle` or `waiting` (finished a burst of work)
- **Scroll timing fix**: The existing scroll-to-bottom on session focus was firing before layout settled; the multi-pass approach ensures it sticks
- **PTY resize optimization**: Tracks `lastCols`/`lastRows` per session and skips no-op resizes to reduce unnecessary ConPTY churn on Windows

## Test plan
- [ ] Open multiple sessions, resize the window, switch between sessions — verify past output reflows to correct width
- [ ] Let Claude complete a task — verify terminal scrolls to show latest output when it goes idle
- [ ] Switch between sessions — verify terminal is scrolled to bottom, not top
- [ ] Verify no regressions with terminal input, copy/paste, or context menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)