### PR TITLE
fix(BDHLNDR-48): session reorder no longer drops to bottom (GH #42)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -604,6 +604,9 @@ const App: React.FC = () => {
 
   const handleSessionDrop = (e: React.DragEvent, targetSessionId: string, targetGroupId: string) => {
     e.preventDefault();
+    e.stopPropagation(); // BDHLNDR-48 (GH #42): without this the drop bubbles to
+    // the parent .group-sessions handleGroupAreaDrop, which re-reorders the
+    // session to the end of the list, overwriting the correct dropped position.
 
     // Read from dataTransfer (race-condition safe on macOS)
     const data = e.dataTransfer.getData('text/plain');


### PR DESCRIPTION
## BDHLNDR-48 / GH #42 — session reorder always moved to bottom

`handleSessionDrop` (`App.tsx`) computed the correct target index, then called `reorderSession(...)` — but lacked `e.stopPropagation()`. The drop bubbled to the parent `.group-sessions` `onDrop={handleGroupAreaDrop}`, which re-reordered the session to `targetGroupSessions.length` (end of list), overwriting the correct position. Every reorder landed at the bottom.

**Fix:** add `e.stopPropagation()` in `handleSessionDrop` (right after `preventDefault()`), matching `handleGroupDrop` and the other drop handlers. One line.

**Verification:** `build:renderer` (webpack prod) green. Empirical (drag session #1 → after #2 → lands at #2's position, not the bottom; cross-group + group reorder unaffected) is manual — no test framework (documented project deviation); covered by the next beta pass. Targets `development`.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)