### PR TITLE
BDHLNDR-31: Multi-account Claude Max support

### DIFF
--- a/src/main/account-auth.ts
+++ b/src/main/account-auth.ts
@@ -1,0 +1,231 @@
+/**
+ * Account login-flow orchestration (BDHLNDR-31).
+ *
+ * Each registered Claude account owns an isolated CLAUDE_CONFIG_DIR under
+ * <userData>/claude-accounts/<id>/.claude. This module:
+ *   1. Creates that directory and inserts the account row.
+ *   2. Spawns an in-app login pty running `claude` with CLAUDE_CONFIG_DIR set.
+ *   3. Watches for the credentials file to appear (Linux/Windows) and parses
+ *      the account email for display.
+ *   4. Cleans up the pty, watcher, row, and directory on cancel/delete.
+ *
+ * macOS note: Claude Code stores tokens in Keychain rather than a plain file
+ * when running on macOS, so the watcher will not fire for the OAuth-login
+ * path. The renderer must let the user confirm "I'm logged in" manually on
+ * macOS; the pty exit alone isn't sufficient evidence.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { app, BrowserWindow } from 'electron';
+import log from 'electron-log';
+import { PtyManager } from './pty-manager';
+import * as accountsRepo from './repositories/accounts';
+import { ClaudeAccount } from '../shared/types';
+
+interface LoginFlow {
+  accountId: string;
+  ptyId: string;
+  configDir: string;
+  watcher: fs.FSWatcher | null;
+  completed: boolean;
+  exitListener: (event: { id: string; exitCode: number }) => void;
+}
+
+const activeFlows = new Map<string, LoginFlow>();
+
+export interface StartLoginResult {
+  account: ClaudeAccount;
+  ptyId: string;
+}
+
+function accountRoot(accountId: string): string {
+  return path.join(app.getPath('userData'), 'claude-accounts', accountId);
+}
+
+function configDirFor(accountId: string): string {
+  return path.join(accountRoot(accountId), '.claude');
+}
+
+/**
+ * Begin an interactive login flow for a new account.
+ * Returns the new account row + the login pty id the renderer should attach to.
+ */
+export function startLoginFlow(
+  ptyManager: PtyManager,
+  mainWindow: BrowserWindow | null,
+  label: string,
+): StartLoginResult {
+  const accountId = crypto.randomUUID();
+  const configDir = configDirFor(accountId);
+  fs.mkdirSync(configDir, { recursive: true });
+
+  // First account becomes the default fallback.
+  const isFirst = accountsRepo.getAllAccounts().length === 0;
+  const account = accountsRepo.createAccount({
+    id: accountId,
+    label,
+    configDir,
+    isDefault: isFirst,
+  });
+
+  const ptyId = `__login-${accountId}`;
+
+  try {
+    ptyManager.createLoginSession(ptyId, configDir);
+  } catch (err) {
+    // Roll back the account row + directory if we couldn't spawn the pty.
+    try {
+      accountsRepo.deleteAccount(accountId);
+      fs.rmSync(accountRoot(accountId), { recursive: true, force: true });
+    } catch (cleanupErr) {
+      log.error(`[Accounts] Cleanup after failed login spawn failed for ${accountId}:`, cleanupErr);
+    }
+    throw err;
+  }
+
+  const watcher = fs.watch(configDir, (_eventType, filename) => {
+    if (!filename) return;
+    const name = filename.toString();
+    if (name === '.credentials.json' || name === 'auth.json') {
+      const flow = activeFlows.get(ptyId);
+      if (flow && !flow.completed) {
+        flow.completed = true;
+        handleLoginCompleted(ptyId, mainWindow);
+      }
+    }
+  });
+
+  const exitListener = (event: { id: string; exitCode: number }) => {
+    if (event.id !== ptyId) return;
+    const flow = activeFlows.get(ptyId);
+    if (flow && !flow.completed) {
+      log.warn(`[Accounts] Login pty ${ptyId} exited (code ${event.exitCode}) before credentials appeared`);
+      flow.watcher?.close();
+      mainWindow?.webContents.send('accounts:login-exited', { accountId: flow.accountId, exitCode: event.exitCode });
+    }
+    ptyManager.off('exit', exitListener);
+    activeFlows.delete(ptyId);
+  };
+  ptyManager.on('exit', exitListener);
+
+  activeFlows.set(ptyId, {
+    accountId,
+    ptyId,
+    configDir,
+    watcher,
+    completed: false,
+    exitListener,
+  });
+
+  log.info(`[Accounts] Started login flow for account ${accountId} (label="${label}", ptyId=${ptyId})`);
+
+  return { account, ptyId };
+}
+
+function handleLoginCompleted(ptyId: string, mainWindow: BrowserWindow | null): void {
+  const flow = activeFlows.get(ptyId);
+  if (!flow) return;
+
+  const email = parseAccountEmail(flow.configDir);
+  accountsRepo.updateAccount(flow.accountId, { email });
+
+  mainWindow?.webContents.send('accounts:login-completed', {
+    accountId: flow.accountId,
+    email,
+  });
+  log.info(`[Accounts] Login completed for ${flow.accountId}${email ? ` (${email})` : ''}`);
+}
+
+/**
+ * Best-effort parse of the logged-in account's email from the credentials file.
+ * Shapes vary across Claude Code versions, so we check several common paths
+ * and silently return null if none match.
+ */
+function parseAccountEmail(configDir: string): string | null {
+  try {
+    const credsPath = path.join(configDir, '.credentials.json');
+    if (!fs.existsSync(credsPath)) return null;
+    const creds = JSON.parse(fs.readFileSync(credsPath, 'utf-8'));
+    return (
+      creds?.claudeAiOauth?.subscriptionEmail ??
+      creds?.claudeAiOauth?.email ??
+      creds?.account?.email ??
+      creds?.email ??
+      null
+    );
+  } catch (err) {
+    log.warn('[Accounts] Failed to parse credentials for email:', err);
+    return null;
+  }
+}
+
+/**
+ * Called when the user confirms macOS login manually (where the credentials
+ * file doesn't appear because Keychain is used instead). Marks the flow
+ * completed and emits the same event as the file watcher path.
+ */
+export function confirmLoginMacOS(
+  mainWindow: BrowserWindow | null,
+  ptyId: string,
+): void {
+  const flow = activeFlows.get(ptyId);
+  if (!flow || flow.completed) return;
+  flow.completed = true;
+  handleLoginCompleted(ptyId, mainWindow);
+}
+
+/**
+ * Cancel an in-progress login flow. If `deleteAccount` is true (user aborted
+ * before completing login), the account row and its config directory are
+ * removed. If false (user is just closing the modal after success), the
+ * account is kept.
+ */
+export function cancelLoginFlow(
+  ptyManager: PtyManager,
+  ptyId: string,
+  deleteAccount: boolean,
+): void {
+  const flow = activeFlows.get(ptyId);
+  if (!flow) return;
+
+  flow.watcher?.close();
+  ptyManager.off('exit', flow.exitListener);
+  try {
+    ptyManager.kill(ptyId);
+  } catch (err) {
+    // Pty may have already exited.
+  }
+
+  if (deleteAccount) {
+    try {
+      accountsRepo.deleteAccount(flow.accountId);
+      fs.rmSync(accountRoot(flow.accountId), { recursive: true, force: true });
+    } catch (err) {
+      log.error(`[Accounts] Failed to clean up cancelled login for ${flow.accountId}:`, err);
+    }
+  }
+
+  activeFlows.delete(ptyId);
+}
+
+/**
+ * Delete an account and its on-disk config directory. Referring sessions and
+ * groups are NULL-ed out by the repository layer.
+ */
+export function deleteAccountAndDir(accountId: string): void {
+  const account = accountsRepo.getAccount(accountId);
+  if (!account) return;
+
+  accountsRepo.deleteAccount(accountId);
+
+  try {
+    const root = accountRoot(accountId);
+    if (fs.existsSync(root)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  } catch (err) {
+    log.error(`[Accounts] Failed to remove config dir for ${accountId}:`, err);
+  }
+}

--- a/src/main/account-auth.ts
+++ b/src/main/account-auth.ts
@@ -22,6 +22,7 @@ import { app, BrowserWindow } from 'electron';
 import log from 'electron-log';
 import { PtyManager } from './pty-manager';
 import * as accountsRepo from './repositories/accounts';
+import { registerMcpServer, registerHooks } from './mcp-config';
 import { ClaudeAccount } from '../shared/types';
 
 interface LoginFlow {
@@ -69,6 +70,16 @@ export function startLoginFlow(
     configDir,
     isDefault: isFirst,
   });
+
+  // Register the Bodhilander MCP server + hooks into the new account's
+  // isolated config before spawning the login pty, so the session has them
+  // available from the first turn (BDHLNDR-31).
+  try {
+    registerMcpServer(configDir);
+    registerHooks(configDir);
+  } catch (err) {
+    log.warn(`[Accounts] MCP/hooks registration failed for new account ${accountId}:`, err);
+  }
 
   const ptyId = `__login-${accountId}`;
 

--- a/src/main/api/routes/groups.ts
+++ b/src/main/api/routes/groups.ts
@@ -90,6 +90,7 @@ export function createGroupsRouter(): Router {
           createdAt: now,
           parentId: parentId || null,
           collapsed: false,
+          claudeAccountId: null,
         };
 
         groupsRepo.createGroup(group);

--- a/src/main/api/routes/sessions.ts
+++ b/src/main/api/routes/sessions.ts
@@ -83,6 +83,7 @@ export function createSessionsRouter(): Router {
           claudeSessionId: null,
           endedAt: null,
           durationSeconds: 0,
+          claudeAccountId: null,
         };
 
         sessionsRepo.createSession(session);

--- a/src/main/claude-launcher.ts
+++ b/src/main/claude-launcher.ts
@@ -26,6 +26,13 @@ export interface ClaudeLaunchConfig {
    * behavior (no flag), which is only used if resume infrastructure is disabled.
    */
   claudeSession?: ClaudeSessionLaunch;
+  /**
+   * Absolute path to an isolated Claude config directory (BDHLNDR-31).
+   * When set, exported as CLAUDE_CONFIG_DIR so Claude Code reads/writes
+   * credentials and settings there instead of ~/.claude. Omit to use the
+   * current user's global ~/.claude.
+   */
+  claudeConfigDir?: string;
 }
 
 export function getClaudeCommand(config: ClaudeLaunchConfig): { command: string; args: string[]; env: NodeJS.ProcessEnv } {
@@ -43,6 +50,10 @@ export function getClaudeCommand(config: ClaudeLaunchConfig): { command: string;
     // Enable experimental MCP CLI features
     ENABLE_EXPERIMENTAL_MCP_CLI: 'true',
   };
+
+  if (config.claudeConfigDir) {
+    env.CLAUDE_CONFIG_DIR = config.claudeConfigDir;
+  }
 
   // Build args for the Claude session UUID (BDHLNDR-9).
   // UUIDs are alphanumeric + hyphens, so they are safe to inline into shell

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -81,6 +81,19 @@ function initializeTables(database: Database.Database): void {
       key TEXT PRIMARY KEY,
       value TEXT
     );
+
+    CREATE TABLE IF NOT EXISTS claude_accounts (
+      id TEXT PRIMARY KEY,
+      label TEXT NOT NULL,
+      config_dir TEXT NOT NULL UNIQUE,
+      email TEXT,
+      color TEXT DEFAULT '#888888',
+      is_default INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      last_used_at TEXT
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_claude_accounts_single_default
+      ON claude_accounts(is_default) WHERE is_default = 1;
   `);
 
   // Migration: Add working_dir column to groups if it doesn't exist
@@ -115,6 +128,19 @@ function initializeTables(database: Database.Database): void {
   if (!sessionColsBdhlndr17.includes('duration_seconds')) {
     database.exec("ALTER TABLE sessions ADD COLUMN duration_seconds REAL DEFAULT 0");
     durationColumnJustAdded = true;
+  }
+
+  // Migration: Add claude_account_id column to groups and sessions (BDHLNDR-31).
+  // Multi-account support — session inherits from group if session's own column
+  // is NULL; group falls back to the default account, then to legacy ~/.claude.
+  // ON DELETE SET NULL is enforced in the repositories/app layer (SQLite doesn't
+  // support adding FK constraints via ALTER TABLE); deleteAccount() in the
+  // accounts repo explicitly nulls referring rows before removing the account.
+  if (!columns.some(col => col.name === 'claude_account_id')) {
+    database.exec("ALTER TABLE groups ADD COLUMN claude_account_id TEXT DEFAULT NULL");
+  }
+  if (!sessionColsBdhlndr17.includes('claude_account_id')) {
+    database.exec("ALTER TABLE sessions ADD COLUMN claude_account_id TEXT DEFAULT NULL");
   }
 
   // Migration: Create session_events table (BDHLNDR-17)

--- a/src/main/group-import-export.ts
+++ b/src/main/group-import-export.ts
@@ -191,6 +191,7 @@ export async function importGroupsAndSessions(): Promise<ImportResult> {
         collapsed: g.collapsed,
         order: g.order,
         createdAt: new Date(g.createdAt),
+        claudeAccountId: null,
       });
       groupCount++;
     }
@@ -223,6 +224,7 @@ export async function importGroupsAndSessions(): Promise<ImportResult> {
         lastActivityAt: new Date(s.lastActivityAt),
         endedAt: null,
         durationSeconds: 0,
+        claudeAccountId: null,
       });
       sessionCount++;
     }
@@ -327,6 +329,7 @@ export async function importFromClaudeLander(): Promise<ImportResult> {
         collapsed: Boolean(row.collapsed),
         order: row.order || 0,
         createdAt: new Date(row.created_at || Date.now()),
+        claudeAccountId: null,
       });
       groupCount++;
     }
@@ -359,6 +362,7 @@ export async function importFromClaudeLander(): Promise<ImportResult> {
         lastActivityAt: new Date(row.last_activity_at || Date.now()),
         endedAt: null,
         durationSeconds: 0,
+        claudeAccountId: null,
       });
       sessionCount++;
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,8 @@ import * as sessionsRepo from './repositories/sessions';
 import * as prefsRepo from './repositories/preferences';
 import * as memoriesRepo from './repositories/memories';
 import * as sessionEventsRepo from './repositories/session-events';
+import * as accountsRepo from './repositories/accounts';
+import * as accountAuth from './account-auth';
 import { exportSessions, ExportFormat } from './session-export';
 import { exportGroupsAndSessions, importGroupsAndSessions, importFromClaudeLander } from './group-import-export';
 import { StateMonitor } from './state-monitor';
@@ -632,6 +634,40 @@ ipcMain.handle('db:sessions:delete', async (_, id: string) => {
   }
   sessionsRepo.deleteSession(id);
   getApiServer().broadcastSessionsUpdated();
+});
+
+// Claude account IPC handlers (BDHLNDR-31)
+safeHandle('accounts:list', () => {
+  return accountsRepo.getAllAccounts();
+});
+
+safeHandle('accounts:startLogin', (label: string) => {
+  const trimmed = (label ?? '').toString().trim();
+  if (!trimmed) throw new Error('Account label is required');
+  return accountAuth.startLoginFlow(ptyManager, mainWindow, trimmed);
+});
+
+safeHandle('accounts:cancelLogin', (ptyId: string, deleteAccount: boolean) => {
+  accountAuth.cancelLoginFlow(ptyManager, ptyId, deleteAccount);
+});
+
+safeHandle('accounts:confirmLoginMacOS', (ptyId: string) => {
+  accountAuth.confirmLoginMacOS(mainWindow, ptyId);
+});
+
+safeHandle('accounts:delete', (id: string) => {
+  accountAuth.deleteAccountAndDir(id);
+});
+
+safeHandle('accounts:update', (
+  id: string,
+  updates: { label?: string; color?: string; email?: string | null },
+) => {
+  accountsRepo.updateAccount(id, updates);
+});
+
+safeHandle('accounts:setDefault', (id: string) => {
+  accountsRepo.setDefaultAccount(id);
 });
 
 // Database IPC Handlers - Memories

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -296,29 +296,52 @@ function createSplashWindow(): void {
   });
 }
 
+/**
+ * Register the Bodhilander Memory MCP server and hook script into every
+ * Claude config dir we know about: the global ~/.claude plus each registered
+ * account's isolated .claude (BDHLNDR-31).
+ */
+function registerMcpAndHooksEverywhere(): void {
+  const targets: (string | undefined)[] = [undefined]; // undefined = global ~/.claude
+  try {
+    for (const acc of accountsRepo.getAllAccounts()) {
+      targets.push(acc.configDir);
+    }
+  } catch (err) {
+    log.warn('[MCP Config] Failed to list accounts for MCP registration:', err);
+  }
+
+  for (const configDir of targets) {
+    const label = configDir ?? '(default)';
+    const mcpResult = registerMcpServer(configDir);
+    if (mcpResult.success) {
+      if (mcpResult.action !== 'unchanged') {
+        log.info(`MCP server ${mcpResult.action} for ${label}: ${mcpResult.path}`);
+      }
+    } else {
+      log.warn(`MCP server registration failed for ${label}:`, mcpResult.error);
+    }
+
+    const hooksResult = registerHooks(configDir);
+    if (hooksResult.success) {
+      if (hooksResult.action !== 'unchanged') {
+        log.info(`Hooks ${hooksResult.action} for ${label}`);
+      }
+    } else {
+      log.warn(`Hooks registration failed for ${label}:`, hooksResult.error);
+    }
+  }
+}
+
 function createWindow(): void {
   // Initialize database
   getDatabase();
 
-  // Register MCP server with Claude Code (auto-configure on startup)
-  const mcpResult = registerMcpServer();
-  if (mcpResult.success) {
-    if (mcpResult.action !== 'unchanged') {
-      log.info(`MCP server ${mcpResult.action}: ${mcpResult.path}`);
-    }
-  } else {
-    log.warn('MCP server registration failed:', mcpResult.error);
-  }
-
-  // Register hooks with Claude Code (auto-configure on startup)
-  const hooksResult = registerHooks();
-  if (hooksResult.success) {
-    if (hooksResult.action !== 'unchanged') {
-      log.info(`Hooks ${hooksResult.action}`);
-    }
-  } else {
-    log.warn('Hooks registration failed:', hooksResult.error);
-  }
+  // Register MCP server + hooks with Claude Code (auto-configure on startup).
+  // Registers into the user's global ~/.claude plus each registered account's
+  // isolated config dir (BDHLNDR-31), so the Bodhilander memory MCP and hook
+  // script work regardless of which account the session is running under.
+  registerMcpAndHooksEverywhere();
 
   // Mark all sessions as stopped on startup (PTY processes don't survive restarts)
   sessionsRepo.markAllSessionsStopped();

--- a/src/main/mcp-config.ts
+++ b/src/main/mcp-config.ts
@@ -139,21 +139,32 @@ function getMcpServerPath(): string {
 }
 
 /**
- * Get the path to Claude Code's config file
- * MCP servers are stored in ~/.claude.json (not ~/.claude/settings.json)
+ * Resolve the `.claude` config directory for a given account (BDHLNDR-31).
+ * When configDir is omitted, defaults to the user's global ~/.claude.
+ * Pass an account's isolated configDir to register MCP/hooks into that
+ * account's sandbox instead of the global one.
  */
-function getClaudeConfigPath(): string {
-  const homeDir = os.homedir();
-
-  // Claude Code stores MCP servers in ~/.claude.json on all platforms
-  return path.join(homeDir, '.claude.json');
+function resolveConfigDir(configDir?: string): string {
+  return configDir ?? path.join(os.homedir(), '.claude');
 }
 
 /**
- * Read Claude Code MCP config (~/.claude.json), returning empty object if doesn't exist
+ * Get the path to Claude Code's MCP config file for the given config dir.
+ * Claude Code keeps MCP servers in a `.claude.json` that sits alongside the
+ * `.claude/` directory (not inside it). For the default case this is
+ * `~/.claude.json`; for an isolated account it's `<parent>/.claude.json`
+ * next to the account's `.claude/`.
  */
-function readClaudeMcpConfig(): ClaudeMcpConfig {
-  const configPath = getClaudeConfigPath();
+function getClaudeConfigPath(configDir?: string): string {
+  const claudeDir = resolveConfigDir(configDir);
+  return path.join(path.dirname(claudeDir), '.claude.json');
+}
+
+/**
+ * Read Claude Code MCP config, returning empty object if the file doesn't exist
+ */
+function readClaudeMcpConfig(configDir?: string): ClaudeMcpConfig {
+  const configPath = getClaudeConfigPath(configDir);
 
   try {
     if (fs.existsSync(configPath)) {
@@ -170,10 +181,12 @@ function readClaudeMcpConfig(): ClaudeMcpConfig {
 /**
  * Write Claude Code MCP config
  */
-function writeClaudeMcpConfig(config: ClaudeMcpConfig): boolean {
-  const configPath = getClaudeConfigPath();
+function writeClaudeMcpConfig(config: ClaudeMcpConfig, configDir?: string): boolean {
+  const configPath = getClaudeConfigPath(configDir);
 
   try {
+    // Ensure parent dir exists (account root may not exist until first write).
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
     return true;
   } catch (err) {
@@ -183,19 +196,19 @@ function writeClaudeMcpConfig(config: ClaudeMcpConfig): boolean {
 }
 
 /**
- * Get path to Claude Code settings file (~/.claude/settings.json)
- * This is where hooks are configured
+ * Get path to Claude Code settings file. Hooks are configured here.
+ * Default: `~/.claude/settings.json`. With a configDir passed: `<configDir>/settings.json`.
  */
-function getClaudeSettingsPath(): string {
-  const homeDir = os.homedir();
-  return path.join(homeDir, '.claude', 'settings.json');
+function getClaudeSettingsPath(configDir?: string): string {
+  return path.join(resolveConfigDir(configDir), 'settings.json');
 }
 
 /**
- * Read Claude Code settings (~/.claude/settings.json)
+ * Read Claude Code settings for the given config dir.
+ * Default target: `~/.claude/settings.json`.
  */
-function readClaudeSettings(): ClaudeSettingsConfig {
-  const settingsPath = getClaudeSettingsPath();
+function readClaudeSettings(configDir?: string): ClaudeSettingsConfig {
+  const settingsPath = getClaudeSettingsPath(configDir);
 
   try {
     if (fs.existsSync(settingsPath)) {
@@ -212,11 +225,11 @@ function readClaudeSettings(): ClaudeSettingsConfig {
 /**
  * Write Claude Code settings
  */
-function writeClaudeSettings(settings: ClaudeSettingsConfig): boolean {
-  const settingsPath = getClaudeSettingsPath();
+function writeClaudeSettings(settings: ClaudeSettingsConfig, configDir?: string): boolean {
+  const settingsPath = getClaudeSettingsPath(configDir);
 
   try {
-    // Ensure .claude directory exists
+    // Ensure the target .claude directory exists
     const claudeDir = path.dirname(settingsPath);
     if (!fs.existsSync(claudeDir)) {
       fs.mkdirSync(claudeDir, { recursive: true });
@@ -284,7 +297,7 @@ function areHooksConfigured(settings: ClaudeSettingsConfig, hookScriptPath: stri
  * Register the Bodhilander Memory MCP server with Claude Code
  * Returns true if configuration was added/updated, false if already configured
  */
-export function registerMcpServer(): { success: boolean; action: 'added' | 'updated' | 'unchanged' | 'error'; path?: string; error?: string } {
+export function registerMcpServer(configDir?: string): { success: boolean; action: 'added' | 'updated' | 'unchanged' | 'error'; path?: string; error?: string } {
   try {
     const mcpServerPath = getMcpServerPath();
 
@@ -294,11 +307,11 @@ export function registerMcpServer(): { success: boolean; action: 'added' | 'upda
       return { success: false, action: 'error', error: `MCP server not found at ${mcpServerPath}` };
     }
 
-    const config = readClaudeMcpConfig();
+    const config = readClaudeMcpConfig(configDir);
 
     // Check if already configured correctly
     if (isServerConfigured(config, mcpServerPath)) {
-      log.info('[MCP Config] MCP server already configured correctly');
+      log.info(`[MCP Config] MCP server already configured correctly for ${configDir ?? '(default)'}`);
       return { success: true, action: 'unchanged', path: mcpServerPath };
     }
 
@@ -316,8 +329,8 @@ export function registerMcpServer(): { success: boolean; action: 'added' | 'upda
     };
 
     // Write the updated config
-    if (writeClaudeMcpConfig(config)) {
-      log.info(`[MCP Config] MCP server ${action} successfully:`, mcpServerPath);
+    if (writeClaudeMcpConfig(config, configDir)) {
+      log.info(`[MCP Config] MCP server ${action} successfully for ${configDir ?? '(default)'}:`, mcpServerPath);
       return { success: true, action, path: mcpServerPath };
     } else {
       return { success: false, action: 'error', error: 'Failed to write config file' };
@@ -337,10 +350,10 @@ export function registerMcpServer(): { success: boolean; action: 'added' | 'upda
  * name) are purged from ALL hook types before any file-existence check, so
  * users of renamed/removed installs aren't left with broken hook commands.
  */
-export function registerHooks(): { success: boolean; action: 'added' | 'updated' | 'unchanged' | 'error'; error?: string } {
+export function registerHooks(configDir?: string): { success: boolean; action: 'added' | 'updated' | 'unchanged' | 'error'; error?: string } {
   try {
     const hookScriptPath = getHookScriptPath();
-    const settings = readClaudeSettings();
+    const settings = readClaudeSettings(configDir);
 
     // Purge stale Bodhilander/ClaudeLander entries FIRST — do this before any
     // early return, so users whose new hook script is missing still get their
@@ -348,8 +361,8 @@ export function registerHooks(): { success: boolean; action: 'added' | 'updated'
     // valid entries in place so repeated startups don't thrash settings.
     const purged = purgeOurHooks(settings, hookScriptPath);
     if (purged) {
-      writeClaudeSettings(settings);
-      log.info('[Hooks Config] Purged stale Bodhilander/ClaudeLander hook entries');
+      writeClaudeSettings(settings, configDir);
+      log.info(`[Hooks Config] Purged stale Bodhilander/ClaudeLander hook entries from ${configDir ?? '(default)'}`);
     }
 
     // Verify the hook script exists before attempting to register new entries
@@ -360,7 +373,7 @@ export function registerHooks(): { success: boolean; action: 'added' | 'updated'
 
     // Check if current (correct-path) entries are already configured
     if (areHooksConfigured(settings, hookScriptPath)) {
-      log.info('[Hooks Config] Hooks already configured');
+      log.info(`[Hooks Config] Hooks already configured for ${configDir ?? '(default)'}`);
       return { success: true, action: 'unchanged' };
     }
 
@@ -389,8 +402,8 @@ export function registerHooks(): { success: boolean; action: 'added' | 'updated'
     settings.hooks.Stop = [...(settings.hooks.Stop ?? []), stopHook];
 
     // Write the updated settings
-    if (writeClaudeSettings(settings)) {
-      log.info(`[Hooks Config] Hooks ${action} successfully`);
+    if (writeClaudeSettings(settings, configDir)) {
+      log.info(`[Hooks Config] Hooks ${action} successfully for ${configDir ?? '(default)'}`);
       return { success: true, action };
     } else {
       return { success: false, action: 'error', error: 'Failed to write settings file' };
@@ -405,9 +418,9 @@ export function registerHooks(): { success: boolean; action: 'added' | 'updated'
 /**
  * Unregister the Bodhilander Memory MCP server from Claude Code
  */
-export function unregisterMcpServer(): boolean {
+export function unregisterMcpServer(configDir?: string): boolean {
   try {
-    const config = readClaudeMcpConfig();
+    const config = readClaudeMcpConfig(configDir);
 
     if (config.mcpServers?.[MCP_SERVER_NAME]) {
       delete config.mcpServers[MCP_SERVER_NAME];
@@ -417,8 +430,8 @@ export function unregisterMcpServer(): boolean {
         delete config.mcpServers;
       }
 
-      if (writeClaudeMcpConfig(config)) {
-        log.info('[MCP Config] MCP server unregistered successfully');
+      if (writeClaudeMcpConfig(config, configDir)) {
+        log.info(`[MCP Config] MCP server unregistered successfully for ${configDir ?? '(default)'}`);
         return true;
       }
     }
@@ -434,14 +447,14 @@ export function unregisterMcpServer(): boolean {
  * Unregister Bodhilander hooks from Claude Code (including any legacy
  * ClaudeLander entries from before the app rename).
  */
-export function unregisterHooks(): boolean {
+export function unregisterHooks(configDir?: string): boolean {
   try {
-    const settings = readClaudeSettings();
+    const settings = readClaudeSettings(configDir);
 
     if (!purgeOurHooks(settings)) return false;
 
-    if (writeClaudeSettings(settings)) {
-      log.info('[Hooks Config] Hooks unregistered successfully');
+    if (writeClaudeSettings(settings, configDir)) {
+      log.info(`[Hooks Config] Hooks unregistered successfully for ${configDir ?? '(default)'}`);
       return true;
     }
 
@@ -455,10 +468,10 @@ export function unregisterHooks(): boolean {
 /**
  * Get the current MCP server configuration status
  */
-export function getMcpServerStatus(): { configured: boolean; path?: string; expectedPath?: string } {
+export function getMcpServerStatus(configDir?: string): { configured: boolean; path?: string; expectedPath?: string } {
   try {
     const expectedPath = getMcpServerPath();
-    const config = readClaudeMcpConfig();
+    const config = readClaudeMcpConfig(configDir);
     const serverConfig = config.mcpServers?.[MCP_SERVER_NAME];
 
     if (!serverConfig) {
@@ -479,10 +492,10 @@ export function getMcpServerStatus(): { configured: boolean; path?: string; expe
 /**
  * Get the current hooks configuration status
  */
-export function getHooksStatus(): { configured: boolean; hookScriptPath?: string } {
+export function getHooksStatus(configDir?: string): { configured: boolean; hookScriptPath?: string } {
   try {
     const hookScriptPath = getHookScriptPath();
-    const settings = readClaudeSettings();
+    const settings = readClaudeSettings(configDir);
     const configured = areHooksConfigured(settings, hookScriptPath);
 
     return { configured, hookScriptPath };

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -348,6 +348,32 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   getEditorOptions: (): Promise<{ value: string; label: string }[]> =>
     ipcRenderer.invoke('editor:getOptions'),
+
+  // Claude accounts (BDHLNDR-31)
+  listAccounts: (): Promise<ClaudeAccount[]> =>
+    ipcRenderer.invoke('accounts:list'),
+  startAccountLogin: (label: string): Promise<{ account: ClaudeAccount; ptyId: string }> =>
+    ipcRenderer.invoke('accounts:startLogin', label),
+  cancelAccountLogin: (ptyId: string, deleteAccount: boolean): Promise<void> =>
+    ipcRenderer.invoke('accounts:cancelLogin', ptyId, deleteAccount),
+  confirmAccountLoginMacOS: (ptyId: string): Promise<void> =>
+    ipcRenderer.invoke('accounts:confirmLoginMacOS', ptyId),
+  deleteAccount: (id: string): Promise<void> =>
+    ipcRenderer.invoke('accounts:delete', id),
+  updateAccount: (id: string, updates: { label?: string; color?: string; email?: string | null }): Promise<void> =>
+    ipcRenderer.invoke('accounts:update', id, updates),
+  setDefaultAccount: (id: string): Promise<void> =>
+    ipcRenderer.invoke('accounts:setDefault', id),
+  onAccountLoginCompleted: (callback: (data: { accountId: string; email: string | null }) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, data: { accountId: string; email: string | null }) => callback(data);
+    ipcRenderer.on('accounts:login-completed', listener);
+    return () => ipcRenderer.removeListener('accounts:login-completed', listener);
+  },
+  onAccountLoginExited: (callback: (data: { accountId: string; exitCode: number }) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, data: { accountId: string; exitCode: number }) => callback(data);
+    ipcRenderer.on('accounts:login-exited', listener);
+    return () => ipcRenderer.removeListener('accounts:login-exited', listener);
+  },
 
   // Error logging — forward renderer errors to main process log file
   logError: (source: string, message: string, stack?: string): Promise<void> =>

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -10,6 +10,7 @@ import {
   setClaudeSessionId as storeClaudeSessionId,
   clearClaudeSessionId as clearStoredClaudeSessionId,
 } from './repositories/sessions';
+import { resolveAccountForSession, touchAccount } from './repositories/accounts';
 import { writeMemoryFile, getMemoryInjectionContent } from './memory/injector';
 import log from 'electron-log';
 
@@ -161,11 +162,19 @@ class PtyManager extends EventEmitter {
         storeClaudeSessionId(id, claudeSessionId);
       }
 
+      // Resolve which Claude account this session should launch under (BDHLNDR-31).
+      // Returns null when no accounts are registered, preserving legacy ~/.claude behavior.
+      const account = resolveAccountForSession(id);
+      if (account) {
+        touchAccount(account.id);
+      }
+
       const claudeConfig = getClaudeCommand({
         sessionId: id,
         projectDir: cwd,
         socketPath: this.socketPath,
         claudeSession: { id: claudeSessionId, mode: claudeSessionMode },
+        claudeConfigDir: account?.configDir,
       });
 
       // Suffix appended to every shell's claude command. UUIDs are alphanumeric

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -96,7 +96,7 @@ const WAITING_PATTERNS = [
   /proceed with/i,                        // "Proceed with this approach?"
 ] as const;
 
-class PtyManager extends EventEmitter {
+export class PtyManager extends EventEmitter {
   private sessions: Map<string, PtySession> = new Map();
   private socketPath: string;
 
@@ -353,6 +353,109 @@ class PtyManager extends EventEmitter {
       killing: false,
     });
 
+  }
+
+  /**
+   * Spawn a pty running `claude` under an isolated CLAUDE_CONFIG_DIR for the
+   * interactive add-account login flow (BDHLNDR-31). Keyed by an arbitrary pty
+   * id that's not tied to a DB session — reuses the standard pty events so the
+   * renderer Terminal can attach unchanged.
+   *
+   * Skips memory injection, session-UUID management, and state detection; this
+   * pty exists only long enough for the user to complete `/login` via browser
+   * OAuth, after which the caller tears it down.
+   */
+  createLoginSession(id: string, configDir: string): void {
+    const shellInfo = this.getShellInfo();
+    if (!shellInfo.shell || !fs.existsSync(shellInfo.shell)) {
+      throw new Error(`Shell not found: ${shellInfo.shell || '(empty)'}`);
+    }
+
+    const cwd = require('os').homedir();
+    const processEnv: { [key: string]: string } = {
+      ...(process.env as { [key: string]: string }),
+      CLAUDE_CONFIG_DIR: configDir,
+    };
+    const claudeCmd = 'claude';
+
+    let shell: string;
+    let args: string[];
+
+    if (shellInfo.isWSL) {
+      shell = 'wsl.exe';
+      args = [...shellInfo.args, '--', 'bash', '-c', claudeCmd];
+    } else if (process.platform === 'win32') {
+      shell = shellInfo.shell;
+      if (shellInfo.shell.toLowerCase().includes('powershell')) {
+        args = ['-NoLogo', '-Command', claudeCmd];
+      } else if (shellInfo.shell.toLowerCase().includes('cmd')) {
+        args = ['/c', claudeCmd];
+      } else {
+        args = ['-c', claudeCmd];
+      }
+    } else {
+      shell = shellInfo.shell;
+      args = ['-l', '-i', '-c', claudeCmd];
+    }
+
+    log.info(`[PTY] Starting login pty ${id} with CLAUDE_CONFIG_DIR=${configDir}`);
+
+    const ptyProcess = pty.spawn(shell, args, {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+      cwd: shellInfo.isWSL ? undefined : cwd,
+      env: processEnv,
+      ...(process.platform === 'win32' ? {
+        useConptyDll: true,
+        conptyInheritCursor: false,
+      } : {}),
+    });
+
+    ptyProcess.onData((data) => {
+      const session = this.sessions.get(id);
+      if (!session || session.killing) return;
+
+      let filteredData = data;
+      if (process.platform === 'win32') {
+        filteredData = filteredData.replace(/windows pid \d+, Win32 error \d+/gi, '');
+        if (filteredData.trim() === '') return;
+      }
+
+      session.scrollbackBuffer += filteredData;
+      if (session.scrollbackBuffer.length > MAX_SCROLLBACK_SIZE) {
+        session.scrollbackBuffer = session.scrollbackBuffer.slice(-MAX_SCROLLBACK_SIZE);
+      }
+
+      this.emit('data', { id, data: filteredData });
+    });
+
+    ptyProcess.onExit(({ exitCode }) => {
+      this.emit('exit', { id, exitCode });
+      this.sessions.delete(id);
+    });
+
+    this.sessions.set(id, {
+      id,
+      pty: ptyProcess,
+      cwd,
+      groupId: null,
+      isClaudeSession: true,
+      shellInfo,
+      lastState: 'idle',
+      outputBuffer: '',
+      scrollbackBuffer: '',
+      idleTimeout: null,
+      workingDebounce: null,
+      recentOutputBytes: 0,
+      lastOutputTime: 0,
+      claudeSessionId: null,
+      claudeResumeAttempted: false,
+      spawnedAt: Date.now(),
+      lastCols: 80,
+      lastRows: 24,
+      killing: false,
+    });
   }
 
   write(id: string, data: string): void {

--- a/src/main/repositories/accounts.ts
+++ b/src/main/repositories/accounts.ts
@@ -1,0 +1,163 @@
+import { getDatabase } from '../database';
+import { ClaudeAccount } from '../../shared/types';
+
+function mapRow(row: any): ClaudeAccount {
+  return {
+    id: row.id,
+    label: row.label,
+    configDir: row.config_dir,
+    email: row.email ?? null,
+    color: row.color ?? '#888888',
+    isDefault: Boolean(row.is_default),
+    createdAt: new Date(row.created_at),
+    lastUsedAt: row.last_used_at ? new Date(row.last_used_at) : null,
+  };
+}
+
+export function getAllAccounts(): ClaudeAccount[] {
+  const db = getDatabase();
+  const rows = db.prepare('SELECT * FROM claude_accounts ORDER BY is_default DESC, created_at ASC').all() as any[];
+  return rows.map(mapRow);
+}
+
+export function getAccount(id: string): ClaudeAccount | null {
+  const db = getDatabase();
+  const row = db.prepare('SELECT * FROM claude_accounts WHERE id = ?').get(id);
+  return row ? mapRow(row) : null;
+}
+
+export function getDefaultAccount(): ClaudeAccount | null {
+  const db = getDatabase();
+  const row = db.prepare('SELECT * FROM claude_accounts WHERE is_default = 1 LIMIT 1').get();
+  return row ? mapRow(row) : null;
+}
+
+export interface CreateAccountInput {
+  id: string;
+  label: string;
+  configDir: string;
+  color?: string;
+  isDefault?: boolean;
+}
+
+export function createAccount(input: CreateAccountInput): ClaudeAccount {
+  const db = getDatabase();
+  const createdAt = new Date();
+  const isDefault = input.isDefault ?? false;
+
+  const insert = db.transaction(() => {
+    if (isDefault) {
+      db.prepare('UPDATE claude_accounts SET is_default = 0 WHERE is_default = 1').run();
+    }
+    db.prepare(`
+      INSERT INTO claude_accounts (id, label, config_dir, email, color, is_default, created_at, last_used_at)
+      VALUES (?, ?, ?, NULL, ?, ?, ?, NULL)
+    `).run(
+      input.id,
+      input.label,
+      input.configDir,
+      input.color ?? '#888888',
+      isDefault ? 1 : 0,
+      createdAt.toISOString()
+    );
+  });
+  insert();
+
+  return {
+    id: input.id,
+    label: input.label,
+    configDir: input.configDir,
+    email: null,
+    color: input.color ?? '#888888',
+    isDefault,
+    createdAt,
+    lastUsedAt: null,
+  };
+}
+
+export interface UpdateAccountInput {
+  label?: string;
+  email?: string | null;
+  color?: string;
+}
+
+export function updateAccount(id: string, updates: UpdateAccountInput): void {
+  const db = getDatabase();
+  const fields: string[] = [];
+  const values: any[] = [];
+
+  if (updates.label !== undefined) {
+    fields.push('label = ?');
+    values.push(updates.label);
+  }
+  if (updates.email !== undefined) {
+    fields.push('email = ?');
+    values.push(updates.email);
+  }
+  if (updates.color !== undefined) {
+    fields.push('color = ?');
+    values.push(updates.color);
+  }
+
+  if (fields.length === 0) return;
+
+  values.push(id);
+  db.prepare(`UPDATE claude_accounts SET ${fields.join(', ')} WHERE id = ?`).run(...values);
+}
+
+export function setDefaultAccount(id: string): void {
+  const db = getDatabase();
+  const tx = db.transaction(() => {
+    db.prepare('UPDATE claude_accounts SET is_default = 0 WHERE is_default = 1').run();
+    db.prepare('UPDATE claude_accounts SET is_default = 1 WHERE id = ?').run(id);
+  });
+  tx();
+}
+
+export function touchAccount(id: string): void {
+  const db = getDatabase();
+  db.prepare('UPDATE claude_accounts SET last_used_at = ? WHERE id = ?').run(
+    new Date().toISOString(),
+    id
+  );
+}
+
+/**
+ * Delete an account and NULL out any sessions/groups that referred to it.
+ * SQLite ALTER TABLE can't add a real FK, so we enforce SET NULL semantics here.
+ * Caller is responsible for removing the on-disk config directory.
+ */
+export function deleteAccount(id: string): void {
+  const db = getDatabase();
+  const tx = db.transaction(() => {
+    db.prepare('UPDATE sessions SET claude_account_id = NULL WHERE claude_account_id = ?').run(id);
+    db.prepare('UPDATE groups SET claude_account_id = NULL WHERE claude_account_id = ?').run(id);
+    db.prepare('DELETE FROM claude_accounts WHERE id = ?').run(id);
+  });
+  tx();
+}
+
+/**
+ * Resolve which Claude account a given session should launch under (BDHLNDR-31).
+ * Fallback chain: session → group → default → null (legacy ~/.claude behavior).
+ * Returns null if no accounts are configured, preserving pre-feature behavior.
+ */
+export function resolveAccountForSession(sessionId: string): ClaudeAccount | null {
+  const db = getDatabase();
+
+  const row = db.prepare(`
+    SELECT
+      s.claude_account_id AS session_account_id,
+      g.claude_account_id AS group_account_id
+    FROM sessions s
+    LEFT JOIN groups g ON g.id = s.group_id
+    WHERE s.id = ?
+  `).get(sessionId) as { session_account_id: string | null; group_account_id: string | null } | undefined;
+
+  const candidateId = row?.session_account_id ?? row?.group_account_id ?? null;
+  if (candidateId) {
+    const account = getAccount(candidateId);
+    if (account) return account;
+  }
+  return getDefaultAccount();
+}

--- a/src/main/repositories/groups.ts
+++ b/src/main/repositories/groups.ts
@@ -14,14 +14,15 @@ export function getAllGroups(): Group[] {
     createdAt: new Date(row.created_at),
     parentId: row.parent_id || null,
     collapsed: Boolean(row.collapsed),
+    claudeAccountId: row.claude_account_id ?? null,
   }));
 }
 
 export function createGroup(group: Group): void {
   const db = getDatabase();
   db.prepare(`
-    INSERT INTO groups (id, name, color, working_dir, "order", created_at, parent_id, collapsed)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO groups (id, name, color, working_dir, "order", created_at, parent_id, collapsed, claude_account_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     group.id,
     group.name,
@@ -30,7 +31,8 @@ export function createGroup(group: Group): void {
     group.order,
     group.createdAt.toISOString(),
     group.parentId || null,
-    group.collapsed ? 1 : 0
+    group.collapsed ? 1 : 0,
+    group.claudeAccountId ?? null
   );
 }
 
@@ -62,6 +64,10 @@ export function updateGroup(id: string, updates: Partial<Group>): void {
   if (updates.collapsed !== undefined) {
     fields.push('collapsed = ?');
     values.push(updates.collapsed ? 1 : 0);
+  }
+  if (updates.claudeAccountId !== undefined) {
+    fields.push('claude_account_id = ?');
+    values.push(updates.claudeAccountId);
   }
 
   if (fields.length > 0) {

--- a/src/main/repositories/sessions.ts
+++ b/src/main/repositories/sessions.ts
@@ -24,14 +24,15 @@ export function getAllSessions(): Session[] {
     claudeSessionId: row.claude_session_id ?? null,
     endedAt: row.ended_at ? new Date(row.ended_at) : null,
     durationSeconds: row.duration_seconds ?? 0,
+    claudeAccountId: row.claude_account_id ?? null,
   }));
 }
 
 export function createSession(session: Session): void {
   const db = getDatabase();
   db.prepare(`
-    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at, claude_session_id, ended_at, duration_seconds)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at, claude_session_id, ended_at, duration_seconds, claude_account_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     session.id,
     session.groupId,
@@ -44,7 +45,8 @@ export function createSession(session: Session): void {
     session.lastActivityAt.toISOString(),
     session.claudeSessionId ?? null,
     session.endedAt ? session.endedAt.toISOString() : null,
-    session.durationSeconds ?? 0
+    session.durationSeconds ?? 0,
+    session.claudeAccountId ?? null
   );
 }
 
@@ -109,6 +111,10 @@ export function updateSession(id: string, updates: Partial<Session>): void {
   if (updates.durationSeconds !== undefined) {
     fields.push('duration_seconds = ?');
     values.push(updates.durationSeconds);
+  }
+  if (updates.claudeAccountId !== undefined) {
+    fields.push('claude_account_id = ?');
+    values.push(updates.claudeAccountId);
   }
 
   if (fields.length > 0) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import { MemoryPanel } from './components/panels/MemoryPanel';
 import AnalyticsPanel from './components/panels/AnalyticsPanel';
 import { SessionStatsBadge } from './components/SessionStatsBadge';
 import { CodeSearchModal } from './components/CodeSearchModal';
+import { ClaudeAccountsModal } from './components/ClaudeAccountsModal';
 import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
 import { useSharing } from './store/sharing';
@@ -74,6 +75,7 @@ const App: React.FC = () => {
   const [shareModalSessionId, setShareModalSessionId] = useState<string | null>(null);
   const [joinModalOpen, setJoinModalOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [claudeAccountsOpen, setClaudeAccountsOpen] = useState(false);
   const [sharingSessions, setSharingSessions] = useState<Set<string>>(new Set());
   const { user, isAuthenticated } = useSharing();
 
@@ -870,6 +872,14 @@ const App: React.FC = () => {
             </button>
             <button
               className="icon-button"
+              onClick={() => setClaudeAccountsOpen(true)}
+              title="Claude accounts"
+              aria-label="Claude accounts"
+            >
+              🔑
+            </button>
+            <button
+              className="icon-button"
               onClick={() => setJoinModalOpen(true)}
               title={isAuthenticated ? 'Join Shared Session' : 'Sign in to join sessions'}
               aria-label="Join Shared Session"
@@ -1516,6 +1526,12 @@ const App: React.FC = () => {
       <SettingsModal
         isOpen={settingsOpen}
         onClose={() => setSettingsOpen(false)}
+      />
+
+      {/* Claude accounts modal (BDHLNDR-31) */}
+      <ClaudeAccountsModal
+        isOpen={claudeAccountsOpen}
+        onClose={() => setClaudeAccountsOpen(false)}
       />
 
       {/* Code Search modal */}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,6 +13,7 @@ import AnalyticsPanel from './components/panels/AnalyticsPanel';
 import { SessionStatsBadge } from './components/SessionStatsBadge';
 import { CodeSearchModal } from './components/CodeSearchModal';
 import { ClaudeAccountsModal } from './components/ClaudeAccountsModal';
+import { ClaudeAccount } from '../shared/types';
 import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
 import { useSharing } from './store/sharing';
@@ -76,6 +77,7 @@ const App: React.FC = () => {
   const [joinModalOpen, setJoinModalOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [claudeAccountsOpen, setClaudeAccountsOpen] = useState(false);
+  const [claudeAccounts, setClaudeAccounts] = useState<ClaudeAccount[]>([]);
   const [sharingSessions, setSharingSessions] = useState<Set<string>>(new Set());
   const { user, isAuthenticated } = useSharing();
 
@@ -191,6 +193,33 @@ const App: React.FC = () => {
     return cleanup;
   }, [activeRemoteCode]);
 
+  // Claude accounts cache — kept in sync with main process so context menus
+  // and creation dialogs can offer account pickers without refetching each time.
+  useEffect(() => {
+    let cancelled = false;
+    const reload = async () => {
+      try {
+        const list = await window.electronAPI.listAccounts();
+        if (!cancelled) setClaudeAccounts(list);
+      } catch (err) {
+        console.error('Failed to load Claude accounts:', err);
+      }
+    };
+    reload();
+    const offCompleted = window.electronAPI.onAccountLoginCompleted(() => reload());
+    return () => {
+      cancelled = true;
+      offCompleted();
+    };
+  }, []);
+
+  // Refresh accounts whenever the accounts modal closes (covers delete/rename).
+  useEffect(() => {
+    if (!claudeAccountsOpen) {
+      window.electronAPI.listAccounts().then(setClaudeAccounts).catch(() => {});
+    }
+  }, [claudeAccountsOpen]);
+
   // Show prompt for new session name
   const handleNewSession = useCallback((groupId: string) => {
     if (!groupId) {
@@ -216,15 +245,17 @@ const App: React.FC = () => {
   };
 
   // Actually create the group after name is confirmed
-  const handleConfirmGroup = async (name: string, path?: string) => {
+  const handleConfirmGroup = async (name: string, path?: string, claudeAccountId?: string | null) => {
     setGroupPrompt(null);
 
     // Create the group first
     const newGroup = await createGroup(name);
 
-    // If path was selected during creation, update the group
-    if (path) {
-      await updateGroup(newGroup.id, { workingDir: path });
+    const updates: Partial<typeof newGroup> = {};
+    if (path) updates.workingDir = path;
+    if (claudeAccountId !== undefined) updates.claudeAccountId = claudeAccountId;
+    if (Object.keys(updates).length > 0) {
+      await updateGroup(newGroup.id, updates);
     }
   };
 
@@ -238,12 +269,16 @@ const App: React.FC = () => {
   };
 
   // Actually create the sub-group after name is confirmed
-  const handleConfirmSubGroup = async (name: string, path?: string) => {
+  const handleConfirmSubGroup = async (name: string, path?: string, claudeAccountId?: string | null) => {
     if (!subGroupPrompt) return;
     const newGroup = await createGroup(name, subGroupPrompt.parentId);
-    // If path was selected, update the subgroup (overrides inherited parent path)
-    if (path && newGroup) {
-      await updateGroup(newGroup.id, { workingDir: path });
+    if (newGroup) {
+      const updates: Partial<typeof newGroup> = {};
+      if (path) updates.workingDir = path;
+      if (claudeAccountId !== undefined) updates.claudeAccountId = claudeAccountId;
+      if (Object.keys(updates).length > 0) {
+        await updateGroup(newGroup.id, updates);
+      }
     }
     setSubGroupPrompt(null);
   };
@@ -292,38 +327,74 @@ const App: React.FC = () => {
 
   const handleSessionContextMenu = (e: React.MouseEvent, sessionId: string, sessionName: string) => {
     e.preventDefault();
-    setContextMenu({
-      x: e.clientX,
-      y: e.clientY,
-      items: [
-        { label: 'Rename', onClick: () => handleStartEditSession(sessionId, sessionName) },
-        { label: 'Share Session', onClick: () => setShareModalSessionId(sessionId), disabled: !isAuthenticated },
-        { label: 'separator', onClick: () => {}, separator: true },
-        { label: 'Close Session', onClick: () => handleRemoveSession(sessionId), danger: true },
-      ],
-    });
+    const session = sessions.find(s => s.id === sessionId);
+    const currentAccountId = session?.claudeAccountId ?? null;
+
+    const items: MenuItem[] = [
+      { label: 'Rename', onClick: () => handleStartEditSession(sessionId, sessionName) },
+      { label: 'Share Session', onClick: () => setShareModalSessionId(sessionId), disabled: !isAuthenticated },
+    ];
+
+    // Account-assignment items (BDHLNDR-31) — only shown when accounts are registered.
+    if (claudeAccounts.length > 0) {
+      items.push({ label: 'separator', onClick: () => {}, separator: true });
+      items.push({
+        label: `${currentAccountId === null ? '✓ ' : '   '}Inherit account from group`,
+        onClick: () => updateSession(sessionId, { claudeAccountId: null }),
+      });
+      for (const acc of claudeAccounts) {
+        const isCurrent = currentAccountId === acc.id;
+        items.push({
+          label: `${isCurrent ? '✓ ' : '   '}Use "${acc.label}"${acc.isDefault ? ' (default)' : ''}`,
+          onClick: () => updateSession(sessionId, { claudeAccountId: acc.id }),
+        });
+      }
+    }
+
+    items.push({ label: 'separator', onClick: () => {}, separator: true });
+    items.push({ label: 'Close Session', onClick: () => handleRemoveSession(sessionId), danger: true });
+
+    setContextMenu({ x: e.clientX, y: e.clientY, items });
   };
 
   const handleGroupContextMenu = (e: React.MouseEvent, groupId: string, groupName: string) => {
     e.preventDefault();
     const sessionsInGroup = getSessionsByGroup(groupId);
-    setContextMenu({
-      x: e.clientX,
-      y: e.clientY,
-      items: [
-        { label: 'New Session', onClick: () => handleNewSession(groupId) },
-        { label: 'Rename', onClick: () => handleStartEditGroup(groupId, groupName) },
-        { label: 'Set Working Directory', onClick: () => handleSetGroupDirectory(groupId) },
-        { label: 'New Sub-Group', onClick: () => handleCreateSubGroup(groupId), disabled: !!groups.find(g => g.id === groupId)?.parentId },
-        { label: 'separator', onClick: () => {}, separator: true },
-        {
-          label: 'Delete Group',
-          onClick: () => handleDeleteGroup(groupId),
-          danger: true,
-          disabled: sessionsInGroup.length > 0,
-        },
-      ],
+    const group = groups.find(g => g.id === groupId);
+    const currentAccountId = group?.claudeAccountId ?? null;
+
+    const items: MenuItem[] = [
+      { label: 'New Session', onClick: () => handleNewSession(groupId) },
+      { label: 'Rename', onClick: () => handleStartEditGroup(groupId, groupName) },
+      { label: 'Set Working Directory', onClick: () => handleSetGroupDirectory(groupId) },
+      { label: 'New Sub-Group', onClick: () => handleCreateSubGroup(groupId), disabled: !!groups.find(g => g.id === groupId)?.parentId },
+    ];
+
+    // Account-assignment items (BDHLNDR-31) — only shown when accounts are registered.
+    if (claudeAccounts.length > 0) {
+      items.push({ label: 'separator', onClick: () => {}, separator: true });
+      items.push({
+        label: `${currentAccountId === null ? '✓ ' : '   '}Use default account`,
+        onClick: () => updateGroup(groupId, { claudeAccountId: null }),
+      });
+      for (const acc of claudeAccounts) {
+        const isCurrent = currentAccountId === acc.id;
+        items.push({
+          label: `${isCurrent ? '✓ ' : '   '}Use "${acc.label}"${acc.isDefault ? ' (default)' : ''}`,
+          onClick: () => updateGroup(groupId, { claudeAccountId: acc.id }),
+        });
+      }
+    }
+
+    items.push({ label: 'separator', onClick: () => {}, separator: true });
+    items.push({
+      label: 'Delete Group',
+      onClick: () => handleDeleteGroup(groupId),
+      danger: true,
+      disabled: sessionsInGroup.length > 0,
     });
+
+    setContextMenu({ x: e.clientX, y: e.clientY, items });
   };
 
   const handleRemoteGroupContextMenu = (e: React.MouseEvent) => {
@@ -1489,6 +1560,7 @@ const App: React.FC = () => {
         onConfirm={handleConfirmGroup}
         onCancel={() => setGroupPrompt(null)}
         showPathSelector={true}
+        accountPicker={{ accounts: claudeAccounts, initialAccountId: null }}
       />
 
       <NamePromptModal
@@ -1500,6 +1572,11 @@ const App: React.FC = () => {
         onCancel={() => setSubGroupPrompt(null)}
         showPathSelector={true}
         pathLabel="Working Directory (optional, inherits from parent)"
+        accountPicker={{
+          accounts: claudeAccounts,
+          initialAccountId: null,
+          label: 'Claude account (optional, inherits from parent)',
+        }}
       />
 
       {/* Choice menu for + button on groups */}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -137,6 +137,26 @@ const App: React.FC = () => {
   const activeSession = sessions.find(s => s.id === activeSessionId);
   const activeGroupId = activeSession?.groupId || null;
 
+  // Resolve the effective Claude account for a session, applying the same
+  // fallback chain the main process uses (session → group → default). Used by
+  // the sidebar badge so the user can see which account a session will run
+  // under at a glance (BDHLNDR-31).
+  const effectiveAccountForSession = useCallback((sessionId: string): ClaudeAccount | null => {
+    if (claudeAccounts.length === 0) return null;
+    const session = sessions.find(s => s.id === sessionId);
+    if (!session) return null;
+    const direct = session.claudeAccountId
+      ? claudeAccounts.find(a => a.id === session.claudeAccountId)
+      : null;
+    if (direct) return direct;
+    const group = groups.find(g => g.id === session.groupId);
+    const inherited = group?.claudeAccountId
+      ? claudeAccounts.find(a => a.id === group.claudeAccountId)
+      : null;
+    if (inherited) return inherited;
+    return claudeAccounts.find(a => a.isDefault) ?? null;
+  }, [sessions, groups, claudeAccounts]);
+
   // Dismiss color picker on Escape or click-outside
   useEffect(() => {
     if (!colorPickerGroupId) return;
@@ -1090,6 +1110,19 @@ const App: React.FC = () => {
                     onDragOver={(e) => handleSessionDragOver(e, session.id, group.id)}
                     onDrop={(e) => handleSessionDrop(e, session.id, group.id)}
                   >
+                    {(() => {
+                      const acc = effectiveAccountForSession(session.id);
+                      if (!acc) return null;
+                      return (
+                        <span
+                          className="session-account-dot"
+                          style={{ background: acc.color || '#888888' }}
+                          title={`Claude account: ${acc.label}${acc.email ? ` (${acc.email})` : ''}${session.claudeAccountId ? ' — session override' : ' — inherited'}`}
+                          aria-label={`Account: ${acc.label}`}
+                          draggable={false}
+                        />
+                      );
+                    })()}
                     <div className="session-info">
                       {editingSessionId === session.id ? (
                         <input
@@ -1262,6 +1295,18 @@ const App: React.FC = () => {
                       onDragOver={(e) => handleSessionDragOver(e, session.id, subGroup.id)}
                       onDrop={(e) => handleSessionDrop(e, session.id, subGroup.id)}
                     >
+                      {(() => {
+                        const acc = effectiveAccountForSession(session.id);
+                        if (!acc) return null;
+                        return (
+                          <span
+                            className="session-account-dot"
+                            style={{ background: acc.color || '#888888' }}
+                            title={`Claude account: ${acc.label}${acc.email ? ` (${acc.email})` : ''}${session.claudeAccountId ? ' — session override' : ' — inherited'}`}
+                            aria-label={`Account: ${acc.label}`}
+                          />
+                        );
+                      })()}
                       <div className="session-info">
                         {editingSessionId === session.id ? (
                           <input

--- a/src/renderer/components/ClaudeAccountsModal.css
+++ b/src/renderer/components/ClaudeAccountsModal.css
@@ -1,0 +1,256 @@
+/* Claude accounts modal (BDHLNDR-31) — reuses the global .modal-overlay */
+
+.claude-accounts-modal {
+  background: #252526;
+  border: 1px solid #3c3c3c;
+  border-radius: 8px;
+  padding: 20px 24px;
+  min-width: 520px;
+  max-width: 640px;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  color: #d4d4d4;
+}
+
+.claude-accounts-modal h3 {
+  margin: 0 0 4px 0;
+  font-size: 15px;
+  font-weight: 500;
+  color: #e0e0e0;
+}
+
+.claude-accounts-modal .subtitle {
+  margin: 0 0 16px 0;
+  font-size: 12px;
+  color: #888;
+}
+
+.claude-accounts-modal .empty {
+  padding: 24px;
+  text-align: center;
+  color: #888;
+  font-size: 13px;
+  background: #1e1e1e;
+  border: 1px dashed #3c3c3c;
+  border-radius: 6px;
+}
+
+.claude-accounts-modal .account-list {
+  list-style: none;
+  margin: 0 0 12px 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.claude-accounts-modal .account-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: #1e1e1e;
+  border: 1px solid #2c2c2c;
+  border-radius: 6px;
+}
+
+.claude-accounts-modal .account-row .swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex: 0 0 10px;
+}
+
+.claude-accounts-modal .account-row .label {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.claude-accounts-modal .account-row .label .name {
+  font-size: 13px;
+  font-weight: 500;
+  color: #e0e0e0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.claude-accounts-modal .account-row .label .email {
+  font-size: 11px;
+  color: #888;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.claude-accounts-modal .account-row .default-tag {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #69ADFF;
+  border: 1px solid #3a5a8f;
+  padding: 1px 6px;
+  border-radius: 10px;
+}
+
+.claude-accounts-modal .account-row .row-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.claude-accounts-modal button {
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+  border: none;
+  background: #3c3c3c;
+  color: #d4d4d4;
+}
+
+.claude-accounts-modal button:hover {
+  background: #4c4c4c;
+}
+
+.claude-accounts-modal button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.claude-accounts-modal .modal-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.claude-accounts-modal .add-btn {
+  background: linear-gradient(135deg, #5a7aff 0%, #69ADFF 100%);
+  color: #ffffff;
+  font-weight: 500;
+  padding: 8px 14px;
+}
+
+.claude-accounts-modal .add-btn:hover {
+  opacity: 0.9;
+}
+
+.claude-accounts-modal .close-btn {
+  background: #2c2c2c;
+}
+
+.claude-accounts-modal .delete-btn {
+  background: #5a2c2c;
+  color: #f0d0d0;
+}
+
+.claude-accounts-modal .delete-btn:hover {
+  background: #7a3c3c;
+}
+
+/* Add-account login modal */
+.claude-account-login-modal {
+  background: #252526;
+  border: 1px solid #3c3c3c;
+  border-radius: 8px;
+  padding: 20px 24px;
+  width: 760px;
+  max-width: 92vw;
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  color: #d4d4d4;
+}
+
+.claude-account-login-modal h3 {
+  margin: 0 0 4px 0;
+  font-size: 15px;
+  color: #e0e0e0;
+}
+
+.claude-account-login-modal .hint {
+  font-size: 12px;
+  color: #888;
+  margin: 0 0 14px 0;
+  line-height: 1.5;
+}
+
+.claude-account-login-modal input[type="text"] {
+  width: 100%;
+  padding: 10px 12px;
+  background: #1e1e1e;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+  color: #d4d4d4;
+  font-size: 14px;
+  outline: none;
+  margin-bottom: 12px;
+  box-sizing: border-box;
+}
+
+.claude-account-login-modal input[type="text"]:focus {
+  border-color: #69ADFF;
+}
+
+.claude-account-login-modal .terminal-host {
+  flex: 1;
+  min-height: 360px;
+  background: #000;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+
+.claude-account-login-modal .completion-banner {
+  background: #1e3a1e;
+  border: 1px solid #2e5a2e;
+  color: #b8f0b8;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+
+.claude-account-login-modal .footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.claude-account-login-modal button {
+  padding: 8px 14px;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  border: none;
+  background: #3c3c3c;
+  color: #d4d4d4;
+}
+
+.claude-account-login-modal button:hover {
+  background: #4c4c4c;
+}
+
+.claude-account-login-modal .primary {
+  background: linear-gradient(135deg, #5a7aff 0%, #69ADFF 100%);
+  color: #fff;
+  font-weight: 500;
+}
+
+.claude-account-login-modal .primary:hover {
+  opacity: 0.9;
+}
+
+.claude-account-login-modal .danger {
+  background: #5a2c2c;
+  color: #f0d0d0;
+}
+
+.claude-account-login-modal .danger:hover {
+  background: #7a3c3c;
+}

--- a/src/renderer/components/ClaudeAccountsModal.tsx
+++ b/src/renderer/components/ClaudeAccountsModal.tsx
@@ -1,0 +1,302 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ClaudeAccount } from '../../shared/types';
+import Terminal from './Terminal';
+import './ClaudeAccountsModal.css';
+
+interface ClaudeAccountsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const ClaudeAccountsModal: React.FC<ClaudeAccountsModalProps> = ({ isOpen, onClose }) => {
+  const [accounts, setAccounts] = useState<ClaudeAccount[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loginFlow, setLoginFlow] = useState<{ account: ClaudeAccount; ptyId: string } | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const list = await window.electronAPI.listAccounts();
+      setAccounts(list);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) refresh();
+  }, [isOpen, refresh]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const off = window.electronAPI.onAccountLoginCompleted(() => {
+      refresh();
+    });
+    return off;
+  }, [isOpen, refresh]);
+
+  const handleAdd = useCallback(async (label: string) => {
+    const result = await window.electronAPI.startAccountLogin(label);
+    setLoginFlow(result);
+    await refresh();
+  }, [refresh]);
+
+  const handleSetDefault = useCallback(async (id: string) => {
+    await window.electronAPI.setDefaultAccount(id);
+    await refresh();
+  }, [refresh]);
+
+  const handleDelete = useCallback(async (id: string, label: string) => {
+    const confirmed = window.confirm(
+      `Delete account "${label}"?\n\nThis removes its saved credentials and unsets any sessions or groups that were bound to it. Sessions themselves are kept.`
+    );
+    if (!confirmed) return;
+    await window.electronAPI.deleteAccount(id);
+    await refresh();
+  }, [refresh]);
+
+  const handleLoginDone = useCallback(async () => {
+    setLoginFlow(null);
+    await refresh();
+  }, [refresh]);
+
+  const handleLoginCancel = useCallback(async (deleteAccount: boolean) => {
+    if (loginFlow) {
+      await window.electronAPI.cancelAccountLogin(loginFlow.ptyId, deleteAccount);
+    }
+    setLoginFlow(null);
+    await refresh();
+  }, [loginFlow, refresh]);
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <div className="modal-overlay" onClick={onClose}>
+        <div
+          className="claude-accounts-modal"
+          onClick={e => e.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="claude-accounts-title"
+        >
+          <h3 id="claude-accounts-title">Claude accounts</h3>
+          <p className="subtitle">
+            Register one or more Claude Max subscriptions. Each account gets its own isolated
+            login, so sessions assigned to different accounts can run at the same time.
+          </p>
+
+          {loading && accounts.length === 0 ? (
+            <div className="empty">Loading…</div>
+          ) : accounts.length === 0 ? (
+            <div className="empty">No accounts yet. Click "Add account" to log in for the first time.</div>
+          ) : (
+            <ul className="account-list">
+              {accounts.map(acc => (
+                <li key={acc.id} className="account-row">
+                  <span className="swatch" style={{ background: acc.color || '#888888' }} />
+                  <div className="label">
+                    <span className="name">{acc.label}</span>
+                    <span className="email">{acc.email || 'Not yet logged in'}</span>
+                  </div>
+                  {acc.isDefault && <span className="default-tag">default</span>}
+                  <div className="row-actions">
+                    {!acc.isDefault && (
+                      <button onClick={() => handleSetDefault(acc.id)} title="Use as the default account when a group or session doesn't specify one">
+                        Make default
+                      </button>
+                    )}
+                    <button className="delete-btn" onClick={() => handleDelete(acc.id, acc.label)}>
+                      Delete
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="modal-footer">
+            <button className="close-btn" onClick={onClose}>Close</button>
+            <AddAccountButton onAdd={handleAdd} disabled={!!loginFlow} />
+          </div>
+        </div>
+      </div>
+
+      {loginFlow && (
+        <ClaudeAccountLoginModal
+          account={loginFlow.account}
+          ptyId={loginFlow.ptyId}
+          onDone={handleLoginDone}
+          onCancel={handleLoginCancel}
+        />
+      )}
+    </>
+  );
+};
+
+// -----------------------------------------------------------------------------
+// Add-account button — inline label prompt before starting the login flow.
+// -----------------------------------------------------------------------------
+
+const AddAccountButton: React.FC<{ onAdd: (label: string) => Promise<void>; disabled?: boolean }> = ({ onAdd, disabled }) => {
+  const [editing, setEditing] = useState(false);
+  const [label, setLabel] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = label.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      await onAdd(trimmed);
+      setLabel('');
+      setEditing(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!editing) {
+    return (
+      <button className="add-btn" disabled={disabled} onClick={() => setEditing(true)}>
+        + Add account
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={submit} style={{ display: 'flex', gap: 6 }}>
+      <input
+        type="text"
+        autoFocus
+        placeholder="Label (e.g. Personal)"
+        value={label}
+        onChange={e => setLabel(e.target.value)}
+        style={{
+          padding: '6px 10px',
+          background: '#1e1e1e',
+          border: '1px solid #3c3c3c',
+          borderRadius: 4,
+          color: '#d4d4d4',
+          fontSize: 12,
+          outline: 'none',
+          minWidth: 160,
+        }}
+      />
+      <button type="submit" className="add-btn" disabled={submitting || !label.trim()}>
+        {submitting ? 'Starting…' : 'Start login'}
+      </button>
+      <button type="button" onClick={() => { setEditing(false); setLabel(''); }}>
+        Cancel
+      </button>
+    </form>
+  );
+};
+
+// -----------------------------------------------------------------------------
+// Login modal — embeds a Terminal attached to the login pty. Auto-closes when
+// the credentials file appears (Linux/Windows). On macOS, shows an explicit
+// "I'm logged in" button since tokens go to Keychain.
+// -----------------------------------------------------------------------------
+
+interface ClaudeAccountLoginModalProps {
+  account: ClaudeAccount;
+  ptyId: string;
+  onDone: () => void;
+  onCancel: (deleteAccount: boolean) => void;
+}
+
+const ClaudeAccountLoginModal: React.FC<ClaudeAccountLoginModalProps> = ({
+  account,
+  ptyId,
+  onDone,
+  onCancel,
+}) => {
+  const [completed, setCompleted] = useState(false);
+  const [exited, setExited] = useState(false);
+  const isMac = useMemo(() => window.electronAPI.platform === 'darwin', []);
+
+  useEffect(() => {
+    const offCompleted = window.electronAPI.onAccountLoginCompleted((data) => {
+      if (data.accountId === account.id) {
+        setCompleted(true);
+      }
+    });
+    const offExited = window.electronAPI.onAccountLoginExited((data) => {
+      if (data.accountId === account.id) {
+        setExited(true);
+      }
+    });
+    return () => {
+      offCompleted();
+      offExited();
+    };
+  }, [account.id]);
+
+  const confirmMac = useCallback(async () => {
+    await window.electronAPI.confirmAccountLoginMacOS(ptyId);
+  }, [ptyId]);
+
+  const handleClose = useCallback(() => {
+    // Successful login: keep the account, just kill the pty.
+    onDone();
+    window.electronAPI.cancelAccountLogin(ptyId, false).catch(() => {});
+  }, [onDone, ptyId]);
+
+  const handleAbort = useCallback(() => {
+    const confirmed = window.confirm(
+      `Abort login for "${account.label}"? The account and its config directory will be deleted.`
+    );
+    if (!confirmed) return;
+    onCancel(true);
+  }, [onCancel, account.label]);
+
+  return (
+    <div className="modal-overlay" onClick={e => e.stopPropagation()}>
+      <div
+        className="claude-account-login-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="claude-account-login-title"
+      >
+        <h3 id="claude-account-login-title">Log in to "{account.label}"</h3>
+        <p className="hint">
+          {completed ? (
+            <>Login detected{' — '}credentials were saved to this account's isolated config directory. You can close this window.</>
+          ) : exited ? (
+            <>The login process exited before credentials were saved. Abort and try again, or close this window to keep the empty account.</>
+          ) : isMac ? (
+            <>Run <code>/login</code> in the terminal below and complete OAuth in your browser. Because macOS stores tokens in Keychain, click "I'm logged in" once you see "Logged in" in the terminal.</>
+          ) : (
+            <>Run <code>/login</code> in the terminal below and complete OAuth in your browser. This window will close itself once your credentials are saved.</>
+          )}
+        </p>
+
+        {completed && <div className="completion-banner">Login saved. It's safe to close this window.</div>}
+
+        <div className="terminal-host">
+          <Terminal
+            sessionId={ptyId}
+            cwd={window.electronAPI.homedir}
+            launchClaude={true}
+            externalPty={true}
+            isActive={true}
+          />
+        </div>
+
+        <div className="footer">
+          <button className="danger" onClick={handleAbort}>Abort & delete</button>
+          <div style={{ display: 'flex', gap: 8 }}>
+            {isMac && !completed && !exited && (
+              <button className="primary" onClick={confirmMac}>I'm logged in</button>
+            )}
+            <button className="primary" onClick={handleClose} disabled={!completed && !exited}>
+              {completed ? 'Done' : exited ? 'Close' : 'Waiting…'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/components/NamePromptModal.tsx
+++ b/src/renderer/components/NamePromptModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { ClaudeAccount } from '../../shared/types';
 import './NamePromptModal.css';
 
 interface NamePromptModalProps {
@@ -6,11 +7,22 @@ interface NamePromptModalProps {
   title: string;
   placeholder: string;
   defaultValue: string;
-  onConfirm: (name: string, path?: string) => void;
+  onConfirm: (name: string, path?: string, claudeAccountId?: string | null) => void;
   onCancel: () => void;
   /** Show an optional path selector for group creation */
   showPathSelector?: boolean;
   pathLabel?: string;
+  /**
+   * When provided, show a Claude account dropdown (BDHLNDR-31). The onConfirm
+   * callback receives the selected accountId (or null for "use default") as
+   * the third argument.
+   */
+  accountPicker?: {
+    accounts: ClaudeAccount[];
+    initialAccountId?: string | null;
+    /** Override the dropdown label. Default: "Claude account". */
+    label?: string;
+  };
 }
 
 export const NamePromptModal: React.FC<NamePromptModalProps> = ({
@@ -22,31 +34,34 @@ export const NamePromptModal: React.FC<NamePromptModalProps> = ({
   onCancel,
   showPathSelector = false,
   pathLabel = 'Working Directory (optional)',
+  accountPicker,
 }) => {
   const [value, setValue] = useState(defaultValue);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(
+    accountPicker?.initialAccountId ?? null,
+  );
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (isOpen) {
       setValue(defaultValue);
       setSelectedPath(null);
+      setSelectedAccountId(accountPicker?.initialAccountId ?? null);
       // Focus and select input after modal opens
       setTimeout(() => {
         inputRef.current?.focus();
         inputRef.current?.select();
       }, 50);
     }
-  }, [isOpen, defaultValue]);
+  }, [isOpen, defaultValue, accountPicker?.initialAccountId]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = value.trim();
-    if (trimmed) {
-      onConfirm(trimmed, selectedPath || undefined);
-    } else {
-      onConfirm(defaultValue, selectedPath || undefined);
-    }
+    const finalName = trimmed || defaultValue;
+    const finalAccountId = accountPicker ? selectedAccountId : undefined;
+    onConfirm(finalName, selectedPath || undefined, finalAccountId);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -127,6 +142,28 @@ export const NamePromptModal: React.FC<NamePromptModalProps> = ({
                   Browse...
                 </button>
               </div>
+            </div>
+          )}
+          {accountPicker && (
+            <div className="path-selector">
+              <label>{accountPicker.label ?? 'Claude account'}</label>
+              <select
+                value={selectedAccountId ?? ''}
+                onChange={e => setSelectedAccountId(e.target.value || null)}
+                className="path-input"
+                style={{ width: '100%', padding: '10px 12px', cursor: 'pointer' }}
+              >
+                <option value="">
+                  {accountPicker.accounts.length === 0
+                    ? 'No accounts registered — will use ~/.claude'
+                    : 'Use default account'}
+                </option>
+                {accountPicker.accounts.map(acc => (
+                  <option key={acc.id} value={acc.id}>
+                    {acc.label}{acc.email ? ` (${acc.email})` : ''}{acc.isDefault ? ' — default' : ''}
+                  </option>
+                ))}
+              </select>
             </div>
           )}
           <div className="modal-buttons">

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -15,6 +15,12 @@ interface TerminalProps {
   sessionState?: string;
   onStart?: () => void;
   onError?: (error: string) => void;
+  /**
+   * When true, skip the pty:create IPC call — caller has already spawned the
+   * pty out-of-band (e.g. the add-account login flow in BDHLNDR-31). The
+   * Terminal will just attach its data/exit listeners to `sessionId`.
+   */
+  externalPty?: boolean;
 }
 
 interface ContextMenuState {
@@ -36,7 +42,7 @@ const AUTO_SCROLL_THRESHOLD = 5;
 const MIN_COLS = 10;
 const MIN_ROWS = 2;
 
-const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true, isStopped = false, restartKey = 0, isActive = false, sessionState, onStart, onError }) => {
+const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true, isStopped = false, restartKey = 0, isActive = false, sessionState, onStart, onError, externalPty = false }) => {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -308,26 +314,39 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     xtermRef.current = term;
     fitAddonRef.current = fitAddon;
 
-    // Create PTY session with error handling
-    window.electronAPI.createSession(sessionId, cwd, launchClaude)
-      .then(() => {
-        // Send resize after PTY creation to fix Windows ConPTY race condition
-        // where input doesn't register until a resize event syncs the terminal.
-        // Guard against bogus dimensions from a container that hasn't laid out yet.
-        if (fitAddonRef.current && xtermRef.current) {
-          fitAddonRef.current.fit();
-          const { cols, rows } = xtermRef.current;
-          if (cols >= MIN_COLS && rows >= MIN_ROWS) {
-            window.electronAPI.resizeSession(sessionId, cols, rows);
-          }
+    // Create PTY session with error handling. When externalPty is true, the
+    // caller has already spawned the pty out-of-band (account login flow,
+    // BDHLNDR-31) and we should just attach listeners below.
+    if (externalPty) {
+      // Still kick a resize so the initial dimensions reach the existing pty.
+      if (fitAddonRef.current && xtermRef.current) {
+        fitAddonRef.current.fit();
+        const { cols, rows } = xtermRef.current;
+        if (cols >= MIN_COLS && rows >= MIN_ROWS) {
+          window.electronAPI.resizeSession(sessionId, cols, rows);
         }
-      })
-      .catch((err) => {
-        const errorMsg = err?.message || 'Failed to start session';
-        console.error('Failed to create PTY session:', err);
-        setError(errorMsg);
-        onError?.(errorMsg);
-      });
+      }
+    } else {
+      window.electronAPI.createSession(sessionId, cwd, launchClaude)
+        .then(() => {
+          // Send resize after PTY creation to fix Windows ConPTY race condition
+          // where input doesn't register until a resize event syncs the terminal.
+          // Guard against bogus dimensions from a container that hasn't laid out yet.
+          if (fitAddonRef.current && xtermRef.current) {
+            fitAddonRef.current.fit();
+            const { cols, rows } = xtermRef.current;
+            if (cols >= MIN_COLS && rows >= MIN_ROWS) {
+              window.electronAPI.resizeSession(sessionId, cols, rows);
+            }
+          }
+        })
+        .catch((err) => {
+          const errorMsg = err?.message || 'Failed to start session';
+          console.error('Failed to create PTY session:', err);
+          setError(errorMsg);
+          onError?.(errorMsg);
+        });
+    }
 
     // Handle PTY data with smart auto-scroll (BDHLNDR-30)
     // During rapid streaming — especially when Claude rewrites lines in-place

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -168,6 +168,17 @@ interface ElectronAPI {
   logError: (source: string, message: string, stack?: string) => Promise<void>;
   logWarn: (source: string, message: string) => Promise<void>;
   getLogPaths: () => Promise<{ logFile: string | null; crashDumps: string }>;
+
+  // Claude accounts (BDHLNDR-31)
+  listAccounts: () => Promise<ClaudeAccount[]>;
+  startAccountLogin: (label: string) => Promise<{ account: ClaudeAccount; ptyId: string }>;
+  cancelAccountLogin: (ptyId: string, deleteAccount: boolean) => Promise<void>;
+  confirmAccountLoginMacOS: (ptyId: string) => Promise<void>;
+  deleteAccount: (id: string) => Promise<void>;
+  updateAccount: (id: string, updates: { label?: string; color?: string; email?: string | null }) => Promise<void>;
+  setDefaultAccount: (id: string) => Promise<void>;
+  onAccountLoginCompleted: (callback: (data: { accountId: string; email: string | null }) => void) => () => void;
+  onAccountLoginExited: (callback: (data: { accountId: string; exitCode: number }) => void) => () => void;
 }
 
 declare global {

--- a/src/renderer/store/groups.ts
+++ b/src/renderer/store/groups.ts
@@ -39,6 +39,7 @@ export function useGroups() {
           createdAt: new Date(),
           parentId: parentId || null,
           collapsed: false,
+          claudeAccountId: parentGroup?.claudeAccountId ?? null,
         };
 
         window.electronAPI.createGroup(group)

--- a/src/renderer/store/sessions.ts
+++ b/src/renderer/store/sessions.ts
@@ -62,6 +62,7 @@ export function useSessions() {
           claudeSessionId: null,
           endedAt: null,
           durationSeconds: 0,
+          claudeAccountId: null,
         };
 
         // Activate immediately so the Terminal mounts in a visible container.

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -377,6 +377,17 @@ body {
   gap: 1px;
 }
 
+/* Account badge — small colored dot shown on sessions when Claude accounts
+ * are registered (BDHLNDR-31). Color matches the assigned account. */
+.session-account-dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35) inset;
+}
+
 .session-name {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -19,6 +19,12 @@ export interface Session {
   endedAt: Date | null;
   /** Active time in seconds (working + waiting states), not wall clock (BDHLNDR-17). */
   durationSeconds: number;
+  /**
+   * Optional Claude account override for this session (BDHLNDR-31). When null,
+   * the session inherits from its group (and if the group has none, falls back
+   * to the global default account, then to the legacy ~/.claude config).
+   */
+  claudeAccountId: string | null;
 }
 
 export interface Group {
@@ -30,6 +36,32 @@ export interface Group {
   createdAt: Date;
   parentId: string | null;
   collapsed: boolean;
+  /**
+   * Default Claude account for sessions in this group (BDHLNDR-31). Sessions
+   * inherit this unless they set their own claudeAccountId.
+   */
+  claudeAccountId: string | null;
+}
+
+/**
+ * A Claude.ai account registered with Bodhilander (BDHLNDR-31). Each account
+ * owns an isolated CLAUDE_CONFIG_DIR so that multiple accounts can run
+ * concurrent sessions without credential contention.
+ */
+export interface ClaudeAccount {
+  id: string;
+  /** Human-readable label (e.g. "Personal", "Acme Corp"). */
+  label: string;
+  /** Absolute path to the account's isolated .claude directory. */
+  configDir: string;
+  /** Email parsed from credentials after login, for display. */
+  email: string | null;
+  /** Hex color for UI badge. */
+  color: string;
+  /** True for the single account used as the global default fallback. */
+  isDefault: boolean;
+  createdAt: Date;
+  lastUsedAt: Date | null;
 }
 
 export interface AppState {


### PR DESCRIPTION
## Summary

Closes **[BDHLNDR-31](https://gobodhi.atlassian.net/browse/BDHLNDR-31)**.

Lets a single user register multiple Claude.ai Max subscriptions, assign a default per group (folder/project), override per session, and run any mix of accounts **concurrently** without credential contention. Uses Claude Code's officially supported `CLAUDE_CONFIG_DIR` env var — each account owns an isolated `<userData>/claude-accounts/<id>/.claude` directory, which is set as `CLAUDE_CONFIG_DIR` on pty spawn.

Until a user registers an account, behavior is unchanged: sessions still use `~/.claude` and existing users see no difference after upgrade.

## What's in the branch (6 commits)

| Commit | Scope |
|---|---|
| `5dc875a` | **Data layer.** `claude_accounts` table (partial unique index enforces single default), `claude_account_id` FK on `sessions` + `groups`, new `accounts` repo with `resolveAccountForSession()` session → group → default fallback. |
| `0bc8f54` | **Spawn integration.** `claude-launcher.ts` accepts `claudeConfigDir`; `pty-manager.ts` resolves the account at `createSession()` time and sets `CLAUDE_CONFIG_DIR`. |
| `cc158e1` | **Login flow backend.** `PtyManager.createLoginSession` spawns a pty running `claude` under an isolated config dir (no DB session). `account-auth.ts` orchestrates the flow: create dir, insert row, watch for `.credentials.json`, parse email, emit event. IPC: `accounts:list/startLogin/cancelLogin/confirmLoginMacOS/delete/update/setDefault`. |
| `d8288d9` | **Management UI.** `ClaudeAccountsModal` + embedded login modal with a `Terminal` attached to the login pty (new `externalPty` prop). Trigger is the 🔑 icon next to ⚙ in the sidebar. Auto-closes on credentials detection (Windows/Linux); macOS gets an explicit "I'm logged in" button since tokens go to Keychain. |
| `5f093f6` | **Assignment UI.** `NamePromptModal` gets an optional account dropdown for group/sub-group creation. Right-clicking a group or session appends inline account items with ✓ on the current choice. |
| `6c9f56b` | **Per-account MCP + session badge.** `mcp-config.ts` accepts an optional `configDir`; MCP/hooks are registered into every account's isolated dir on startup and at account-add time. Session list rows show a colored account dot with tooltip. |

## Test plan

- [ ] Fresh install: app starts, no accounts registered, existing sessions spawn against `~/.claude` as before.
- [ ] Upgrade over an existing DB: migrations run (`claude_accounts` table, `claude_account_id` columns on `sessions`/`groups`) without losing data.
- [ ] Add an account via the 🔑 button: config dir is created at `%APPDATA%\bodhilander\claude-accounts\<id>\.claude`, login pty opens, `/login` completes OAuth, credentials file appears, modal auto-closes, email is populated.
- [ ] Add a second account. Both appear in the list with their own colors. Toggle "Make default" — ✓ moves.
- [ ] Create a group with "Claude account" set to account A. Open a session in it, run `/status`, confirm it's account A.
- [ ] Right-click the session → "Use {account B}". ✓ mark updates. Run `/status` after restart (or new session in the same group) — account B.
- [ ] Run one session on A and one on B **at the same time**. `/logout` in A must not log out B. `/status` in each must show its own account.
- [ ] Restart the app. Sessions resume under the same accounts (BDHLNDR-9 resume still works).
- [ ] Delete an account from the modal. Sessions/groups that referred to it fall back to default (NULL-ed). Config dir on disk is removed.
- [ ] Memory MCP / hooks still fire in an isolated-account session (i.e. Bodhilander memory works across accounts).
- [ ] Renderer side: session rows show a colored account dot. Tooltip distinguishes "session override" vs "inherited".

## Known gaps / follow-ups

- **macOS Keychain behavior is untested.** Claude Code on macOS stores tokens in Keychain, not `.credentials.json`. If Keychain items are per-`CLAUDE_CONFIG_DIR` (expected), isolation is clean. If not, the plan's fallback is `CLAUDE_CODE_OAUTH_TOKEN` via `claude setup-token` — not built in this PR. Needs a Mac tester.
- **`.claude.json` path when `CLAUDE_CONFIG_DIR` is set.** I put the per-account MCP json at `<parent-of-configDir>/.claude.json`, mirroring the default `<home>/.claude.json + <home>/.claude/` layout. If Claude Code actually keeps `.claude.json` pinned to `$HOME` regardless, per-account MCP registration won't take effect — easy fix in `mcp-config.ts`.
- **Haven't run `bun run build && electron .`** — TypeScript is clean for both tsconfigs but no live smoke test yet.

These are tracked informally; no separate ticket yet unless someone hits them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-31]: https://gobodhi.atlassian.net/browse/BDHLNDR-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ