### PR TITLE
Promote development → production: BDHLNDR-46 q8 embedding (3.3.3)

### DIFF
--- a/docs/designs/BDHLNDR-46-quantized-embedding.md
+++ b/docs/designs/BDHLNDR-46-quantized-embedding.md
@@ -1,0 +1,62 @@
+# BDHLNDR-46 — Quantized embedding + token-bounded truncation + re-index migration
+
+Second half of the BDHLNDR-40 root-cause fix (the embedding-neutral safe
+subset — `enableCpuMemArena:false` + `BATCH_SIZE` 32→16 — shipped in v3.3.1).
+This is the higher-headroom but quality-affecting half, on `development`/beta.
+
+## Root cause recap
+
+5 identical `.ips`: `EXC_BREAKPOINT/SIGTRAP` in `onnxruntime::BFCArena::Extend
+→ CPUAllocator::Alloc` — ONNX memory exhaustion in the embedding path. The
+pipeline ran the **fp32** model (no `dtype` set) — ~4× the memory of the
+quantized variant, with correspondingly larger activation tensors.
+
+## Changes
+
+1. **`dtype: 'q8'`** in the `@huggingface/transformers` pipeline options
+   (`embedding-provider.ts`). Quantized bge-base — the main memory-headroom
+   fix. Changes embedding numerics vs fp32.
+2. **Token-bounded truncation** — `MAX_EMBED_CHARS = 2048` replaces the
+   `slice(0, 8000)` cap in `embed()` / `embedSingle()`. bge-base attends to
+   only its first 512 tokens (the tokenizer truncates there anyway); ~4
+   chars/token for code ⇒ 2048 chars reliably yields ≥512 tokens, so the
+   model sees the same content it did under the 8000-char cap, with bounded,
+   predictable tokenization + peak tensor.
+
+## Re-index migration (the non-trivial part)
+
+q8 vectors are **not comparable** to existing fp32 vectors — mixing them
+breaks search. Versioned, auto-healing migration:
+
+- `EMBEDDING_VERSION` constant in `embedding-provider.ts` (1 = fp32 through
+  v3.3.1; 2 = q8 + token bound). Bump on any future embedding-affecting change.
+- New `code_indexes.embedding_version` column (`CREATE TABLE` + `ALTER`
+  migration, default 1 so pre-existing rows are detected as stale).
+- `startIndexing()`: if the persisted version ≠ `EMBEDDING_VERSION` →
+  - has indexed data → `clearIndexData()` (drops vec/chunks/symbols/files,
+    resets counts + status `'pending'` + stamps new version) → normal
+    auto-index path rebuilds from scratch at q8;
+  - nothing indexed yet → just stamp the new version.
+  Runs **before** the BDHLNDR-40 circuit breaker, and `clearIndexData` sets
+  status `'pending'`, so a stale `'indexing'` can't be miscounted as a crash.
+- `handleIndexingComplete()` stamps `EMBEDDING_VERSION` so a clean build
+  records what it was built with.
+
+Net upgrade behaviour: first index-open after updating detects v1→v2, wipes
+the old fp32 vectors, and transparently re-indexes at q8 — no mixed vectors,
+no user action.
+
+## Acceptance mapping
+
+- AC1 (q8, ~1300-file repo completes on arm64 w/ bounded memory): code in
+  place; **needs the beta-bake repro to confirm empirically.**
+- AC2 (auto re-index migration, no mixed vectors): implemented.
+- AC3 (search relevance vs fp32 spot-check): **manual beta validation.**
+- AC4 (beta bake before production): release routing — `development` flow.
+
+## Verification
+
+No test framework in repo (documented BDHLNDR-40 deviation). `build:main`
+(tsc) + `build:worker` (esbuild) green; logic trace of the migration paths
+(new index / upgraded index / nothing-indexed / breaker interaction).
+Empirical memory + relevance validation happens on the beta channel (AC1/3).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.3.0-beta.2",
+  "version": "3.3.2-beta.0",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -246,7 +246,8 @@ function initializeCodeSearchTables(database: Database.Database): void {
       model_name TEXT DEFAULT 'bge-base-en-v1.5',
       embedding_dimensions INTEGER DEFAULT 768,
       error_message TEXT,
-      consecutive_failures INTEGER DEFAULT 0
+      consecutive_failures INTEGER DEFAULT 0,
+      embedding_version INTEGER DEFAULT 1
     )
   `);
 
@@ -261,6 +262,15 @@ function initializeCodeSearchTables(database: Database.Database): void {
     .all() as { name: string }[];
   if (!codeIndexColumns.some(col => col.name === 'consecutive_failures')) {
     database.exec("ALTER TABLE code_indexes ADD COLUMN consecutive_failures INTEGER DEFAULT 0");
+  }
+
+  // Migration: Add embedding_version to code_indexes if it doesn't exist
+  // (BDHLNDR-46). Existing rows default to 1 (fp32, shipped through v3.3.1);
+  // the current build embeds at EMBEDDING_VERSION=2 (q8), so the mismatch
+  // triggers a one-time clean re-index — old fp32 vectors are not comparable
+  // to q8 query vectors and must not be mixed.
+  if (!codeIndexColumns.some(col => col.name === 'embedding_version')) {
+    database.exec("ALTER TABLE code_indexes ADD COLUMN embedding_version INTEGER DEFAULT 1");
   }
 
   // Indexed files table

--- a/src/main/repositories/code-search.ts
+++ b/src/main/repositories/code-search.ts
@@ -150,6 +150,55 @@ export function deleteIndex(id: string): void {
   })();
 }
 
+/**
+ * Embedding version the index's stored vectors were generated with
+ * (BDHLNDR-46). Defaults to 1 for pre-migration rows.
+ */
+export function getEmbeddingVersion(id: string): number {
+  const db = getDatabase();
+  const row = db
+    .prepare('SELECT embedding_version FROM code_indexes WHERE id = ?')
+    .get(id) as { embedding_version: number } | undefined;
+  return row?.embedding_version ?? 1;
+}
+
+/** Record the embedding version an index was (re)built with (BDHLNDR-46). */
+export function setEmbeddingVersion(id: string, version: number): void {
+  const db = getDatabase();
+  db.prepare('UPDATE code_indexes SET embedding_version = ? WHERE id = ?').run(version, id);
+}
+
+/**
+ * Wipe all indexed data for an index but keep the code_indexes row
+ * (BDHLNDR-46). Used when the embedding version changed: old vectors are
+ * incomparable to the new model's output and must not be mixed. Resets the
+ * index to a clean 'pending' state at the new embedding version so the normal
+ * auto-index path rebuilds it from scratch.
+ */
+export function clearIndexData(id: string, embeddingVersion: number): void {
+  const db = getDatabase();
+  db.transaction(() => {
+    if (isSqliteVecAvailable()) {
+      db.prepare(
+        'DELETE FROM code_chunks_vec WHERE chunk_id IN (SELECT id FROM code_chunks WHERE index_id = ?)'
+      ).run(id);
+    }
+    db.prepare('DELETE FROM code_chunks WHERE index_id = ?').run(id);
+    db.prepare('DELETE FROM symbols WHERE index_id = ?').run(id);
+    db.prepare('DELETE FROM indexed_files WHERE index_id = ?').run(id);
+    db.prepare(
+      `UPDATE code_indexes
+         SET file_count = 0,
+             chunk_count = 0,
+             status = 'pending',
+             error_message = NULL,
+             consecutive_failures = 0,
+             embedding_version = ?
+       WHERE id = ?`
+    ).run(embeddingVersion, id);
+  })();
+}
+
 // ============ Indexed Files ============
 
 export function getIndexedFile(indexId: string, filePath: string): IndexedFile | null {

--- a/src/main/vector-search/embedding-provider.ts
+++ b/src/main/vector-search/embedding-provider.ts
@@ -12,6 +12,20 @@ let pipeline: typeof import('@huggingface/transformers').pipeline;
 // pins the machine during long indexing runs. Half the cores, max 4, min 1.
 const EMBEDDING_THREAD_COUNT = Math.max(1, Math.min(4, Math.floor(os.cpus().length / 2)));
 
+// BDHLNDR-46: bumped whenever a change alters embedding numerics so stored
+// vectors become incomparable to freshly-generated ones. Persisted per index
+// (code_indexes.embedding_version); a mismatch forces a clean re-index.
+//   1 = fp32 (original, shipped through v3.3.1)
+//   2 = q8 quantized + token-bounded truncation
+export const EMBEDDING_VERSION = 2;
+
+// bge-base-en-v1.5 only attends to its first 512 tokens; the tokenizer
+// truncates to that anyway. Bounding input chars keeps tokenization and the
+// peak ONNX tensor predictable (BDHLNDR-46/40). ~4 chars/token for code, so
+// 2048 chars reliably yields ≥512 tokens — the model sees the same content
+// it did under the old 8000-char cap, just without the wasted work.
+const MAX_EMBED_CHARS = 2048;
+
 try {
   const transformers = require('@huggingface/transformers');
   pipeline = transformers.pipeline;
@@ -81,6 +95,11 @@ export class HuggingFaceEmbeddingProvider implements EmbeddingProvider {
         // session_options caps onnxruntime-node thread usage so indexing doesn't
         // pin every core.
         this.pipeline = await (pipeline as any)('feature-extraction', this.name, {
+          // BDHLNDR-46: quantized (int8) model — ~4× smaller weights and
+          // activation tensors than the fp32 default, the main headroom fix
+          // for the ONNX arena-exhaustion crash. Changes embedding numerics
+          // (see EMBEDDING_VERSION) so a re-index is forced on upgrade.
+          dtype: 'q8',
           session_options: {
             intraOpNumThreads: EMBEDDING_THREAD_COUNT,
             interOpNumThreads: 1,
@@ -120,7 +139,7 @@ export class HuggingFaceEmbeddingProvider implements EmbeddingProvider {
     if (texts.length === 0) return [];
 
     // Truncate to model max token budget before handing to the pipeline.
-    const truncated = texts.map(t => t.slice(0, 8000));
+    const truncated = texts.map(t => t.slice(0, MAX_EMBED_CHARS));
 
     // Real batched inference: feed the whole array once so ONNX can amortize
     // the forward pass. Previously this looped one text at a time, which meant
@@ -189,7 +208,7 @@ export class HuggingFaceEmbeddingProvider implements EmbeddingProvider {
     if (!this.pipeline) throw new Error('Pipeline not initialized');
 
     // Truncate text if too long (model has max token limit)
-    const truncatedText = text.slice(0, 8000);
+    const truncatedText = text.slice(0, MAX_EMBED_CHARS);
 
     const output = await this.pipeline(truncatedText, {
       pooling: 'mean',

--- a/src/main/vector-search/index.ts
+++ b/src/main/vector-search/index.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from 'events';
 import { app } from 'electron';
 import log from 'electron-log';
 import * as codeSearchRepo from '../repositories/code-search';
-import { getEmbeddingProvider } from './embedding-provider';
+import { getEmbeddingProvider, EMBEDDING_VERSION } from './embedding-provider';
 import { ParsedSymbol } from './parser';
 import type { CodeIndex, IndexProgress, CodeSearchResult, SymbolSearchResult, SymbolType, IndexStatus, IndexPhase } from '../../shared/types';
 
@@ -200,6 +200,27 @@ export class VectorSearchManager extends EventEmitter {
     if (this.workers.has(index.id)) {
       console.log('[VectorSearch] Indexing already in progress for:', directoryPath);
       return;
+    }
+
+    // BDHLNDR-46: if this index's stored vectors were generated with a
+    // different embedding version (e.g. fp32 from <= v3.3.1, now embedding at
+    // q8), they are not comparable to new query vectors. Wipe and rebuild from
+    // scratch rather than mixing incompatible vectors. Runs before the circuit
+    // breaker below: clearIndexData resets status to 'pending', so a stale
+    // 'indexing' from an old crash can't be miscounted as a fresh crash here.
+    const persistedEmbeddingVersion = codeSearchRepo.getEmbeddingVersion(index.id);
+    if (persistedEmbeddingVersion !== EMBEDDING_VERSION) {
+      if ((index.chunkCount ?? 0) > 0) {
+        log.warn(
+          `[VectorSearch] Embedding version changed ` +
+            `(${persistedEmbeddingVersion} → ${EMBEDDING_VERSION}) for ${directoryPath}; ` +
+            `clearing stale vectors and re-indexing from scratch`
+        );
+        codeSearchRepo.clearIndexData(index.id, EMBEDDING_VERSION);
+      } else {
+        // Nothing indexed yet — just stamp the current embedding version.
+        codeSearchRepo.setEmbeddingVersion(index.id, EMBEDDING_VERSION);
+      }
     }
 
     // BDHLNDR-40 circuit breaker: a fresh status of 'indexing' here means a
@@ -517,6 +538,9 @@ export class VectorSearchManager extends EventEmitter {
     codeSearchRepo.updateIndexStatus(indexId, 'ready');
     // BDHLNDR-40: a clean completion clears the crash-loop circuit breaker.
     codeSearchRepo.resetConsecutiveFailures(indexId);
+    // BDHLNDR-46: record the embedding version this index was built with so a
+    // future model/dtype change is detected and forces a clean re-index.
+    codeSearchRepo.setEmbeddingVersion(indexId, EMBEDDING_VERSION);
     this.emit('indexing-complete', { indexId, directoryPath: index?.directoryPath });
 
     // Start file watcher


### PR DESCRIPTION
## Promote 3.3.3-beta.0 → stable

Promotes **BDHLNDR-46** (q8 quantized embedding + token-bounded truncation + auto re-index migration) from `development` to `production`. Validated on `3.3.3-beta.0` by the maintainer: **AC1** (~1300-file repo indexes on macOS arm64 — completes, bounded memory, no crash), **AC2** (auto re-index migration fires: fp32 wiped → rebuilt q8), **AC3** (search relevance acceptable vs fp32).

Net new vs `production` (which already has -40 in v3.3.1 and -42 in v3.3.2 via direct hotfixes): the **BDHLNDR-46 q8 work** (commit `8b5a9cb`); the rest are the -40/-42 forward-merge commits already represented in production.

### ⚠️ Post-merge: required version bump (maintainer, releases stable)
Merging this **does not release** — `package.json` is `3.3.3-beta.0`; `release.yml`'s channel gate rejects a `-beta.` version on `production` and short-circuits (no build). To cut stable, on `production`:
```
npm version patch -m "3.3.3"   # 3.3.3-beta.0 → 3.3.3 (drops prerelease)
git push                        # NOT --tags
```

### User-impact note
On upgrade to 3.3.3, every stable user's existing fp32 index is **auto-wiped and rebuilt at q8** (EMBEDDING_VERSION 1→2 migration) — one-time, no user action, but indexing runs once after update. This is intended and validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)