### PR TITLE
BDHLNDR-54: PWA pair flow (typed 6-digit code) + IndexedDB token + RequireAuth

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.2.1",
         "helmet": "^8.1.0",
+        "idb": "^8.0.0",
         "ignore": "^7.0.4",
         "node-pty": "^1.1.0",
         "qrcode": "^1.5.4",
@@ -1187,7 +1188,7 @@
 
     "icss-utils": ["icss-utils@5.1.0", "", { "peerDependencies": { "postcss": "^8.1.0" } }, "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="],
 
-    "idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
+    "idb": ["idb@8.0.3", "", {}, "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -2171,11 +2172,15 @@
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
+    "workbox-background-sync/idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
+
     "workbox-build/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "workbox-build/pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 
     "workbox-build/source-map": ["source-map@0.8.0-beta.0", "", { "dependencies": { "whatwg-url": "^7.0.0" } }, "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA=="],
+
+    "workbox-expiration/idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
 
     "@develar/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
     "helmet": "^8.1.0",
+    "idb": "^8.0.0",
     "ignore": "^7.0.4",
     "node-pty": "^1.1.0",
     "qrcode": "^1.5.4",

--- a/src/pwa/src/App.tsx
+++ b/src/pwa/src/App.tsx
@@ -1,18 +1,23 @@
 /**
  * Top-level route table for the mobile PWA.
  *
- * Pages here are intentionally placeholders — the real implementations land
- * in follow-up tickets:
- *   - /pair                → BDHLNDR-54 (pair flow + IndexedDB token storage)
+ * Real implementations of the placeholders land in follow-ups:
+ *   - /pair                → BDHLNDR-54 (this ticket: typed pair flow)
  *   - /sessions            → BDHLNDR-55 (session list)
  *   - /sessions/:sessionId → BDHLNDR-56 (chat view consuming chat-events)
+ *
+ * <RequireAuth> is a wrapper component (not a layout route) so each
+ * protected route can opt in individually — the more common react-router-v7
+ * shape and the one that matches our flat route table.
  */
 
+import { useEffect, useState, type ReactElement } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import { Pair } from './pages/Pair';
 import { SessionList } from './pages/SessionList';
 import { SessionDetail } from './pages/SessionDetail';
+import { getAuth } from './lib/auth';
 
 export function App() {
   return (
@@ -20,12 +25,58 @@ export function App() {
       <Routes>
         <Route path="/" element={<Navigate to="/sessions" replace />} />
         <Route path="/pair" element={<Pair />} />
-        <Route path="/sessions" element={<SessionList />} />
-        <Route path="/sessions/:sessionId" element={<SessionDetail />} />
+        <Route
+          path="/sessions"
+          element={
+            <RequireAuth>
+              <SessionList />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/sessions/:sessionId"
+          element={
+            <RequireAuth>
+              <SessionDetail />
+            </RequireAuth>
+          }
+        />
         {/* Unknown paths bounce back to the session list so the SPA fallback
             from the desktop never lands on a blank screen. */}
         <Route path="*" element={<Navigate to="/sessions" replace />} />
       </Routes>
     </div>
   );
+}
+
+/**
+ * Gate a route on having an auth row in IndexedDB. While the check is in
+ * flight we render a blank shell to avoid a flash of either the protected
+ * page or /pair.
+ */
+function RequireAuth({ children }: { children: ReactElement }): ReactElement {
+  const [state, setState] = useState<'checking' | 'authed' | 'unauthed'>('checking');
+
+  useEffect(() => {
+    let cancelled = false;
+    getAuth().then((auth) => {
+      if (cancelled) return;
+      setState(auth ? 'authed' : 'unauthed');
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state === 'checking') {
+    // Empty shell — the IndexedDB read is fast, this is sub-frame in
+    // practice. Avoids a flash of /pair for paired users.
+    return <div aria-hidden className="min-h-screen" />;
+  }
+
+  if (state === 'unauthed') {
+    return <Navigate to="/pair" replace />;
+  }
+
+  return children;
 }

--- a/src/pwa/src/lib/api.ts
+++ b/src/pwa/src/lib/api.ts
@@ -1,25 +1,27 @@
 /**
  * Minimal fetch wrapper for the Bodhilander REST API.
  *
- * Real token loading from IndexedDB lands in BDHLNDR-54 (pair flow). For now
- * this exposes a stub `getAuthToken()` hook so call sites can be written now
- * and swapped to the real implementation without touching every call site.
+ * Token loading is delegated to `./auth.ts` (IndexedDB-backed, wired in
+ * BDHLNDR-54). Call sites import `apiFetch` and `getAuthToken` from here;
+ * neither cares where the token actually lives.
  *
  * Contract (from BDHLNDR-51):
  *   - Bearer token in the `Authorization` header for paired devices.
  *   - All endpoints are namespaced under `/api/v1/...`.
  */
 
+import { getAuth } from './auth';
+
 const API_BASE = '/api/v1';
 
 /**
- * Stub — replaced by an IndexedDB-backed implementation in BDHLNDR-54.
- * Returns `null` today so requests go out un-authenticated and the desktop's
- * auth middleware can reject them with a clean 401 (which the UI can then
- * route to /pair). That keeps the call sites stable across tickets.
+ * Resolve the current device bearer token, or null if the PWA isn't paired.
+ * Reads from IndexedDB via `getAuth()` so the result survives reloads and
+ * matches whatever the user paired with on the desktop.
  */
 export async function getAuthToken(): Promise<string | null> {
-  return null;
+  const auth = await getAuth();
+  return auth?.token ?? null;
 }
 
 export interface ApiRequestOptions extends Omit<RequestInit, 'body'> {

--- a/src/pwa/src/lib/auth.ts
+++ b/src/pwa/src/lib/auth.ts
@@ -1,0 +1,109 @@
+/**
+ * IndexedDB-backed auth/token store for the mobile PWA.
+ *
+ * The PWA stores a single auth row (id = 'current') containing the device
+ * bearer token returned by `POST /api/v1/pairing/confirm` and the device
+ * metadata the desktop sent back. IndexedDB survives reloads, installs as
+ * a "real app" via the PWA manifest, and works offline — exactly what we
+ * need so the user doesn't have to re-pair every time.
+ *
+ * Wire-up (BDHLNDR-54):
+ *   - `Pair.tsx` calls `saveAuth(token, device)` after a successful confirm.
+ *   - `api.ts:getAuthToken()` reads from here so all REST calls carry the
+ *     Authorization header.
+ *   - `App.tsx:<RequireAuth>` reads from here to gate `/sessions/*`.
+ *   - The unpair button in SessionList calls `clearAuth()` after the
+ *     server-side DELETE succeeds.
+ */
+
+import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
+
+const DB_NAME = 'bodhilander';
+const DB_VERSION = 1;
+const STORE_NAME = 'auth';
+const ROW_ID = 'current';
+
+/**
+ * Subset of the device payload the desktop returns from
+ * `POST /api/v1/pairing/confirm` plus the platform string the PWA itself
+ * sent (the desktop echoes it back via `GET /pairing/devices`, but not on
+ * confirm, so we re-attach it here to keep the row self-describing).
+ */
+export interface AuthDevice {
+  id: string;
+  name: string;
+  platform: string;
+  canControl: boolean;
+  canModify: boolean;
+}
+
+export interface AuthRecord {
+  id: typeof ROW_ID;
+  token: string;
+  device: AuthDevice;
+  paired_at: number;
+}
+
+interface BodhilanderDB extends DBSchema {
+  [STORE_NAME]: {
+    key: string;
+    value: AuthRecord;
+  };
+}
+
+let dbPromise: Promise<IDBPDatabase<BodhilanderDB>> | null = null;
+
+function getDB(): Promise<IDBPDatabase<BodhilanderDB>> {
+  if (!dbPromise) {
+    dbPromise = openDB<BodhilanderDB>(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        }
+      },
+    });
+  }
+  return dbPromise;
+}
+
+/**
+ * Persist a fresh auth record after a successful pair. Overwrites any
+ * existing row — re-pairing on the same device is the explicit reset path.
+ */
+export async function saveAuth(token: string, device: AuthDevice): Promise<void> {
+  const db = await getDB();
+  const record: AuthRecord = {
+    id: ROW_ID,
+    token,
+    device,
+    paired_at: Date.now(),
+  };
+  await db.put(STORE_NAME, record);
+}
+
+/**
+ * Read the current auth row, or null if the PWA has never paired (or the
+ * user just unpaired).
+ */
+export async function getAuth(): Promise<AuthRecord | null> {
+  try {
+    const db = await getDB();
+    const record = await db.get(STORE_NAME, ROW_ID);
+    return record ?? null;
+  } catch (err) {
+    // IndexedDB can throw in private-browsing / locked-down contexts.
+    // Treat as "no auth" so the UI falls through to /pair instead of
+    // hanging on a thrown promise.
+    console.error('[auth] Failed to read IndexedDB:', err);
+    return null;
+  }
+}
+
+/**
+ * Wipe the auth row. Called after the desktop confirms unpair so the PWA
+ * forgets the (now-invalid) token and bounces back to /pair.
+ */
+export async function clearAuth(): Promise<void> {
+  const db = await getDB();
+  await db.delete(STORE_NAME, ROW_ID);
+}

--- a/src/pwa/src/lib/platform.ts
+++ b/src/pwa/src/lib/platform.ts
@@ -1,0 +1,74 @@
+/**
+ * Browser / device sniffing for the PWA.
+ *
+ * Two outputs:
+ *   - `detectPlatform()` returns one of 'ios' | 'android' | 'web', which is
+ *     the value the desktop's `validatePairingConfirm` middleware expects
+ *     for the `platform` field. This is also the value the QR-pair flow
+ *     (BDHLNDR-14) will send, so keep them in sync.
+ *   - `suggestDeviceName()` produces a friendly default for the device-name
+ *     input on /pair, e.g. "iPhone (Safari)" or "Pixel (Chrome)".
+ *
+ * Best-effort UA sniffing — we don't need this to be perfect, the user can
+ * always edit the name. We avoid `navigator.userAgentData` because it's
+ * gated behind a permissions prompt in some browsers and not yet
+ * universally supported on iOS.
+ */
+
+export type Platform = 'ios' | 'android' | 'web';
+
+export function detectPlatform(): Platform {
+  if (typeof navigator === 'undefined') return 'web';
+  const ua = navigator.userAgent;
+  // iPad on iPadOS 13+ reports as Mac; check for touch points to catch it.
+  const isIpadOS =
+    /Macintosh/.test(ua) &&
+    typeof navigator.maxTouchPoints === 'number' &&
+    navigator.maxTouchPoints > 1;
+  if (/iPhone|iPad|iPod/.test(ua) || isIpadOS) return 'ios';
+  if (/Android/.test(ua)) return 'android';
+  return 'web';
+}
+
+/**
+ * Build a default device-name string like `Pixel (Chrome)` or
+ * `iPhone (Safari)`. Falls back to platform + generic browser when the UA
+ * doesn't yield anything more specific.
+ */
+export function suggestDeviceName(): string {
+  if (typeof navigator === 'undefined') return 'Web';
+  const ua = navigator.userAgent;
+  const device = detectDeviceModel(ua);
+  const browser = detectBrowser(ua);
+  return `${device} (${browser})`;
+}
+
+function detectDeviceModel(ua: string): string {
+  if (/iPad/.test(ua)) return 'iPad';
+  if (/iPhone/.test(ua)) return 'iPhone';
+  if (/iPod/.test(ua)) return 'iPod';
+  if (/Android/.test(ua)) {
+    // Try to pull a model name out of the UA: `; <Model> Build/...`
+    const m = /Android[^;]*;\s*([^;)]+?)(?:\s+Build|;|\))/.exec(ua);
+    if (m && m[1]) return m[1].trim();
+    return 'Android';
+  }
+  if (/Macintosh/.test(ua)) return 'Mac';
+  if (/Windows/.test(ua)) return 'Windows';
+  if (/Linux/.test(ua)) return 'Linux';
+  return 'Device';
+}
+
+function detectBrowser(ua: string): string {
+  // Order matters: Edge / Opera / Brave masquerade as Chrome.
+  if (/Edg\//.test(ua)) return 'Edge';
+  if (/OPR\//.test(ua)) return 'Opera';
+  if (/Firefox\//.test(ua)) return 'Firefox';
+  if (/CriOS\//.test(ua)) return 'Chrome'; // Chrome on iOS
+  if (/FxiOS\//.test(ua)) return 'Firefox'; // Firefox on iOS
+  // Safari check must come after CriOS/FxiOS because iOS browsers also
+  // include "Safari" in the UA.
+  if (/Chrome\//.test(ua)) return 'Chrome';
+  if (/Safari\//.test(ua)) return 'Safari';
+  return 'Browser';
+}

--- a/src/pwa/src/pages/Pair.tsx
+++ b/src/pwa/src/pages/Pair.tsx
@@ -1,23 +1,202 @@
 /**
- * /pair — placeholder. Real pairing flow lands in BDHLNDR-54.
+ * /pair — typed 6-digit code pair flow (BDHLNDR-54).
+ *
+ * The user runs `Pair device` on the desktop, gets a 6-digit code on
+ * screen, types it here, and the desktop responds with a bearer token we
+ * persist in IndexedDB. On success we redirect to /sessions.
+ *
+ * QR-code-driven pairing (no typing required) lands in BDHLNDR-14 and
+ * will reuse the same POST body shape — `{ code, deviceName, platform }`.
  */
 
-import { Link } from 'react-router-dom';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+
+import { ApiError, apiFetch } from '../lib/api';
+import { type AuthDevice, getAuth, saveAuth } from '../lib/auth';
+import { detectPlatform, suggestDeviceName } from '../lib/platform';
+
+interface ConfirmResponse {
+  token: string;
+  device: {
+    id: string;
+    name: string;
+    canControl: boolean;
+    canModify: boolean;
+  };
+}
+
+type Status =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'error'; message: string; raw?: string };
 
 export function Pair() {
+  const navigate = useNavigate();
+
+  // If we're already paired, skip the form. Using local state instead of a
+  // suspense boundary so the rest of the form renders immediately for
+  // first-time users (the common case).
+  const [alreadyPaired, setAlreadyPaired] = useState<boolean | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    getAuth().then((auth) => {
+      if (!cancelled) setAlreadyPaired(auth !== null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const platform = useMemo(() => detectPlatform(), []);
+  const [deviceName, setDeviceName] = useState(() => suggestDeviceName());
+  const [code, setCode] = useState('');
+  const [status, setStatus] = useState<Status>({ kind: 'idle' });
+
+  const codeIsValid = /^\d{6}$/.test(code);
+  const submitting = status.kind === 'submitting';
+  const canSubmit = codeIsValid && deviceName.trim().length > 0 && !submitting;
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!canSubmit) return;
+
+    setStatus({ kind: 'submitting' });
+
+    try {
+      const res = await apiFetch<ConfirmResponse>('/pairing/confirm', {
+        method: 'POST',
+        body: {
+          code,
+          deviceName: deviceName.trim(),
+          platform,
+        },
+      });
+
+      // The confirm endpoint doesn't echo platform back, but we sent it,
+      // so stash it in the local row so callers (settings, debug, etc.)
+      // don't have to re-derive it from navigator.userAgent later.
+      const device: AuthDevice = {
+        id: res.device.id,
+        name: res.device.name,
+        platform,
+        canControl: res.device.canControl,
+        canModify: res.device.canModify,
+      };
+      await saveAuth(res.token, device);
+
+      navigate('/sessions', { replace: true });
+    } catch (err) {
+      setStatus(toErrorStatus(err));
+    }
+  }
+
+  if (alreadyPaired) {
+    return <Navigate to="/sessions" replace />;
+  }
+
   return (
     <main className="mx-auto max-w-md p-4">
-      <nav className="mb-4 text-sm text-neutral-400">
-        <Link to="/sessions" className="hover:text-neutral-200">
-          Sessions
-        </Link>
-        <span className="mx-2">/</span>
-        <span className="text-neutral-200">Pair</span>
-      </nav>
       <h1 className="text-2xl font-semibold">Pair device</h1>
-      <p className="mt-2 text-neutral-300">
-        Pairing UI lands in BDHLNDR-54.
+      <p className="mt-2 text-sm text-neutral-300">
+        On your desktop, open Bodhilander &rarr; <em>Pair device</em> to get a
+        6-digit code, then type it here.
       </p>
+
+      <form onSubmit={handleSubmit} className="mt-6 space-y-4" noValidate>
+        <label className="block">
+          <span className="text-sm font-medium text-neutral-200">Device name</span>
+          <input
+            type="text"
+            value={deviceName}
+            onChange={(e) => setDeviceName(e.target.value)}
+            maxLength={100}
+            autoComplete="off"
+            className="mt-1 block w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-base text-neutral-100 outline-none focus:border-neutral-400"
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-sm font-medium text-neutral-200">Pairing code</span>
+          <input
+            type="text"
+            value={code}
+            onChange={(e) => {
+              // Strip anything that isn't a digit, clamp to 6.
+              const next = e.target.value.replace(/\D/g, '').slice(0, 6);
+              setCode(next);
+            }}
+            inputMode="numeric"
+            pattern="\d{6}"
+            maxLength={6}
+            autoFocus
+            autoComplete="one-time-code"
+            placeholder="000000"
+            aria-invalid={code.length > 0 && !codeIsValid}
+            className="mt-1 block w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-3 text-center font-mono text-2xl tracking-[0.5em] text-neutral-100 outline-none focus:border-neutral-400"
+          />
+        </label>
+
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="w-full rounded-md bg-emerald-600 px-4 py-3 text-base font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:bg-neutral-700 disabled:text-neutral-400"
+        >
+          {submitting ? 'Pairing…' : 'Pair'}
+        </button>
+
+        {status.kind === 'error' && (
+          <div
+            role="alert"
+            className="rounded-md border border-red-700/60 bg-red-900/30 px-3 py-2 text-sm text-red-200"
+          >
+            <p>{status.message}</p>
+            {status.raw && (
+              <details className="mt-2 text-xs text-red-300/80">
+                <summary className="cursor-pointer">Details</summary>
+                <pre className="mt-1 whitespace-pre-wrap break-words">{status.raw}</pre>
+              </details>
+            )}
+          </div>
+        )}
+      </form>
     </main>
   );
+}
+
+function toErrorStatus(err: unknown): Status {
+  if (err instanceof ApiError) {
+    if (err.status === 400) {
+      return { kind: 'error', message: 'Invalid or expired pairing code.' };
+    }
+    return {
+      kind: 'error',
+      message: `Pairing failed (HTTP ${err.status}).`,
+      raw: safeStringify(err.body) ?? err.message,
+    };
+  }
+  // fetch() rejects with a TypeError on network failures (DNS, CORS,
+  // offline, wrong host). That's the case where the desktop is unreachable.
+  if (err instanceof TypeError) {
+    return {
+      kind: 'error',
+      message:
+        "Could not reach desktop — make sure you're on the same Wi-Fi or Tailscale tailnet.",
+      raw: err.message,
+    };
+  }
+  return {
+    kind: 'error',
+    message: 'Pairing failed.',
+    raw: err instanceof Error ? err.message : String(err),
+  };
+}
+
+function safeStringify(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }

--- a/src/pwa/src/pages/SessionList.tsx
+++ b/src/pwa/src/pages/SessionList.tsx
@@ -1,10 +1,59 @@
 /**
- * /sessions — placeholder. Real list view lands in BDHLNDR-55.
+ * /sessions — placeholder list (real list view lands in BDHLNDR-55).
+ *
+ * For BDHLNDR-54 we add the unpair-this-device button at the bottom so the
+ * pair → store → redirect flow has a working "back out" path. When the
+ * server-side DELETE succeeds (or returns the specific "Cannot unpair the
+ * current device" message — see note below) we wipe IndexedDB and bounce
+ * back to /pair.
  */
 
-import { Link } from 'react-router-dom';
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+
+import { ApiError, apiFetch } from '../lib/api';
+import { clearAuth, getAuth } from '../lib/auth';
 
 export function SessionList() {
+  const navigate = useNavigate();
+  const [unpairing, setUnpairing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleUnpair() {
+    setError(null);
+    setUnpairing(true);
+    try {
+      const auth = await getAuth();
+      if (!auth) {
+        // Nothing to unpair — just bounce.
+        navigate('/pair', { replace: true });
+        return;
+      }
+
+      try {
+        await apiFetch(`/pairing/devices/${encodeURIComponent(auth.device.id)}`, {
+          method: 'DELETE',
+        });
+      } catch (err) {
+        // The desktop rejects self-unpair with HTTP 400 ("Cannot unpair the
+        // current device"). From the PWA's perspective the user is asking
+        // to forget *this* token, so we still clear locally — they can
+        // unpair from the desktop UI if they want the row gone server-side.
+        // Re-throw anything else.
+        if (!(err instanceof ApiError && err.status === 400)) {
+          throw err;
+        }
+      }
+
+      await clearAuth();
+      navigate('/pair', { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUnpairing(false);
+    }
+  }
+
   return (
     <main className="mx-auto max-w-md p-4">
       <nav className="mb-4 text-sm text-neutral-400">
@@ -16,17 +65,27 @@ export function SessionList() {
       </p>
       <div className="mt-6 space-y-2 text-sm">
         <Link
-          to="/pair"
-          className="block rounded-md bg-neutral-800 px-4 py-2 hover:bg-neutral-700"
-        >
-          Pair a new device
-        </Link>
-        <Link
           to="/sessions/example"
           className="block rounded-md bg-neutral-800 px-4 py-2 hover:bg-neutral-700"
         >
           Open example session
         </Link>
+      </div>
+
+      <div className="mt-8 border-t border-neutral-800 pt-4">
+        <button
+          type="button"
+          onClick={handleUnpair}
+          disabled={unpairing}
+          className="w-full rounded-md border border-red-700/60 bg-red-900/20 px-4 py-2 text-sm text-red-200 transition-colors hover:bg-red-900/40 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {unpairing ? 'Unpairing…' : 'Unpair this device'}
+        </button>
+        {error && (
+          <p role="alert" className="mt-2 text-xs text-red-300">
+            {error}
+          </p>
+        )}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

Wires the end-to-end **typed 6-digit code pair flow** in the PWA. User generates a code on the desktop, types it in the PWA, gets back a device token, stored in IndexedDB, redirects to `/sessions`. Includes RequireAuth route gating and an unpair-this-device flow.

**Closes:** [BDHLNDR-54](https://gobodhi.atlassian.net/browse/BDHLNDR-54) · Parent Epic: [BDHLNDR-50](https://gobodhi.atlassian.net/browse/BDHLNDR-50)

## What's in

**3 commits:**
- `2f528fc feat(BDHLNDR-54): IndexedDB-backed auth token store for PWA`
- `c85e1f8 feat(BDHLNDR-54): /pair typed 6-digit code flow`
- `ec0d5d7 feat(BDHLNDR-54): RequireAuth gate + unpair-this-device button`

**Files:**
- Added: `src/pwa/src/lib/auth.ts`, `src/pwa/src/lib/platform.ts`
- Modified: `src/pwa/src/lib/api.ts`, `src/pwa/src/pages/{Pair,SessionList}.tsx`, `src/pwa/src/App.tsx`
- Dep added: `idb ^8.0.0`

## Locked contracts (downstream consumers)

**AuthRecord shape** (IndexedDB `bodhilander` v1, store `auth`, keyPath `id`):
```ts
{
  id: 'current',
  token: string,
  device: { id, name, platform, canControl, canModify },
  paired_at: number  // Date.now() at pair time
}
```

**Request body** to `POST /api/v1/pairing/confirm` (matches `validatePairingConfirm` middleware):
```json
{ "code": "123456", "deviceName": "iPhone (Safari)", "platform": "ios" }
```

**Platform detection** (`src/pwa/src/lib/platform.ts`):
- `detectPlatform()` → `'ios' | 'android' | 'web'` (UA-based, handles iPadOS-as-Mac via `maxTouchPoints`)
- `suggestDeviceName()` → `${model} (${browser})`

BDHLNDR-14 (QR pair) reuses both helpers + the same request shape.

## RequireAuth pattern

Wrapper component (not v7 layout route). Each protected route wraps its element. Renders a blank shell during the in-flight IndexedDB read to avoid flashing `/pair` for paired users. `/pair` mirrors the inverse with its own `<Navigate>` check (paired users skip the pair screen).

## Error UX

Inline, no toast library. Pair errors render in a `role="alert"` red panel with optional `<details>` for the raw payload. Unpair errors render as a short red `<p>` below the button. Network-failure copy: "Could not reach desktop — make sure you're on the same Wi-Fi or Tailscale tailnet".

## Test plan

- [x] `bunx tsc --noEmit -p tsconfig.pwa.json` clean
- [x] `bun run build:pwa` succeeds — 96 modules, 268.22 kB JS (85.20 kB gzip), 10.01 kB CSS, SW + manifest emitted, 919ms
- [ ] Manual: type a valid 6-digit code, verify pair → token in IndexedDB → redirect /sessions
- [ ] Manual: enter wrong code → "Invalid or expired pairing code"
- [ ] Manual: with no desktop reachable → "Could not reach desktop" message
- [ ] Manual: unpair → IndexedDB cleared → redirect /pair
- [ ] Manual: reload PWA while paired → stays on /sessions (token persists)

## Flagged decisions

- **Self-unpair edge case**: desktop's `DELETE /pairing/devices/:id` returns HTTP 400 when `req.device?.id === id` (the same device trying to unpair itself). Workaround: PWA swallows that specific 400 and clears IndexedDB locally so the user can re-pair. Worth a follow-up to add a dedicated `DELETE /pairing/self` endpoint OR relax the self-unpair check on the desktop.
- **`navigator.userAgentData` not used** — gated/inconsistent; UA sniffing is good-enough for a default device name the user can edit.
- **No SW token cache** — `apiFetch` awaits `getAuthToken()` per request (IDB hit each time). Easy to memoize later if it shows up in profiling.

## Notes for downstream tickets

- **#55 (session list)**: unpair button currently lives in `SessionList.tsx`. If #55 introduces a Settings route, move it there.
- **#14 (QR pair)**: same request body + platform values; reuse `detectPlatform()` + `suggestDeviceName()`; call `saveAuth(token, device)` on success.
- **#61 (iOS install)**: `lib/platform.ts:detectPlatform()` already handles iPadOS-as-Mac correctly.
- **#55/#56 WS work**: WS handshake (now first-message via BDHLNDR-60) should read the token via `getAuth().then(a => a.token)` — same path as REST.

Built by a parallel subagent alongside BDHLNDR-60. `bun install --ignore-scripts` used (BDHLNDR-66 winpty workaround).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-54]: https://gobodhi.atlassian.net/browse/BDHLNDR-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-50]: https://gobodhi.atlassian.net/browse/BDHLNDR-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ