### PR TITLE
Release: macOS default zsh shell fix

### DIFF
--- a/src/main/shell-detector.ts
+++ b/src/main/shell-detector.ts
@@ -83,11 +83,19 @@ function detectWindowsShell(): ShellInfo {
 }
 
 function detectUnixShell(): ShellInfo {
-  const shell = process.env.SHELL || '/bin/zsh';
+  let actualShell: string;
+
+  if (process.platform === 'darwin') {
+    // macOS: default to /bin/zsh (default shell since Catalina).
+    // process.env.SHELL may be stale or unavailable when Electron is
+    // launched from Finder/Dock, causing claude to not be found on PATH.
+    actualShell = '/bin/zsh';
+  } else {
+    actualShell = process.env.SHELL || '/bin/bash';
+  }
 
   // Verify shell exists, fallback to common shells
-  let actualShell = shell;
-  if (!fs.existsSync(shell)) {
+  if (!fs.existsSync(actualShell)) {
     const fallbacks = ['/bin/zsh', '/bin/bash', '/bin/sh'];
     for (const fb of fallbacks) {
       if (fs.existsSync(fb)) {


### PR DESCRIPTION
## Summary

- Merges the macOS zsh default shell fix into production for release
- On macOS, defaults to `/bin/zsh` instead of `process.env.SHELL` in `detectUnixShell()` — fixes fresh installs not finding `claude`

## Test plan

- [ ] Fresh macOS install: launch from Finder without custom shell path — claude should be found
- [ ] Existing installs with custom shell path — should continue working
- [ ] Linux: verify `$SHELL` is still respected
- [ ] Windows/WSL: verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)