### PR TITLE
fix: terminal width/scroll improvements

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -43,6 +43,9 @@ interface PtySession {
   claudeResumeAttempted: boolean;
   /** Wall-clock spawn time (ms) for early-exit detection. */
   spawnedAt: number;
+  /** Last known column/row count — used to detect actual size changes. */
+  lastCols: number;
+  lastRows: number;
 }
 
 /**
@@ -331,6 +334,8 @@ class PtyManager extends EventEmitter {
       claudeSessionId,
       claudeResumeAttempted: claudeSessionMode === 'resume',
       spawnedAt: Date.now(),
+      lastCols: 80,
+      lastRows: 24,
     });
 
   }
@@ -344,9 +349,12 @@ class PtyManager extends EventEmitter {
 
   resize(id: string, cols: number, rows: number): void {
     const session = this.sessions.get(id);
-    if (session) {
-      session.pty.resize(cols, rows);
-    }
+    if (!session) return;
+    // Skip no-op resizes to avoid unnecessary ConPTY churn on Windows
+    if (session.lastCols === cols && session.lastRows === rows) return;
+    session.lastCols = cols;
+    session.lastRows = rows;
+    session.pty.resize(cols, rows);
   }
 
   kill(id: string): Promise<void> {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1330,6 +1330,7 @@ const App: React.FC = () => {
                   isStopped={session.state === 'stopped'}
                   restartKey={restartKeys[session.id] || 0}
                   isActive={session.id === activeSessionId}
+                  sessionState={session.state}
                   onStart={() => updateSession(session.id, { state: 'idle' })}
                   onError={() => updateSession(session.id, { state: 'error' })}
                 />

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -12,6 +12,7 @@ interface TerminalProps {
   isStopped?: boolean;
   restartKey?: number;
   isActive?: boolean;
+  sessionState?: string;
   onStart?: () => void;
   onError?: (error: string) => void;
 }
@@ -25,12 +26,13 @@ interface ContextMenuState {
 
 const PASTE_DEBOUNCE_MS = 300;
 
-const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true, isStopped = false, restartKey = 0, isActive = false, onStart, onError }) => {
+const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true, isStopped = false, restartKey = 0, isActive = false, sessionState, onStart, onError }) => {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const webglAddonRef = useRef<WebglAddon | null>(null);
   const lastPasteTimeRef = useRef<number>(0);
+  const prevSessionStateRef = useRef<string | undefined>(sessionState);
   const [isRunning, setIsRunning] = useState(!isStopped);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({ visible: false, x: 0, y: 0, hasSelection: false });
   const [error, setError] = useState<string | null>(null);
@@ -88,14 +90,49 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   // with `display: none` (App.tsx:1293). Without a PTY resize here, the shell
   // keeps emitting at the stale column count and the visible output appears
   // hard-wrapped to a narrow width (BDHLNDR-12).
+  //
+  // The double-rAF + setTimeout ensures xterm has fully laid out after the
+  // display:none→flex transition before we attempt to scroll. A single rAF
+  // can fire before the browser has flushed the new layout.
   useEffect(() => {
     if (isActive && xtermRef.current && fitAddonRef.current) {
       requestAnimationFrame(() => {
         handleResize();
         xtermRef.current?.scrollToBottom();
+        // Second pass: re-fit after the browser has flushed the display
+        // change, which triggers xterm buffer reflow to correct width.
+        requestAnimationFrame(() => {
+          handleResize();
+          xtermRef.current?.scrollToBottom();
+        });
       });
+      // Third pass as a safety net for slower layout transitions.
+      const safetyTimer = setTimeout(() => {
+        if (fitAddonRef.current && xtermRef.current) {
+          handleResize();
+          xtermRef.current.scrollToBottom();
+        }
+      }, 150);
+      return () => clearTimeout(safetyTimer);
     }
   }, [isActive, handleResize]);
+
+  // Scroll to bottom when Claude transitions to idle or waiting (i.e. it
+  // finished a burst of work). This keeps the latest output visible without
+  // the user having to manually scroll down after every task.
+  useEffect(() => {
+    const prev = prevSessionStateRef.current;
+    prevSessionStateRef.current = sessionState;
+
+    if (!xtermRef.current || !isActive) return;
+
+    const scrollTargets = ['idle', 'waiting'];
+    if (sessionState && scrollTargets.includes(sessionState) && prev && prev !== sessionState) {
+      requestAnimationFrame(() => {
+        xtermRef.current?.scrollToBottom();
+      });
+    }
+  }, [sessionState, isActive]);
 
   // Copy text from terminal selection
   const handleCopy = useCallback(() => {


### PR DESCRIPTION
## Summary
- Multi-pass fit+resize on session activation fixes terminal width mismatch for past entries
- Auto scroll-to-bottom when Claude transitions to idle or waiting
- Improved scroll timing on session focus (double-rAF + safety timer)
- PTY resize optimization: skip no-op resizes to reduce ConPTY churn

## Test plan
- [x] Verified clean merge from development
- [ ] Smoke test terminal width on session switch
- [ ] Verify scroll-to-bottom on idle transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)