### PR TITLE
ci: enable macOS code signing and notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,11 @@ jobs:
         run: bun run dist:mac
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Disable code signing unless MAC_CERTS is configured
-          CSC_IDENTITY_AUTO_DISCOVERY: false
+          CSC_LINK: ${{ secrets.MAC_CERTS }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Remove `CSC_IDENTITY_AUTO_DISCOVERY: false` that was disabling Mac signing
- Pass `MAC_CERTS` / `MAC_CERTS_PASSWORD` for code signing via electron-builder
- Pass `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` for notarization

All supporting infrastructure (entitlements, notarize.js, hardened runtime config) was already in place — this just wires up the secrets.

## Test plan
- [ ] Next release build produces a signed + notarized `.dmg`
- [ ] macOS users can install without Gatekeeper warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)