### PR TITLE
beta.2: macOS fixes + first-run cleanup (BDHLNDR-33/34/35/36)

### DIFF
--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -218,16 +218,12 @@ function initializeTables(database: Database.Database): void {
     console.log('FTS5 setup (may already exist):', e);
   }
 
-  // Insert default group if none exists
-  const groupCount = database.prepare('SELECT COUNT(*) as count FROM groups').get() as { count: number };
-  if (groupCount.count === 0) {
-    database.prepare(`
-      INSERT INTO groups (id, name, color, working_dir, "order")
-      VALUES ('default', 'Default', '#e06c75', '', 0)
-    `).run();
-  }
-
-  // Ensure __global__ group exists for global context memories
+  // Ensure __global__ group exists for global context memories (BDHLNDR-35).
+  // This row is required by the memory system (memories with group_id =
+  // '__global__' inject into every session as global context) but is hidden
+  // from the sidebar UI — see the store filter in src/renderer/store/groups.ts.
+  // Note: we no longer seed a visible "Default" group on first run. Users
+  // create their own groups; existing installs keep whatever's already there.
   const globalGroup = database.prepare('SELECT id FROM groups WHERE id = ?').get('__global__');
   if (!globalGroup) {
     database.prepare(`

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -594,6 +594,14 @@ safeOn('pty:kill', (id: string) => {
   ptyManager.kill(id);
 });
 
+// Prime a deferred-emission pty (BDHLNDR-33): flushes any buffered scrollback
+// as a single 'data' event then unlocks live emission. Used by the Terminal
+// component for the Add Account login flow, which attaches its listener
+// after the pty has already started producing output.
+safeOn('pty:prime', (id: string) => {
+  ptyManager.primePty(id);
+});
+
 // Database IPC Handlers - Groups
 safeHandle('db:groups:getAll', () => {
   return groupsRepo.getAllGroups();
@@ -615,11 +623,14 @@ safeHandle('db:groups:delete', (id: string) => {
 });
 
 // Dialog IPC Handlers
-safeHandle('dialog:selectDirectory', async () => {
+safeHandle('dialog:selectDirectory', async (defaultPath?: string) => {
   if (!mainWindow) return null;
   const result = await dialog.showOpenDialog(mainWindow, {
     properties: ['openDirectory', 'showHiddenFiles'],
     title: 'Select Working Directory',
+    // BDHLNDR-36: open the picker at the group's current working directory
+    // (or the last path the caller passed), not the OS's last-remembered dir.
+    ...(defaultPath ? { defaultPath } : {}),
   });
   if (result.canceled || result.filePaths.length === 0) {
     return null;

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -17,6 +17,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.send('pty:resize', id, cols, rows),
   killSession: (id: string) =>
     ipcRenderer.send('pty:kill', id),
+  primePty: (id: string) =>
+    ipcRenderer.send('pty:prime', id),
 
   // PTY events
   onPtyData: (callback: (id: string, data: string) => void) => {
@@ -100,8 +102,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   // Dialogs
-  selectDirectory: (): Promise<string | null> =>
-    ipcRenderer.invoke('dialog:selectDirectory'),
+  selectDirectory: (defaultPath?: string): Promise<string | null> =>
+    ipcRenderer.invoke('dialog:selectDirectory', defaultPath),
 
   // Database - Groups
   getAllGroups: (): Promise<Group[]> =>

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -49,6 +49,15 @@ interface PtySession {
   lastRows: number;
   /** Set to true when kill() is in progress — guards against use-after-free on native PTY handle. */
   killing: boolean;
+  /**
+   * When true, incoming pty output is accumulated in scrollbackBuffer but NOT
+   * emitted as 'data' events (BDHLNDR-33). Used by the interactive-login pty
+   * to avoid losing startup output in the window between pty spawn and the
+   * renderer attaching its listener. Flipped to false by primePty() once the
+   * renderer signals it's ready; primePty emits the buffered scrollback as a
+   * single 'data' event first, guaranteeing ordered delivery.
+   */
+  deferEmission: boolean;
 }
 
 /**
@@ -351,6 +360,9 @@ export class PtyManager extends EventEmitter {
       lastCols: 80,
       lastRows: 24,
       killing: false,
+      // Regular sessions spawn only after the renderer explicitly called
+      // pty:create, so listeners are already attached — no deferral needed.
+      deferEmission: false,
     });
 
   }
@@ -427,10 +439,21 @@ export class PtyManager extends EventEmitter {
         session.scrollbackBuffer = session.scrollbackBuffer.slice(-MAX_SCROLLBACK_SIZE);
       }
 
+      // Hold emission until the renderer primes this pty (BDHLNDR-33). The
+      // scrollback is accumulated above regardless, so nothing is lost.
+      if (session.deferEmission) return;
+
       this.emit('data', { id, data: filteredData });
     });
 
     ptyProcess.onExit(({ exitCode }) => {
+      // If the pty exited before being primed, flush whatever it managed to
+      // print so the renderer can show the error instead of a blank box.
+      const session = this.sessions.get(id);
+      if (session?.deferEmission && session.scrollbackBuffer) {
+        this.emit('data', { id, data: session.scrollbackBuffer });
+        session.deferEmission = false;
+      }
       this.emit('exit', { id, exitCode });
       this.sessions.delete(id);
     });
@@ -455,7 +478,27 @@ export class PtyManager extends EventEmitter {
       lastCols: 80,
       lastRows: 24,
       killing: false,
+      // Login ptys defer event emission until the renderer attaches its
+      // listener and calls primePty — avoids losing claude's startup banner
+      // in the IPC-round-trip + React-render gap (BDHLNDR-33).
+      deferEmission: true,
     });
+  }
+
+  /**
+   * Flush a login pty's accumulated scrollback to the renderer as a single
+   * 'data' event, then unlock live emission (BDHLNDR-33). The two operations
+   * happen in the same synchronous tick so no live data sneaks in between —
+   * preserving strict ordering even on the renderer side. Idempotent: after
+   * the first call, subsequent calls are no-ops.
+   */
+  primePty(id: string): void {
+    const session = this.sessions.get(id);
+    if (!session || !session.deferEmission) return;
+    if (session.scrollbackBuffer) {
+      this.emit('data', { id, data: session.scrollbackBuffer });
+    }
+    session.deferEmission = false;
   }
 
   write(id: string, data: string): void {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -348,7 +348,11 @@ const App: React.FC = () => {
   }, [getSessionsByGroup]);
 
   const handleSetGroupDirectory = async (groupId: string) => {
-    const dir = await window.electronAPI.selectDirectory();
+    // Open the picker at the group's current working directory so it's
+    // obvious which group we're editing (BDHLNDR-36). Falls through to the
+    // OS default when the group has no wd set yet.
+    const group = groups.find(g => g.id === groupId);
+    const dir = await window.electronAPI.selectDirectory(group?.workingDir || undefined);
     if (dir) {
       await updateGroup(groupId, { workingDir: dir });
     }

--- a/src/renderer/components/NamePromptModal.css
+++ b/src/renderer/components/NamePromptModal.css
@@ -91,6 +91,19 @@
   cursor: default;
 }
 
+/* BDHLNDR-34: Explicit colors on select and its <option>s so Linux / fallback
+ * popup renderers (which don't always honor color-scheme) still read. */
+.name-prompt-modal select.path-input {
+  color: #d4d4d4;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+}
+
+.name-prompt-modal select.path-input option {
+  background: #1e1e1e;
+  color: #d4d4d4;
+}
+
 .name-prompt-modal .path-input::placeholder {
   color: #555;
   font-style: italic;

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -378,6 +378,16 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       }
     });
 
+    // Prime external ptys (BDHLNDR-33). The login-flow pty in the Add Account
+    // modal is spawned in main before this component renders, so any output
+    // claude produced during the IPC round-trip + React render would be lost.
+    // primePty asks main to flush the accumulated scrollback as a 'data' event
+    // and unlock live emission atomically — the listener above receives the
+    // flush first, then subsequent live events in correct order.
+    if (externalPty) {
+      window.electronAPI.primePty(sessionId);
+    }
+
     // Handle keyboard shortcuts
     term.attachCustomKeyEventHandler((event) => {
       const isMod = event.ctrlKey || event.metaKey;

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -9,6 +9,7 @@ interface ElectronAPI {
   writeToSession: (id: string, data: string) => void;
   resizeSession: (id: string, cols: number, rows: number) => void;
   killSession: (id: string) => void;
+  primePty: (id: string) => void;
 
   // PTY events
   onPtyData: (callback: (id: string, data: string) => void) => () => void;
@@ -34,7 +35,7 @@ interface ElectronAPI {
   onOpenSettings: (callback: () => void) => () => void;
 
   // Dialogs
-  selectDirectory: () => Promise<string | null>;
+  selectDirectory: (defaultPath?: string) => Promise<string | null>;
 
   // Database - Groups
   getAllGroups: () => Promise<Group[]>;

--- a/src/renderer/store/groups.ts
+++ b/src/renderer/store/groups.ts
@@ -1,7 +1,18 @@
 import { useState, useCallback, useEffect } from 'react';
-import { Group } from '../../shared/types';
+import { Group, GLOBAL_CONTEXT_GROUP_ID } from '../../shared/types';
 
 const DEFAULT_COLORS = ['#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2'];
+
+/**
+ * Filter out system-managed groups that should never appear in the UI
+ * (BDHLNDR-35). The `__global__` group is required by the memory system's
+ * global-context injection but must stay hidden from the sidebar, pickers,
+ * and context menus. MemoryPanel references it directly via the constant,
+ * not through this store.
+ */
+function visibleGroups(all: Group[]): Group[] {
+  return all.filter(g => g.id !== GLOBAL_CONTEXT_GROUP_ID);
+}
 
 export function useGroups() {
   const [groups, setGroups] = useState<Group[]>([]);
@@ -12,7 +23,7 @@ export function useGroups() {
     const loadGroups = async () => {
       try {
         const dbGroups = await window.electronAPI.getAllGroups();
-        setGroups(dbGroups);
+        setGroups(visibleGroups(dbGroups));
       } catch (error) {
         console.error('Failed to load groups:', error);
       } finally {

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -40,6 +40,12 @@ body {
   color: #d4d4d4;
   height: 100vh;
   overflow: hidden;
+  /* BDHLNDR-34: Tell WebKit/Chromium to render all native form controls
+   * (<select> popups, checkboxes, radios, scrollbars) with dark styling
+   * by default. Without this, the account-picker dropdown on macOS
+   * renders with near-black text on the light default popup background,
+   * which our dark modal surrounds — producing an unreadable black box. */
+  color-scheme: dark;
 }
 
 .app {


### PR DESCRIPTION
## Summary

Four fixes bundled for the **v3.3.0-beta.2** cut. Three came from Mac tester feedback on v3.3.0-beta.1; one is a first-run-UX cleanup the maintainer asked for.

Closes:
- **[BDHLNDR-33](https://gobodhi.atlassian.net/browse/BDHLNDR-33)** / GH [#40](https://github.com/Software-Development-LLC/Bodhilander/issues/40) — Add Account modal terminal invisible on macOS
- **[BDHLNDR-34](https://gobodhi.atlassian.net/browse/BDHLNDR-34)** / GH [#39](https://github.com/Software-Development-LLC/Bodhilander/issues/39) — Dark-on-dark account dropdown on macOS
- **[BDHLNDR-35](https://gobodhi.atlassian.net/browse/BDHLNDR-35)** — Remove default groups from sidebar on first run
- **[BDHLNDR-36](https://gobodhi.atlassian.net/browse/BDHLNDR-36)** / GH [#38](https://github.com/Software-Development-LLC/Bodhilander/issues/38) — Group wd picker opens at current dir

## What each change does

### BDHLNDR-33 — login terminal race (critical)
Root cause: the login pty spawns in main **before** the React modal mounts, so `claude`'s startup banner fires `pty:data` events that the renderer has no listener for yet — those bytes are gone. The Terminal displays a blank black box because there's nothing queued up to render until claude redraws (which it might not do until input/resize).

Fix: `PtyManager.createLoginSession` now sets a `deferEmission` flag on the session. Output still accumulates in `scrollbackBuffer` but no `'data'` event fires. A new `pty:prime` IPC, called from `Terminal.tsx` once xterm is mounted and its listener is attached, atomically emits the buffered scrollback as a single `'data'` event and flips `deferEmission = false` in the same synchronous tick — preserving strict ordering with subsequent live emissions. The pty's exit handler also flushes on exit, so if `claude` fails to launch the user sees the shell's error output instead of a blank modal.

### BDHLNDR-34 — dark-on-dark dropdown
Root cause: native `<select>` popups on macOS use the system theme for their chrome. Without `color-scheme: dark` declared, WebKit assumes light and renders dark text on a light popup — on a dark modal this reads as a black void.

Fix: `color-scheme: dark` on `body` in `global.css` — applies to every native form control in the app. Explicit `background`/`color` on `option` elements in `NamePromptModal.css` for Linux popup fallbacks.

### BDHLNDR-35 — hide system groups from first-run UI
- **Stop seeding `Default`** — removed the `INSERT` block in `database.ts`. Nothing references `default` by id, so removing it is clean. Existing installs keep whatever's already there.
- **Keep seeding `__global__`, hide from UI** — the memory system needs the row (global-context memory injection); `useGroups` store now filters it out via a `visibleGroups` helper. `MemoryPanel` already references `GLOBAL_CONTEXT_GROUP_ID` directly, not through the store, so global memories keep working.

### BDHLNDR-36 — wd picker default
Extended `dialog:selectDirectory` IPC with an optional `defaultPath`. `handleSetGroupDirectory` now passes the group's current `workingDir` so the picker opens where you'd expect. Groups without a wd fall through to the OS default (prior behavior).

## Test plan

**Windows (my env):**
- [x] `bunx tsc -p tsconfig.main.json --noEmit` clean
- [x] `bunx tsc -p tsconfig.json --noEmit` clean
- [ ] Build + run `bun run start`; add an account; login terminal shows claude immediately (primePty race fix applies cross-platform).
- [ ] New Group modal: account dropdown is readable.
- [ ] Fresh install (delete DB, restart): sidebar is empty.
- [ ] Click ⌂ on an existing group: picker opens at that group's wd.

**macOS (Mac tester on beta.2):**
- [ ] Add Account modal shows the terminal, `/login` works end-to-end.
- [ ] Account dropdown readable in both New Group and New Sub-Group modals.
- [ ] Fresh install (delete `~/Library/Application Support/Bodhilander`): empty sidebar.
- [ ] wd picker default behavior.

## Rollout

Merge → bump `3.3.0-beta.1` → `3.3.0-beta.2` via `npm version prerelease && git push` on development → CI cuts the beta release with the BDHLNDR-32 channel flow → Mac testers validate via in-app update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-33]: https://gobodhi.atlassian.net/browse/BDHLNDR-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-34]: https://gobodhi.atlassian.net/browse/BDHLNDR-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-35]: https://gobodhi.atlassian.net/browse/BDHLNDR-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-36]: https://gobodhi.atlassian.net/browse/BDHLNDR-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ