### PR TITLE
Release 3.2.5

### DIFF
--- a/src/main/group-import-export.ts
+++ b/src/main/group-import-export.ts
@@ -1,0 +1,380 @@
+/**
+ * Group & Session Import/Export
+ *
+ * Portable JSON format for transferring groups and sessions between
+ * Bodhilander and ClaudeLander (or any compatible app). Sessions carry their
+ * claudeSessionId so Claude Code conversations can be resumed after import.
+ */
+
+import { dialog, app } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import Database from 'better-sqlite3';
+import * as groupsRepo from './repositories/groups';
+import * as sessionsRepo from './repositories/sessions';
+import log from 'electron-log';
+
+// ---------------------------------------------------------------------------
+// Portable format types
+// ---------------------------------------------------------------------------
+
+interface PortableGroup {
+  id: string;
+  name: string;
+  color: string;
+  workingDir: string;
+  parentId: string | null;
+  collapsed: boolean;
+  order: number;
+  createdAt: string; // ISO 8601
+}
+
+interface PortableSession {
+  id: string;
+  groupId: string;
+  name: string;
+  workingDir: string;
+  shellType: string;
+  claudeSessionId: string | null;
+  order: number;
+  createdAt: string;
+  lastActivityAt: string;
+}
+
+interface PortableData {
+  version: 1;
+  sourceApp: string;
+  exportedAt: string;
+  groups: PortableGroup[];
+  sessions: PortableSession[];
+}
+
+interface ExportResult {
+  success: boolean;
+  filePath?: string;
+  error?: string;
+  groupCount?: number;
+  sessionCount?: number;
+}
+
+interface ImportResult {
+  success: boolean;
+  error?: string;
+  groupCount?: number;
+  sessionCount?: number;
+  skippedGroups?: number;
+  skippedSessions?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export async function exportGroupsAndSessions(): Promise<ExportResult> {
+  try {
+    const groups = groupsRepo.getAllGroups();
+    const sessions = sessionsRepo.getAllSessions();
+
+    const data: PortableData = {
+      version: 1,
+      sourceApp: 'bodhilander',
+      exportedAt: new Date().toISOString(),
+      groups: groups.map(g => ({
+        id: g.id,
+        name: g.name,
+        color: g.color,
+        workingDir: g.workingDir,
+        parentId: g.parentId,
+        collapsed: g.collapsed,
+        order: g.order,
+        createdAt: g.createdAt instanceof Date ? g.createdAt.toISOString() : String(g.createdAt),
+      })),
+      sessions: sessions.map(s => ({
+        id: s.id,
+        groupId: s.groupId,
+        name: s.name,
+        workingDir: s.workingDir,
+        shellType: s.shellType,
+        claudeSessionId: s.claudeSessionId ?? null,
+        order: s.order,
+        createdAt: s.createdAt instanceof Date ? s.createdAt.toISOString() : String(s.createdAt),
+        lastActivityAt: s.lastActivityAt instanceof Date ? s.lastActivityAt.toISOString() : String(s.lastActivityAt),
+      })),
+    };
+
+    const defaultName = `bodhilander-export-${new Date().toISOString().slice(0, 10)}`;
+    const result = await dialog.showSaveDialog({
+      title: 'Export Groups & Sessions',
+      defaultPath: path.join(app.getPath('documents'), `${defaultName}.json`),
+      filters: [{ name: 'JSON Files', extensions: ['json'] }],
+    });
+
+    if (result.canceled || !result.filePath) {
+      return { success: false, error: 'Export cancelled' };
+    }
+
+    fs.writeFileSync(result.filePath, JSON.stringify(data, null, 2), 'utf-8');
+    log.info(`[Import/Export] Exported ${groups.length} groups, ${sessions.length} sessions to ${result.filePath}`);
+
+    return {
+      success: true,
+      filePath: result.filePath,
+      groupCount: groups.length,
+      sessionCount: sessions.length,
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    log.error('[Import/Export] Export failed:', msg);
+    return { success: false, error: msg };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Import
+// ---------------------------------------------------------------------------
+
+export async function importGroupsAndSessions(): Promise<ImportResult> {
+  try {
+    const result = await dialog.showOpenDialog({
+      title: 'Import Groups & Sessions',
+      filters: [{ name: 'JSON Files', extensions: ['json'] }],
+      properties: ['openFile'],
+    });
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return { success: false, error: 'Import cancelled' };
+    }
+
+    const raw = fs.readFileSync(result.filePaths[0], 'utf-8');
+    const data: PortableData = JSON.parse(raw);
+
+    if (data.version !== 1 || !Array.isArray(data.groups) || !Array.isArray(data.sessions)) {
+      return { success: false, error: 'Invalid export file format' };
+    }
+
+    // Build a map from old group IDs → new group IDs
+    const existingGroups = new Set(groupsRepo.getAllGroups().map(g => g.id));
+    const existingSessions = new Set(sessionsRepo.getAllSessions().map(s => s.id));
+    const groupIdMap = new Map<string, string>();
+
+    let groupCount = 0;
+    let skippedGroups = 0;
+
+    // First pass: create groups without parentId (resolve hierarchy after)
+    // Sort so that top-level groups (parentId == null) come first
+    const sorted = [...data.groups].sort((a, b) => {
+      if (a.parentId === null && b.parentId !== null) return -1;
+      if (a.parentId !== null && b.parentId === null) return 1;
+      return 0;
+    });
+
+    for (const g of sorted) {
+      if (existingGroups.has(g.id)) {
+        // ID collision — map to existing
+        groupIdMap.set(g.id, g.id);
+        skippedGroups++;
+        continue;
+      }
+
+      const newId = randomUUID();
+      groupIdMap.set(g.id, newId);
+
+      const resolvedParentId = g.parentId ? (groupIdMap.get(g.parentId) ?? null) : null;
+
+      groupsRepo.createGroup({
+        id: newId,
+        name: g.name,
+        color: g.color,
+        workingDir: g.workingDir,
+        parentId: resolvedParentId,
+        collapsed: g.collapsed,
+        order: g.order,
+        createdAt: new Date(g.createdAt),
+      });
+      groupCount++;
+    }
+
+    let sessionCount = 0;
+    let skippedSessions = 0;
+
+    for (const s of data.sessions) {
+      const mappedGroupId = groupIdMap.get(s.groupId);
+      if (!mappedGroupId) {
+        skippedSessions++;
+        continue; // orphan session — group wasn't imported
+      }
+
+      if (existingSessions.has(s.id)) {
+        skippedSessions++;
+        continue;
+      }
+
+      sessionsRepo.createSession({
+        id: randomUUID(),
+        groupId: mappedGroupId,
+        name: s.name,
+        workingDir: s.workingDir,
+        state: 'idle',
+        shellType: s.shellType || 'bash',
+        claudeSessionId: s.claudeSessionId ?? null,
+        order: s.order,
+        createdAt: new Date(s.createdAt),
+        lastActivityAt: new Date(s.lastActivityAt),
+        endedAt: null,
+        durationSeconds: 0,
+      });
+      sessionCount++;
+    }
+
+    log.info(`[Import/Export] Imported ${groupCount} groups, ${sessionCount} sessions (skipped ${skippedGroups} groups, ${skippedSessions} sessions)`);
+
+    return {
+      success: true,
+      groupCount,
+      sessionCount,
+      skippedGroups,
+      skippedSessions,
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    log.error('[Import/Export] Import failed:', msg);
+    return { success: false, error: msg };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Direct import from ClaudeLander database
+// ---------------------------------------------------------------------------
+
+function findClaudeLanderDb(): string | null {
+  // ClaudeLander stores its DB at {userData}/claudelander.db
+  // On Windows: %APPDATA%/claudelander/claudelander.db
+  // On macOS:   ~/Library/Application Support/claudelander/claudelander.db
+  // On Linux:   ~/.config/claudelander/claudelander.db
+  const appData = process.env.APPDATA
+    || (process.platform === 'darwin'
+      ? path.join(process.env.HOME || '', 'Library', 'Application Support')
+      : path.join(process.env.HOME || '', '.config'));
+
+  const dbPath = path.join(appData, 'claudelander', 'claudelander.db');
+  if (fs.existsSync(dbPath)) return dbPath;
+
+  // Also check legacy "ClaudeLander" casing
+  const dbPathAlt = path.join(appData, 'ClaudeLander', 'claudelander.db');
+  if (fs.existsSync(dbPathAlt)) return dbPathAlt;
+
+  return null;
+}
+
+export async function importFromClaudeLander(): Promise<ImportResult> {
+  try {
+    const dbPath = findClaudeLanderDb();
+
+    if (!dbPath) {
+      return {
+        success: false,
+        error: 'ClaudeLander database not found. Make sure ClaudeLander has been installed and run at least once.',
+      };
+    }
+
+    log.info(`[Import/Export] Opening ClaudeLander database at ${dbPath}`);
+
+    // Open read-only so we don't interfere with a running ClaudeLander
+    const clDb = new Database(dbPath, { readonly: true });
+
+    let clGroups: any[];
+    let clSessions: any[];
+
+    try {
+      clGroups = clDb.prepare('SELECT * FROM groups ORDER BY "order"').all() as any[];
+      clSessions = clDb.prepare('SELECT * FROM sessions ORDER BY "order"').all() as any[];
+    } finally {
+      clDb.close();
+    }
+
+    const existingGroups = new Set(groupsRepo.getAllGroups().map(g => g.id));
+    const existingSessions = new Set(sessionsRepo.getAllSessions().map(s => s.id));
+    const groupIdMap = new Map<string, string>();
+
+    let groupCount = 0;
+    let skippedGroups = 0;
+
+    // Sort so top-level groups come first
+    const sorted = [...clGroups].sort((a, b) => {
+      if (a.parent_id === null && b.parent_id !== null) return -1;
+      if (a.parent_id !== null && b.parent_id === null) return 1;
+      return 0;
+    });
+
+    for (const row of sorted) {
+      if (existingGroups.has(row.id)) {
+        groupIdMap.set(row.id, row.id);
+        skippedGroups++;
+        continue;
+      }
+
+      const newId = randomUUID();
+      groupIdMap.set(row.id, newId);
+      const resolvedParentId = row.parent_id ? (groupIdMap.get(row.parent_id) ?? null) : null;
+
+      groupsRepo.createGroup({
+        id: newId,
+        name: row.name,
+        color: row.color || '#888888',
+        workingDir: row.working_dir || '',
+        parentId: resolvedParentId,
+        collapsed: Boolean(row.collapsed),
+        order: row.order || 0,
+        createdAt: new Date(row.created_at || Date.now()),
+      });
+      groupCount++;
+    }
+
+    let sessionCount = 0;
+    let skippedSessions = 0;
+
+    for (const row of clSessions) {
+      const mappedGroupId = groupIdMap.get(row.group_id);
+      if (!mappedGroupId) {
+        skippedSessions++;
+        continue;
+      }
+
+      if (existingSessions.has(row.id)) {
+        skippedSessions++;
+        continue;
+      }
+
+      sessionsRepo.createSession({
+        id: randomUUID(),
+        groupId: mappedGroupId,
+        name: row.name,
+        workingDir: row.working_dir || '',
+        state: 'idle',
+        shellType: row.shell_type || 'bash',
+        claudeSessionId: row.claude_session_id ?? null,
+        order: row.order || 0,
+        createdAt: new Date(row.created_at || Date.now()),
+        lastActivityAt: new Date(row.last_activity_at || Date.now()),
+        endedAt: null,
+        durationSeconds: 0,
+      });
+      sessionCount++;
+    }
+
+    log.info(`[Import/Export] Direct import from ClaudeLander: ${groupCount} groups, ${sessionCount} sessions (skipped ${skippedGroups} groups, ${skippedSessions} sessions)`);
+
+    return {
+      success: true,
+      groupCount,
+      sessionCount,
+      skippedGroups,
+      skippedSessions,
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    log.error('[Import/Export] Direct import from ClaudeLander failed:', msg);
+    return { success: false, error: msg };
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import * as prefsRepo from './repositories/preferences';
 import * as memoriesRepo from './repositories/memories';
 import * as sessionEventsRepo from './repositories/session-events';
 import { exportSessions, ExportFormat } from './session-export';
+import { exportGroupsAndSessions, importGroupsAndSessions, importFromClaudeLander } from './group-import-export';
 import { StateMonitor } from './state-monitor';
 import { createApplicationMenu } from './menu';
 import { initAutoUpdater, checkForUpdatesManual, downloadUpdate } from './auto-updater';
@@ -679,6 +680,11 @@ safeHandle('db:sessionEvents:getToolUseCounts', (sessionId?: string) =>
 safeHandle('export:sessions', (format: ExportFormat, since?: string) =>
   exportSessions({ format, since })
 );
+
+// Group & Session Import/Export
+safeHandle('export:groups', () => exportGroupsAndSessions());
+safeHandle('import:groups', () => importGroupsAndSessions());
+safeHandle('import:fromClaudeLander', () => importFromClaudeLander());
 
 // Preferences IPC Handlers
 safeHandle('prefs:get', (key: string) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog, shell, crashReporter } from 'electron';
 import * as path from 'path';
 import { ptyManager } from './pty-manager';
 import { getDatabase, closeDatabase } from './database';
@@ -25,6 +25,22 @@ import log from 'electron-log';
 import { getApiServer } from './api';
 import { getVectorSearchManager, disposeVectorSearchManager } from './vector-search';
 import { openInEditor, detectAvailableEditors, getEditorOptions, EditorType } from './editor-launcher';
+
+// ---------------------------------------------------------------------------
+// Logging & crash reporting configuration
+// ---------------------------------------------------------------------------
+
+// Enable Electron's native crash reporter — writes minidump files locally
+// so we can diagnose native-module crashes (e.g. node-pty SIGSEGV).
+crashReporter.start({
+  submitURL: '',       // No remote server — dumps stay local
+  uploadToServer: false,
+  compress: false,
+});
+
+// Configure electron-log: file rotation to prevent unbounded disk growth
+log.transports.file.maxSize = 5 * 1024 * 1024; // 5 MB per log file
+log.transports.file.level = 'info';
 
 // Global error handlers to catch uncaught exceptions and prevent silent crashes
 process.on('uncaughtException', (error: Error) => {
@@ -1143,6 +1159,24 @@ app.on('render-process-gone', (event, webContents, details) => {
 // Handle child process crashes
 app.on('child-process-gone', (event, details) => {
   log.error('[Main] Child process gone:', details.type, details.reason, details.exitCode);
+});
+
+// Renderer error forwarding — renderer calls this via IPC so errors land in the log file
+safeHandle('log:error', (source: string, message: string, stack?: string) => {
+  log.error(`[Renderer:${source}]`, message);
+  if (stack) log.error(`[Renderer:${source}] Stack:`, stack);
+});
+
+safeHandle('log:warn', (source: string, message: string) => {
+  log.warn(`[Renderer:${source}]`, message);
+});
+
+// Expose log file path and crash dump directory so user can find them
+safeHandle('log:getPaths', () => {
+  return {
+    logFile: log.transports.file.getFile()?.path || null,
+    crashDumps: app.getPath('crashDumps'),
+  };
 });
 
 app.on('window-all-closed', () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -164,6 +164,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   exportSessions: (format: 'csv' | 'json', since?: string): Promise<{ success: boolean; filePath?: string; error?: string; sessionCount?: number; eventCount?: number }> =>
     ipcRenderer.invoke('export:sessions', format, since),
 
+  // Group & Session Import/Export
+  exportGroups: (): Promise<{ success: boolean; filePath?: string; error?: string; groupCount?: number; sessionCount?: number }> =>
+    ipcRenderer.invoke('export:groups'),
+  importGroups: (): Promise<{ success: boolean; error?: string; groupCount?: number; sessionCount?: number; skippedGroups?: number; skippedSessions?: number }> =>
+    ipcRenderer.invoke('import:groups'),
+  importFromClaudeLander: (): Promise<{ success: boolean; error?: string; groupCount?: number; sessionCount?: number; skippedGroups?: number; skippedSessions?: number }> =>
+    ipcRenderer.invoke('import:fromClaudeLander'),
+
   // Preferences
   getPreference: (key: string): Promise<string | null> =>
     ipcRenderer.invoke('prefs:get', key),

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -348,4 +348,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   getEditorOptions: (): Promise<{ value: string; label: string }[]> =>
     ipcRenderer.invoke('editor:getOptions'),
+
+  // Error logging — forward renderer errors to main process log file
+  logError: (source: string, message: string, stack?: string): Promise<void> =>
+    ipcRenderer.invoke('log:error', source, message, stack),
+  logWarn: (source: string, message: string): Promise<void> =>
+    ipcRenderer.invoke('log:warn', source, message),
+  getLogPaths: (): Promise<{ logFile: string | null; crashDumps: string }> =>
+    ipcRenderer.invoke('log:getPaths'),
 });

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -46,6 +46,8 @@ interface PtySession {
   /** Last known column/row count — used to detect actual size changes. */
   lastCols: number;
   lastRows: number;
+  /** Set to true when kill() is in progress — guards against use-after-free on native PTY handle. */
+  killing: boolean;
 }
 
 /**
@@ -242,6 +244,10 @@ class PtyManager extends EventEmitter {
     });
 
     ptyProcess.onData((data) => {
+      const session = this.sessions.get(id);
+      // Guard: reject data from a PTY that is being torn down
+      if (!session || session.killing) return;
+
       // Filter out Windows ConPTY error messages
       // Win32 error 299 (ERROR_PARTIAL_COPY) is a race condition when reading from
       // a terminating process. Using useConptyDll should reduce these occurrences.
@@ -257,7 +263,6 @@ class PtyManager extends EventEmitter {
       }
 
       // Append to scrollback buffer
-      const session = this.sessions.get(id);
       if (session) {
         session.scrollbackBuffer += filteredData;
         // Trim if too large (keep last MAX_SCROLLBACK_SIZE bytes)
@@ -336,20 +341,21 @@ class PtyManager extends EventEmitter {
       spawnedAt: Date.now(),
       lastCols: 80,
       lastRows: 24,
+      killing: false,
     });
 
   }
 
   write(id: string, data: string): void {
     const session = this.sessions.get(id);
-    if (session) {
+    if (session && !session.killing) {
       session.pty.write(data);
     }
   }
 
   resize(id: string, cols: number, rows: number): void {
     const session = this.sessions.get(id);
-    if (!session) return;
+    if (!session || session.killing) return;
     // Skip no-op resizes to avoid unnecessary ConPTY churn on Windows
     if (session.lastCols === cols && session.lastRows === rows) return;
     session.lastCols = cols;
@@ -365,6 +371,10 @@ class PtyManager extends EventEmitter {
         return;
       }
 
+      // Mark as killing FIRST — prevents write/resize/onData from touching
+      // the native PTY handle during teardown.
+      session.killing = true;
+
       if (session.idleTimeout) {
         clearTimeout(session.idleTimeout);
       }
@@ -373,45 +383,49 @@ class PtyManager extends EventEmitter {
       }
 
       const pid = session.pty.pid;
-      let exited = false;
 
-      const onExit = () => {
-        if (exited) return;
-        exited = true;
-        this.sessions.delete(id);
-        resolve();
-      };
-
-      // Listen for normal exit
-      session.pty.onExit(() => onExit());
+      // Remove from map BEFORE calling pty.kill() so concurrent IPC calls
+      // (write, resize) get a null lookup and bail out instead of hitting
+      // a freed native handle.
+      this.sessions.delete(id);
 
       // Send graceful kill signal
       session.pty.kill();
 
+      // The onExit handler registered in createSession will fire and emit
+      // the 'exit' event. We just need to resolve this promise once the
+      // process is gone.
+      let resolved = false;
+      const done = () => {
+        if (resolved) return;
+        resolved = true;
+        resolve();
+      };
+
       // Force-kill after 3 seconds if process hasn't exited (Windows only)
       if (process.platform === 'win32' && pid) {
         setTimeout(() => {
-          if (!exited) {
+          if (!resolved) {
             log.warn(`[PTY] Force-killing session ${id} (pid ${pid}) after 3s timeout`);
             try {
               execFile('taskkill', ['/F', '/T', '/PID', String(pid)], (err) => {
                 if (err) {
                   log.error(`[PTY] taskkill failed for pid ${pid}:`, err);
                 }
-                onExit();
+                done();
               });
             } catch (err) {
               log.error(`[PTY] Failed to spawn taskkill for pid ${pid}:`, err);
-              onExit();
+              done();
             }
           }
         }, 3000);
       } else {
         // On non-Windows, fall back to a timeout cleanup
         setTimeout(() => {
-          if (!exited) {
+          if (!resolved) {
             log.warn(`[PTY] Session ${id} did not exit within 3s, cleaning up`);
-            onExit();
+            done();
           }
         }, 3000);
       }

--- a/src/main/vector-search/index.ts
+++ b/src/main/vector-search/index.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as chokidar from 'chokidar';
 import { EventEmitter } from 'events';
 import { app } from 'electron';
+import log from 'electron-log';
 import * as codeSearchRepo from '../repositories/code-search';
 import { getEmbeddingProvider } from './embedding-provider';
 import { ParsedSymbol } from './parser';
@@ -240,17 +241,16 @@ export class VectorSearchManager extends EventEmitter {
 
     this.workers.set(index.id, worker);
 
-    // Forward worker stdout to console
+    // Forward worker stdout/stderr to electron-log so they land in the log file
     if (worker.stdout) {
       worker.stdout.on('data', (data: Buffer) => {
-        console.log('[VectorSearch Worker]', data.toString().trim());
+        log.info('[VectorSearch Worker]', data.toString().trim());
       });
     }
 
-    // Forward worker stderr to console
     if (worker.stderr) {
       worker.stderr.on('data', (data: Buffer) => {
-        console.error('[VectorSearch Worker Error]', data.toString().trim());
+        log.error('[VectorSearch Worker]', data.toString().trim());
       });
     }
 
@@ -259,8 +259,8 @@ export class VectorSearchManager extends EventEmitter {
     });
 
     worker.on('error', (err: Error) => {
-      console.error('[VectorSearch] Worker error:', err);
-      console.error('[VectorSearch] Worker error stack:', err.stack);
+      log.error('[VectorSearch] Worker error:', err);
+      log.error('[VectorSearch] Worker error stack:', err.stack);
       const errorMsg = err.message || 'Worker thread error';
       codeSearchRepo.updateIndexStatus(index.id, 'error', errorMsg);
       this.workers.delete(index.id);
@@ -275,7 +275,7 @@ export class VectorSearchManager extends EventEmitter {
       this.workers.delete(index.id);
       if (code !== 0 && !this.cancelledIndexes.has(index.id)) {
         const errorMsg = `Worker exited with code ${code}`;
-        console.error('[VectorSearch]', errorMsg);
+        log.error('[VectorSearch]', errorMsg);
         codeSearchRepo.updateIndexStatus(index.id, 'error', errorMsg);
         this.emit('indexing-error', {
           indexId: index.id,
@@ -289,7 +289,7 @@ export class VectorSearchManager extends EventEmitter {
     const timeout = setTimeout(() => {
       if (this.workers.has(index.id)) {
         const errorMsg = 'Worker timed out during initialization (model download may have failed)';
-        console.error('[VectorSearch]', errorMsg);
+        log.error('[VectorSearch]', errorMsg);
         // Fire-and-forget — the timeout handler isn't async. Termination
         // races are bounded here since we just update DB/emit after.
         void this.cancelIndexing(index.id);

--- a/src/renderer/components/ErrorBoundary.tsx
+++ b/src/renderer/components/ErrorBoundary.tsx
@@ -21,6 +21,11 @@ class ErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     console.error('[ErrorBoundary] Caught error:', error, errorInfo);
+    window.electronAPI?.logError?.(
+      'ErrorBoundary',
+      error.message,
+      [error.stack, errorInfo.componentStack].filter(Boolean).join('\n'),
+    );
   }
 
   render() {

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -633,6 +633,39 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                     <span className="settings-hint">Reads the ClaudeLander database directly — no export step needed</span>
                   </div>
                 </div>
+
+                <div className="settings-group">
+                  <h4>Diagnostics</h4>
+                  <div className="settings-row">
+                    <label>Log Files:</label>
+                    <button
+                      className="settings-button"
+                      onClick={async () => {
+                        const paths = await window.electronAPI.getLogPaths();
+                        if (paths.logFile) {
+                          const dir = paths.logFile.replace(/[\\/][^\\/]+$/, '');
+                          window.electronAPI.openExternal(`file://${dir}`);
+                        }
+                      }}
+                    >
+                      Open Log Folder
+                    </button>
+                    <span className="settings-hint">View application logs for troubleshooting</span>
+                  </div>
+                  <div className="settings-row">
+                    <label>Crash Dumps:</label>
+                    <button
+                      className="settings-button"
+                      onClick={async () => {
+                        const paths = await window.electronAPI.getLogPaths();
+                        window.electronAPI.openExternal(`file://${paths.crashDumps}`);
+                      }}
+                    >
+                      Open Crash Dumps Folder
+                    </button>
+                    <span className="settings-hint">View native crash dumps (minidump files)</span>
+                  </div>
+                </div>
               </div>
             )}
 

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -572,6 +572,67 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                     <span className="settings-hint">Minimize to system tray instead of quitting when closing window</span>
                   </div>
                 </div>
+
+                <div className="settings-group">
+                  <h4>Data</h4>
+                  <div className="settings-row">
+                    <label>Import / Export:</label>
+                    <div style={{ display: 'flex', gap: '8px' }}>
+                      <button
+                        className="settings-button"
+                        onClick={async () => {
+                          const result = await window.electronAPI.exportGroups();
+                          if (result.success) {
+                            alert(`Exported ${result.groupCount} groups and ${result.sessionCount} sessions.`);
+                          } else if (result.error && result.error !== 'Export cancelled') {
+                            alert(`Export failed: ${result.error}`);
+                          }
+                        }}
+                      >
+                        Export Groups & Sessions
+                      </button>
+                      <button
+                        className="settings-button"
+                        onClick={async () => {
+                          const result = await window.electronAPI.importGroups();
+                          if (result.success) {
+                            alert(`Imported ${result.groupCount} groups and ${result.sessionCount} sessions.` +
+                              (result.skippedGroups || result.skippedSessions
+                                ? ` (Skipped ${result.skippedGroups} existing groups, ${result.skippedSessions} existing sessions)`
+                                : ''));
+                            window.location.reload();
+                          } else if (result.error && result.error !== 'Import cancelled') {
+                            alert(`Import failed: ${result.error}`);
+                          }
+                        }}
+                      >
+                        Import Groups & Sessions
+                      </button>
+                    </div>
+                    <span className="settings-hint">Transfer groups and sessions between Bodhilander and ClaudeLander</span>
+                  </div>
+                  <div className="settings-row">
+                    <label>ClaudeLander:</label>
+                    <button
+                      className="settings-button"
+                      onClick={async () => {
+                        const result = await window.electronAPI.importFromClaudeLander();
+                        if (result.success) {
+                          alert(`Imported ${result.groupCount} groups and ${result.sessionCount} sessions from ClaudeLander.` +
+                            (result.skippedGroups || result.skippedSessions
+                              ? ` (Skipped ${result.skippedGroups} existing groups, ${result.skippedSessions} existing sessions)`
+                              : ''));
+                          window.location.reload();
+                        } else if (result.error) {
+                          alert(result.error);
+                        }
+                      }}
+                    >
+                      Import directly from ClaudeLander
+                    </button>
+                    <span className="settings-hint">Reads the ClaudeLander database directly — no export step needed</span>
+                  </div>
+                </div>
               </div>
             )}
 

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -70,6 +70,11 @@ interface ElectronAPI {
   // Session Export (BDHLNDR-20)
   exportSessions: (format: 'csv' | 'json', since?: string) => Promise<{ success: boolean; filePath?: string; error?: string; sessionCount?: number; eventCount?: number }>;
 
+  // Group & Session Import/Export
+  exportGroups: () => Promise<{ success: boolean; filePath?: string; error?: string; groupCount?: number; sessionCount?: number }>;
+  importGroups: () => Promise<{ success: boolean; error?: string; groupCount?: number; sessionCount?: number; skippedGroups?: number; skippedSessions?: number }>;
+  importFromClaudeLander: () => Promise<{ success: boolean; error?: string; groupCount?: number; sessionCount?: number; skippedGroups?: number; skippedSessions?: number }>;
+
   // Preferences
   getPreference: (key: string) => Promise<string | null>;
   setPreference: (key: string, value: string) => Promise<void>;

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -163,6 +163,11 @@ interface ElectronAPI {
   openInEditor: (filePath: string, line?: number, column?: number) => Promise<{ success: boolean; error?: string }>;
   detectAvailableEditors: () => Promise<string[]>;
   getEditorOptions: () => Promise<{ value: string; label: string }[]>;
+
+  // Error logging
+  logError: (source: string, message: string, stack?: string) => Promise<void>;
+  logWarn: (source: string, message: string) => Promise<void>;
+  getLogPaths: () => Promise<{ logFile: string | null; crashDumps: string }>;
 }
 
 declare global {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -3,6 +3,20 @@ import { createRoot } from 'react-dom/client';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
 
+// Forward uncaught renderer errors to main process log file
+window.onerror = (message, source, lineno, colno, error) => {
+  const msg = typeof message === 'string' ? message : 'Unknown error';
+  const loc = source ? `${source}:${lineno}:${colno}` : 'unknown';
+  window.electronAPI?.logError?.('window.onerror', `${msg} at ${loc}`, error?.stack);
+};
+
+window.onunhandledrejection = (event: PromiseRejectionEvent) => {
+  const reason = event.reason;
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  const stack = reason instanceof Error ? reason.stack : undefined;
+  window.electronAPI?.logError?.('unhandledrejection', msg, stack);
+};
+
 // Set up sound player to respond to main process sound events
 if (window.electronAPI?.onSoundPlay) {
   window.electronAPI.onSoundPlay(({ path, volume }) => {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -186,6 +186,11 @@ export interface ElectronAPI {
   openInEditor: (filePath: string, line?: number, column?: number) => Promise<{ success: boolean; error?: string }>;
   detectAvailableEditors: () => Promise<string[]>;
   getEditorOptions: () => Promise<{ value: string; label: string }[]>;
+
+  // Error logging
+  logError: (source: string, message: string, stack?: string) => Promise<void>;
+  logWarn: (source: string, message: string) => Promise<void>;
+  getLogPaths: () => Promise<{ logFile: string | null; crashDumps: string }>;
 }
 
 declare global {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -92,6 +92,11 @@ export interface ElectronAPI {
   // Session Export (BDHLNDR-20)
   exportSessions: (format: 'csv' | 'json', since?: string) => Promise<{ success: boolean; filePath?: string; error?: string; sessionCount?: number; eventCount?: number }>;
 
+  // Group & Session Import/Export
+  exportGroups: () => Promise<{ success: boolean; filePath?: string; error?: string; groupCount?: number; sessionCount?: number }>;
+  importGroups: () => Promise<{ success: boolean; error?: string; groupCount?: number; sessionCount?: number; skippedGroups?: number; skippedSessions?: number }>;
+  importFromClaudeLander: () => Promise<{ success: boolean; error?: string; groupCount?: number; sessionCount?: number; skippedGroups?: number; skippedSessions?: number }>;
+
   // Preferences
   getPreference: (key: string) => Promise<string | null>;
   setPreference: (key: string, value: string) => Promise<void>;


### PR DESCRIPTION
## Summary
Three changes since 3.2.4:

- **fix:** PTY kill race condition causing SIGSEGV on macOS ARM64 (#29)
  - Null pointer dereference when concurrent write/resize hit a freed PTY handle
  - Adds `killing` guard flag and removes session from map before destroying native handle

- **feat:** Group/session import/export with direct ClaudeLander import (#28)
  - Portable JSON export/import for transferring groups and sessions
  - Direct import from ClaudeLander reads SQLite DB — no export step needed

- **feat:** Crash and error logging with disk rotation (#30)
  - Electron crashReporter for native crash minidumps
  - electron-log 5MB max file size rotation
  - Renderer errors forwarded to main process log file
  - Settings > Diagnostics with "Open Log Folder" and "Open Crash Dumps Folder"

🤖 Generated with [Claude Code](https://claude.com/claude-code)