### PR TITLE
chore: forward-merge production hotfixes into development

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,18 @@ jobs:
             platform: linux
           - os: windows-latest
             platform: win
-          - os: macos-latest
-            platform: mac
+          # BDHLNDR-38: build each Mac arch on its native runner so postinstall
+          # (electron-rebuild) and sharp's optional-dep resolution produce
+          # host-native binaries. Cross-packaging from a single arm64 runner
+          # previously shipped arm64 .node files inside the x64 DMG, causing
+          # Intel Mac users to hang at the splash screen when better-sqlite3
+          # failed to load.
+          - os: macos-14
+            platform: mac-arm64
+            mac_arch: arm64
+          - os: macos-13
+            platform: mac-x64
+            mac_arch: x64
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -84,32 +94,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # BDHLNDR-37: GitHub's macos-latest runner is Apple Silicon, so the default
-      # bun install only fetches the darwin-arm64 sharp prebuilt. electron-builder
-      # cross-packages BOTH x64 and arm64 Mac DMGs from this single run, which
-      # left Intel Mac users on 3.2.8 crashing at launch with "could not load the
-      # sharp module using the darwin-x64 runtime". Use `npm pack` (which doesn't
-      # platform-check since it's just downloading tarballs, not installing) and
-      # extract into node_modules/@img/ directly. The --cpu/--os flags on
-      # `npm install` don't override the platform check for explicit installs on
-      # npm 10.8.2 — they only influence optional-dep resolution — so the
-      # pack+extract route is the reliable way to cross-pack a native prebuilt.
-      # Pinned to versions already referenced by sharp@0.34.5 in the lockfile.
-      - name: Install darwin-x64 sharp variant for cross-arch packaging
-        if: matrix.platform == 'mac'
-        run: |
-          mkdir -p node_modules/@img/sharp-darwin-x64 node_modules/@img/sharp-libvips-darwin-x64
-          tarball=$(npm pack "@img/sharp-darwin-x64@0.34.5" --pack-destination /tmp --silent)
-          tar -xzf "/tmp/$tarball" -C node_modules/@img/sharp-darwin-x64 --strip-components=1
-          rm "/tmp/$tarball"
-          tarball=$(npm pack "@img/sharp-libvips-darwin-x64@1.2.4" --pack-destination /tmp --silent)
-          tar -xzf "/tmp/$tarball" -C node_modules/@img/sharp-libvips-darwin-x64 --strip-components=1
-          rm "/tmp/$tarball"
-          ls node_modules/@img/
-
       - name: Build distributables (macOS)
-        if: matrix.platform == 'mac'
-        run: bun run dist:mac
+        if: startsWith(matrix.platform, 'mac')
+        run: bunx electron-builder --mac --${{ matrix.mac_arch }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.MAC_CERTS }}
@@ -149,6 +136,19 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R artifacts
 
+      # BDHLNDR-38: each mac matrix job produces its own arch-scoped
+      # latest-mac.yml. Merge into one so electron-updater clients see both
+      # DMGs and pick the right arch. Then remove the per-job files so the
+      # release upload glob doesn't race on identical filenames.
+      - name: Merge latest-mac.yml from arm64 and x64 builds
+        run: |
+          pip install pyyaml
+          python3 scripts/merge-latest-mac.py \
+            artifacts/dist-mac-arm64/latest-mac.yml \
+            artifacts/dist-mac-x64/latest-mac.yml \
+            artifacts/latest-mac.yml
+          rm artifacts/dist-mac-arm64/latest-mac.yml artifacts/dist-mac-x64/latest-mac.yml
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -164,5 +164,6 @@ jobs:
             artifacts/**/*.dmg
             artifacts/**/*.zip
             artifacts/**/latest*.yml
+            artifacts/latest-mac.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,8 @@ jobs:
           # per release) — larger runners don't use the public-repo free quota.
           - os: macos-14
             platform: mac-arm64
-            mac_arch: arm64
           - os: macos-15-intel
             platform: mac-x64
-            mac_arch: x64
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -100,7 +98,7 @@ jobs:
 
       - name: Build distributables (macOS)
         if: startsWith(matrix.platform, 'mac')
-        run: bunx electron-builder --mac --${{ matrix.mac_arch }}
+        run: bunx electron-builder --mac
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.MAC_CERTS }}
@@ -168,6 +166,5 @@ jobs:
             artifacts/**/*.dmg
             artifacts/**/*.zip
             artifacts/**/latest*.yml
-            artifacts/latest-mac.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # BDHLNDR-37: GitHub's macos-latest runner is Apple Silicon, so the default
+      # bun install only fetches the darwin-arm64 sharp prebuilt. electron-builder
+      # cross-packages BOTH x64 and arm64 Mac DMGs from this single run, which
+      # left Intel Mac users on 3.2.8 crashing at launch with "could not load the
+      # sharp module using the darwin-x64 runtime". Force-install the darwin-x64
+      # sharp + libvips binaries (bypassing npm's cpu/os filter) so the x64 DMG
+      # ships with a usable sharp. Pinned to the sharp@0.34.5 already in lockfile.
+      - name: Install darwin-x64 sharp variant for cross-arch packaging
+        if: matrix.platform == 'mac'
+        run: |
+          npm install --no-save --cpu=x64 --os=darwin \
+            @img/sharp-darwin-x64@0.34.5 \
+            @img/sharp-libvips-darwin-x64@1.2.4
+
       - name: Build distributables (macOS)
         if: matrix.platform == 'mac'
         run: bun run dist:mac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,14 @@ jobs:
           # previously shipped arm64 .node files inside the x64 DMG, causing
           # Intel Mac users to hang at the splash screen when better-sqlite3
           # failed to load.
+          #
+          # macos-15-intel is GitHub's current Intel x64 12-core larger runner
+          # (retired macos-13 replacement). It's a paid tier (~$0.077/min, ~$1
+          # per release) — larger runners don't use the public-repo free quota.
           - os: macos-14
             platform: mac-arm64
             mac_arch: arm64
-          - os: macos-13
+          - os: macos-15-intel
             platform: mac-x64
             mac_arch: x64
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,15 +88,24 @@ jobs:
       # bun install only fetches the darwin-arm64 sharp prebuilt. electron-builder
       # cross-packages BOTH x64 and arm64 Mac DMGs from this single run, which
       # left Intel Mac users on 3.2.8 crashing at launch with "could not load the
-      # sharp module using the darwin-x64 runtime". Force-install the darwin-x64
-      # sharp + libvips binaries (bypassing npm's cpu/os filter) so the x64 DMG
-      # ships with a usable sharp. Pinned to the sharp@0.34.5 already in lockfile.
+      # sharp module using the darwin-x64 runtime". Use `npm pack` (which doesn't
+      # platform-check since it's just downloading tarballs, not installing) and
+      # extract into node_modules/@img/ directly. The --cpu/--os flags on
+      # `npm install` don't override the platform check for explicit installs on
+      # npm 10.8.2 — they only influence optional-dep resolution — so the
+      # pack+extract route is the reliable way to cross-pack a native prebuilt.
+      # Pinned to versions already referenced by sharp@0.34.5 in the lockfile.
       - name: Install darwin-x64 sharp variant for cross-arch packaging
         if: matrix.platform == 'mac'
         run: |
-          npm install --no-save --cpu=x64 --os=darwin \
-            @img/sharp-darwin-x64@0.34.5 \
-            @img/sharp-libvips-darwin-x64@1.2.4
+          mkdir -p node_modules/@img/sharp-darwin-x64 node_modules/@img/sharp-libvips-darwin-x64
+          tarball=$(npm pack "@img/sharp-darwin-x64@0.34.5" --pack-destination /tmp --silent)
+          tar -xzf "/tmp/$tarball" -C node_modules/@img/sharp-darwin-x64 --strip-components=1
+          rm "/tmp/$tarball"
+          tarball=$(npm pack "@img/sharp-libvips-darwin-x64@1.2.4" --pack-destination /tmp --silent)
+          tar -xzf "/tmp/$tarball" -C node_modules/@img/sharp-libvips-darwin-x64 --strip-components=1
+          rm "/tmp/$tarball"
+          ls node_modules/@img/
 
       - name: Build distributables (macOS)
         if: matrix.platform == 'mac'

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -50,15 +50,16 @@ mac:
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
+  # BDHLNDR-38: no explicit arch list — electron-builder defaults to host
+  # arch when unspecified, which is what we want since release.yml now runs
+  # each arch on its native runner (macos-14 arm64 + macos-15-intel x64).
+  # A hardcoded [x64, arm64] here overrode the CLI --x64/--arm64 flags and
+  # caused every matrix job to cross-package both archs, producing colliding
+  # DMG filenames and a latest-mac.yml with duplicate sha512 entries that
+  # broke auto-update for Intel Mac clients on 3.2.10.
   target:
     - target: dmg
-      arch:
-        - x64
-        - arm64
     - target: zip
-      arch:
-        - x64
-        - arm64
 
 # Copy conpty.dll for Windows PTY support (runs after packing)
 afterPack: scripts/copy-conpty.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.2.10",
+  "version": "3.2.11",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {

--- a/scripts/merge-latest-mac.py
+++ b/scripts/merge-latest-mac.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""
+BDHLNDR-38: merge the per-arch latest-mac.yml files produced by the split mac
+build jobs into a single latest-mac.yml listing both x64 and arm64 DMGs, so
+electron-updater picks the right artifact for the client's arch.
+
+Usage: merge-latest-mac.py <arm64.yml> <x64.yml> <out.yml>
+"""
+import sys
+import yaml
+
+arm64_path, x64_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(arm64_path) as f:
+    arm64 = yaml.safe_load(f)
+with open(x64_path) as f:
+    x64 = yaml.safe_load(f)
+
+merged = dict(arm64)
+merged['files'] = arm64['files'] + x64['files']
+
+with open(out_path, 'w') as f:
+    yaml.dump(merged, f, default_flow_style=False, sort_keys=False)
+
+print(f"Merged {len(merged['files'])} mac update entries into {out_path}")

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,5 +1,6 @@
 import { Menu, shell, app, BrowserWindow, ipcMain } from 'electron';
 import * as path from 'path';
+import log from 'electron-log';
 
 const aboutPreloadPath = path.join(__dirname, 'preload-about.js');
 
@@ -215,6 +216,15 @@ export function createApplicationMenu(mainWindow: BrowserWindow): void {
           label: 'Report Issue',
           click: async () => {
             await shell.openExternal('https://github.com/Software-Development-LLC/Bodhilander/issues');
+          },
+        },
+        {
+          label: 'Open Log Folder',
+          click: () => {
+            const logFile = log.transports.file.getFile()?.path;
+            if (logFile) {
+              shell.showItemInFolder(logFile);
+            }
           },
         },
       ],


### PR DESCRIPTION
## Summary
Forward-merges the 3.2.x hotfix series from `production` into `development` so nothing gets lost when we promote beta → stable.

## What's coming in
- **BDHLNDR-37**: bundle darwin-x64 sharp prebuilt (3.2.8 hotfix)
- **BDHLNDR-38**: Intel Mac splash-hang fix
  - Split Mac matrix into native runners (`macos-14` arm64 + `macos-15-intel` x64)
  - Merge per-arch `latest-mac.yml` into one via `scripts/merge-latest-mac.py`
  - Removed `mac.target.arch` arrays from `electron-builder.yml` so each job builds only host arch (fixes the cross-pack duplicate-upload bug that broke auto-update for 3.2.10 Intel users)
- **BDHLNDR-39**: Open Log Folder item in Help menu

## Conflict resolutions
- **package.json**: kept dev's `3.3.0-beta.2` (we're still on the beta channel at this point)
- **.github/workflows/release.yml**: kept dev's beta channel-gating + `latest*.yml` → `beta*.yml` rename step, AND added prod's mac yml merge step. Ordered the merge BEFORE the rename so the merged `artifacts/latest-mac.yml` is what gets renamed to `beta-mac.yml` on prereleases.

## Test plan
- [ ] CI: `check-version` gates correctly — this branch is dev, version is `3.3.0-beta.2`, tag exists, so no release should fire (expected short-circuit).
- [ ] After this lands, next step is a `development` → `production` PR, where on production the version will be bumped `3.2.11` → `3.3.0` to promote beta to stable.