### PR TITLE
BDHLNDR-67: allow self-unpair + close WS on device delete

### DIFF
--- a/src/main/api/http-server.ts
+++ b/src/main/api/http-server.ts
@@ -27,6 +27,12 @@ export interface HttpServerConfig {
   port: number;
   bindAddress: string;
   pairingManager: PairingManager;
+  /**
+   * Called after a successful unpair (BDHLNDR-67) so the WS server can close
+   * any open connections owned by the deleted device. Wired after wsServer
+   * exists; safe to omit during early bootstrap.
+   */
+  onDeviceUnpaired?: (deviceId: string) => void;
 }
 
 export interface HttpServerResult {
@@ -177,7 +183,7 @@ export async function createHttpServer(config: HttpServerConfig): Promise<HttpSe
   });
 
   // Pairing routes (rate limited, no auth required for initiation)
-  app.use('/api/v1/pairing', pairingLimiter, createPairingRouter(config.pairingManager));
+  app.use('/api/v1/pairing', pairingLimiter, createPairingRouter(config.pairingManager, config.onDeviceUnpaired));
 
   // Memory routes for MCP server (localhost-only, no device auth needed)
   app.use('/api/v1/memories', generalLimiter, createMemoriesRouter());

--- a/src/main/api/index.ts
+++ b/src/main/api/index.ts
@@ -79,11 +79,18 @@ class ApiServer extends EventEmitter {
     log.info('[ApiServer] Starting API server...');
 
     try {
-      // Create HTTP server with Express
+      // Create HTTP server with Express.
+      // BDHLNDR-67: onDeviceUnpaired forwards device-id to wsServer so any
+      // open WS owned by the deleted device closes cleanly. The wsServer
+      // doesn't exist at createHttpServer call time, so we read `this.wsServer`
+      // lazily inside the closure — by request-time it's been assigned below.
       const { server, port } = await createHttpServer({
         port: this.config.port,
         bindAddress: this.config.bindAddress,
         pairingManager: this.pairingManager,
+        onDeviceUnpaired: (deviceId) => {
+          this.wsServer?.closeConnectionsForDevice(deviceId);
+        },
       });
 
       this.httpServer = server;

--- a/src/main/api/routes/pairing.ts
+++ b/src/main/api/routes/pairing.ts
@@ -12,7 +12,10 @@ import { PairingManager } from '../pairing/pairing-manager';
 import { validatePairingConfirm, getStringParam } from '../middleware/validation';
 import { authenticateDevice } from '../middleware/auth';
 
-export function createPairingRouter(pairingManager: PairingManager): Router {
+export function createPairingRouter(
+  pairingManager: PairingManager,
+  onDeviceUnpaired?: (deviceId: string) => void,
+): Router {
   const router = Router();
 
   /**
@@ -157,16 +160,18 @@ export function createPairingRouter(pairingManager: PairingManager): Router {
 
   /**
    * DELETE /pairing/devices/:id - Unpair a device (requires auth)
+   *
+   * BDHLNDR-67: self-unpair is allowed. The previous "Cannot unpair the
+   * current device" guard broke the PWA's unpair-this-device flow with no
+   * real safety benefit — the user clicked unpair intentionally, and the
+   * PWA already handles re-pairing gracefully (RequireAuth → /pair on 401).
+   * After a successful delete we fire `onDeviceUnpaired` so any open WS
+   * connection from that device is closed (belt-and-suspenders so the WS
+   * doesn't outlive the device row).
    */
   router.delete('/devices/:id', authenticateDevice(pairingManager), (req: Request, res: Response) => {
     try {
       const id = getStringParam(req.params.id);
-
-      // Don't allow device to unpair itself
-      if (req.device?.id === id) {
-        res.status(400).json({ error: 'Cannot unpair the current device' });
-        return;
-      }
 
       const success = pairingManager.unpairDevice(id);
 
@@ -174,6 +179,8 @@ export function createPairingRouter(pairingManager: PairingManager): Router {
         res.status(404).json({ error: 'Device not found' });
         return;
       }
+
+      onDeviceUnpaired?.(id);
 
       res.json({ success: true });
     } catch (error) {

--- a/src/main/api/ws-server.ts
+++ b/src/main/api/ws-server.ts
@@ -54,6 +54,12 @@ interface PendingAuth {
 export interface WsServer {
   broadcast(message: WsMessage): void;
   broadcastToSession(sessionId: string, message: WsMessage): void;
+  /**
+   * Close (with code 4401) any open connections owned by `deviceId`. Called
+   * after a device is unpaired (BDHLNDR-67) so the WS connection doesn't
+   * outlive the device row server-side.
+   */
+  closeConnectionsForDevice(deviceId: string): void;
   getClientCount(): number;
   close(): void;
 }
@@ -183,6 +189,18 @@ export function createWsServer(httpServer: HttpServer, pairingManager: PairingMa
         if (ws.readyState === WebSocket.OPEN && info.subscribedSessions.has(sessionId)) {
           ws.send(data);
         }
+      }
+    },
+
+    closeConnectionsForDevice(deviceId: string): void {
+      for (const [ws, info] of clients) {
+        if (info.device.id !== deviceId) continue;
+        try {
+          ws.close(WS_CLOSE_UNAUTHORIZED, 'device unpaired');
+        } catch (error) {
+          log.debug('[WsServer] Error closing connection for unpaired device:', error);
+        }
+        clients.delete(ws);
       }
     },
 

--- a/src/pwa/src/pages/SessionList.tsx
+++ b/src/pwa/src/pages/SessionList.tsx
@@ -1,17 +1,16 @@
 /**
  * /sessions — placeholder list (real list view lands in BDHLNDR-55).
  *
- * For BDHLNDR-54 we add the unpair-this-device button at the bottom so the
- * pair → store → redirect flow has a working "back out" path. When the
- * server-side DELETE succeeds (or returns the specific "Cannot unpair the
- * current device" message — see note below) we wipe IndexedDB and bounce
- * back to /pair.
+ * Includes an unpair-this-device button so the pair → store → redirect flow
+ * has a working "back out" path. Server delete + local IndexedDB clear are
+ * symmetric: the desktop allows self-unpair (BDHLNDR-67) and closes any
+ * WS owned by this device, so the PWA just awaits the delete and bounces.
  */
 
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
-import { ApiError, apiFetch } from '../lib/api';
+import { apiFetch } from '../lib/api';
 import { clearAuth, getAuth } from '../lib/auth';
 
 export function SessionList() {
@@ -30,20 +29,9 @@ export function SessionList() {
         return;
       }
 
-      try {
-        await apiFetch(`/pairing/devices/${encodeURIComponent(auth.device.id)}`, {
-          method: 'DELETE',
-        });
-      } catch (err) {
-        // The desktop rejects self-unpair with HTTP 400 ("Cannot unpair the
-        // current device"). From the PWA's perspective the user is asking
-        // to forget *this* token, so we still clear locally — they can
-        // unpair from the desktop UI if they want the row gone server-side.
-        // Re-throw anything else.
-        if (!(err instanceof ApiError && err.status === 400)) {
-          throw err;
-        }
-      }
+      await apiFetch(`/pairing/devices/${encodeURIComponent(auth.device.id)}`, {
+        method: 'DELETE',
+      });
 
       await clearAuth();
       navigate('/pair', { replace: true });


### PR DESCRIPTION
## Summary

Relaxes the self-unpair check on `DELETE /api/v1/pairing/devices/:id` and adds belt-and-suspenders WS connection cleanup so the WS doesn't outlive the device row.

**Closes:** [BDHLNDR-67](https://gobodhi.atlassian.net/browse/BDHLNDR-67) · surfaced during BDHLNDR-54 PR review.

## Problem

Previously, the desktop returned HTTP 400 (\"Cannot unpair the current device\") when the calling device tried to unpair itself. PWA's unpair-this-device button was the only caller, and the 400 broke its natural flow — PWA worked around it by swallowing the response and clearing local IndexedDB anyway.

The guard was paternalistic — the user clicks unpair *intentionally*, and the PWA already handles re-pairing gracefully (RequireAuth redirects to `/pair` on 401, IndexedDB is cleared on unpair).

## Changes

**Backend:**
- `routes/pairing.ts`: removed the `req.device?.id === id` check. Server now treats self-unpair the same as unpair-anyone-else. Calls `onDeviceUnpaired(id)` after successful delete.
- `ws-server.ts`: added `closeConnectionsForDevice(deviceId)` to the `WsServer` interface + implementation. Closes any open WS owned by the deleted device with code 4401 so the WS connection doesn't outlive the device row.
- `http-server.ts`: added `onDeviceUnpaired?: (id) => void` to `HttpServerConfig`; threaded to `createPairingRouter`.
- `api/index.ts`: in `start()`, wires `onDeviceUnpaired` to a closure that calls `this.wsServer?.closeConnectionsForDevice(id)`. Lazy lookup because wsServer is created after httpServer.

**PWA:**
- `SessionList.tsx`: simplified unpair handler. Removed swallow-400 workaround + comment about it. Now: `await delete → clearAuth() → navigate('/pair')`. Updated file header comment to reflect the new behavior.

## Test plan

- [x] `bunx tsc --noEmit -p tsconfig.main.json` clean
- [x] `bunx tsc --noEmit -p tsconfig.pwa.json` clean
- [ ] Manual: self-unpair returns 200, IndexedDB cleared, PWA bounces to /pair
- [ ] Manual: WS open from device, then unpair → WS closes with 4401
- [ ] Manual: unpair OTHER device (not self) still works as before
- [ ] Manual: unpair non-existent id → 404 (unchanged)

## Stats

5 files changed, +55/-29. Single commit.

## Why land this before wave 4?

BDHLNDR-55 (session list) will touch SessionList.tsx — landing this first avoids a merge conflict on the unpair handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-67]: https://gobodhi.atlassian.net/browse/BDHLNDR-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ