### PR TITLE
feat(BDHLNDR-46): quantized (q8) embedding + token-bounded truncation + re-index migration

### DIFF
--- a/docs/designs/BDHLNDR-40-indexing-crash-circuit-breaker.md
+++ b/docs/designs/BDHLNDR-40-indexing-crash-circuit-breaker.md
@@ -1,0 +1,70 @@
+# BDHLNDR-40 — Interim mitigation: vector-search indexing crash-loop circuit breaker
+
+**Status:** interim hotfix (does not fix the underlying native crash — that is gated on the
+macOS `.ips` crash report; see ticket "Investigation needed").
+
+## Problem (from gregory's `main.log`, v3.3.0, macOS arm64)
+
+A native crash (segfault/abort) somewhere in the indexing path (`@huggingface/transformers`
+ONNX Runtime / `sqlite-vec` / `better-sqlite3`) terminates the process **silently** ~25–110 s
+into indexing. Because indexing runs in a `worker_threads.Worker`, a native fault there does
+**not** stay contained — it kills the whole OS process, so `worker.on('exit'|'error')` never
+runs and nothing is logged.
+
+The crash becomes an **infinite relaunch loop** because:
+
+1. `startIndexing()` writes DB status `'indexing'` (`vector-search/index.ts`).
+2. Native crash → process dies → status stays `'indexing'` (no terminal transition runs).
+3. On relaunch, `useCodeSearch.ts` auto-starts indexing when status is `'pending'` **or
+   `'indexing'`** (it treats a persisted `'indexing'` as "stale from an interrupted
+   session"). → back to step 1.
+
+## Why not "supervise / restart the worker"
+
+In-process supervision cannot catch a native segfault in a `worker_threads` worker — the
+whole V8/OS process is gone. True containment requires moving indexing to a separate child
+process (`utilityProcess`/`child_process`). That is the **permanent fix** and remains on the
+ticket; it is too large/risky for a stable hotfix and needs the root-cause frame first.
+
+## Interim design — consecutive-crash circuit breaker
+
+Detect "a previous indexing attempt started but the process never reached a terminal state"
+(== it crashed), count consecutive occurrences, and stop auto-spawning the worker once a
+threshold is hit — breaking the loop and leaving the app usable.
+
+- **Schema:** add `consecutive_failures INTEGER DEFAULT 0` to `code_indexes`
+  (in `CREATE TABLE` for new installs + `ALTER TABLE ADD COLUMN` migration for existing
+  installs, mirroring the established `PRAGMA table_info` pattern in `database.ts`).
+- **`startIndexing()`** (before spawning the worker): read fresh status. If it is
+  `'indexing'` and this index is **not** a known in-process cancel, the prior attempt
+  crashed → `incrementConsecutiveFailures()`. If the new count `>= MAX_CONSECUTIVE_INDEX_CRASHES`
+  (= **2**), set status `'error'` with a clear message and `return` **without spawning the
+  worker**. Otherwise log a warning and proceed (one automatic retry is still allowed).
+- **`handleIndexingComplete()`** → `resetConsecutiveFailures()`.
+- **`retryIndexing()`** (explicit user action) → `resetConsecutiveFailures()` so the user
+  can always re-arm and try again; the breaker re-trips if it crashes again.
+
+`'error'` is reused (no new status value → no painful SQLite CHECK-constraint rebuild). The
+renderer auto-index effect does **not** auto-start on `'error'`, and `IndexStatus.tsx` /
+`retryIndexing` already give a user-visible, recoverable state.
+
+### False-positive safety
+
+A single clean app-quit mid-index also leaves status `'indexing'`. Threshold = 2 means one
+such event just costs one automatic retry (which then succeeds); only *repeated consecutive*
+unfinished attempts trip the breaker. In-process cancels are excluded via the existing
+`cancelledIndexes` set; `retryIndexing()` sets `'pending'` before re-entry so it is never
+miscounted.
+
+## Acceptance mapping (ticket BDHLNDR-40)
+
+- AC2 (native fault contained / no silent main-process kill loop): **partially** — the loop
+  is broken and the app stays usable after ≤2 cycles; full containment is the child-process
+  follow-up.
+- AC1/AC3/AC4: unchanged — still require the `.ips` root cause. Tracked on the ticket.
+
+## Verification
+
+No test framework exists in the repo (no vitest/jest/test script) — TDD phase is infeasible
+without introducing test infra (out of scope for a production hotfix). Verification:
+`tsc` typecheck + `build:main`/`build:worker`, and a logic trace of the loop scenario.

--- a/docs/designs/BDHLNDR-40-indexing-crash-circuit-breaker.md
+++ b/docs/designs/BDHLNDR-40-indexing-crash-circuit-breaker.md
@@ -63,6 +63,28 @@ miscounted.
   follow-up.
 - AC1/AC3/AC4: unchanged — still require the `.ips` root cause. Tracked on the ticket.
 
+## Root-cause safe subset (added after the 5 `.ips` reports)
+
+The crash is confirmed (all 5 `.ips` identical): `EXC_BREAKPOINT/SIGTRAP` in
+`onnxruntime::BFCArena::Extend → CPUAllocator::Alloc` — ORT's CPU arena grows
+to the worst-case embedding batch, never shrinks, and a later larger batch
+traps when `Extend` can't allocate. Memory exhaustion in the embedding path.
+
+The full root-cause fix splits by risk. The **embedding-neutral subset** ships
+here in the production hotfix (no quality change, no re-index):
+
+- `embedding-provider.ts`: `session_options.enableCpuMemArena: false` — ORT
+  allocates per-request instead of holding a growing pool. Directly counters
+  the crash frame; numerically identical output.
+- `indexing-worker.ts`: `BATCH_SIZE` 32 → 16 — halves peak tensor
+  (`≈ BATCH_SIZE × longest-seq`). Per-text embeddings are batch-size
+  independent (no cross-sequence attention) → identical results, no re-index.
+
+The **risky remainder** — `dtype: 'q8'` (quantized model) and token-bounded
+truncation — changes embedding quality and forces a re-index, so it is tracked
+separately for `development`/beta bake (not in this hotfix). The circuit
+breaker above remains as a backstop for any residual/again-regressed crash.
+
 ## Verification
 
 No test framework exists in the repo (no vitest/jest/test script) — TDD phase is infeasible

--- a/docs/designs/BDHLNDR-46-quantized-embedding.md
+++ b/docs/designs/BDHLNDR-46-quantized-embedding.md
@@ -1,0 +1,62 @@
+# BDHLNDR-46 — Quantized embedding + token-bounded truncation + re-index migration
+
+Second half of the BDHLNDR-40 root-cause fix (the embedding-neutral safe
+subset — `enableCpuMemArena:false` + `BATCH_SIZE` 32→16 — shipped in v3.3.1).
+This is the higher-headroom but quality-affecting half, on `development`/beta.
+
+## Root cause recap
+
+5 identical `.ips`: `EXC_BREAKPOINT/SIGTRAP` in `onnxruntime::BFCArena::Extend
+→ CPUAllocator::Alloc` — ONNX memory exhaustion in the embedding path. The
+pipeline ran the **fp32** model (no `dtype` set) — ~4× the memory of the
+quantized variant, with correspondingly larger activation tensors.
+
+## Changes
+
+1. **`dtype: 'q8'`** in the `@huggingface/transformers` pipeline options
+   (`embedding-provider.ts`). Quantized bge-base — the main memory-headroom
+   fix. Changes embedding numerics vs fp32.
+2. **Token-bounded truncation** — `MAX_EMBED_CHARS = 2048` replaces the
+   `slice(0, 8000)` cap in `embed()` / `embedSingle()`. bge-base attends to
+   only its first 512 tokens (the tokenizer truncates there anyway); ~4
+   chars/token for code ⇒ 2048 chars reliably yields ≥512 tokens, so the
+   model sees the same content it did under the 8000-char cap, with bounded,
+   predictable tokenization + peak tensor.
+
+## Re-index migration (the non-trivial part)
+
+q8 vectors are **not comparable** to existing fp32 vectors — mixing them
+breaks search. Versioned, auto-healing migration:
+
+- `EMBEDDING_VERSION` constant in `embedding-provider.ts` (1 = fp32 through
+  v3.3.1; 2 = q8 + token bound). Bump on any future embedding-affecting change.
+- New `code_indexes.embedding_version` column (`CREATE TABLE` + `ALTER`
+  migration, default 1 so pre-existing rows are detected as stale).
+- `startIndexing()`: if the persisted version ≠ `EMBEDDING_VERSION` →
+  - has indexed data → `clearIndexData()` (drops vec/chunks/symbols/files,
+    resets counts + status `'pending'` + stamps new version) → normal
+    auto-index path rebuilds from scratch at q8;
+  - nothing indexed yet → just stamp the new version.
+  Runs **before** the BDHLNDR-40 circuit breaker, and `clearIndexData` sets
+  status `'pending'`, so a stale `'indexing'` can't be miscounted as a crash.
+- `handleIndexingComplete()` stamps `EMBEDDING_VERSION` so a clean build
+  records what it was built with.
+
+Net upgrade behaviour: first index-open after updating detects v1→v2, wipes
+the old fp32 vectors, and transparently re-indexes at q8 — no mixed vectors,
+no user action.
+
+## Acceptance mapping
+
+- AC1 (q8, ~1300-file repo completes on arm64 w/ bounded memory): code in
+  place; **needs the beta-bake repro to confirm empirically.**
+- AC2 (auto re-index migration, no mixed vectors): implemented.
+- AC3 (search relevance vs fp32 spot-check): **manual beta validation.**
+- AC4 (beta bake before production): release routing — `development` flow.
+
+## Verification
+
+No test framework in repo (documented BDHLNDR-40 deviation). `build:main`
+(tsc) + `build:worker` (esbuild) green; logic trace of the migration paths
+(new index / upgraded index / nothing-indexed / breaker interaction).
+Empirical memory + relevance validation happens on the beta channel (AC1/3).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.3.0-beta.2",
+  "version": "3.3.0",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -245,9 +245,23 @@ function initializeCodeSearchTables(database: Database.Database): void {
       chunk_count INTEGER DEFAULT 0,
       model_name TEXT DEFAULT 'bge-base-en-v1.5',
       embedding_dimensions INTEGER DEFAULT 768,
-      error_message TEXT
+      error_message TEXT,
+      consecutive_failures INTEGER DEFAULT 0
     )
   `);
+
+  // Migration: Add consecutive_failures to code_indexes if it doesn't exist
+  // (BDHLNDR-40). Powers the indexing crash-loop circuit breaker — a native
+  // crash in the indexing worker_thread kills the whole process silently and
+  // leaves status stuck at 'indexing', which the renderer then auto-restarts,
+  // producing an infinite crash-relaunch loop. We count consecutive crashed
+  // attempts and trip a breaker. Existing installs need the column added.
+  const codeIndexColumns = database
+    .prepare("PRAGMA table_info(code_indexes)")
+    .all() as { name: string }[];
+  if (!codeIndexColumns.some(col => col.name === 'consecutive_failures')) {
+    database.exec("ALTER TABLE code_indexes ADD COLUMN consecutive_failures INTEGER DEFAULT 0");
+  }
 
   // Indexed files table
   database.exec(`

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -246,7 +246,8 @@ function initializeCodeSearchTables(database: Database.Database): void {
       model_name TEXT DEFAULT 'bge-base-en-v1.5',
       embedding_dimensions INTEGER DEFAULT 768,
       error_message TEXT,
-      consecutive_failures INTEGER DEFAULT 0
+      consecutive_failures INTEGER DEFAULT 0,
+      embedding_version INTEGER DEFAULT 1
     )
   `);
 
@@ -261,6 +262,15 @@ function initializeCodeSearchTables(database: Database.Database): void {
     .all() as { name: string }[];
   if (!codeIndexColumns.some(col => col.name === 'consecutive_failures')) {
     database.exec("ALTER TABLE code_indexes ADD COLUMN consecutive_failures INTEGER DEFAULT 0");
+  }
+
+  // Migration: Add embedding_version to code_indexes if it doesn't exist
+  // (BDHLNDR-46). Existing rows default to 1 (fp32, shipped through v3.3.1);
+  // the current build embeds at EMBEDDING_VERSION=2 (q8), so the mismatch
+  // triggers a one-time clean re-index — old fp32 vectors are not comparable
+  // to q8 query vectors and must not be mixed.
+  if (!codeIndexColumns.some(col => col.name === 'embedding_version')) {
+    database.exec("ALTER TABLE code_indexes ADD COLUMN embedding_version INTEGER DEFAULT 1");
   }
 
   // Indexed files table

--- a/src/main/repositories/code-search.ts
+++ b/src/main/repositories/code-search.ts
@@ -105,6 +105,33 @@ export function updateIndexStatus(
   db.prepare(`UPDATE code_indexes SET ${updates.join(', ')} WHERE id = ?`).run(...params);
 }
 
+/**
+ * Increment the consecutive-crash counter for an index and return the new
+ * value. (BDHLNDR-40) Called when a fresh process observes a prior indexing
+ * attempt left stuck at status 'indexing' — i.e. the previous attempt crashed
+ * the process before reaching a terminal state.
+ */
+export function incrementConsecutiveFailures(id: string): number {
+  const db = getDatabase();
+  db.prepare(
+    'UPDATE code_indexes SET consecutive_failures = consecutive_failures + 1 WHERE id = ?'
+  ).run(id);
+  const row = db
+    .prepare('SELECT consecutive_failures FROM code_indexes WHERE id = ?')
+    .get(id) as { consecutive_failures: number } | undefined;
+  return row?.consecutive_failures ?? 0;
+}
+
+/**
+ * Reset the consecutive-crash counter (BDHLNDR-40). Called on successful
+ * indexing completion and on an explicit user retry, so the circuit breaker
+ * re-arms from a clean state.
+ */
+export function resetConsecutiveFailures(id: string): void {
+  const db = getDatabase();
+  db.prepare('UPDATE code_indexes SET consecutive_failures = 0 WHERE id = ?').run(id);
+}
+
 export function updateIndexCounts(id: string, fileCount: number, chunkCount: number): void {
   const db = getDatabase();
   db.prepare('UPDATE code_indexes SET file_count = ?, chunk_count = ? WHERE id = ?')

--- a/src/main/repositories/code-search.ts
+++ b/src/main/repositories/code-search.ts
@@ -150,6 +150,55 @@ export function deleteIndex(id: string): void {
   })();
 }
 
+/**
+ * Embedding version the index's stored vectors were generated with
+ * (BDHLNDR-46). Defaults to 1 for pre-migration rows.
+ */
+export function getEmbeddingVersion(id: string): number {
+  const db = getDatabase();
+  const row = db
+    .prepare('SELECT embedding_version FROM code_indexes WHERE id = ?')
+    .get(id) as { embedding_version: number } | undefined;
+  return row?.embedding_version ?? 1;
+}
+
+/** Record the embedding version an index was (re)built with (BDHLNDR-46). */
+export function setEmbeddingVersion(id: string, version: number): void {
+  const db = getDatabase();
+  db.prepare('UPDATE code_indexes SET embedding_version = ? WHERE id = ?').run(version, id);
+}
+
+/**
+ * Wipe all indexed data for an index but keep the code_indexes row
+ * (BDHLNDR-46). Used when the embedding version changed: old vectors are
+ * incomparable to the new model's output and must not be mixed. Resets the
+ * index to a clean 'pending' state at the new embedding version so the normal
+ * auto-index path rebuilds it from scratch.
+ */
+export function clearIndexData(id: string, embeddingVersion: number): void {
+  const db = getDatabase();
+  db.transaction(() => {
+    if (isSqliteVecAvailable()) {
+      db.prepare(
+        'DELETE FROM code_chunks_vec WHERE chunk_id IN (SELECT id FROM code_chunks WHERE index_id = ?)'
+      ).run(id);
+    }
+    db.prepare('DELETE FROM code_chunks WHERE index_id = ?').run(id);
+    db.prepare('DELETE FROM symbols WHERE index_id = ?').run(id);
+    db.prepare('DELETE FROM indexed_files WHERE index_id = ?').run(id);
+    db.prepare(
+      `UPDATE code_indexes
+         SET file_count = 0,
+             chunk_count = 0,
+             status = 'pending',
+             error_message = NULL,
+             consecutive_failures = 0,
+             embedding_version = ?
+       WHERE id = ?`
+    ).run(embeddingVersion, id);
+  })();
+}
+
 // ============ Indexed Files ============
 
 export function getIndexedFile(indexId: string, filePath: string): IndexedFile | null {

--- a/src/main/vector-search/embedding-provider.ts
+++ b/src/main/vector-search/embedding-provider.ts
@@ -84,6 +84,14 @@ export class HuggingFaceEmbeddingProvider implements EmbeddingProvider {
           session_options: {
             intraOpNumThreads: EMBEDDING_THREAD_COUNT,
             interOpNumThreads: 1,
+            // BDHLNDR-40: ONNX Runtime's BFC arena grows to the worst-case
+            // batch and never shrinks; a later larger batch forces
+            // BFCArena::Extend, which traps (SIGTRAP) on allocation failure
+            // and kills the whole process. Disabling the CPU arena makes ORT
+            // allocate per-request instead of holding a growing pool —
+            // numerically identical output, just bounded memory. This is the
+            // exact counter to the confirmed crash frame.
+            enableCpuMemArena: false,
           },
         });
         console.log('Embedding model initialized successfully');

--- a/src/main/vector-search/embedding-provider.ts
+++ b/src/main/vector-search/embedding-provider.ts
@@ -12,6 +12,20 @@ let pipeline: typeof import('@huggingface/transformers').pipeline;
 // pins the machine during long indexing runs. Half the cores, max 4, min 1.
 const EMBEDDING_THREAD_COUNT = Math.max(1, Math.min(4, Math.floor(os.cpus().length / 2)));
 
+// BDHLNDR-46: bumped whenever a change alters embedding numerics so stored
+// vectors become incomparable to freshly-generated ones. Persisted per index
+// (code_indexes.embedding_version); a mismatch forces a clean re-index.
+//   1 = fp32 (original, shipped through v3.3.1)
+//   2 = q8 quantized + token-bounded truncation
+export const EMBEDDING_VERSION = 2;
+
+// bge-base-en-v1.5 only attends to its first 512 tokens; the tokenizer
+// truncates to that anyway. Bounding input chars keeps tokenization and the
+// peak ONNX tensor predictable (BDHLNDR-46/40). ~4 chars/token for code, so
+// 2048 chars reliably yields ≥512 tokens — the model sees the same content
+// it did under the old 8000-char cap, just without the wasted work.
+const MAX_EMBED_CHARS = 2048;
+
 try {
   const transformers = require('@huggingface/transformers');
   pipeline = transformers.pipeline;
@@ -81,6 +95,11 @@ export class HuggingFaceEmbeddingProvider implements EmbeddingProvider {
         // session_options caps onnxruntime-node thread usage so indexing doesn't
         // pin every core.
         this.pipeline = await (pipeline as any)('feature-extraction', this.name, {
+          // BDHLNDR-46: quantized (int8) model — ~4× smaller weights and
+          // activation tensors than the fp32 default, the main headroom fix
+          // for the ONNX arena-exhaustion crash. Changes embedding numerics
+          // (see EMBEDDING_VERSION) so a re-index is forced on upgrade.
+          dtype: 'q8',
           session_options: {
             intraOpNumThreads: EMBEDDING_THREAD_COUNT,
             interOpNumThreads: 1,
@@ -120,7 +139,7 @@ export class HuggingFaceEmbeddingProvider implements EmbeddingProvider {
     if (texts.length === 0) return [];
 
     // Truncate to model max token budget before handing to the pipeline.
-    const truncated = texts.map(t => t.slice(0, 8000));
+    const truncated = texts.map(t => t.slice(0, MAX_EMBED_CHARS));
 
     // Real batched inference: feed the whole array once so ONNX can amortize
     // the forward pass. Previously this looped one text at a time, which meant
@@ -189,7 +208,7 @@ export class HuggingFaceEmbeddingProvider implements EmbeddingProvider {
     if (!this.pipeline) throw new Error('Pipeline not initialized');
 
     // Truncate text if too long (model has max token limit)
-    const truncatedText = text.slice(0, 8000);
+    const truncatedText = text.slice(0, MAX_EMBED_CHARS);
 
     const output = await this.pipeline(truncatedText, {
       pooling: 'mean',

--- a/src/main/vector-search/index.ts
+++ b/src/main/vector-search/index.ts
@@ -45,6 +45,15 @@ interface WorkerResult {
 // Timeout for model initialization (downloading 110MB model + loading ONNX runtime)
 const WORKER_INIT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
+// BDHLNDR-40: a native crash in the indexing worker_thread kills the whole
+// process silently — no exit/error handler runs, so status stays 'indexing'
+// in the DB. The renderer auto-restarts indexing on a stale 'indexing' status,
+// producing an infinite crash-relaunch loop. After this many consecutive
+// crashed attempts we trip a circuit breaker and stop auto-spawning the worker
+// (status → 'error', user can still explicitly retry). 2 = allow one automatic
+// retry, then break the loop.
+const MAX_CONSECUTIVE_INDEX_CRASHES = 2;
+
 export class VectorSearchManager extends EventEmitter {
   private workers: Map<string, Worker> = new Map();
   private watchers: Map<string, chokidar.FSWatcher> = new Map();
@@ -191,6 +200,37 @@ export class VectorSearchManager extends EventEmitter {
     if (this.workers.has(index.id)) {
       console.log('[VectorSearch] Indexing already in progress for:', directoryPath);
       return;
+    }
+
+    // BDHLNDR-40 circuit breaker: a fresh status of 'indexing' here means a
+    // previous attempt started but the process never reached a terminal state
+    // (complete/error) — i.e. it crashed the whole process (native segfault in
+    // the worker thread can't be caught in-process). In-process cancels are
+    // excluded via cancelledIndexes; retryIndexing() sets 'pending' first so it
+    // is never miscounted. Count consecutive crashes and stop auto-spawning the
+    // worker once the threshold trips, so we don't relaunch-loop forever.
+    const persisted = codeSearchRepo.getIndexById(index.id);
+    if (persisted?.status === 'indexing' && !this.cancelledIndexes.has(index.id)) {
+      const failures = codeSearchRepo.incrementConsecutiveFailures(index.id);
+      if (failures >= MAX_CONSECUTIVE_INDEX_CRASHES) {
+        const errorMsg =
+          `Indexing disabled after ${failures} consecutive crashes. ` +
+          `Use Retry to try again.`;
+        log.error(
+          `[VectorSearch] Circuit breaker tripped for ${directoryPath} — ${errorMsg}`
+        );
+        codeSearchRepo.updateIndexStatus(index.id, 'error', errorMsg);
+        this.emit('indexing-error', {
+          indexId: index.id,
+          error: errorMsg,
+          directoryPath: index.directoryPath,
+        });
+        return; // do NOT spawn the worker — breaks the crash-relaunch loop
+      }
+      log.warn(
+        `[VectorSearch] Prior indexing attempt for ${directoryPath} did not ` +
+          `complete (likely crashed); retry ${failures}/${MAX_CONSECUTIVE_INDEX_CRASHES}`
+      );
     }
 
     // Clear the cancelled flag since we're starting fresh
@@ -352,7 +392,10 @@ export class VectorSearchManager extends EventEmitter {
       throw new Error('No index found for directory');
     }
 
-    // Clear error state
+    // Clear error state. BDHLNDR-40: an explicit user retry re-arms the
+    // crash-loop circuit breaker from a clean count, and 'pending' (not
+    // 'indexing') ensures startIndexing does not miscount this as a crash.
+    codeSearchRepo.resetConsecutiveFailures(index.id);
     codeSearchRepo.updateIndexStatus(index.id, 'pending', null);
 
     // Restart indexing
@@ -472,6 +515,8 @@ export class VectorSearchManager extends EventEmitter {
     }
 
     codeSearchRepo.updateIndexStatus(indexId, 'ready');
+    // BDHLNDR-40: a clean completion clears the crash-loop circuit breaker.
+    codeSearchRepo.resetConsecutiveFailures(indexId);
     this.emit('indexing-complete', { indexId, directoryPath: index?.directoryPath });
 
     // Start file watcher

--- a/src/main/vector-search/index.ts
+++ b/src/main/vector-search/index.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from 'events';
 import { app } from 'electron';
 import log from 'electron-log';
 import * as codeSearchRepo from '../repositories/code-search';
-import { getEmbeddingProvider } from './embedding-provider';
+import { getEmbeddingProvider, EMBEDDING_VERSION } from './embedding-provider';
 import { ParsedSymbol } from './parser';
 import type { CodeIndex, IndexProgress, CodeSearchResult, SymbolSearchResult, SymbolType, IndexStatus, IndexPhase } from '../../shared/types';
 
@@ -200,6 +200,27 @@ export class VectorSearchManager extends EventEmitter {
     if (this.workers.has(index.id)) {
       console.log('[VectorSearch] Indexing already in progress for:', directoryPath);
       return;
+    }
+
+    // BDHLNDR-46: if this index's stored vectors were generated with a
+    // different embedding version (e.g. fp32 from <= v3.3.1, now embedding at
+    // q8), they are not comparable to new query vectors. Wipe and rebuild from
+    // scratch rather than mixing incompatible vectors. Runs before the circuit
+    // breaker below: clearIndexData resets status to 'pending', so a stale
+    // 'indexing' from an old crash can't be miscounted as a fresh crash here.
+    const persistedEmbeddingVersion = codeSearchRepo.getEmbeddingVersion(index.id);
+    if (persistedEmbeddingVersion !== EMBEDDING_VERSION) {
+      if ((index.chunkCount ?? 0) > 0) {
+        log.warn(
+          `[VectorSearch] Embedding version changed ` +
+            `(${persistedEmbeddingVersion} → ${EMBEDDING_VERSION}) for ${directoryPath}; ` +
+            `clearing stale vectors and re-indexing from scratch`
+        );
+        codeSearchRepo.clearIndexData(index.id, EMBEDDING_VERSION);
+      } else {
+        // Nothing indexed yet — just stamp the current embedding version.
+        codeSearchRepo.setEmbeddingVersion(index.id, EMBEDDING_VERSION);
+      }
     }
 
     // BDHLNDR-40 circuit breaker: a fresh status of 'indexing' here means a
@@ -517,6 +538,9 @@ export class VectorSearchManager extends EventEmitter {
     codeSearchRepo.updateIndexStatus(indexId, 'ready');
     // BDHLNDR-40: a clean completion clears the crash-loop circuit breaker.
     codeSearchRepo.resetConsecutiveFailures(indexId);
+    // BDHLNDR-46: record the embedding version this index was built with so a
+    // future model/dtype change is detected and forces a clean re-index.
+    codeSearchRepo.setEmbeddingVersion(indexId, EMBEDDING_VERSION);
     this.emit('indexing-complete', { indexId, directoryPath: index?.directoryPath });
 
     // Start file watcher

--- a/src/main/vector-search/indexing-worker.ts
+++ b/src/main/vector-search/indexing-worker.ts
@@ -177,8 +177,13 @@ async function runIndexing(
           ? parseCode(content, language)
           : { chunks: [], symbols: [] };
 
-        // Generate embeddings in batches for better throughput
-        const BATCH_SIZE = 32;
+        // Generate embeddings in batches for better throughput.
+        // BDHLNDR-40: peak ONNX tensor ≈ BATCH_SIZE × longest-seq-in-batch.
+        // 32 was a key contributor to the arena-exhaustion crash; 16 halves
+        // peak memory. Per-text embeddings are independent of batch size
+        // (no cross-sequence attention), so this is numerically identical —
+        // no re-index needed.
+        const BATCH_SIZE = 16;
         const chunksWithEmbeddings: ChunkWithEmbedding[] = [];
         if (chunks.length > 0) {
           const textsToEmbed = chunks.map(chunk => {


### PR DESCRIPTION
## BDHLNDR-46 — root-cause pt.2 (development/beta)

Second half of the BDHLNDR-40 fix. The embedding-neutral safe subset (`enableCpuMemArena:false` + `BATCH_SIZE` 32→16) already shipped in **v3.3.1**; this is the higher-headroom, quality-affecting half that needs beta bake.

### Changes
- `embedding-provider.ts`: **`dtype: 'q8'`** (quantized bge-base, ~4× less memory — the main headroom fix for the ONNX `BFCArena` exhaustion crash); **`MAX_EMBED_CHARS=2048`** replaces the 8000-char cap (bge-base only attends to 512 tokens; bounds tokenization + peak tensor).
- **Re-index migration**: `EMBEDDING_VERSION` (1=fp32≤v3.3.1, 2=q8) persisted via new `code_indexes.embedding_version` column (CREATE + ALTER, default 1). `startIndexing()` detects a version mismatch → `clearIndexData()` wipes stale fp32 vectors and rebuilds at q8 automatically (no user action, no mixed vectors); runs before the BDHLNDR-40 breaker and resets status to `'pending'` so it can't be miscounted as a crash. `handleIndexingComplete()` stamps the version.

### Stacking / merge order
⚠️ Branched off `chore/BDHLNDR-40-forward-merge` (so it builds on the v3.3.1 fix). **Merge after PR #51** (the forward-merge into `development`) — until #51 lands, this PR's diff also shows the -40 changes; it reduces to just the -46 diff once #51 merges.

### Validation
`build:main` + `build:worker` green; logic trace of migration paths. **AC1 (q8 ~1300-file repo completes on arm64, bounded memory) and AC3 (search relevance vs fp32 spot-check) require empirical beta validation** — that's why this targets `development`/beta, not a hotfix. Draft until #51 merges + beta bake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)