### PR TITLE
fix(BDHLNDR-44): recover from GPU/renderer crashes + gate window creation on app-ready

### DIFF
--- a/docs/designs/BDHLNDR-44-gpu-window-race.md
+++ b/docs/designs/BDHLNDR-44-gpu-window-race.md
@@ -1,0 +1,52 @@
+# BDHLNDR-44 — GPU process crashes + BrowserWindow-before-ready race
+
+Two low-severity main-process robustness gaps in `src/main/index.ts`.
+
+## Part A — renderer/GPU crash leaves UI blank
+
+`render-process-gone` and `child-process-gone` handlers **only logged**
+(`Child process gone: GPU crashed 5` ×5 in gregory's log). Electron
+auto-relaunches the GPU process, but on macOS the renderer is frequently left
+blank/unresponsive, and a dead renderer is never reloaded.
+
+**Fix:** `recoverWindowAfterCrash(reason)`:
+- `render-process-gone`: ignore intentional teardown (`clean-exit`/`killed`);
+  for `crashed`/`oom`/`abnormal-exit`/`launch-failed` → reload the main
+  window (or recreate it if destroyed and app is ready).
+- `child-process-gone` with `type === 'GPU'` (not `clean-exit`) → reload so
+  the renderer re-establishes its GPU channel and re-paints.
+- **Reload-storm guard:** at most `MAX_PROCESS_RELOADS` (3) within
+  `RELOAD_WINDOW_MS` (60 s); past that, stop and log only — never trade a
+  crash loop for a reload loop.
+
+Tradeoff: a GPU crash where the page was actually fine still triggers one
+reload. Reliably detecting "renderer actually broken" is complex; the bounded
+reload is the pragmatic, documented choice and matches AC1 ("recovers
+visibly, not left blank").
+
+## Part B — "Cannot create BrowserWindow before app is ready"
+
+Seen once during the (now-fixed, BDHLNDR-40) rapid relaunch cluster. The
+normal path is already gated (`app.whenReady().then(() => { createSplashWindow();
+createWindow(); })`), and `second-instance`/`activate` don't construct windows
+pre-ready — the exact race under chaotic relaunch couldn't be pinpointed and
+isn't reproducible.
+
+**Fix (defensive, race-agnostic):** guard `createWindow()` and
+`createSplashWindow()` — if `!app.isReady()`, defer via
+`app.whenReady().then(...)` and return instead of constructing. This makes the
+exception **impossible by construction** regardless of caller/timing (AC2),
+without chasing an unreproducible race.
+
+## Acceptance mapping
+
+- AC1: renderer/GPU crash → app reloads and recovers (not blank), bounded
+  against storms; behavior documented here.
+- AC2: no code path can construct a `BrowserWindow` before app ready — both
+  factories self-defer.
+
+## Verification
+
+`build:main` (tsc) green. Empirical (simulate via DevTools
+`process.crash()` / GPU crash, and rapid relaunch) is manual — no test
+framework (documented project deviation); suggest a pass on the next beta.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -279,6 +279,14 @@ function handleStateChange(sessionId: string, state: string, sessionName?: strin
 }
 
 function createSplashWindow(): void {
+  // BDHLNDR-44: a BrowserWindow must never be constructed before app 'ready'
+  // (the "Cannot create BrowserWindow before app is ready" uncaught exception
+  // seen under rapid relaunch). Defer instead of throwing so the error is
+  // impossible regardless of caller/timing.
+  if (!app.isReady()) {
+    app.whenReady().then(() => createSplashWindow());
+    return;
+  }
   splashWindow = new BrowserWindow({
     icon: path.join(__dirname, '../../build/icon.png'),
     width: 500,
@@ -339,6 +347,14 @@ function registerMcpAndHooksEverywhere(): void {
 }
 
 function createWindow(): void {
+  // BDHLNDR-44: never construct a BrowserWindow before app 'ready' — defends
+  // the rapid-relaunch race that produced "Cannot create BrowserWindow before
+  // app is ready". Defer rather than throw.
+  if (!app.isReady()) {
+    app.whenReady().then(() => createWindow());
+    return;
+  }
+
   // Initialize database
   getDatabase();
 
@@ -1243,14 +1259,57 @@ app.whenReady().then(() => {
   log.error('[Main] Failed to initialize app:', error);
 });
 
+// BDHLNDR-44: recover from renderer/GPU process crashes instead of leaving
+// the window blank. Bounded against a crash→reload storm: at most
+// MAX_PROCESS_RELOADS within RELOAD_WINDOW_MS, then stop and just log.
+const MAX_PROCESS_RELOADS = 3;
+const RELOAD_WINDOW_MS = 60_000;
+let processReloadTimes: number[] = [];
+
+function recoverWindowAfterCrash(reason: string): void {
+  const now = Date.now();
+  processReloadTimes = processReloadTimes.filter((t) => now - t < RELOAD_WINDOW_MS);
+  if (processReloadTimes.length >= MAX_PROCESS_RELOADS) {
+    log.error(
+      `[Main] Skipping recovery after ${reason} — ${processReloadTimes.length} ` +
+        `reloads within ${RELOAD_WINDOW_MS}ms (reload-storm guard)`
+    );
+    return;
+  }
+  processReloadTimes.push(now);
+
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    log.warn(`[Main] Recovering UI after ${reason} — reloading main window`);
+    try {
+      mainWindow.webContents.reload();
+    } catch (e) {
+      log.error('[Main] Reload after crash failed:', e);
+    }
+  } else if (app.isReady()) {
+    log.warn(`[Main] Recovering after ${reason} — recreating main window`);
+    createWindow();
+  }
+}
+
 // Handle render process crashes (if any child window crashes)
 app.on('render-process-gone', (event, webContents, details) => {
   log.error('[Main] Render process gone:', details.reason, details.exitCode);
+  // 'clean-exit'/'killed' are intentional teardown (quit, manual kill) — don't
+  // fight those. Anything else (crashed/oom/abnormal-exit/launch-failed) left
+  // the renderer dead → reload so the user isn't staring at a blank window.
+  if (details.reason === 'clean-exit' || details.reason === 'killed') return;
+  recoverWindowAfterCrash(`render-process-gone (${details.reason})`);
 });
 
 // Handle child process crashes
 app.on('child-process-gone', (event, details) => {
   log.error('[Main] Child process gone:', details.type, details.reason, details.exitCode);
+  // Electron auto-relaunches the GPU process, but on macOS the renderer is
+  // often left blank/unresponsive afterwards — reload so it re-establishes
+  // its GPU channel and re-paints. (Bounded by the reload-storm guard.)
+  if (details.type === 'GPU' && details.reason !== 'clean-exit') {
+    recoverWindowAfterCrash('GPU process crash');
+  }
 });
 
 // Renderer error forwarding — renderer calls this via IPC so errors land in the log file


### PR DESCRIPTION
## BDHLNDR-44 — GPU crash recovery + BrowserWindow-before-ready

### Part A — crashes left the UI blank
`render-process-gone`/`child-process-gone` only logged (`GPU crashed 5` ×5). Added `recoverWindowAfterCrash()`: reload (or recreate) the main window on abnormal `render-process-gone` and on GPU `child-process-gone`; ignore intentional `clean-exit`/`killed`. **Reload-storm guard**: max 3 reloads / 60 s, then log-only — never turn a crash loop into a reload loop.

### Part B — "Cannot create BrowserWindow before app is ready"
Rare race under rapid relaunch (couldn't be pinpointed / not reproducible). `createWindow()` and `createSplashWindow()` now **defer via `app.whenReady()` and return if `!app.isReady()`** — makes the exception impossible by construction, race-agnostic. Normal path unchanged.

### Verification
`build:main` (tsc) green. AC1 (simulated renderer/GPU crash → visible recovery, not blank) and AC2 (no pre-ready window construction; rapid relaunch) are **manual** — no test framework (documented deviation); suggest a pass on the next beta. Design: `docs/designs/BDHLNDR-44-gpu-window-race.md`. Targets `development` (normal fix flow; severity Low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)