### PR TITLE
feat: crash and error logging with disk rotation

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog, shell, crashReporter } from 'electron';
 import * as path from 'path';
 import { ptyManager } from './pty-manager';
 import { getDatabase, closeDatabase } from './database';
@@ -25,6 +25,22 @@ import log from 'electron-log';
 import { getApiServer } from './api';
 import { getVectorSearchManager, disposeVectorSearchManager } from './vector-search';
 import { openInEditor, detectAvailableEditors, getEditorOptions, EditorType } from './editor-launcher';
+
+// ---------------------------------------------------------------------------
+// Logging & crash reporting configuration
+// ---------------------------------------------------------------------------
+
+// Enable Electron's native crash reporter — writes minidump files locally
+// so we can diagnose native-module crashes (e.g. node-pty SIGSEGV).
+crashReporter.start({
+  submitURL: '',       // No remote server — dumps stay local
+  uploadToServer: false,
+  compress: false,
+});
+
+// Configure electron-log: file rotation to prevent unbounded disk growth
+log.transports.file.maxSize = 5 * 1024 * 1024; // 5 MB per log file
+log.transports.file.level = 'info';
 
 // Global error handlers to catch uncaught exceptions and prevent silent crashes
 process.on('uncaughtException', (error: Error) => {
@@ -1143,6 +1159,24 @@ app.on('render-process-gone', (event, webContents, details) => {
 // Handle child process crashes
 app.on('child-process-gone', (event, details) => {
   log.error('[Main] Child process gone:', details.type, details.reason, details.exitCode);
+});
+
+// Renderer error forwarding — renderer calls this via IPC so errors land in the log file
+safeHandle('log:error', (source: string, message: string, stack?: string) => {
+  log.error(`[Renderer:${source}]`, message);
+  if (stack) log.error(`[Renderer:${source}] Stack:`, stack);
+});
+
+safeHandle('log:warn', (source: string, message: string) => {
+  log.warn(`[Renderer:${source}]`, message);
+});
+
+// Expose log file path and crash dump directory so user can find them
+safeHandle('log:getPaths', () => {
+  return {
+    logFile: log.transports.file.getFile()?.path || null,
+    crashDumps: app.getPath('crashDumps'),
+  };
 });
 
 app.on('window-all-closed', () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -348,4 +348,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   getEditorOptions: (): Promise<{ value: string; label: string }[]> =>
     ipcRenderer.invoke('editor:getOptions'),
+
+  // Error logging — forward renderer errors to main process log file
+  logError: (source: string, message: string, stack?: string): Promise<void> =>
+    ipcRenderer.invoke('log:error', source, message, stack),
+  logWarn: (source: string, message: string): Promise<void> =>
+    ipcRenderer.invoke('log:warn', source, message),
+  getLogPaths: (): Promise<{ logFile: string | null; crashDumps: string }> =>
+    ipcRenderer.invoke('log:getPaths'),
 });

--- a/src/main/vector-search/index.ts
+++ b/src/main/vector-search/index.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as chokidar from 'chokidar';
 import { EventEmitter } from 'events';
 import { app } from 'electron';
+import log from 'electron-log';
 import * as codeSearchRepo from '../repositories/code-search';
 import { getEmbeddingProvider } from './embedding-provider';
 import { ParsedSymbol } from './parser';
@@ -240,17 +241,16 @@ export class VectorSearchManager extends EventEmitter {
 
     this.workers.set(index.id, worker);
 
-    // Forward worker stdout to console
+    // Forward worker stdout/stderr to electron-log so they land in the log file
     if (worker.stdout) {
       worker.stdout.on('data', (data: Buffer) => {
-        console.log('[VectorSearch Worker]', data.toString().trim());
+        log.info('[VectorSearch Worker]', data.toString().trim());
       });
     }
 
-    // Forward worker stderr to console
     if (worker.stderr) {
       worker.stderr.on('data', (data: Buffer) => {
-        console.error('[VectorSearch Worker Error]', data.toString().trim());
+        log.error('[VectorSearch Worker]', data.toString().trim());
       });
     }
 
@@ -259,8 +259,8 @@ export class VectorSearchManager extends EventEmitter {
     });
 
     worker.on('error', (err: Error) => {
-      console.error('[VectorSearch] Worker error:', err);
-      console.error('[VectorSearch] Worker error stack:', err.stack);
+      log.error('[VectorSearch] Worker error:', err);
+      log.error('[VectorSearch] Worker error stack:', err.stack);
       const errorMsg = err.message || 'Worker thread error';
       codeSearchRepo.updateIndexStatus(index.id, 'error', errorMsg);
       this.workers.delete(index.id);
@@ -275,7 +275,7 @@ export class VectorSearchManager extends EventEmitter {
       this.workers.delete(index.id);
       if (code !== 0 && !this.cancelledIndexes.has(index.id)) {
         const errorMsg = `Worker exited with code ${code}`;
-        console.error('[VectorSearch]', errorMsg);
+        log.error('[VectorSearch]', errorMsg);
         codeSearchRepo.updateIndexStatus(index.id, 'error', errorMsg);
         this.emit('indexing-error', {
           indexId: index.id,
@@ -289,7 +289,7 @@ export class VectorSearchManager extends EventEmitter {
     const timeout = setTimeout(() => {
       if (this.workers.has(index.id)) {
         const errorMsg = 'Worker timed out during initialization (model download may have failed)';
-        console.error('[VectorSearch]', errorMsg);
+        log.error('[VectorSearch]', errorMsg);
         // Fire-and-forget — the timeout handler isn't async. Termination
         // races are bounded here since we just update DB/emit after.
         void this.cancelIndexing(index.id);

--- a/src/renderer/components/ErrorBoundary.tsx
+++ b/src/renderer/components/ErrorBoundary.tsx
@@ -21,6 +21,11 @@ class ErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     console.error('[ErrorBoundary] Caught error:', error, errorInfo);
+    window.electronAPI?.logError?.(
+      'ErrorBoundary',
+      error.message,
+      [error.stack, errorInfo.componentStack].filter(Boolean).join('\n'),
+    );
   }
 
   render() {

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -633,6 +633,39 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                     <span className="settings-hint">Reads the ClaudeLander database directly — no export step needed</span>
                   </div>
                 </div>
+
+                <div className="settings-group">
+                  <h4>Diagnostics</h4>
+                  <div className="settings-row">
+                    <label>Log Files:</label>
+                    <button
+                      className="settings-button"
+                      onClick={async () => {
+                        const paths = await window.electronAPI.getLogPaths();
+                        if (paths.logFile) {
+                          const dir = paths.logFile.replace(/[\\/][^\\/]+$/, '');
+                          window.electronAPI.openExternal(`file://${dir}`);
+                        }
+                      }}
+                    >
+                      Open Log Folder
+                    </button>
+                    <span className="settings-hint">View application logs for troubleshooting</span>
+                  </div>
+                  <div className="settings-row">
+                    <label>Crash Dumps:</label>
+                    <button
+                      className="settings-button"
+                      onClick={async () => {
+                        const paths = await window.electronAPI.getLogPaths();
+                        window.electronAPI.openExternal(`file://${paths.crashDumps}`);
+                      }}
+                    >
+                      Open Crash Dumps Folder
+                    </button>
+                    <span className="settings-hint">View native crash dumps (minidump files)</span>
+                  </div>
+                </div>
               </div>
             )}
 

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -163,6 +163,11 @@ interface ElectronAPI {
   openInEditor: (filePath: string, line?: number, column?: number) => Promise<{ success: boolean; error?: string }>;
   detectAvailableEditors: () => Promise<string[]>;
   getEditorOptions: () => Promise<{ value: string; label: string }[]>;
+
+  // Error logging
+  logError: (source: string, message: string, stack?: string) => Promise<void>;
+  logWarn: (source: string, message: string) => Promise<void>;
+  getLogPaths: () => Promise<{ logFile: string | null; crashDumps: string }>;
 }
 
 declare global {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -3,6 +3,20 @@ import { createRoot } from 'react-dom/client';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
 
+// Forward uncaught renderer errors to main process log file
+window.onerror = (message, source, lineno, colno, error) => {
+  const msg = typeof message === 'string' ? message : 'Unknown error';
+  const loc = source ? `${source}:${lineno}:${colno}` : 'unknown';
+  window.electronAPI?.logError?.('window.onerror', `${msg} at ${loc}`, error?.stack);
+};
+
+window.onunhandledrejection = (event: PromiseRejectionEvent) => {
+  const reason = event.reason;
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  const stack = reason instanceof Error ? reason.stack : undefined;
+  window.electronAPI?.logError?.('unhandledrejection', msg, stack);
+};
+
 // Set up sound player to respond to main process sound events
 if (window.electronAPI?.onSoundPlay) {
   window.electronAPI.onSoundPlay(({ path, volume }) => {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -186,6 +186,11 @@ export interface ElectronAPI {
   openInEditor: (filePath: string, line?: number, column?: number) => Promise<{ success: boolean; error?: string }>;
   detectAvailableEditors: () => Promise<string[]>;
   getEditorOptions: () => Promise<{ value: string; label: string }[]>;
+
+  // Error logging
+  logError: (source: string, message: string, stack?: string) => Promise<void>;
+  logWarn: (source: string, message: string) => Promise<void>;
+  getLogPaths: () => Promise<{ logFile: string | null; crashDumps: string }>;
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- Enable Electron's `crashReporter` for native crash minidumps (like the macOS ARM64 SIGSEGV from node-pty)
- Configure electron-log with **5MB max file size** rotation to prevent unbounded disk growth
- Forward renderer `window.onerror` and `unhandledrejection` to the main process log file via IPC
- `ErrorBoundary` now forwards React errors to the log file
- Vector search worker stderr/stdout routed through electron-log instead of bare console
- Settings > General > Diagnostics section with "Open Log Folder" and "Open Crash Dumps Folder" buttons

## Disk space safeguards
- Log files capped at 5MB with automatic rotation (electron-log default keeps 1 old file)
- Crash dumps are only written on actual native crashes — very low volume
- No debug-level logging enabled — file level stays at `info`

## Test plan
- [ ] Verify log file appears at the expected path
- [ ] Trigger a renderer error (e.g. React component crash) and verify it appears in the log file
- [ ] Verify "Open Log Folder" button opens the correct directory
- [ ] Verify "Open Crash Dumps Folder" button opens the correct directory
- [ ] Verify log file does not grow past ~5MB (fills and rotates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)