### PR TITLE
BDHLNDR-65: gate terminal REST input/resize on canControl perm

### DIFF
--- a/src/main/api/routes/terminal.ts
+++ b/src/main/api/routes/terminal.ts
@@ -6,6 +6,7 @@
 
 import { Router, Request, Response } from 'express';
 import { ptyManager } from '../../pty-manager';
+import { requireControlPermission } from '../middleware/auth';
 import { getStringParam } from '../middleware/validation';
 
 export function createTerminalRouter(): Router {
@@ -15,7 +16,7 @@ export function createTerminalRouter(): Router {
    * POST /api/v1/terminal/:sessionId/input
    * Send input to terminal
    */
-  router.post('/:sessionId/input', (req: Request, res: Response) => {
+  router.post('/:sessionId/input', requireControlPermission, (req: Request, res: Response) => {
     const sessionId = getStringParam(req.params.sessionId);
     const { data } = req.body;
 
@@ -38,7 +39,7 @@ export function createTerminalRouter(): Router {
    * POST /api/v1/terminal/:sessionId/resize
    * Resize terminal
    */
-  router.post('/:sessionId/resize', (req: Request, res: Response) => {
+  router.post('/:sessionId/resize', requireControlPermission, (req: Request, res: Response) => {
     const sessionId = getStringParam(req.params.sessionId);
     const { cols, rows } = req.body;
 


### PR DESCRIPTION
## Summary

Pre-existing security gap surfaced during the BDHLNDR-50 design session: two terminal REST routes mutated state without checking the device's `canControl` permission, while the WS path for the same operations already enforced it. A read-only paired device could write to terminals over REST.

**Closes:** [BDHLNDR-65](https://gobodhi.atlassian.net/browse/BDHLNDR-65) · Parent Epic: [BDHLNDR-50](https://gobodhi.atlassian.net/browse/BDHLNDR-50)

## Fix

Add `requireControlPermission` middleware to:
- `POST /api/v1/terminal/:sessionId/input`
- `POST /api/v1/terminal/:sessionId/resize`

`GET /:sessionId/buffer` deliberately left alone (read-only, matches WS pattern).

## What's in

**1 commit:** `fix(BDHLNDR-65): gate terminal REST input/resize on canControl perm`

**Files changed (`src/main/api/routes/terminal.ts`):**
- Line 9: added `import { requireControlPermission } from '../middleware/auth';`
- Line 19: added `requireControlPermission` as middleware on `POST /:sessionId/input`
- Line 42: added `requireControlPermission` as middleware on `POST /:sessionId/resize`

## Test plan

- [x] `bunx tsc --noEmit -p tsconfig.json` clean
- [x] WS path unchanged (already had the check at `ws-server.ts:188`)
- [ ] Manual: read-only device gets 403 on `/input` and `/resize`
- [ ] Manual: control-capable device unchanged
- Built by a parallel subagent alongside BDHLNDR-51 and BDHLNDR-52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-65]: https://gobodhi.atlassian.net/browse/BDHLNDR-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-50]: https://gobodhi.atlassian.net/browse/BDHLNDR-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ