### PR TITLE
BDHLNDR-32: Beta release channel with in-app opt-in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - production
+      - development
     paths-ignore:
       - '**.md'
       - '.gitignore'
@@ -15,6 +16,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       should_release: ${{ steps.check.outputs.should_release }}
+      is_prerelease: ${{ steps.check.outputs.is_prerelease }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,14 +26,41 @@ jobs:
         id: version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
-      - name: Check if tag exists
+      - name: Decide whether to release, and on which channel (BDHLNDR-32)
         id: check
+        env:
+          BRANCH: ${{ github.ref_name }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "Tag v${{ steps.version.outputs.version }} already exists"
+          # Beta versions carry a "-beta." pre-release segment (e.g. 3.3.0-beta.1).
+          if [[ "$VERSION" == *"-beta."* ]]; then
+            IS_PRERELEASE=true
+          else
+            IS_PRERELEASE=false
+          fi
+          echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
+
+          # Gate which channel each branch is allowed to cut.
+          # - production → stable only (no -beta. suffix)
+          # - development → beta only (must carry -beta. suffix)
+          # This keeps the two channels from accidentally cross-publishing.
+          if [[ "$BRANCH" == "production" && "$IS_PRERELEASE" == "true" ]]; then
+            echo "Skipping: beta version $VERSION pushed to production. Betas must be cut from development."
+            echo "should_release=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [[ "$BRANCH" == "development" && "$IS_PRERELEASE" == "false" ]]; then
+            echo "Skipping: stable version $VERSION pushed to development. Stable cuts go through production."
+            echo "should_release=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Standard "have we already tagged this version?" guard.
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists"
             echo "should_release=false" >> $GITHUB_OUTPUT
           else
-            echo "Tag v${{ steps.version.outputs.version }} does not exist, will create release"
+            echo "Tag v$VERSION does not exist — will create release (prerelease=$IS_PRERELEASE)"
             echo "should_release=true" >> $GITHUB_OUTPUT
           fi
 
@@ -105,7 +134,7 @@ jobs:
             release/*.exe
             release/*.dmg
             release/*.zip
-            release/latest*.yml
+            release/*.yml
           if-no-files-found: ignore
 
   release:
@@ -130,9 +159,10 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
-          name: Bodhilander v${{ needs.check-version.outputs.version }}
+          name: ${{ needs.check-version.outputs.is_prerelease == 'true' && format('Bodhilander v{0} (beta)', needs.check-version.outputs.version) || format('Bodhilander v{0}', needs.check-version.outputs.version) }}
           draft: false
-          prerelease: false
+          prerelease: ${{ needs.check-version.outputs.is_prerelease }}
+          make_latest: ${{ needs.check-version.outputs.is_prerelease == 'true' && 'false' || 'true' }}
           generate_release_notes: true
           files: |
             artifacts/**/*.AppImage
@@ -140,6 +170,6 @@ jobs:
             artifacts/**/*.exe
             artifacts/**/*.dmg
             artifacts/**/*.zip
-            artifacts/**/latest*.yml
+            artifacts/**/*.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,33 @@ The GitHub Actions workflow (`release.yml`) checks if the tag exists:
 1. Delete the tag: `git tag -d v1.x.x && git push origin :refs/tags/v1.x.x`
 2. Re-trigger: `gh workflow run "Build and Release"`
 
+## Beta Release Workflow (BDHLNDR-32)
+
+Bodhilander ships two auto-update channels: **stable** (default) and **beta** (opt-in via Settings → Updates).
+
+**To cut a beta (on the `development` branch):**
+
+```bash
+npm version prerelease --preid=beta   # e.g. 3.3.0 → 3.3.0-beta.1
+git push                              # DO NOT use --tags
+```
+
+The same `release.yml` workflow handles it — it sees the `-beta.N` suffix on the package.json version and:
+- marks the GitHub Release as a **pre-release**,
+- sets `make_latest: false` so stable users don't pick it up,
+- uploads `beta.yml` (produced automatically by electron-builder because the semver contains a pre-release segment) alongside the installers.
+
+Users who flipped "Beta (opt-in)" in Settings → Updates get the new build on their next auto-update check; everyone else stays on the last stable release.
+
+**Channel gating by branch** (enforced in `release.yml`'s `check-version` job):
+- `production` accepts stable versions only (no `-beta.` suffix).
+- `development` accepts beta versions only (must carry `-beta.` suffix).
+- Mismatched pushes short-circuit with a log message; no partial release is produced.
+
+**Bumping a subsequent beta:** `npm version prerelease` (without `--preid`) bumps the suffix (`3.3.0-beta.1` → `3.3.0-beta.2`).
+
+**Promoting a beta to stable:** merge `development` → `production`, then on `production` run `npm version minor` (or patch/major) to drop the pre-release suffix and bump to the final version. Push.
+
 ## Project Structure
 
 - Electron app for managing Claude Code sessions

--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ Receive session event notifications in Microsoft Teams:
 - OAuth authentication via Microsoft Graph API
 
 ### Auto-Update
-New versions download and install automatically via GitHub Releases.
+New versions download and install automatically via GitHub Releases. Two channels are available:
+
+- **Stable** (default) — tested releases only.
+- **Beta** (opt-in) — earlier access to new features while they're being validated. Enable from **Settings → Updates**. You'll see a small **BETA** pill in the sidebar while running a beta build. Switch back to Stable any time; the next stable release ≥ your current beta will auto-install.
 
 ### Cross-Platform Support
 - Windows (native + WSL)
@@ -166,6 +169,7 @@ Bodhilander offers extensive configuration across multiple tabs:
 - **Sound** - Master toggle, per-event sounds, volume, debounce frequency, custom audio files
 - **Mobile** - API server, pairing, device management, remote access
 - **Integrations** - GitHub authentication, Microsoft Teams notifications
+- **Updates** - Release channel (Stable / Beta opt-in)
 
 ---
 

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -1,6 +1,7 @@
 import { autoUpdater, UpdateInfo } from 'electron-updater';
 import { BrowserWindow, dialog, Notification } from 'electron';
 import * as log from 'electron-log';
+import { getPreference, setPreference } from './repositories/preferences';
 
 // Configure logging
 autoUpdater.logger = log;
@@ -16,6 +17,49 @@ let isDialogOpen = false;
 let isDownloadingFromAbout = false;
 let manualCheckResolver: ((result: { updateAvailable: boolean; version?: string; error?: string }) => void) | null = null;
 
+// Update channels supported by Bodhilander (BDHLNDR-32). "stable" maps to
+// electron-updater's default `latest` channel; "beta" opts into the beta
+// channel published alongside stable from the development branch.
+export type UpdateChannel = 'stable' | 'beta';
+const UPDATE_CHANNEL_PREF_KEY = 'updateChannel';
+
+function parseChannel(raw: string | null): UpdateChannel {
+  return raw === 'beta' ? 'beta' : 'stable';
+}
+
+export function getUpdateChannel(): UpdateChannel {
+  return parseChannel(getPreference(UPDATE_CHANNEL_PREF_KEY));
+}
+
+/**
+ * Apply the stored update channel to the electron-updater runtime. "stable"
+ * uses `latest` (the default), "beta" pulls from `beta.yml`. Called at startup
+ * and whenever the user flips the toggle in Settings.
+ */
+function applyUpdateChannel(channel: UpdateChannel): void {
+  // electron-updater maps `channel` directly to the remote yml feed name.
+  // It accepts `null` to mean "default" (latest).
+  autoUpdater.channel = channel === 'beta' ? 'beta' : null;
+  // Allow downgrade from beta → stable so users flipping the toggle back
+  // don't stay stuck on a newer-than-stable beta forever. Harmless on the
+  // stable channel because stable versions only move forward.
+  autoUpdater.allowDowngrade = channel === 'stable';
+  log.info(`[auto-updater] Channel set to ${channel} (autoUpdater.channel=${autoUpdater.channel ?? 'latest'})`);
+}
+
+/**
+ * Persist a new channel choice and immediately re-check. The renderer calls
+ * this from the Settings toggle; the change takes effect without an app
+ * restart so testers get a responsive opt-in experience (BDHLNDR-32).
+ */
+export function setUpdateChannel(channel: UpdateChannel): void {
+  setPreference(UPDATE_CHANNEL_PREF_KEY, channel);
+  applyUpdateChannel(channel);
+  // Kick an immediate background check so the user sees the new channel's
+  // latest release (if any) without waiting for the 4-hour interval.
+  checkForUpdates();
+}
+
 // Broadcast event to all windows (including About dialog)
 function broadcastToAllWindows(channel: string, ...args: unknown[]): void {
   BrowserWindow.getAllWindows().forEach(win => {
@@ -27,6 +71,10 @@ function broadcastToAllWindows(channel: string, ...args: unknown[]): void {
 
 export function initAutoUpdater(window: BrowserWindow): void {
   mainWindow = window;
+
+  // Honor the saved update channel preference before the first check so
+  // existing beta opt-ins pick up beta.yml on startup (BDHLNDR-32).
+  applyUpdateChannel(getUpdateChannel());
 
   // Check for updates on startup (with delay to not block app launch)
   setTimeout(() => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,7 +11,7 @@ import { exportSessions, ExportFormat } from './session-export';
 import { exportGroupsAndSessions, importGroupsAndSessions, importFromClaudeLander } from './group-import-export';
 import { StateMonitor } from './state-monitor';
 import { createApplicationMenu } from './menu';
-import { initAutoUpdater, checkForUpdatesManual, downloadUpdate } from './auto-updater';
+import { initAutoUpdater, checkForUpdatesManual, downloadUpdate, getUpdateChannel, setUpdateChannel, UpdateChannel } from './auto-updater';
 import { notificationManager } from './notification-manager';
 import { trayManager } from './tray-manager';
 import { soundManager, SoundEvent } from './sound-manager';
@@ -811,6 +811,23 @@ safeHandle('app:download-update', () => {
 safeHandle('app:restart-and-update', async () => {
   const { autoUpdater } = await import('electron-updater');
   autoUpdater.quitAndInstall(false, true);
+});
+
+// Update channel (BDHLNDR-32) — opt-in beta builds
+safeHandle('app:get-update-channel', () => {
+  return getUpdateChannel();
+});
+
+safeHandle('app:set-update-channel', (channel: UpdateChannel) => {
+  const normalized: UpdateChannel = channel === 'beta' ? 'beta' : 'stable';
+  setUpdateChannel(normalized);
+  return normalized;
+});
+
+// Whether the currently-running build is itself a beta — used by the
+// renderer to show a BETA pill in the title bar.
+safeHandle('app:is-prerelease-build', () => {
+  return app.getVersion().includes('-beta.');
 });
 
 // Sharing IPC handlers (host)

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -349,6 +349,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getEditorOptions: (): Promise<{ value: string; label: string }[]> =>
     ipcRenderer.invoke('editor:getOptions'),
 
+  // Update channel (BDHLNDR-32) — opt-in beta builds
+  getUpdateChannel: (): Promise<'stable' | 'beta'> =>
+    ipcRenderer.invoke('app:get-update-channel'),
+  setUpdateChannel: (channel: 'stable' | 'beta'): Promise<'stable' | 'beta'> =>
+    ipcRenderer.invoke('app:set-update-channel', channel),
+  isPrereleaseBuild: (): Promise<boolean> =>
+    ipcRenderer.invoke('app:is-prerelease-build'),
+
   // Error logging — forward renderer errors to main process log file
   logError: (source: string, message: string, stack?: string): Promise<void> =>
     ipcRenderer.invoke('log:error', source, message, stack),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -74,6 +74,10 @@ const App: React.FC = () => {
   const [shareModalSessionId, setShareModalSessionId] = useState<string | null>(null);
   const [joinModalOpen, setJoinModalOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  // True when the running build is itself a beta (version contains -beta.).
+  // Shows a BETA pill in the sidebar so opt-in testers know what they're on
+  // (BDHLNDR-32).
+  const [isBetaBuild, setIsBetaBuild] = useState(false);
   const [sharingSessions, setSharingSessions] = useState<Set<string>>(new Set());
   const { user, isAuthenticated } = useSharing();
 
@@ -188,6 +192,15 @@ const App: React.FC = () => {
     });
     return cleanup;
   }, [activeRemoteCode]);
+
+  // Determine once at mount whether the running app build is a beta —
+  // controls the BETA pill shown in the sidebar header (BDHLNDR-32).
+  useEffect(() => {
+    window.electronAPI
+      .isPrereleaseBuild()
+      .then(setIsBetaBuild)
+      .catch(() => { /* leave default (false) on failure */ });
+  }, []);
 
   // Show prompt for new session name
   const handleNewSession = useCallback((groupId: string) => {
@@ -834,7 +847,17 @@ const App: React.FC = () => {
           onMouseDown={handleResizeStart}
         />
         <div className="sidebar-header">
-          <h2>Groups</h2>
+          <h2>
+            Groups
+            {isBetaBuild && (
+              <span
+                className="beta-pill"
+                title="You're running a beta build. Report issues on GitHub."
+              >
+                BETA
+              </span>
+            )}
+          </h2>
           <div className="sidebar-header-actions">
             <button
               className={`icon-button ${memoryPanelOpen ? 'active' : ''}`}

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -7,8 +7,12 @@ interface SettingsModalProps {
 }
 
 export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
-  type SettingsTab = 'general' | 'appearance' | 'terminal' | 'sound' | 'integrations' | 'mobile';
+  type SettingsTab = 'general' | 'appearance' | 'terminal' | 'sound' | 'integrations' | 'mobile' | 'updates';
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
+
+  // Update channel state (BDHLNDR-32)
+  const [updateChannel, setUpdateChannelState] = useState<'stable' | 'beta'>('stable');
+  const [updateChannelLoading, setUpdateChannelLoading] = useState(false);
 
   // Mobile API state
   const [apiStatus, setApiStatus] = useState<ApiServerStatus>({ running: false });
@@ -68,11 +72,12 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
 
     const loadState = async () => {
       try {
-        const [status, devices, hasPairingResult, remoteAccessStatus] = await Promise.all([
+        const [status, devices, hasPairingResult, remoteAccessStatus, channel] = await Promise.all([
           window.electronAPI.apiGetStatus(),
           window.electronAPI.apiGetPairedDevices(),
           window.electronAPI.apiHasPairingCode(),
           window.electronAPI.apiGetRemoteAccessStatus(),
+          window.electronAPI.getUpdateChannel(),
         ]);
         setApiStatus(status);
         setPairedDevices(devices);
@@ -80,6 +85,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
           setPairingCode(null);
         }
         setRemoteStatus(remoteAccessStatus);
+        setUpdateChannelState(channel);
 
         // Load sound settings
         const [
@@ -497,6 +503,12 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
             >
               Integrations
             </button>
+            <button
+              className={`settings-nav-item ${activeTab === 'updates' ? 'active' : ''}`}
+              onClick={() => setActiveTab('updates')}
+            >
+              Updates
+            </button>
           </nav>
 
           <div className="settings-content">
@@ -786,6 +798,73 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                       Coming Soon
                     </button>
                   </div>
+                </div>
+              </div>
+            )}
+
+            {activeTab === 'updates' && (
+              <div className="settings-section">
+                <h3>Updates</h3>
+                <p className="settings-description">
+                  Choose which release channel Bodhilander auto-updates from. Changing
+                  the channel triggers an immediate background check.
+                </p>
+
+                <div className="settings-group">
+                  <h4>Release channel</h4>
+                  <div className="settings-radio-group">
+                    <label className="settings-radio-row">
+                      <input
+                        type="radio"
+                        name="updateChannel"
+                        value="stable"
+                        checked={updateChannel === 'stable'}
+                        disabled={updateChannelLoading}
+                        onChange={async () => {
+                          setUpdateChannelLoading(true);
+                          try {
+                            const applied = await window.electronAPI.setUpdateChannel('stable');
+                            setUpdateChannelState(applied);
+                          } finally {
+                            setUpdateChannelLoading(false);
+                          }
+                        }}
+                      />
+                      <span>
+                        <strong>Stable</strong>
+                        <span className="settings-hint"> — the default. Tested releases only.</span>
+                      </span>
+                    </label>
+                    <label className="settings-radio-row">
+                      <input
+                        type="radio"
+                        name="updateChannel"
+                        value="beta"
+                        checked={updateChannel === 'beta'}
+                        disabled={updateChannelLoading}
+                        onChange={async () => {
+                          setUpdateChannelLoading(true);
+                          try {
+                            const applied = await window.electronAPI.setUpdateChannel('beta');
+                            setUpdateChannelState(applied);
+                          } finally {
+                            setUpdateChannelLoading(false);
+                          }
+                        }}
+                      />
+                      <span>
+                        <strong>Beta (opt-in)</strong>
+                        <span className="settings-hint"> — earlier access to new features. May be unstable; please report issues.</span>
+                      </span>
+                    </label>
+                  </div>
+                  {updateChannel === 'beta' && (
+                    <p className="settings-hint" style={{ marginTop: 8 }}>
+                      You'll receive beta builds as they're cut from the development branch.
+                      Switch back to Stable at any time — the next stable release ≥ your
+                      current beta will auto-install.
+                    </p>
+                  )}
                 </div>
               </div>
             )}

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -168,6 +168,11 @@ interface ElectronAPI {
   logError: (source: string, message: string, stack?: string) => Promise<void>;
   logWarn: (source: string, message: string) => Promise<void>;
   getLogPaths: () => Promise<{ logFile: string | null; crashDumps: string }>;
+
+  // Update channel (BDHLNDR-32)
+  getUpdateChannel: () => Promise<'stable' | 'beta'>;
+  setUpdateChannel: (channel: 'stable' | 'beta') => Promise<'stable' | 'beta'>;
+  isPrereleaseBuild: () => Promise<boolean>;
 }
 
 declare global {

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -377,6 +377,50 @@ body {
   gap: 1px;
 }
 
+/* BETA pill shown in the sidebar header when the running build is a beta
+ * release (BDHLNDR-32). Purely informational — not clickable. */
+.beta-pill {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 7px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #fff;
+  background: linear-gradient(135deg, #c08a2e 0%, #e0a647 100%);
+  border-radius: 10px;
+  vertical-align: middle;
+  text-transform: uppercase;
+}
+
+/* Radio-list used by the Updates settings section (BDHLNDR-32). */
+.settings-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.settings-radio-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.settings-radio-row input[type="radio"] {
+  margin-top: 3px;
+  cursor: pointer;
+}
+
+.settings-radio-row input[type="radio"]:disabled {
+  cursor: default;
+}
+
+.settings-radio-row .settings-hint {
+  display: inline;
+  color: #888;
+}
+
 .session-name {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

Closes **[BDHLNDR-32](https://gobodhi.atlassian.net/browse/BDHLNDR-32)**.

Adds a second auto-update channel (**beta**) alongside the existing stable channel, opt-in from Settings → Updates. Lets trusted testers — especially Mac/Linux users — validate pre-release builds without disrupting stable users. Motivated by not wanting to ship the Mac-side of [#36 (BDHLNDR-31 multi-account)](https://github.com/Software-Development-LLC/Bodhilander/pull/36) to everyone before at least one Mac user has exercised it.

Existing stable users are unaffected until they flip the toggle.

## What changed

### CI (`.github/workflows/release.yml`)

- Trigger now fires on push to both `production` and `development`.
- `check-version` detects `-beta.N` in the `package.json` version and emits `is_prerelease`.
- **Branch gating**: `production` accepts only stable versions, `development` accepts only betas. Mismatched pushes short-circuit with a log message — no partial release.
- `softprops/action-gh-release` uses `prerelease: ${is_prerelease}` and `make_latest: ${!is_prerelease}`. The artifact glob is broadened from `latest*.yml` to `*.yml` so `beta.yml` ships alongside the installers (electron-builder generates the right feed name automatically based on the semver pre-release segment).

### Main process

- New `updateChannel` preference (`'stable' | 'beta'`, default `stable`) persisted via the existing preferences table.
- `auto-updater.ts`:
  - `applyUpdateChannel()` sets `autoUpdater.channel` (`null` for stable, `'beta'` for beta) and `allowDowngrade` (true on stable so flipping back unsticks a beta tester).
  - `initAutoUpdater` honors the saved channel before the first check.
  - `setUpdateChannel(channel)` persists + applies + kicks an immediate background check.
- Three new IPCs: `app:get-update-channel`, `app:set-update-channel`, `app:is-prerelease-build`. Exposed in `preload.ts` and typed in `electron.d.ts`.

### UI

- **Settings → Updates** (new tab): Stable / Beta (opt-in) radio group with descriptive hints. Live toggling triggers an immediate channel re-check.
- **BETA pill** in the sidebar header whenever `app.getVersion()` contains `-beta.` — purely informational so opt-in testers always know what they're on.

### Docs

- `CLAUDE.md` — new Beta Release Workflow section covering cut (`npm version prerelease --preid=beta && git push`), bump, and stable-promotion flow, plus the branch-gating rules enforced by CI.
- `README.md` — user-facing note under Auto-Update and the new Settings tab in the settings list.

## Test plan

**CI smoke**
- [ ] Push a commit with a stable `package.json` version (e.g. `3.3.0`) to `production` → workflow produces a regular GitHub Release (not pre-release), `latest.yml` in the artifacts, marked as latest.
- [ ] Push a commit with `3.3.0-beta.1` to `development` → workflow produces a **pre-release** GitHub Release, `beta.yml` in the artifacts, **not** marked as latest.
- [ ] Push beta version to `production` or stable version to `development` → workflow logs the mismatch and skips the build (no release created).

**Runtime**
- [ ] Fresh install, default stable — pref is `stable`, `autoUpdater.channel` is `null` → reads `latest.yml` as before.
- [ ] Open Settings → Updates → toggle to Beta → log shows `Channel set to beta` and a background update check fires.
- [ ] Toggle back to Stable → `allowDowngrade` lets the next stable ≥ current beta install without manual intervention.
- [ ] On a beta build (`-beta.N` version), the sidebar shows a **BETA** pill; on stable it's hidden.
- [ ] Opt-in persists across app restart.

**Type-check**
- [x] `bunx tsc -p tsconfig.main.json --noEmit` clean.
- [x] `bunx tsc -p tsconfig.json --noEmit` clean.

## Rollout

Recommend merging this before #36 (BDHLNDR-31) so the first thing cut to `development` can be a beta of the multi-account feature, distributed to testers via the new channel. Once Mac Keychain isolation is validated by a real tester, we can promote to stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-32]: https://gobodhi.atlassian.net/browse/BDHLNDR-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ