### PR TITLE
fix(BDHLNDR-45): re-scope to local crash minidump capture

### DIFF
--- a/docs/designs/BDHLNDR-45-crashreporter-rescope.md
+++ b/docs/designs/BDHLNDR-45-crashreporter-rescope.md
@@ -1,0 +1,46 @@
+# BDHLNDR-45 — RE-SCOPED: local crash minidump capture
+
+## Scope change
+
+Original ticket: move vector-search indexing `worker_threads` → Electron
+`utilityProcess` to *contain* a native crash. **Superseded:** BDHLNDR-40
+(circuit breaker + ONNX arena bound, v3.3.1) and BDHLNDR-46 (q8 + token cap +
+migration, v3.3.3) fixed the actual crash. A full transport refactor is now
+large effort for sharply reduced value, so per maintainer decision this is
+re-scoped to its only remaining valuable, root-cause-agnostic residue:
+**reliable local crash minidump capture**.
+
+## Finding
+
+`crashReporter.start({ uploadToServer: false })` already exists in
+`src/main/index.ts` (added with the BDHLNDR-30 logging work). It runs at
+module load — before app lifecycle — so renderer/GPU/utility crashes and
+in-process `worker_threads` native faults are captured by Crashpad into
+`app.getPath('crashDumps')`, already exposed via the `log:getPaths` IPC.
+
+So the re-scoped goal was essentially already met. This change adds the two
+small, high-leverage touches that directly address this session's pain (we had
+to talk the user through hand-finding gregory's `.ips`):
+
+- `extra: { appVersion: app.getVersion() }` — dumps are tagged with the
+  version, so triage doesn't need the version guessed/asked.
+- Startup `log.info('[CrashReporter] Native crash minidumps written to: …')`
+  — the dump directory is now in `main.log`, so "where are the crash files"
+  is answerable from the log alone.
+
+Remote upload of these dumps is explicitly **out of scope** → BDHLNDR-47
+(phone-home), which this complements.
+
+## Acceptance (re-scoped)
+
+1. Native crashes produce a local minidump in `app.getPath('crashDumps')` —
+   already true; verified the start() call runs pre-lifecycle.
+2. Dumps carry the app version; the dump path is logged at startup.
+3. No worker→utilityProcess refactor (dropped; rationale recorded on the
+   ticket).
+
+## Verification
+
+`build:main` (tsc) green. Empirical (trigger a native crash, confirm a
+minidump + the startup log line) is manual — no test framework (documented
+project deviation).

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,12 +33,23 @@ import { openInEditor, detectAvailableEditors, getEditorOptions, EditorType } fr
 // ---------------------------------------------------------------------------
 
 // Enable Electron's native crash reporter — writes minidump files locally
-// so we can diagnose native-module crashes (e.g. node-pty SIGSEGV).
+// so we can diagnose native-module crashes (e.g. node-pty SIGSEGV, the
+// onnxruntime BFCArena trap behind BDHLNDR-40). BDHLNDR-45 (re-scoped from a
+// worker→utilityProcess refactor — superseded by the -40/-46 fixes — down to
+// just local minidump capture): tag dumps with the app version so they're
+// triageable without guesswork, and log the dump directory at startup so we
+// never again have to talk a user through hunting for crash reports by hand.
 crashReporter.start({
-  submitURL: '',       // No remote server — dumps stay local
+  submitURL: '',       // No remote server — dumps stay local (upload = BDHLNDR-47)
   uploadToServer: false,
   compress: false,
+  extra: { appVersion: app.getVersion() },
 });
+try {
+  log.info('[CrashReporter] Native crash minidumps written to:', app.getPath('crashDumps'));
+} catch {
+  // getPath('crashDumps') can throw very early on some platforms — non-fatal.
+}
 
 // Configure electron-log: file rotation to prevent unbounded disk growth
 log.transports.file.maxSize = 5 * 1024 * 1024; // 5 MB per log file


### PR DESCRIPTION
## BDHLNDR-45 — RE-SCOPED

Original (worker→utilityProcess containment) **superseded** by BDHLNDR-40 (v3.3.1) + BDHLNDR-46 (v3.3.3), which fixed the actual native crash. Per maintainer decision, re-scoped to the only valuable, root-cause-agnostic residue: **reliable local crash minidump capture**.

**Finding:** `crashReporter.start({ uploadToServer: false })` already exists (`index.ts`, from BDHLNDR-30) and runs pre-lifecycle, so renderer/GPU/utility + in-process `worker_threads` native faults are already captured to `app.getPath('crashDumps')` (exposed via `log:getPaths`).

**This change** adds the two small touches that directly fix this session's pain (we hand-hunted gregory's `.ips`):
- `extra: { appVersion }` — dumps are version-tagged for triage.
- Startup log of the crashDumps dir — "where are the crash files" is now answerable from `main.log`.

Remote upload is **out of scope → BDHLNDR-47** (phone-home), which this complements.

`build:main` green. Empirical (trigger native crash → minidump + log line) is manual — no test framework (documented deviation). Targets `development`. Recommend updating the ticket summary to reflect the re-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)