### PR TITLE
chore: forward-merge production → development (BDHLNDR-37 sharp fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # BDHLNDR-37: GitHub's macos-latest runner is Apple Silicon, so the default
+      # bun install only fetches the darwin-arm64 sharp prebuilt. electron-builder
+      # cross-packages BOTH x64 and arm64 Mac DMGs from this single run, which
+      # left Intel Mac users on 3.2.8 crashing at launch with "could not load the
+      # sharp module using the darwin-x64 runtime". Force-install the darwin-x64
+      # sharp + libvips binaries (bypassing npm's cpu/os filter) so the x64 DMG
+      # ships with a usable sharp. Pinned to the sharp@0.34.5 already in lockfile.
+      - name: Install darwin-x64 sharp variant for cross-arch packaging
+        if: matrix.platform == 'mac'
+        run: |
+          npm install --no-save --cpu=x64 --os=darwin \
+            @img/sharp-darwin-x64@0.34.5 \
+            @img/sharp-libvips-darwin-x64@1.2.4
+
       - name: Build distributables (macOS)
         if: matrix.platform == 'mac'
         run: bun run dist:mac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,15 +88,24 @@ jobs:
       # bun install only fetches the darwin-arm64 sharp prebuilt. electron-builder
       # cross-packages BOTH x64 and arm64 Mac DMGs from this single run, which
       # left Intel Mac users on 3.2.8 crashing at launch with "could not load the
-      # sharp module using the darwin-x64 runtime". Force-install the darwin-x64
-      # sharp + libvips binaries (bypassing npm's cpu/os filter) so the x64 DMG
-      # ships with a usable sharp. Pinned to the sharp@0.34.5 already in lockfile.
+      # sharp module using the darwin-x64 runtime". Use `npm pack` (which doesn't
+      # platform-check since it's just downloading tarballs, not installing) and
+      # extract into node_modules/@img/ directly. The --cpu/--os flags on
+      # `npm install` don't override the platform check for explicit installs on
+      # npm 10.8.2 — they only influence optional-dep resolution — so the
+      # pack+extract route is the reliable way to cross-pack a native prebuilt.
+      # Pinned to versions already referenced by sharp@0.34.5 in the lockfile.
       - name: Install darwin-x64 sharp variant for cross-arch packaging
         if: matrix.platform == 'mac'
         run: |
-          npm install --no-save --cpu=x64 --os=darwin \
-            @img/sharp-darwin-x64@0.34.5 \
-            @img/sharp-libvips-darwin-x64@1.2.4
+          mkdir -p node_modules/@img/sharp-darwin-x64 node_modules/@img/sharp-libvips-darwin-x64
+          tarball=$(npm pack "@img/sharp-darwin-x64@0.34.5" --pack-destination /tmp --silent)
+          tar -xzf "/tmp/$tarball" -C node_modules/@img/sharp-darwin-x64 --strip-components=1
+          rm "/tmp/$tarball"
+          tarball=$(npm pack "@img/sharp-libvips-darwin-x64@1.2.4" --pack-destination /tmp --silent)
+          tar -xzf "/tmp/$tarball" -C node_modules/@img/sharp-libvips-darwin-x64 --strip-components=1
+          rm "/tmp/$tarball"
+          ls node_modules/@img/
 
       - name: Build distributables (macOS)
         if: matrix.platform == 'mac'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {


### PR DESCRIPTION
## Summary

Forward-merges `production` into `development` so the sharp darwin-x64 CI fix from [BDHLNDR-37](https://gobodhi.atlassian.net/browse/BDHLNDR-37) (shipped in stable v3.2.9) lands on the beta branch. Without this, the next beta.3 cut would go out still broken for Intel Mac users.

## What moves across

Two commits from `production`:
- `4fc96c8` — original hotfix attempt (`--cpu=x64 --os=darwin` install flag approach)
- `07e6ef2` — follow-up that swapped to `npm pack + tar` because the flag approach failed with EBADPLATFORM on npm 10.8.2

The second supersedes the first functionally, but keeping both preserves the `production` history faithfully on `development`.

## Conflicts resolved

- **`.github/workflows/release.yml`** — auto-merged cleanly. Ended up with **both** sets of changes:
  - BDHLNDR-32 beta-channel handling (branch trigger on `development`, `is_prerelease` gating, renaming `latest*.yml` → `beta*.yml` for prereleases, softprops `prerelease` + `name` conditionals)
  - BDHLNDR-37 Mac `npm pack` step (Apple Silicon runner cross-installs darwin-x64 sharp binaries)
- **`package.json`** — version conflict, resolved to `3.3.0-beta.2` (development was ahead). Nothing else in the file changed.

## Type-check

- [x] `bunx tsc -p tsconfig.main.json --noEmit` clean
- [x] `bunx tsc -p tsconfig.json --noEmit` clean

## Test plan

- [ ] Next beta cut (`npm version prerelease && git push` on `development`) should produce a build where the macOS job runs BOTH the sharp-install step AND the channel-rename step, and the published release contains both `beta.yml` feeds AND Mac DMGs with working sharp on Intel.
- [ ] Apple Silicon Mac beta users are unaffected (no regression).

## Why this is a separate PR

Push to `development` triggers the beta-channel gate in `release.yml`, which now correctly skips stable versions (`3.2.9`) pushed to development. So merging `production` (stable `3.2.9`) would normally short-circuit the beta gate — but since the resolved version is `3.3.0-beta.2` (development's own), the merge lands without triggering any CI release. Safe merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-37]: https://gobodhi.atlassian.net/browse/BDHLNDR-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ