### PR TITLE
chore: forward-merge production (v3.3.1 / BDHLNDR-40) into development

### DIFF
--- a/docs/designs/BDHLNDR-40-indexing-crash-circuit-breaker.md
+++ b/docs/designs/BDHLNDR-40-indexing-crash-circuit-breaker.md
@@ -1,0 +1,70 @@
+# BDHLNDR-40 — Interim mitigation: vector-search indexing crash-loop circuit breaker
+
+**Status:** interim hotfix (does not fix the underlying native crash — that is gated on the
+macOS `.ips` crash report; see ticket "Investigation needed").
+
+## Problem (from gregory's `main.log`, v3.3.0, macOS arm64)
+
+A native crash (segfault/abort) somewhere in the indexing path (`@huggingface/transformers`
+ONNX Runtime / `sqlite-vec` / `better-sqlite3`) terminates the process **silently** ~25–110 s
+into indexing. Because indexing runs in a `worker_threads.Worker`, a native fault there does
+**not** stay contained — it kills the whole OS process, so `worker.on('exit'|'error')` never
+runs and nothing is logged.
+
+The crash becomes an **infinite relaunch loop** because:
+
+1. `startIndexing()` writes DB status `'indexing'` (`vector-search/index.ts`).
+2. Native crash → process dies → status stays `'indexing'` (no terminal transition runs).
+3. On relaunch, `useCodeSearch.ts` auto-starts indexing when status is `'pending'` **or
+   `'indexing'`** (it treats a persisted `'indexing'` as "stale from an interrupted
+   session"). → back to step 1.
+
+## Why not "supervise / restart the worker"
+
+In-process supervision cannot catch a native segfault in a `worker_threads` worker — the
+whole V8/OS process is gone. True containment requires moving indexing to a separate child
+process (`utilityProcess`/`child_process`). That is the **permanent fix** and remains on the
+ticket; it is too large/risky for a stable hotfix and needs the root-cause frame first.
+
+## Interim design — consecutive-crash circuit breaker
+
+Detect "a previous indexing attempt started but the process never reached a terminal state"
+(== it crashed), count consecutive occurrences, and stop auto-spawning the worker once a
+threshold is hit — breaking the loop and leaving the app usable.
+
+- **Schema:** add `consecutive_failures INTEGER DEFAULT 0` to `code_indexes`
+  (in `CREATE TABLE` for new installs + `ALTER TABLE ADD COLUMN` migration for existing
+  installs, mirroring the established `PRAGMA table_info` pattern in `database.ts`).
+- **`startIndexing()`** (before spawning the worker): read fresh status. If it is
+  `'indexing'` and this index is **not** a known in-process cancel, the prior attempt
+  crashed → `incrementConsecutiveFailures()`. If the new count `>= MAX_CONSECUTIVE_INDEX_CRASHES`
+  (= **2**), set status `'error'` with a clear message and `return` **without spawning the
+  worker**. Otherwise log a warning and proceed (one automatic retry is still allowed).
+- **`handleIndexingComplete()`** → `resetConsecutiveFailures()`.
+- **`retryIndexing()`** (explicit user action) → `resetConsecutiveFailures()` so the user
+  can always re-arm and try again; the breaker re-trips if it crashes again.
+
+`'error'` is reused (no new status value → no painful SQLite CHECK-constraint rebuild). The
+renderer auto-index effect does **not** auto-start on `'error'`, and `IndexStatus.tsx` /
+`retryIndexing` already give a user-visible, recoverable state.
+
+### False-positive safety
+
+A single clean app-quit mid-index also leaves status `'indexing'`. Threshold = 2 means one
+such event just costs one automatic retry (which then succeeds); only *repeated consecutive*
+unfinished attempts trip the breaker. In-process cancels are excluded via the existing
+`cancelledIndexes` set; `retryIndexing()` sets `'pending'` before re-entry so it is never
+miscounted.
+
+## Acceptance mapping (ticket BDHLNDR-40)
+
+- AC2 (native fault contained / no silent main-process kill loop): **partially** — the loop
+  is broken and the app stays usable after ≤2 cycles; full containment is the child-process
+  follow-up.
+- AC1/AC3/AC4: unchanged — still require the `.ips` root cause. Tracked on the ticket.
+
+## Verification
+
+No test framework exists in the repo (no vitest/jest/test script) — TDD phase is infeasible
+without introducing test infra (out of scope for a production hotfix). Verification:
+`tsc` typecheck + `build:main`/`build:worker`, and a logic trace of the loop scenario.

--- a/docs/designs/BDHLNDR-40-indexing-crash-circuit-breaker.md
+++ b/docs/designs/BDHLNDR-40-indexing-crash-circuit-breaker.md
@@ -63,6 +63,28 @@ miscounted.
   follow-up.
 - AC1/AC3/AC4: unchanged — still require the `.ips` root cause. Tracked on the ticket.
 
+## Root-cause safe subset (added after the 5 `.ips` reports)
+
+The crash is confirmed (all 5 `.ips` identical): `EXC_BREAKPOINT/SIGTRAP` in
+`onnxruntime::BFCArena::Extend → CPUAllocator::Alloc` — ORT's CPU arena grows
+to the worst-case embedding batch, never shrinks, and a later larger batch
+traps when `Extend` can't allocate. Memory exhaustion in the embedding path.
+
+The full root-cause fix splits by risk. The **embedding-neutral subset** ships
+here in the production hotfix (no quality change, no re-index):
+
+- `embedding-provider.ts`: `session_options.enableCpuMemArena: false` — ORT
+  allocates per-request instead of holding a growing pool. Directly counters
+  the crash frame; numerically identical output.
+- `indexing-worker.ts`: `BATCH_SIZE` 32 → 16 — halves peak tensor
+  (`≈ BATCH_SIZE × longest-seq`). Per-text embeddings are batch-size
+  independent (no cross-sequence attention) → identical results, no re-index.
+
+The **risky remainder** — `dtype: 'q8'` (quantized model) and token-bounded
+truncation — changes embedding quality and forces a re-index, so it is tracked
+separately for `development`/beta bake (not in this hotfix). The circuit
+breaker above remains as a backstop for any residual/again-regressed crash.
+
 ## Verification
 
 No test framework exists in the repo (no vitest/jest/test script) — TDD phase is infeasible

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.3.0-beta.2",
+  "version": "3.3.0",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -245,9 +245,23 @@ function initializeCodeSearchTables(database: Database.Database): void {
       chunk_count INTEGER DEFAULT 0,
       model_name TEXT DEFAULT 'bge-base-en-v1.5',
       embedding_dimensions INTEGER DEFAULT 768,
-      error_message TEXT
+      error_message TEXT,
+      consecutive_failures INTEGER DEFAULT 0
     )
   `);
+
+  // Migration: Add consecutive_failures to code_indexes if it doesn't exist
+  // (BDHLNDR-40). Powers the indexing crash-loop circuit breaker — a native
+  // crash in the indexing worker_thread kills the whole process silently and
+  // leaves status stuck at 'indexing', which the renderer then auto-restarts,
+  // producing an infinite crash-relaunch loop. We count consecutive crashed
+  // attempts and trip a breaker. Existing installs need the column added.
+  const codeIndexColumns = database
+    .prepare("PRAGMA table_info(code_indexes)")
+    .all() as { name: string }[];
+  if (!codeIndexColumns.some(col => col.name === 'consecutive_failures')) {
+    database.exec("ALTER TABLE code_indexes ADD COLUMN consecutive_failures INTEGER DEFAULT 0");
+  }
 
   // Indexed files table
   database.exec(`

--- a/src/main/repositories/code-search.ts
+++ b/src/main/repositories/code-search.ts
@@ -105,6 +105,33 @@ export function updateIndexStatus(
   db.prepare(`UPDATE code_indexes SET ${updates.join(', ')} WHERE id = ?`).run(...params);
 }
 
+/**
+ * Increment the consecutive-crash counter for an index and return the new
+ * value. (BDHLNDR-40) Called when a fresh process observes a prior indexing
+ * attempt left stuck at status 'indexing' — i.e. the previous attempt crashed
+ * the process before reaching a terminal state.
+ */
+export function incrementConsecutiveFailures(id: string): number {
+  const db = getDatabase();
+  db.prepare(
+    'UPDATE code_indexes SET consecutive_failures = consecutive_failures + 1 WHERE id = ?'
+  ).run(id);
+  const row = db
+    .prepare('SELECT consecutive_failures FROM code_indexes WHERE id = ?')
+    .get(id) as { consecutive_failures: number } | undefined;
+  return row?.consecutive_failures ?? 0;
+}
+
+/**
+ * Reset the consecutive-crash counter (BDHLNDR-40). Called on successful
+ * indexing completion and on an explicit user retry, so the circuit breaker
+ * re-arms from a clean state.
+ */
+export function resetConsecutiveFailures(id: string): void {
+  const db = getDatabase();
+  db.prepare('UPDATE code_indexes SET consecutive_failures = 0 WHERE id = ?').run(id);
+}
+
 export function updateIndexCounts(id: string, fileCount: number, chunkCount: number): void {
   const db = getDatabase();
   db.prepare('UPDATE code_indexes SET file_count = ?, chunk_count = ? WHERE id = ?')

--- a/src/main/vector-search/embedding-provider.ts
+++ b/src/main/vector-search/embedding-provider.ts
@@ -84,6 +84,14 @@ export class HuggingFaceEmbeddingProvider implements EmbeddingProvider {
           session_options: {
             intraOpNumThreads: EMBEDDING_THREAD_COUNT,
             interOpNumThreads: 1,
+            // BDHLNDR-40: ONNX Runtime's BFC arena grows to the worst-case
+            // batch and never shrinks; a later larger batch forces
+            // BFCArena::Extend, which traps (SIGTRAP) on allocation failure
+            // and kills the whole process. Disabling the CPU arena makes ORT
+            // allocate per-request instead of holding a growing pool —
+            // numerically identical output, just bounded memory. This is the
+            // exact counter to the confirmed crash frame.
+            enableCpuMemArena: false,
           },
         });
         console.log('Embedding model initialized successfully');

--- a/src/main/vector-search/index.ts
+++ b/src/main/vector-search/index.ts
@@ -45,6 +45,15 @@ interface WorkerResult {
 // Timeout for model initialization (downloading 110MB model + loading ONNX runtime)
 const WORKER_INIT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
+// BDHLNDR-40: a native crash in the indexing worker_thread kills the whole
+// process silently — no exit/error handler runs, so status stays 'indexing'
+// in the DB. The renderer auto-restarts indexing on a stale 'indexing' status,
+// producing an infinite crash-relaunch loop. After this many consecutive
+// crashed attempts we trip a circuit breaker and stop auto-spawning the worker
+// (status → 'error', user can still explicitly retry). 2 = allow one automatic
+// retry, then break the loop.
+const MAX_CONSECUTIVE_INDEX_CRASHES = 2;
+
 export class VectorSearchManager extends EventEmitter {
   private workers: Map<string, Worker> = new Map();
   private watchers: Map<string, chokidar.FSWatcher> = new Map();
@@ -191,6 +200,37 @@ export class VectorSearchManager extends EventEmitter {
     if (this.workers.has(index.id)) {
       console.log('[VectorSearch] Indexing already in progress for:', directoryPath);
       return;
+    }
+
+    // BDHLNDR-40 circuit breaker: a fresh status of 'indexing' here means a
+    // previous attempt started but the process never reached a terminal state
+    // (complete/error) — i.e. it crashed the whole process (native segfault in
+    // the worker thread can't be caught in-process). In-process cancels are
+    // excluded via cancelledIndexes; retryIndexing() sets 'pending' first so it
+    // is never miscounted. Count consecutive crashes and stop auto-spawning the
+    // worker once the threshold trips, so we don't relaunch-loop forever.
+    const persisted = codeSearchRepo.getIndexById(index.id);
+    if (persisted?.status === 'indexing' && !this.cancelledIndexes.has(index.id)) {
+      const failures = codeSearchRepo.incrementConsecutiveFailures(index.id);
+      if (failures >= MAX_CONSECUTIVE_INDEX_CRASHES) {
+        const errorMsg =
+          `Indexing disabled after ${failures} consecutive crashes. ` +
+          `Use Retry to try again.`;
+        log.error(
+          `[VectorSearch] Circuit breaker tripped for ${directoryPath} — ${errorMsg}`
+        );
+        codeSearchRepo.updateIndexStatus(index.id, 'error', errorMsg);
+        this.emit('indexing-error', {
+          indexId: index.id,
+          error: errorMsg,
+          directoryPath: index.directoryPath,
+        });
+        return; // do NOT spawn the worker — breaks the crash-relaunch loop
+      }
+      log.warn(
+        `[VectorSearch] Prior indexing attempt for ${directoryPath} did not ` +
+          `complete (likely crashed); retry ${failures}/${MAX_CONSECUTIVE_INDEX_CRASHES}`
+      );
     }
 
     // Clear the cancelled flag since we're starting fresh
@@ -352,7 +392,10 @@ export class VectorSearchManager extends EventEmitter {
       throw new Error('No index found for directory');
     }
 
-    // Clear error state
+    // Clear error state. BDHLNDR-40: an explicit user retry re-arms the
+    // crash-loop circuit breaker from a clean count, and 'pending' (not
+    // 'indexing') ensures startIndexing does not miscount this as a crash.
+    codeSearchRepo.resetConsecutiveFailures(index.id);
     codeSearchRepo.updateIndexStatus(index.id, 'pending', null);
 
     // Restart indexing
@@ -472,6 +515,8 @@ export class VectorSearchManager extends EventEmitter {
     }
 
     codeSearchRepo.updateIndexStatus(indexId, 'ready');
+    // BDHLNDR-40: a clean completion clears the crash-loop circuit breaker.
+    codeSearchRepo.resetConsecutiveFailures(indexId);
     this.emit('indexing-complete', { indexId, directoryPath: index?.directoryPath });
 
     // Start file watcher

--- a/src/main/vector-search/indexing-worker.ts
+++ b/src/main/vector-search/indexing-worker.ts
@@ -177,8 +177,13 @@ async function runIndexing(
           ? parseCode(content, language)
           : { chunks: [], symbols: [] };
 
-        // Generate embeddings in batches for better throughput
-        const BATCH_SIZE = 32;
+        // Generate embeddings in batches for better throughput.
+        // BDHLNDR-40: peak ONNX tensor ≈ BATCH_SIZE × longest-seq-in-batch.
+        // 32 was a key contributor to the arena-exhaustion crash; 16 halves
+        // peak memory. Per-text embeddings are independent of batch size
+        // (no cross-sequence attention), so this is numerically identical —
+        // no re-index needed.
+        const BATCH_SIZE = 16;
         const chunksWithEmbeddings: ChunkWithEmbedding[] = [];
         if (chunks.length > 0) {
           const textsToEmbed = chunks.map(chunk => {


### PR DESCRIPTION
Forward-merges the BDHLNDR-40 hotfix shipped in **v3.3.1** (PR #50: indexing crash-loop circuit breaker + ONNX arena/batch memory bound) from `production` into `development`, so beta/dev carries the fix and BDHLNDR-46 (q8) builds on top of it.

- Code merged cleanly (development had no competing changes in the touched files).
- **`package.json` version intentionally kept at `3.3.0-beta.2`** (git auto-resolved it to production's `3.3.1`; corrected back) — matches the prior forward-merge convention (5985bbd / PR #48) and the beta-channel invariant in CLAUDE.md (`development` requires a `-beta.` version). Tag `v3.3.0-beta.2` already exists, so merging this does **not** trigger a stray beta build.
- ⚠️ Note for maintainer: the beta version (`3.3.0-beta.2`) is now behind stable `3.3.1`. The **next beta cut should bump above 3.3.1** (e.g. `npm version prerelease` to `3.3.2-beta.0`) so beta opt-in users actually receive updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)