### PR TITLE
BDHLNDR-37: hotfix — bundle darwin-x64 sharp so Intel Macs don't crash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # BDHLNDR-37: GitHub's macos-latest runner is Apple Silicon, so the default
+      # bun install only fetches the darwin-arm64 sharp prebuilt. electron-builder
+      # cross-packages BOTH x64 and arm64 Mac DMGs from this single run, which
+      # left Intel Mac users on 3.2.8 crashing at launch with "could not load the
+      # sharp module using the darwin-x64 runtime". Force-install the darwin-x64
+      # sharp + libvips binaries (bypassing npm's cpu/os filter) so the x64 DMG
+      # ships with a usable sharp. Pinned to the sharp@0.34.5 already in lockfile.
+      - name: Install darwin-x64 sharp variant for cross-arch packaging
+        if: matrix.platform == 'mac'
+        run: |
+          npm install --no-save --cpu=x64 --os=darwin \
+            @img/sharp-darwin-x64@0.34.5 \
+            @img/sharp-libvips-darwin-x64@1.2.4
+
       - name: Build distributables (macOS)
         if: matrix.platform == 'mac'
         run: bun run dist:mac


### PR DESCRIPTION
## Summary

**Hotfix to stable.** Closes **[BDHLNDR-37](https://gobodhi.atlassian.net/browse/BDHLNDR-37)**. Targets `production` directly — skipping the `development`/beta path because 3.2.8 is currently shipping and Intel Mac users can't open the app.

## Problem

Intel Mac users on **v3.2.8** crash at launch:

> Uncaught Exception error: could not load the "sharp" module using the darwin-x64 runtime

## Root cause

- `sharp` is a transitive dep of `@huggingface/transformers` (used by `src/main/vector-search/embedding-provider.ts`).
- `sharp` ships prebuilt binaries via platform-filtered `optionalDependencies` (`@img/sharp-<os>-<arch>`). npm/bun skip any whose `cpu`/`os` don't match the host.
- GitHub's `macos-latest` runner is **Apple Silicon (arm64)**, so default `bun install` only fetches `@img/sharp-darwin-arm64` + `@img/sharp-libvips-darwin-arm64`.
- electron-builder cross-packages **both x64 and arm64 Mac DMGs** from that one CI run — but the `node_modules` it bundles only has arm64 sharp.
- Intel Mac installs the x64 DMG → `require('sharp')` throws → uncaught.

Note: adding these to top-level `optionalDependencies` in `package.json` **doesn't work** because npm/bun still honor the `cpu`/`os` constraints in the inner packages. The only way to install an arch-foreign optional dep is an explicit CLI install with `--cpu` / `--os` overrides.

## Fix

Added a single workflow step in `release.yml`'s Mac job, right before `bun run dist:mac`:

```yaml
- name: Install darwin-x64 sharp variant for cross-arch packaging
  if: matrix.platform == 'mac'
  run: |
    npm install --no-save --cpu=x64 --os=darwin \
      @img/sharp-darwin-x64@0.34.5 \
      @img/sharp-libvips-darwin-x64@1.2.4
```

This layers `darwin-x64` into `node_modules/@img/` alongside the already-installed `darwin-arm64`. Bundle size grows by ~30 MB per Mac DMG (one extra libvips + sharp prebuilt). Versions pinned to match the `sharp@0.34.5` in the existing lockfile.

Linux + Windows unchanged — both are single-arch builds that already get matching binaries.

## Test plan

- [ ] CI green on all three platforms (Linux/Windows skip, Mac picks up new step).
- [ ] Mac build log shows `npm install --cpu=x64` step succeeding and producing `@img/sharp-darwin-x64` in the workspace `node_modules`.
- [ ] arm64 DMG launches and vector-search works (smoke test on an Apple Silicon Mac).
- [ ] **x64 DMG launches on Intel Mac without the sharp crash** (the target fix).

## Release plan

1. Merge this PR to `production`.
2. On `production`: `npm version patch && git push` → version bumps to `3.2.9`, CI builds and publishes stable release.
3. Intel Mac users on stable channel pick up 3.2.9 via auto-update (or manual DMG re-install, if the broken 3.2.8 is already open).
4. **Forward-merge** `production` → `development` so the beta branch also gets the fix. (I'll open a second PR for that after this one ships.)

## Out of scope

A follow-up cleanup (separate ticket) will drop sharp from the main-process tree entirely via a runtime `Module._resolveFilename` hook + `electron-builder.yml` `files` exclusion, reclaiming ~60 MB per install. Not needed to fix the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-37]: https://gobodhi.atlassian.net/browse/BDHLNDR-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ