### PR TITLE
fix(BDHLNDR-30): smart auto-scroll to prevent terminal viewport jumps

### DIFF
--- a/docs/plans/2026-04-06-smart-auto-scroll-design.md
+++ b/docs/plans/2026-04-06-smart-auto-scroll-design.md
@@ -1,0 +1,40 @@
+# BDHLNDR-30: Smart Auto-Scroll for Terminal
+
+## Problem
+
+During long Claude Code streaming output, the xterm.js terminal viewport spontaneously jumps to random scroll positions. The jump distance varies. Root cause: xterm.js viewport loses sync during rapid `term.write()` calls.
+
+## Solution: Smart Auto-Scroll
+
+Before each `term.write()`, check if the user's viewport is "near the bottom" of the terminal buffer. If yes, call `scrollToBottom()` after the write to keep it pinned. If the user has intentionally scrolled up (viewport is far from bottom), leave them alone.
+
+### Detection Logic
+
+```
+isNearBottom = (buffer.baseY - buffer.viewportY) <= SCROLL_THRESHOLD
+```
+
+- `buffer.baseY` — how many lines have scrolled off the top (grows as output streams)
+- `buffer.viewportY` — current viewport scroll offset
+- `SCROLL_THRESHOLD` — 5 lines of tolerance to account for minor drift
+
+### Change Scope
+
+**Single file:** `src/renderer/components/Terminal.tsx`
+
+In the `onPtyData` handler (line 263-267), wrap the `term.write()` call:
+
+1. Read `term.buffer.active.baseY` and `term.buffer.active.viewportY`
+2. Determine if user is near bottom (`baseY - viewportY <= 5`)
+3. Call `term.write(data)`
+4. If was near bottom, call `term.scrollToBottom()`
+
+### Fallback Plan
+
+If smart auto-scroll is insufficient:
+- **Phase 2:** Add pin-to-bottom toggle button in TerminalHeader
+- **Phase 3:** Full setting in SettingsModal terminal tab
+
+## Risk
+
+Low — single file change, no new dependencies, no settings/IPC changes. The threshold (5 lines) can be tuned if needed.

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -25,6 +25,10 @@ interface ContextMenuState {
 }
 
 const PASTE_DEBOUNCE_MS = 300;
+// BDHLNDR-30: Number of lines from bottom to consider "near bottom" for auto-scroll.
+// If the user is within this many lines of the bottom, new output will pin the
+// viewport to the bottom. If they've scrolled further up, they won't be disturbed.
+const AUTO_SCROLL_THRESHOLD = 5;
 
 const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true, isStopped = false, restartKey = 0, isActive = false, sessionState, onStart, onError }) => {
   const terminalRef = useRef<HTMLDivElement>(null);
@@ -296,10 +300,20 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
         onError?.(errorMsg);
       });
 
-    // Handle PTY data
+    // Handle PTY data with smart auto-scroll (BDHLNDR-30)
+    // During rapid streaming, xterm.js viewport can lose sync and jump to random
+    // positions. Fix: if the user is near the bottom before the write, pin them
+    // to the bottom after the write. If they've scrolled up intentionally, leave
+    // them alone.
     const cleanupPtyData = window.electronAPI.onPtyData((id, data) => {
       if (id === sessionId) {
-        term.write(data);
+        const buf = term.buffer.active;
+        const wasNearBottom = (buf.baseY - buf.viewportY) <= AUTO_SCROLL_THRESHOLD;
+        term.write(data, () => {
+          if (wasNearBottom) {
+            term.scrollToBottom();
+          }
+        });
       }
     });
 

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -301,19 +301,32 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       });
 
     // Handle PTY data with smart auto-scroll (BDHLNDR-30)
-    // During rapid streaming, xterm.js viewport can lose sync and jump to random
-    // positions. Fix: if the user is near the bottom before the write, pin them
-    // to the bottom after the write. If they've scrolled up intentionally, leave
-    // them alone.
+    // During rapid streaming — especially when Claude rewrites lines in-place
+    // (task lists, progress indicators) via ANSI cursor-movement codes — the
+    // xterm.js viewport can desync and jump to random positions. Fix: if the
+    // user is near the bottom before the write, schedule a single
+    // requestAnimationFrame scroll correction that fires after the browser has
+    // processed all writes and redraws for that frame.
+    let scrollRafId = 0;
+    let shouldPin = false;
     const cleanupPtyData = window.electronAPI.onPtyData((id, data) => {
       if (id === sessionId) {
         const buf = term.buffer.active;
-        const wasNearBottom = (buf.baseY - buf.viewportY) <= AUTO_SCROLL_THRESHOLD;
-        term.write(data, () => {
-          if (wasNearBottom) {
-            term.scrollToBottom();
-          }
-        });
+        const nearBottom = (buf.baseY - buf.viewportY) <= AUTO_SCROLL_THRESHOLD;
+        if (nearBottom) {
+          shouldPin = true;
+        }
+        term.write(data);
+        // Coalesce: many writes per frame → one scroll correction after paint
+        if (shouldPin && !scrollRafId) {
+          scrollRafId = requestAnimationFrame(() => {
+            scrollRafId = 0;
+            if (shouldPin) {
+              term.scrollToBottom();
+              shouldPin = false;
+            }
+          });
+        }
       }
     });
 
@@ -406,6 +419,7 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
 
     return () => {
       mounted = false;
+      if (scrollRafId) cancelAnimationFrame(scrollRafId);
       window.removeEventListener('resize', handleResize);
       resizeObserver.disconnect();
       cleanupPtyData();


### PR DESCRIPTION
## Summary

- Fixes terminal viewport spontaneously jumping to random scroll positions during long Claude streaming output
- Adds smart auto-scroll: detects if user is near bottom before each `term.write()`, pins viewport after write completes
- Users who scroll up intentionally are not disturbed (5-line threshold)

## Details

Root cause: xterm.js viewport loses sync during rapid `term.write()` calls. The fix checks `buffer.active.baseY - buffer.active.viewportY` before each write, and calls `scrollToBottom()` in the write callback only if the user was within 5 lines of the bottom.

**Jira:** [BDHLNDR-30](https://gobodhi.atlassian.net/browse/BDHLNDR-30)

## Test plan

- [ ] Launch Bodhilander, start a Claude session
- [ ] Give Claude a long-running task that produces lots of streaming output
- [ ] Verify the terminal stays pinned to the bottom throughout
- [ ] Scroll up during streaming — verify it does NOT yank you back down
- [ ] Scroll back to bottom — verify auto-scroll re-engages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-30]: https://gobodhi.atlassian.net/browse/BDHLNDR-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ