### PR TITLE
hotfix: fix Intel Mac splash hang + add Open Log Folder menu (BDHLNDR-38, BDHLNDR-39)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,18 @@ jobs:
             platform: linux
           - os: windows-latest
             platform: win
-          - os: macos-latest
-            platform: mac
+          # BDHLNDR-38: build each Mac arch on its native runner so postinstall
+          # (electron-rebuild) and sharp's optional-dep resolution produce
+          # host-native binaries. Cross-packaging from a single arm64 runner
+          # previously shipped arm64 .node files inside the x64 DMG, causing
+          # Intel Mac users to hang at the splash screen when better-sqlite3
+          # failed to load.
+          - os: macos-14
+            platform: mac-arm64
+            mac_arch: arm64
+          - os: macos-13
+            platform: mac-x64
+            mac_arch: x64
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -84,32 +94,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # BDHLNDR-37: GitHub's macos-latest runner is Apple Silicon, so the default
-      # bun install only fetches the darwin-arm64 sharp prebuilt. electron-builder
-      # cross-packages BOTH x64 and arm64 Mac DMGs from this single run, which
-      # left Intel Mac users on 3.2.8 crashing at launch with "could not load the
-      # sharp module using the darwin-x64 runtime". Use `npm pack` (which doesn't
-      # platform-check since it's just downloading tarballs, not installing) and
-      # extract into node_modules/@img/ directly. The --cpu/--os flags on
-      # `npm install` don't override the platform check for explicit installs on
-      # npm 10.8.2 — they only influence optional-dep resolution — so the
-      # pack+extract route is the reliable way to cross-pack a native prebuilt.
-      # Pinned to versions already referenced by sharp@0.34.5 in the lockfile.
-      - name: Install darwin-x64 sharp variant for cross-arch packaging
-        if: matrix.platform == 'mac'
-        run: |
-          mkdir -p node_modules/@img/sharp-darwin-x64 node_modules/@img/sharp-libvips-darwin-x64
-          tarball=$(npm pack "@img/sharp-darwin-x64@0.34.5" --pack-destination /tmp --silent)
-          tar -xzf "/tmp/$tarball" -C node_modules/@img/sharp-darwin-x64 --strip-components=1
-          rm "/tmp/$tarball"
-          tarball=$(npm pack "@img/sharp-libvips-darwin-x64@1.2.4" --pack-destination /tmp --silent)
-          tar -xzf "/tmp/$tarball" -C node_modules/@img/sharp-libvips-darwin-x64 --strip-components=1
-          rm "/tmp/$tarball"
-          ls node_modules/@img/
-
       - name: Build distributables (macOS)
-        if: matrix.platform == 'mac'
-        run: bun run dist:mac
+        if: startsWith(matrix.platform, 'mac')
+        run: bunx electron-builder --mac --${{ matrix.mac_arch }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.MAC_CERTS }}
@@ -149,6 +136,19 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R artifacts
 
+      # BDHLNDR-38: each mac matrix job produces its own arch-scoped
+      # latest-mac.yml. Merge into one so electron-updater clients see both
+      # DMGs and pick the right arch. Then remove the per-job files so the
+      # release upload glob doesn't race on identical filenames.
+      - name: Merge latest-mac.yml from arm64 and x64 builds
+        run: |
+          pip install pyyaml
+          python3 scripts/merge-latest-mac.py \
+            artifacts/dist-mac-arm64/latest-mac.yml \
+            artifacts/dist-mac-x64/latest-mac.yml \
+            artifacts/latest-mac.yml
+          rm artifacts/dist-mac-arm64/latest-mac.yml artifacts/dist-mac-x64/latest-mac.yml
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -164,5 +164,6 @@ jobs:
             artifacts/**/*.dmg
             artifacts/**/*.zip
             artifacts/**/latest*.yml
+            artifacts/latest-mac.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/merge-latest-mac.py
+++ b/scripts/merge-latest-mac.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""
+BDHLNDR-38: merge the per-arch latest-mac.yml files produced by the split mac
+build jobs into a single latest-mac.yml listing both x64 and arm64 DMGs, so
+electron-updater picks the right artifact for the client's arch.
+
+Usage: merge-latest-mac.py <arm64.yml> <x64.yml> <out.yml>
+"""
+import sys
+import yaml
+
+arm64_path, x64_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(arm64_path) as f:
+    arm64 = yaml.safe_load(f)
+with open(x64_path) as f:
+    x64 = yaml.safe_load(f)
+
+merged = dict(arm64)
+merged['files'] = arm64['files'] + x64['files']
+
+with open(out_path, 'w') as f:
+    yaml.dump(merged, f, default_flow_style=False, sort_keys=False)
+
+print(f"Merged {len(merged['files'])} mac update entries into {out_path}")

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,5 +1,6 @@
 import { Menu, shell, app, BrowserWindow, ipcMain } from 'electron';
 import * as path from 'path';
+import log from 'electron-log';
 
 const aboutPreloadPath = path.join(__dirname, 'preload-about.js');
 
@@ -215,6 +216,15 @@ export function createApplicationMenu(mainWindow: BrowserWindow): void {
           label: 'Report Issue',
           click: async () => {
             await shell.openExternal('https://github.com/Software-Development-LLC/Bodhilander/issues');
+          },
+        },
+        {
+          label: 'Open Log Folder',
+          click: () => {
+            const logFile = log.transports.file.getFile()?.path;
+            if (logFile) {
+              shell.showItemInFolder(logFile);
+            }
           },
         },
       ],


### PR DESCRIPTION
## Summary
- **BDHLNDR-38**: Intel Mac users on v3.2.9 were stuck at the splash screen. Log from affected user confirmed `dlopen ... incompatible architecture (have 'arm64', need 'x86_64h')` on `better_sqlite3.node` — postinstall's `electron-rebuild` ran only on the arm64 macos-latest runner, so the cross-packaged x64 DMG shipped arm64 native modules. Fix: split the mac matrix into `macos-14` (arm64) and `macos-13` (x64) jobs, each building natively. Drops the BDHLNDR-37 `npm pack` sharp workaround (no longer needed). Adds `scripts/merge-latest-mac.py` to combine per-arch `latest-mac.yml` into one so electron-updater resolves correctly for both archs.
- **BDHLNDR-39**: Adds an *Open Log Folder* item to the Help menu using `shell.showItemInFolder(log.transports.file.getFile().path)` so users can grab logs for support without hunting through `%APPDATA%` / `~/Library/Logs`.

## Test plan
- [ ] CI: both `mac-arm64` (macos-14) and `mac-x64` (macos-13) matrix jobs succeed and produce single-arch DMGs
- [ ] CI release job: `scripts/merge-latest-mac.py` runs cleanly; final `latest-mac.yml` lists both DMGs under `files:`
- [ ] Intel Mac user installs 3.2.10 x64 DMG → gets past splash to main UI
- [ ] Apple Silicon Mac user installs 3.2.10 arm64 DMG → still works (regression check)
- [ ] Help → Open Log Folder opens the logs dir with `main.log` highlighted on Windows, macOS, and Linux
- [ ] Auto-update from 3.2.9 → 3.2.10 works on both Intel and Apple Silicon Mac

## Release steps after merge
After merging to `production`, bump version and push (per CLAUDE.md, NO `--tags`):
```
git checkout production && git pull
npm version patch   # 3.2.9 → 3.2.10
git push
```