### PR TITLE
fix(BDHLNDR-42): make beta channel opt-in actually work (allowPrerelease)

### DIFF
--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -37,14 +37,24 @@ export function getUpdateChannel(): UpdateChannel {
  * and whenever the user flips the toggle in Settings.
  */
 function applyUpdateChannel(channel: UpdateChannel): void {
-  // electron-updater maps `channel` directly to the remote yml feed name.
-  // It accepts `null` to mean "default" (latest).
-  autoUpdater.channel = channel === 'beta' ? 'beta' : null;
+  const isBeta = channel === 'beta';
+  // electron-updater maps `channel` to the remote yml feed name. Use the
+  // explicit 'latest' string for stable, never null — older electron-updater
+  // throws "Channel must be a string, but got: null" from the channel setter
+  // (BDHLNDR-42 Defect A).
+  autoUpdater.channel = isBeta ? 'beta' : 'latest';
+  // BDHLNDR-42 Defect B: betas are published as GitHub *pre-releases*. Without
+  // allowPrerelease the GitHubProvider resolves "latest" to the newest
+  // non-prerelease tag and fetches beta.yml from *that* release's assets →
+  // 404 ("Cannot find beta.yml ... releases/download/v3.3.1/beta.yml"). With
+  // allowPrerelease the provider considers the beta pre-release, where
+  // beta.yml actually lives. Stable must NOT see pre-releases.
+  autoUpdater.allowPrerelease = isBeta;
   // Allow downgrade from beta → stable so users flipping the toggle back
   // don't stay stuck on a newer-than-stable beta forever. Harmless on the
   // stable channel because stable versions only move forward.
-  autoUpdater.allowDowngrade = channel === 'stable';
-  log.info(`[auto-updater] Channel set to ${channel} (autoUpdater.channel=${autoUpdater.channel ?? 'latest'})`);
+  autoUpdater.allowDowngrade = !isBeta;
+  log.info(`[auto-updater] Channel set to ${channel} (autoUpdater.channel=${autoUpdater.channel}, allowPrerelease=${autoUpdater.allowPrerelease})`);
 }
 
 /**


### PR DESCRIPTION
## BDHLNDR-42 — hotfix → production

Confirmed first-hand on v3.3.1 (Windows): Settings → Updates → Beta + Check for updates →
`Cannot find beta.yml in the latest release artifacts (.../releases/download/v3.3.1/beta.yml): HttpError: 404`.

### Root cause
`applyUpdateChannel()` set `autoUpdater.channel='beta'` but never `allowPrerelease`. Betas are GitHub **pre-releases**; without `allowPrerelease` the GitHubProvider resolves "latest" to the newest non-prerelease tag (`v3.3.1`) and fetches `beta.yml` from *its* assets → 404. `beta.yml` only exists in the `v3.3.2-beta.0` pre-release.

### Fix (3 lines, `applyUpdateChannel`)
- `channel: 'latest'` string for stable (never `null` → also closes Defect A: the "Channel must be a string, but got: null" throw)
- `allowPrerelease = isBeta` → GitHubProvider considers the beta pre-release where `beta.yml` lives
- `allowDowngrade = !isBeta` (same behavior, clearer)

### Impact
Unblocks the beta channel for **all stable users** and **unblocks BDHLNDR-46** (q8 `3.3.2-beta.0` can't be received/validated until this is in stable). Blocks-link set in Jira.

### Verification
`build:main` (tsc) green. Manual: after this ships to stable, flipping Beta resolves the `v3.3.2-beta.0` pre-release instead of 404. No automated test (repo has no test framework — documented deviation). Design record: inline comments + BDHLNDR-42 Jira root-cause comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)