### PR TITLE
fix(BDHLNDR-43): stop xterm resize-after-dispose handleResize TypeError

### DIFF
--- a/docs/designs/BDHLNDR-43-renderer-handleresize.md
+++ b/docs/designs/BDHLNDR-43-renderer-handleresize.md
@@ -1,0 +1,62 @@
+# BDHLNDR-43 — Recurring renderer `handleResize` TypeError
+
+## Symptom
+
+`Uncaught TypeError: Cannot read properties of undefined (reading 'handleResize')`
+in `dist/renderer/renderer.js` — ×38 across gregory's log, same call site
+across builds (offset shifts only with version).
+
+## Root cause (found by building & inspecting the prod bundle)
+
+Our source has **no** `.handleResize` property access — only two local
+closures (`Terminal.tsx`, `RemoteTerminal.tsx`). Grepping the built
+`renderer.js` showed every `handleResize` token is **xterm.js internal**:
+`this._renderService.handleResize(cols,rows)`, `this._renderer.value.handleResize(e,t)`,
+the deferred `_pausedResizeTask` closure, and the WebGL renderer.
+
+So the undefined `.handleResize` is xterm's own renderer/renderService being
+read after it's disposed/paused. Trigger: our `handleResize()` calls
+`fitAddon.fit()`, which drives `terminal.resize()` → `onResize` →
+`_renderService.handleResize(...)`. A resize queued **before** teardown but
+delivered **during/after** it reaches torn-down xterm internals:
+
+- The `ResizeObserver` callback scheduled `requestAnimationFrame(handleResize)`
+  but that rAF was **never cancelled** on cleanup.
+- `xtermRef`/`fitAddonRef` were **never nulled**, so the existing
+  `if (!fitAddonRef.current || !xtermRef.current) return;` guard could not
+  catch a late call — `fit()` ran on a disposed terminal.
+- Window `'resize'` between `term.dispose()` and `removeEventListener`, plus
+  the activation-effect rAF/`[100,250,500]ms` timer chain, hit the same path.
+
+Same family as BDHLNDR-8 (xterm WebGL dispose race) but via the resize path,
+hence the ticket's "distinct" note was only partly right.
+
+## Fix (Terminal.tsx + RemoteTerminal.tsx — identical pattern)
+
+1. **Track & cancel the ResizeObserver's deferred rAF** (`resizeRafId`) in
+   cleanup, so it can't fire into a disposed terminal. Also `entries[0]?.`
+   defensive access.
+2. **Null `xtermRef`/`fitAddonRef` in cleanup** (after `term.dispose()`), so
+   any residual late `handleResize` (window resize between dispose and
+   listener removal, activation timers) hits the early-return guard.
+3. **Wrap `fitAddon.fit()` + resize in `try/catch`** inside `handleResize` —
+   final safety net (mirrors BDHLNDR-8's "never let an xterm lifecycle error
+   escape to the React tree"); covers the paused-renderer / dispose micro-race
+   that nulled refs alone can't fully close.
+
+`term.dispose()` in RemoteTerminal is now also `try/catch`-wrapped for parity
+with Terminal.tsx.
+
+## Acceptance mapping
+
+- AC1 (open/close windows, rapid session/view switching → zero `handleResize`
+  `window.onerror`): addressed; empirical verification is manual (no test
+  framework — documented project deviation).
+- AC2 (resize behavior unchanged for live components): handleResize logic is
+  unchanged on the live path; guards/try-catch only affect the teardown race.
+
+## Verification
+
+`build:renderer` (webpack production) green. Empirical: rapidly open/close
+windows and switch sessions on a build → expect zero new `handleResize`
+`window.onerror` entries (manual / next beta).

--- a/src/renderer/components/RemoteTerminal.tsx
+++ b/src/renderer/components/RemoteTerminal.tsx
@@ -116,17 +116,29 @@ const RemoteTerminal: React.FC<RemoteTerminalProps> = ({ code, permission, isAct
       });
     }
 
-    // Handle resize
+    // Handle resize. BDHLNDR-43: fitAddon.fit() drives xterm's internal
+    // resize; a queued resize landing during/after teardown hits undefined
+    // xterm internals ("Cannot read properties of undefined (reading
+    // 'handleResize')"). Refs are nulled on cleanup so this normally
+    // early-returns; the try/catch is the final safety net.
+    let resizeRafId = 0;
     const handleResize = () => {
-      if (fitAddonRef.current && xtermRef.current) {
+      if (!fitAddonRef.current || !xtermRef.current) return;
+      try {
         fitAddonRef.current.fit();
+      } catch (e) {
+        console.warn('[RemoteTerminal] resize during teardown (non-fatal):', e);
       }
     };
 
     const resizeObserver = new ResizeObserver((entries) => {
-      const { width, height } = entries[0].contentRect;
-      if (width > 0 && height > 0) {
-        requestAnimationFrame(handleResize);
+      const rect = entries[0]?.contentRect;
+      if (rect && rect.width > 0 && rect.height > 0) {
+        if (resizeRafId) cancelAnimationFrame(resizeRafId);
+        resizeRafId = requestAnimationFrame(() => {
+          resizeRafId = 0;
+          handleResize();
+        });
       }
     });
 
@@ -139,10 +151,21 @@ const RemoteTerminal: React.FC<RemoteTerminalProps> = ({ code, permission, isAct
 
     return () => {
       window.removeEventListener('resize', handleResize);
+      // BDHLNDR-43: cancel the deferred resize so it can't fire into the
+      // disposed terminal after cleanup.
+      if (resizeRafId) cancelAnimationFrame(resizeRafId);
       resizeObserver.disconnect();
       cleanupData();
       cleanupEnded();
-      term.dispose();
+      try {
+        term.dispose();
+      } catch (e) {
+        console.warn('[RemoteTerminal] dispose error (non-fatal):', e);
+      }
+      // Null refs so any late handleResize (window 'resize' / init timer)
+      // early-returns instead of calling fit() on the disposed terminal.
+      xtermRef.current = null;
+      fitAddonRef.current = null;
     };
   }, [code, permission]);
 

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -72,11 +72,24 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     // resize when the terminal becomes visible again.
     if (!isActiveRef.current) return;
 
-    fitAddonRef.current.fit();
-    const { cols, rows } = xtermRef.current;
-    // Guard: don't propagate bogus dimensions from an unsized container.
-    if (cols >= MIN_COLS && rows >= MIN_ROWS) {
-      window.electronAPI.resizeSession(sessionId, cols, rows);
+    // BDHLNDR-43: fitAddon.fit() drives xterm's internal resize
+    // (onResize → _renderService.handleResize / the deferred
+    // _pausedResizeTask). If a queued resize (ResizeObserver rAF, window
+    // 'resize', activation-effect timers) lands during/after teardown, those
+    // xterm internals are undefined and throw the recurring
+    // "Cannot read properties of undefined (reading 'handleResize')". Refs are
+    // nulled on cleanup so this normally early-returns; this try/catch is the
+    // final safety net so any residual dispose/paused-renderer race can never
+    // escape to window.onerror (same posture as the BDHLNDR-8 dispose guards).
+    try {
+      fitAddonRef.current.fit();
+      const { cols, rows } = xtermRef.current;
+      // Guard: don't propagate bogus dimensions from an unsized container.
+      if (cols >= MIN_COLS && rows >= MIN_ROWS) {
+        window.electronAPI.resizeSession(sessionId, cols, rows);
+      }
+    } catch (e) {
+      console.warn('[Terminal] resize during teardown (non-fatal):', e);
     }
   }, [sessionId]);
 
@@ -356,6 +369,9 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     // requestAnimationFrame scroll correction that fires after the browser has
     // processed all writes and redraws for that frame.
     let scrollRafId = 0;
+    // BDHLNDR-43: the ResizeObserver schedules a deferred handleResize via rAF;
+    // tracked so cleanup can cancel it before it fires into a disposed xterm.
+    let resizeRafId = 0;
     let shouldPin = false;
     const cleanupPtyData = window.electronAPI.onPtyData((id, data) => {
       if (id === sessionId) {
@@ -456,9 +472,11 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
 
     // Use ResizeObserver to detect when container actually has dimensions
     const resizeObserver = new ResizeObserver((entries) => {
-      const { width, height } = entries[0].contentRect;
-      if (width > 0 && height > 0) {
-        requestAnimationFrame(() => {
+      const rect = entries[0]?.contentRect;
+      if (rect && rect.width > 0 && rect.height > 0) {
+        if (resizeRafId) cancelAnimationFrame(resizeRafId);
+        resizeRafId = requestAnimationFrame(() => {
+          resizeRafId = 0;
           handleResize();
         });
       }
@@ -478,6 +496,9 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     return () => {
       mounted = false;
       if (scrollRafId) cancelAnimationFrame(scrollRafId);
+      // BDHLNDR-43: cancel the ResizeObserver's deferred resize so it can't
+      // fire handleResize into the disposed terminal after this cleanup.
+      if (resizeRafId) cancelAnimationFrame(resizeRafId);
       window.removeEventListener('resize', handleResize);
       resizeObserver.disconnect();
       cleanupPtyData();
@@ -502,6 +523,13 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       } catch (e) {
         console.warn('Terminal dispose error (non-fatal):', e);
       }
+
+      // BDHLNDR-43: null the refs so any handleResize that still slips through
+      // (a window 'resize' between dispose and listener removal, or the
+      // activation-effect rAF/timer chain) hits the early-return guard instead
+      // of calling fit() on the disposed terminal.
+      xtermRef.current = null;
+      fitAddonRef.current = null;
     };
   }, [sessionId, cwd, launchClaude, isRunning, handleResize]);
 


### PR DESCRIPTION
## BDHLNDR-43 — recurring renderer `handleResize` TypeError (×38)

**Root cause (found by building & grepping the prod bundle):** the undefined `.handleResize` is **xterm.js internal** (`_renderService.handleResize` / `_renderer.value.handleResize` / deferred `_pausedResizeTask`), not our code. Our `fitAddon.fit()` (via `handleResize`) drives `terminal.resize() → onResize → _renderService.handleResize(...)`; a resize **queued before teardown but delivered during/after it** hits disposed xterm internals. The ResizeObserver's `rAF(handleResize)` was never cancelled and the refs were never nulled, so the existing guard couldn't catch the late call. Same family as BDHLNDR-8, via the resize path.

**Fix** (`Terminal.tsx` + `RemoteTerminal.tsx`, identical pattern):
1. Track & cancel the ResizeObserver's deferred rAF on cleanup (+ `entries[0]?` guard).
2. Null `xtermRef`/`fitAddonRef` after `term.dispose()` so any residual late `handleResize` early-returns.
3. `try/catch` `fitAddon.fit()` in `handleResize` — final safety net (same posture as the BDHLNDR-8 dispose guards); RemoteTerminal `term.dispose()` wrapped for parity.

Live-path resize logic is unchanged; guards only affect the teardown race.

**Verification:** `build:renderer` (webpack production) green. AC1 empirical (rapid open/close + session switch → zero `handleResize` window.onerror) is manual — no test framework (documented deviation); suggest a pass on the next beta. Design: `docs/designs/BDHLNDR-43-renderer-handleresize.md`. Targets `development` (normal fix flow; severity Low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)