### PR TITLE
fix(BDHLNDR-41): handle transient mDNS/relay network errors at source

### DIFF
--- a/docs/designs/BDHLNDR-41-network-uncaught-exceptions.md
+++ b/docs/designs/BDHLNDR-41-network-uncaught-exceptions.md
@@ -1,0 +1,60 @@
+# BDHLNDR-41 — Unhandled network errors crash/destabilize main process
+
+## Problem (from gregory's v3.3.0 `main.log`)
+
+Two recurring `[Main] Uncaught exception` classes, caught only by the global
+`process.on('uncaughtException')` logger (which leaves the process in an
+undefined state):
+
+- **mDNS ×32:** `send ENETUNREACH 224.0.0.251:5353` (`node:dgram`).
+- **Relay:** `getaddrinfo ENOTFOUND cl-relay.sytanek.tech`.
+
+## Root causes
+
+1. **mDNS** (`api/discovery/mdns-advertiser.ts`): uses `bonjour-service`, which
+   wraps a `multicast-dns` dgram socket. Transient send failures (sleep/wake,
+   Wi-Fi switch, VPN, no route to the multicast group) are emitted on the
+   **underlying mdns instance/socket**, which has no `'error'` listener →
+   escapes to `uncaughtException`. The existing `service.on('error')` only
+   catches Service-level errors (e.g. name-in-use), not socket send errors.
+2. **Relay** (`api/relay/relay-connection.ts`): the `ws.on('error')` handler
+   does `this.emit('error', error)`. `RelayConnection extends EventEmitter`;
+   emitting `'error'` with **no registered `'error'` listener re-throws** as an
+   uncaught exception (Node EventEmitter semantics). So a DNS failure that *was*
+   handled by the ws error handler is converted into an uncaught exception.
+
+## Fix
+
+1. **mDNS** — `attachMdnsErrorHandler(bonjour)`: reach
+   `(bonjour as any)._server.mdns` (internal to bonjour-service but stable
+   across 1.x; optional-chained so a shape change degrades to today's behavior,
+   no regression) and attach an `'error'` listener on the mdns instance and its
+   `.socket`. Classify transient network codes
+   (`ENETUNREACH/ENETDOWN/EHOSTUNREACH/EHOSTDOWN/ENODEV/EADDRNOTAVAIL/EPERM`)
+   as expected — log at `warn` and swallow. mDNS is best-effort; bonjour
+   re-announces periodically and self-heals when the network returns. Applied
+   to both `MdnsAdvertiser.advertise()` and `MdnsDiscovery.start()`.
+2. **Relay** — guard the re-emit: `if (this.listenerCount('error') > 0)
+   this.emit('error', error)`; downgrade the log to `warn` (transient).
+   Reconnect is already handled by the `'close'` handler that follows a failed
+   ws connection (ws emits `'error'` then `'close'`), so no extra reconnect
+   logic is needed — the only defect is the unguarded re-emit.
+3. **Global handler** (`index.ts`) — audited. It is a non-exiting logger of
+   last resort; correct to keep. With (1)+(2) owning these errors at source it
+   no longer sees the mDNS/relay floods. No behavior change (a comment records
+   the audit). Changing it to relaunch/exit is out of scope.
+
+## Acceptance mapping
+
+- AC1 (no `[Main] Uncaught exception` for mDNS/relay on Wi-Fi off/on,
+  sleep/wake, offline): addressed by (1)+(2). Empirical network-toggle
+  verification is manual (no test framework — documented project deviation).
+- AC2 (auto-recover when network returns): bonjour periodic re-announce +
+  relay `scheduleReconnect` already self-heal once the crashes stop.
+- AC3 (global handler no longer logs those): consequence of (1)+(2).
+
+## Verification
+
+`build:main` (tsc) green; logic trace of the offline → reconnect paths.
+Empirical: toggle Wi-Fi / sleep-wake on a packaged build → expect zero new
+`[Main] Uncaught exception` mDNS/relay lines (manual, pre-merge or on beta).

--- a/src/main/api/discovery/mdns-advertiser.ts
+++ b/src/main/api/discovery/mdns-advertiser.ts
@@ -13,6 +13,49 @@ import log from 'electron-log';
 const SERVICE_TYPE = 'bodhilander';
 const SERVICE_PROTOCOL = 'tcp';
 
+// BDHLNDR-41: bonjour-service wraps a multicast-dns dgram socket. Transient
+// network failures (sleep/wake, Wi-Fi switch, VPN, no route to the mDNS
+// multicast group) surface as `send ENETUNREACH 224.0.0.251:5353` emitted on
+// the underlying mdns instance/socket — which bonjour-service leaves without
+// an 'error' listener, so it escapes to process 'uncaughtException'. mDNS is
+// best-effort; bonjour re-announces periodically and self-heals when the
+// network returns, so these are non-fatal: log and swallow.
+const TRANSIENT_NET_CODES = new Set([
+  'ENETUNREACH', 'ENETDOWN', 'EHOSTUNREACH', 'EHOSTDOWN',
+  'ENODEV', 'EADDRNOTAVAIL', 'EPERM',
+]);
+
+/**
+ * Attach an 'error' handler to the multicast-dns instance/socket inside a
+ * bonjour-service instance so transient socket send failures don't crash the
+ * main process. `_server.mdns` is internal to bonjour-service but stable
+ * across its 1.x; optional-chained so a library shape change degrades to the
+ * prior behavior (no regression) rather than throwing here.
+ */
+function attachMdnsErrorHandler(bonjour: Bonjour, context: string): void {
+  const mdns: any = (bonjour as any)?._server?.mdns;
+  if (!mdns || typeof mdns.on !== 'function') return;
+
+  const onError = (err: NodeJS.ErrnoException) => {
+    const code = err?.code ?? '';
+    if (TRANSIENT_NET_CODES.has(code)) {
+      log.warn(
+        `[${context}] Transient network error (${code}) — mDNS paused, ` +
+          `will recover when the network returns`
+      );
+    } else {
+      log.warn(`[${context}] mDNS socket error (discovery degraded):`, err?.message || err);
+    }
+  };
+
+  mdns.on('error', onError);
+  // Some multicast-dns versions surface socket send errors on the dgram
+  // socket directly rather than on the mdns instance.
+  if (mdns.socket && typeof mdns.socket.on === 'function') {
+    mdns.socket.on('error', onError);
+  }
+}
+
 export class MdnsAdvertiser {
   private bonjour: Bonjour | null = null;
   private service: Service | null = null;
@@ -23,6 +66,7 @@ export class MdnsAdvertiser {
   async advertise(port: number): Promise<void> {
     try {
       this.bonjour = new Bonjour();
+      attachMdnsErrorHandler(this.bonjour, 'MdnsAdvertiser');
 
       // Use a unique name with random suffix to avoid conflicts
       const uniqueId = Math.random().toString(36).substring(2, 8);
@@ -103,6 +147,7 @@ export class MdnsDiscovery {
 
   start(): void {
     this.bonjour = new Bonjour();
+    attachMdnsErrorHandler(this.bonjour, 'MdnsDiscovery');
 
     this.browser = this.bonjour.find({
       type: SERVICE_TYPE,

--- a/src/main/api/relay/relay-connection.ts
+++ b/src/main/api/relay/relay-connection.ts
@@ -167,8 +167,19 @@ export class RelayConnection extends EventEmitter {
       });
 
       this.ws.on('error', (error) => {
-        log.error('[RelayConnection] WebSocket error:', error);
-        this.emit('error', error);
+        // BDHLNDR-41: connection-level failures (e.g. getaddrinfo ENOTFOUND
+        // when offline / DNS down) arrive here. `emit('error', …)` on an
+        // EventEmitter with no registered 'error' listener re-throws as an
+        // uncaught exception, so guard it. Reconnect is handled by the 'close'
+        // handler that follows a failed ws connection — treat this as
+        // transient, not fatal.
+        log.warn(
+          '[RelayConnection] WebSocket error (will retry):',
+          error instanceof Error ? error.message : error
+        );
+        if (this.listenerCount('error') > 0) {
+          this.emit('error', error);
+        }
       });
     } catch (error) {
       log.error('[RelayConnection] Failed to connect:', error);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -44,7 +44,12 @@ crashReporter.start({
 log.transports.file.maxSize = 5 * 1024 * 1024; // 5 MB per log file
 log.transports.file.level = 'info';
 
-// Global error handlers to catch uncaught exceptions and prevent silent crashes
+// Global error handlers — last-resort logger of genuinely unexpected faults.
+// BDHLNDR-41: the recurring mDNS (`send ENETUNREACH 224.0.0.251:5353`) and
+// relay (`getaddrinfo ENOTFOUND`) uncaught exceptions are now handled at their
+// source (mdns-advertiser socket handler / relay emit guard), so this should
+// no longer see those transient network floods. Intentionally non-exiting:
+// keep the process alive and logged rather than hard-crash.
 process.on('uncaughtException', (error: Error) => {
   log.error('[Main] Uncaught exception:', error);
   log.error('[Main] Stack:', error.stack);


### PR DESCRIPTION
## BDHLNDR-41 — mDNS/relay uncaught exceptions

Eliminates two recurring `[Main] Uncaught exception` classes from gregory's log (mDNS `send ENETUNREACH 224.0.0.251:5353` ×32; relay `getaddrinfo ENOTFOUND cl-relay.sytanek.tech`).

### Root causes
- **mDNS**: `bonjour-service` wraps a `multicast-dns` dgram socket; transient send failures are emitted on the underlying mdns instance/socket which has **no `'error'` listener** (the existing `service.on('error')` only catches Service-level errors like name-in-use) → escapes to `uncaughtException`.
- **Relay**: `RelayConnection extends EventEmitter`; the `ws.on('error')` handler does `this.emit('error', err)` — emitting `'error'` with **no registered listener re-throws** (Node EventEmitter), converting a *handled* DNS failure into an uncaught exception.

### Fix
- `mdns-advertiser.ts`: `attachMdnsErrorHandler()` on `_server.mdns` (+ `.socket`) for both `MdnsAdvertiser` and `MdnsDiscovery`; transient net codes logged at `warn` and swallowed (mDNS is best-effort, self-heals on periodic re-announce). Internal bonjour-service access is optional-chained → degrades to prior behavior if the lib shape changes (no regression).
- `relay-connection.ts`: guard the re-emit with `listenerCount('error') > 0`; downgrade to `warn`. Reconnect is already handled by the `'close'` handler that follows a failed ws connection.
- `index.ts`: global `uncaughtException` handler **audited** — kept as non-exiting last-resort logger (comment records the audit); fixes above stop it being the catch-all for these.

### Acceptance / verification
AC1–AC3 addressed in code. `build:main` (tsc) green; logic trace of offline→reconnect paths. **AC1 empirical check (Wi-Fi off/on, sleep/wake, offline → zero new mDNS/relay uncaught lines) is manual** — no test framework (documented project deviation); suggest a quick network-toggle pass on the next beta. Design: `docs/designs/BDHLNDR-41-network-uncaught-exceptions.md`.

Targets `development` (normal fix flow — not a hotfix; severity Medium, no user-facing crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)