### PR TITLE
BDHLNDR-55: PWA session list + WS client foundation

### DIFF
--- a/src/pwa/src/App.tsx
+++ b/src/pwa/src/App.tsx
@@ -2,13 +2,20 @@
  * Top-level route table for the mobile PWA.
  *
  * Real implementations of the placeholders land in follow-ups:
- *   - /pair                → BDHLNDR-54 (this ticket: typed pair flow)
- *   - /sessions            → BDHLNDR-55 (session list)
+ *   - /pair                → BDHLNDR-54 (typed pair flow, shipped)
+ *   - /sessions            → BDHLNDR-55 (this ticket: session list)
  *   - /sessions/:sessionId → BDHLNDR-56 (chat view consuming chat-events)
  *
  * <RequireAuth> is a wrapper component (not a layout route) so each
  * protected route can opt in individually — the more common react-router-v7
  * shape and the one that matches our flat route table.
+ *
+ * <RequireAuth> also owns the WS lifecycle (BDHLNDR-55). On mount with a
+ * valid auth row it calls `wsClient.connect()`; on unmount it does NOT
+ * disconnect (the user is navigating between protected pages, the live
+ * channel should stay warm). The explicit teardown path is the unpair
+ * button inside SessionList which calls `wsClient.disconnect()` before
+ * `clearAuth()` so the socket closes cleanly with code 1000.
  */
 
 import { useEffect, useState, type ReactElement } from 'react';
@@ -18,6 +25,7 @@ import { Pair } from './pages/Pair';
 import { SessionList } from './pages/SessionList';
 import { SessionDetail } from './pages/SessionDetail';
 import { getAuth } from './lib/auth';
+import { wsClient } from './lib/ws';
 
 export function App() {
   return (
@@ -53,6 +61,10 @@ export function App() {
  * Gate a route on having an auth row in IndexedDB. While the check is in
  * flight we render a blank shell to avoid a flash of either the protected
  * page or /pair.
+ *
+ * Side effect: kicks off the singleton WS connection once auth is
+ * confirmed. The WS client is idempotent; subsequent <RequireAuth> mounts
+ * on the same authed session are no-ops.
  */
 function RequireAuth({ children }: { children: ReactElement }): ReactElement {
   const [state, setState] = useState<'checking' | 'authed' | 'unauthed'>('checking');
@@ -61,7 +73,16 @@ function RequireAuth({ children }: { children: ReactElement }): ReactElement {
     let cancelled = false;
     getAuth().then((auth) => {
       if (cancelled) return;
-      setState(auth ? 'authed' : 'unauthed');
+      if (auth) {
+        setState('authed');
+        // Fire-and-forget. Errors surface via wsClient.onStatusChange()
+        // (the SessionList header dot) so we don't need to await here.
+        void wsClient.connect().catch(() => {
+          // intentionally swallowed — status indicator handles UX
+        });
+      } else {
+        setState('unauthed');
+      }
     });
     return () => {
       cancelled = true;

--- a/src/pwa/src/lib/api.ts
+++ b/src/pwa/src/lib/api.ts
@@ -11,6 +11,7 @@
  */
 
 import { getAuth } from './auth';
+import type { Group, Session } from './types';
 
 const API_BASE = '/api/v1';
 
@@ -81,3 +82,29 @@ export async function apiFetch<T = unknown>(
   }
   return (await res.json()) as T;
 }
+
+// ---------------------------------------------------------------------------
+// Typed REST helpers (BDHLNDR-55)
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/v1/sessions — list every session the desktop knows about.
+ *
+ * Server returns `{ sessions: Session[] }`; we unwrap so call sites can
+ * pass the array straight into React Query without dealing with the
+ * envelope. Dates arrive as ISO strings (see `./types.ts`).
+ */
+export async function fetchSessions(): Promise<Session[]> {
+  const { sessions } = await apiFetch<{ sessions: Session[] }>('/sessions');
+  return sessions;
+}
+
+/**
+ * GET /api/v1/groups — list every group. Same unwrap pattern as
+ * `fetchSessions`. Used by the session-list grouping UI.
+ */
+export async function fetchGroups(): Promise<Group[]> {
+  const { groups } = await apiFetch<{ groups: Group[] }>('/groups');
+  return groups;
+}
+

--- a/src/pwa/src/lib/types.ts
+++ b/src/pwa/src/lib/types.ts
@@ -1,0 +1,54 @@
+/**
+ * PWA-local copies of shared domain types (BDHLNDR-55).
+ *
+ * The canonical definitions live in `src/shared/types.ts`, but the PWA
+ * tsconfig pins `rootDir` to `src/pwa`, and the shared module transitively
+ * pulls in Electron types (via repositories etc.) — importing from outside
+ * `rootDir` would either fail compilation or bloat the bundle with
+ * Node/Electron-only declarations.
+ *
+ * We therefore redefine the narrow subset the PWA actually consumes over
+ * the wire (REST + WS payloads). Keep these in sync with the server-side
+ * `Session` / `Group` shapes; any new field used by the PWA needs adding
+ * here too.
+ *
+ * Note on `Date` vs `string`: the server JSON-encodes `Date` values to ISO
+ * strings, so over the wire these fields arrive as strings. We type them
+ * as `string` here to match runtime reality — the PWA doesn't need
+ * millisecond-level date math on these.
+ */
+
+export type SessionState =
+  | 'idle'
+  | 'working'
+  | 'waiting'
+  | 'error'
+  | 'stopped';
+
+export interface Session {
+  id: string;
+  groupId: string;
+  name: string;
+  workingDir: string;
+  state: SessionState;
+  shellType: string;
+  order: number;
+  createdAt: string;
+  lastActivityAt: string;
+  claudeSessionId: string | null;
+  endedAt: string | null;
+  durationSeconds: number;
+  claudeAccountId: string | null;
+}
+
+export interface Group {
+  id: string;
+  name: string;
+  color: string;
+  workingDir: string;
+  order: number;
+  createdAt: string;
+  parentId: string | null;
+  collapsed: boolean;
+  claudeAccountId: string | null;
+}

--- a/src/pwa/src/lib/ws.ts
+++ b/src/pwa/src/lib/ws.ts
@@ -1,0 +1,552 @@
+/**
+ * PWA WebSocket client (BDHLNDR-55).
+ *
+ * Singleton, app-wide WS connection to the Bodhilander desktop server.
+ * Designed to be a foundational module reused by:
+ *   - BDHLNDR-55 — session list live refresh (`sessions:updated`, `session:state`)
+ *   - BDHLNDR-56 — chat view (`chat:event` per-session subscription)
+ *   - BDHLNDR-57 — raw terminal fallback (`terminal:output` / `terminal:exit`)
+ *   - BDHLNDR-59 — offline cache replay
+ *
+ * --------------------------------------------------------------------------
+ * Wire contract (locked by BDHLNDR-60 — DO NOT change unilaterally)
+ * --------------------------------------------------------------------------
+ *  1. Open `wss://${host}/` — the desktop's HTTP server intercepts upgrades
+ *     on any path. We use the literal path `/ws` so the vite dev-server
+ *     proxy block (`/ws → ws://localhost:8443`) matches in development;
+ *     the production server ignores the path.
+ *  2. Send `{type: 'auth', token: '<bearer>'}` as the first frame within
+ *     5s, or the server closes with 4408.
+ *  3. Wait for `{type: 'connected', payload: {deviceId, canControl,
+ *     canModify}, timestamp}` ack. Until that arrives, no other frames
+ *     are emitted by the client (and the server would close 4401 if we
+ *     tried).
+ *  4. After the ack, normal message dispatch begins. Server close codes:
+ *       4401 — unauthorized (bad token, malformed frame, msg before auth)
+ *       4408 — auth timeout
+ *
+ * --------------------------------------------------------------------------
+ * Broadcast model — important distinction
+ * --------------------------------------------------------------------------
+ *   - **Global broadcasts** (no subscription required, fire after auth):
+ *       `sessions:updated`, `session:state`, `groups:updated`, `error`, `pong`
+ *   - **Session-scoped** (require explicit `terminal:subscribe`):
+ *       `terminal:output`, `terminal:exit`, `chat:event`, `terminal:subscribed`
+ *
+ *   Call `wsClient.subscribeSession(id)` to receive session-scoped frames
+ *   for a given session id. Subscriptions are remembered across reconnects
+ *   and re-issued automatically after the next `connected` ack.
+ *
+ * --------------------------------------------------------------------------
+ * Lifecycle & reconnect
+ * --------------------------------------------------------------------------
+ *   - Lazy: the first `on()`, `send()`, `subscribeSession()`, or explicit
+ *     `connect()` triggers the socket open. Status flips through
+ *     `idle → connecting → connected` on the happy path.
+ *   - Exponential backoff on unexpected close: 1s, 2s, 4s, 8s, 16s, 30s
+ *     (capped). Reset to 1s after a successful `connected` ack.
+ *   - 4401 / 4408 do NOT trigger reconnect — those mean the token is bad
+ *     or the handshake failed structurally; bouncing would just spam. The
+ *     consumer (RequireAuth in App.tsx) is expected to re-pair.
+ *   - **No idle disconnect.** The PWA is "phone in your pocket": staying
+ *     connected lets live updates (`sessions:updated`, `chat:event`) push
+ *     instantly without reconnect lag on every navigation. The cost is
+ *     one open WS per paired device — acceptable.
+ *   - On `disconnect()` (e.g. unpair) the socket closes with 1000 and no
+ *     reconnect is attempted.
+ *
+ * --------------------------------------------------------------------------
+ * Public API surface (downstream tickets BDHLNDR-56/57/59 consume this)
+ * --------------------------------------------------------------------------
+ *   interface WsClient {
+ *     readonly status: WsStatus;
+ *     onStatusChange(handler: (status: WsStatus) => void): () => void;
+ *     connect(): Promise<void>;                  // idempotent; resolves on 'connected'
+ *     disconnect(): void;                        // explicit close; no reconnect
+ *     on<T extends WsMessageType>(
+ *       type: T,
+ *       handler: (msg: ServerMessage<T>) => void,
+ *     ): () => void;                             // returns unsubscribe
+ *     send(msg: ClientMessage): void;            // queued if not yet connected
+ *     subscribeSession(sessionId: string): () => void;  // ref-counted
+ *   }
+ *   export const wsClient: WsClient
+ */
+
+import { getAuthToken } from './api';
+
+// ---------------------------------------------------------------------------
+// Wire types
+// ---------------------------------------------------------------------------
+
+/** Status of the underlying socket — surface this in UI for the dot indicator. */
+export type WsStatus =
+  | 'idle'           // never connected (or disconnect() called)
+  | 'connecting'     // socket open, awaiting `connected` ack
+  | 'connected'      // handshake complete; messages flowing
+  | 'reconnecting'   // backoff between attempts after an unexpected close
+  | 'closed';        // terminal: auth rejected or explicit disconnect()
+
+/**
+ * Discriminated union of every server → client message type the PWA might
+ * receive. Add new types here as they appear server-side (and bump the
+ * BDHLNDR ticket comment so future readers know who introduced it).
+ */
+export type ServerMessage<T extends WsMessageType = WsMessageType> = Extract<
+  AnyServerMessage,
+  { type: T }
+>;
+
+export type WsMessageType = AnyServerMessage['type'];
+
+export type AnyServerMessage =
+  | ConnectedMessage
+  | SessionsUpdatedMessage
+  | GroupsUpdatedMessage
+  | SessionStateMessage
+  | TerminalOutputMessage
+  | TerminalExitMessage
+  | TerminalSubscribedMessage
+  | ChatEventMessage
+  | ErrorMessage
+  | PongMessage;
+
+export interface ConnectedMessage {
+  type: 'connected';
+  payload: { deviceId: string; canControl: boolean; canModify: boolean };
+  timestamp: number;
+}
+
+export interface SessionsUpdatedMessage {
+  type: 'sessions:updated';
+  timestamp: number;
+}
+
+export interface GroupsUpdatedMessage {
+  type: 'groups:updated';
+  timestamp: number;
+}
+
+export interface SessionStateMessage {
+  type: 'session:state';
+  sessionId: string;
+  payload: { state: string; event?: string };
+  timestamp: number;
+}
+
+export interface TerminalOutputMessage {
+  type: 'terminal:output';
+  sessionId: string;
+  payload: { data: string };
+  timestamp: number;
+}
+
+export interface TerminalExitMessage {
+  type: 'terminal:exit';
+  sessionId: string;
+  payload: { exitCode: number };
+  timestamp: number;
+}
+
+export interface TerminalSubscribedMessage {
+  type: 'terminal:subscribed';
+  sessionId: string;
+  timestamp: number;
+}
+
+/**
+ * `chat:event` payload is intentionally typed as `unknown` here — the full
+ * shape lives in `src/main/api/chat-parser.ts` and changes more often than
+ * the PWA needs to track. Consumers (BDHLNDR-56) narrow at use-site.
+ */
+export interface ChatEventMessage {
+  type: 'chat:event';
+  sessionId: string;
+  payload: unknown;
+  timestamp: number;
+}
+
+export interface ErrorMessage {
+  type: 'error';
+  payload: { message: string };
+  timestamp: number;
+}
+
+export interface PongMessage {
+  type: 'pong';
+  payload: { clientTimestamp?: number };
+  timestamp: number;
+}
+
+/** Client → server messages. Server tolerates extra fields; keep these minimal. */
+export type ClientMessage =
+  | { type: 'ping'; timestamp: number }
+  | { type: 'terminal:subscribe'; sessionId: string }
+  | { type: 'terminal:unsubscribe'; sessionId: string }
+  | { type: 'terminal:input'; sessionId: string; payload: { data: string } }
+  | { type: 'terminal:resize'; sessionId: string; payload: { cols: number; rows: number } };
+
+// ---------------------------------------------------------------------------
+// Client interface
+// ---------------------------------------------------------------------------
+
+export interface WsClient {
+  readonly status: WsStatus;
+  /** Subscribe to status changes — useful for the connection-dot in the header. */
+  onStatusChange(handler: (status: WsStatus) => void): () => void;
+  /** Idempotent. Resolves on `connected` ack; rejects on terminal auth failure. */
+  connect(): Promise<void>;
+  /** Explicit close. No reconnect. Pending subscriptions are dropped. */
+  disconnect(): void;
+  /** Type-safe message handler. Returns an unsubscribe fn. */
+  on<T extends WsMessageType>(
+    type: T,
+    handler: (msg: ServerMessage<T>) => void,
+  ): () => void;
+  /** Queue a message — sent immediately if connected, after handshake otherwise. */
+  send(msg: ClientMessage): void;
+  /**
+   * Subscribe to session-scoped frames for `sessionId`. Ref-counted; the
+   * server-side `terminal:subscribe` fires only on the first subscriber and
+   * `terminal:unsubscribe` only when the last subscriber goes away. Returns
+   * an unsubscribe fn.
+   */
+  subscribeSession(sessionId: string): () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+const BACKOFF_SEQUENCE_MS = [1000, 2000, 4000, 8000, 16000, 30000];
+const AUTH_TIMEOUT_MS = 5000;
+
+/** Server close codes that mean "do not reconnect" — see ws-server.ts. */
+const WS_CLOSE_UNAUTHORIZED = 4401;
+const WS_CLOSE_AUTH_TIMEOUT = 4408;
+
+function createWsClient(): WsClient {
+  // ---- mutable state ------------------------------------------------------
+  let socket: WebSocket | null = null;
+  let status: WsStatus = 'idle';
+  let backoffIndex = 0;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let authTimer: ReturnType<typeof setTimeout> | null = null;
+  let connectPromise: Promise<void> | null = null;
+  let connectResolve: (() => void) | null = null;
+  let connectReject: ((err: Error) => void) | null = null;
+
+  /** Outbound queue — frames sent before `connected` flush after the ack. */
+  const sendQueue: ClientMessage[] = [];
+
+  /** Message-type → handler set. */
+  type AnyHandler = (msg: AnyServerMessage) => void;
+  const handlers = new Map<WsMessageType, Set<AnyHandler>>();
+
+  /** Status-change subscribers. */
+  const statusHandlers = new Set<(s: WsStatus) => void>();
+
+  /** Ref-counted session subscriptions. */
+  const sessionRefCounts = new Map<string, number>();
+
+  // ---- helpers ------------------------------------------------------------
+
+  function setStatus(next: WsStatus): void {
+    if (status === next) return;
+    status = next;
+    for (const h of statusHandlers) {
+      try {
+        h(next);
+      } catch (err) {
+        console.error('[ws] status handler threw', err);
+      }
+    }
+  }
+
+  function buildUrl(): string {
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    // Path `/ws` is a sentinel: the desktop accepts any upgrade path, but the
+    // vite dev-server proxy only matches `/ws`. See vite.config.ts.
+    return `${proto}//${window.location.host}/ws`;
+  }
+
+  function dispatch(msg: AnyServerMessage): void {
+    const set = handlers.get(msg.type);
+    if (!set) return;
+    for (const h of set) {
+      try {
+        h(msg);
+      } catch (err) {
+        console.error(`[ws] handler for ${msg.type} threw`, err);
+      }
+    }
+  }
+
+  function flushQueue(): void {
+    if (!socket || socket.readyState !== WebSocket.OPEN) return;
+    while (sendQueue.length > 0) {
+      const msg = sendQueue.shift()!;
+      socket.send(JSON.stringify(msg));
+    }
+  }
+
+  function clearAuthTimer(): void {
+    if (authTimer) {
+      clearTimeout(authTimer);
+      authTimer = null;
+    }
+  }
+
+  function clearReconnectTimer(): void {
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+  }
+
+  /**
+   * Re-subscribe every session we previously subscribed to. Called after the
+   * `connected` ack on a reconnect so consumers don't have to re-register.
+   */
+  function resubscribeSessions(): void {
+    for (const sessionId of sessionRefCounts.keys()) {
+      socket?.send(
+        JSON.stringify({ type: 'terminal:subscribe', sessionId } satisfies ClientMessage),
+      );
+    }
+  }
+
+  function scheduleReconnect(): void {
+    clearReconnectTimer();
+    const delay = BACKOFF_SEQUENCE_MS[Math.min(backoffIndex, BACKOFF_SEQUENCE_MS.length - 1)];
+    backoffIndex = Math.min(backoffIndex + 1, BACKOFF_SEQUENCE_MS.length - 1);
+    setStatus('reconnecting');
+    reconnectTimer = setTimeout(() => {
+      void openSocket();
+    }, delay);
+  }
+
+  async function openSocket(): Promise<void> {
+    clearReconnectTimer();
+
+    const token = await getAuthToken();
+    if (!token) {
+      // No auth — nothing to do. Caller (RequireAuth) has bounced to /pair.
+      setStatus('closed');
+      const err = new Error('No auth token available');
+      connectReject?.(err);
+      connectPromise = null;
+      connectResolve = null;
+      connectReject = null;
+      return;
+    }
+
+    setStatus('connecting');
+
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(buildUrl());
+    } catch (err) {
+      console.error('[ws] failed to open socket', err);
+      scheduleReconnect();
+      return;
+    }
+    socket = ws;
+
+    ws.onopen = () => {
+      // Step 1: send auth as the first frame.
+      ws.send(JSON.stringify({ type: 'auth', token }));
+      // Step 2: arm a guard so we don't sit forever in `connecting` if the
+      // server never acks. Server-side limit is 5s; we mirror it client-side.
+      clearAuthTimer();
+      authTimer = setTimeout(() => {
+        console.warn('[ws] auth ack timeout — closing');
+        try {
+          ws.close(1000, 'auth ack timeout');
+        } catch {
+          // swallow
+        }
+      }, AUTH_TIMEOUT_MS);
+    };
+
+    ws.onmessage = (event) => {
+      let msg: AnyServerMessage;
+      try {
+        msg = JSON.parse(event.data as string) as AnyServerMessage;
+      } catch (err) {
+        console.error('[ws] failed to parse frame', err);
+        return;
+      }
+
+      if (msg.type === 'connected') {
+        clearAuthTimer();
+        backoffIndex = 0;
+        setStatus('connected');
+        resubscribeSessions();
+        flushQueue();
+        connectResolve?.();
+        connectPromise = null;
+        connectResolve = null;
+        connectReject = null;
+      }
+
+      dispatch(msg);
+    };
+
+    ws.onerror = (event) => {
+      // Browser hides details for security; surface what we can.
+      console.warn('[ws] socket error', event);
+    };
+
+    ws.onclose = (event) => {
+      clearAuthTimer();
+      socket = null;
+
+      // Terminal: bad token or auth handshake failure — bail without retry.
+      if (event.code === WS_CLOSE_UNAUTHORIZED || event.code === WS_CLOSE_AUTH_TIMEOUT) {
+        console.warn(`[ws] terminal close ${event.code}: ${event.reason}`);
+        setStatus('closed');
+        connectReject?.(new Error(`WS closed (${event.code}): ${event.reason}`));
+        connectPromise = null;
+        connectResolve = null;
+        connectReject = null;
+        return;
+      }
+
+      // Explicit local disconnect — already in `closed`, do nothing.
+      if (status === 'closed') {
+        return;
+      }
+
+      // Anything else (network blip, server restart, etc.) → backoff & retry.
+      console.info(`[ws] close ${event.code} ${event.reason} — scheduling reconnect`);
+      scheduleReconnect();
+    };
+  }
+
+  // ---- public API ---------------------------------------------------------
+
+  const client: WsClient = {
+    get status() {
+      return status;
+    },
+
+    onStatusChange(handler) {
+      statusHandlers.add(handler);
+      // Fire once with current state so subscribers can render correctly on mount.
+      try {
+        handler(status);
+      } catch (err) {
+        console.error('[ws] initial status handler threw', err);
+      }
+      return () => {
+        statusHandlers.delete(handler);
+      };
+    },
+
+    connect() {
+      if (status === 'connected') {
+        return Promise.resolve();
+      }
+      if (connectPromise) {
+        return connectPromise;
+      }
+      connectPromise = new Promise<void>((resolve, reject) => {
+        connectResolve = resolve;
+        connectReject = reject;
+      });
+      // If we were in `closed` from an earlier disconnect, treat connect()
+      // as a fresh start.
+      if (status === 'closed') {
+        backoffIndex = 0;
+      }
+      void openSocket();
+      return connectPromise;
+    },
+
+    disconnect() {
+      clearReconnectTimer();
+      clearAuthTimer();
+      setStatus('closed');
+      sendQueue.length = 0;
+      sessionRefCounts.clear();
+      if (socket) {
+        try {
+          socket.close(1000, 'client disconnect');
+        } catch {
+          // swallow
+        }
+        socket = null;
+      }
+      if (connectReject) {
+        connectReject(new Error('disconnected'));
+      }
+      connectPromise = null;
+      connectResolve = null;
+      connectReject = null;
+    },
+
+    on(type, handler) {
+      let set = handlers.get(type);
+      if (!set) {
+        set = new Set();
+        handlers.set(type, set);
+      }
+      set.add(handler as AnyHandler);
+      // Lazy connect: first subscriber triggers the socket. Errors are
+      // swallowed here — the consumer can observe via onStatusChange().
+      if (status === 'idle' || status === 'closed') {
+        void client.connect().catch(() => {
+          // already logged inside openSocket / onclose
+        });
+      }
+      return () => {
+        set.delete(handler as AnyHandler);
+        if (set.size === 0) {
+          handlers.delete(type);
+        }
+      };
+    },
+
+    send(msg) {
+      // Always queue; flushQueue handles the "already connected" fast path.
+      sendQueue.push(msg);
+      if (status === 'idle' || status === 'closed') {
+        void client.connect().catch(() => {
+          // see on() above
+        });
+        return;
+      }
+      if (status === 'connected') {
+        flushQueue();
+      }
+      // For 'connecting' / 'reconnecting' the queue flushes on the next
+      // 'connected' ack.
+    },
+
+    subscribeSession(sessionId) {
+      const prev = sessionRefCounts.get(sessionId) ?? 0;
+      sessionRefCounts.set(sessionId, prev + 1);
+      if (prev === 0) {
+        client.send({ type: 'terminal:subscribe', sessionId });
+      }
+      return () => {
+        const current = sessionRefCounts.get(sessionId) ?? 0;
+        if (current <= 1) {
+          sessionRefCounts.delete(sessionId);
+          // Only send unsubscribe if we have a live socket — on a closed
+          // socket the server-side state is already gone.
+          if (status === 'connected') {
+            client.send({ type: 'terminal:unsubscribe', sessionId });
+          }
+        } else {
+          sessionRefCounts.set(sessionId, current - 1);
+        }
+      };
+    },
+  };
+
+  return client;
+}
+
+export const wsClient: WsClient = createWsClient();

--- a/src/pwa/src/pages/SessionList.tsx
+++ b/src/pwa/src/pages/SessionList.tsx
@@ -1,80 +1,576 @@
 /**
- * /sessions — placeholder list (real list view lands in BDHLNDR-55).
+ * /sessions — real session list view (BDHLNDR-55).
  *
- * Includes an unpair-this-device button so the pair → store → redirect flow
- * has a working "back out" path. Server delete + local IndexedDB clear are
- * symmetric: the desktop allows self-unpair (BDHLNDR-67) and closes any
- * WS owned by this device, so the PWA just awaits the delete and bounces.
+ * Architecture notes:
+ *   - React Query owns the cache for `['sessions']` and `['groups']`.
+ *   - WS `sessions:updated` / `groups:updated` invalidate the matching
+ *     query so the list refetches; `session:state` patches the cache in
+ *     place to avoid refetching the whole list on every state pill flip.
+ *   - Group collapsed state persists in localStorage so the user's layout
+ *     survives reloads (PWA stays installed across days).
+ *   - The unpair button now lives in a header overflow menu so other
+ *     pages (SessionDetail in BDHLNDR-56) can render the same menu later.
+ *
+ * Pull-to-refresh is implemented inline with touch events (~30 LOC, no
+ * new dependency). It triggers a full React Query invalidation rather
+ * than a soft refetch so we pick up any drift since the last `sessions:
+ * updated` broadcast.
  */
 
-import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { apiFetch } from '../lib/api';
+import { apiFetch, fetchGroups, fetchSessions } from '../lib/api';
 import { clearAuth, getAuth } from '../lib/auth';
+import type { Group, Session, SessionState } from '../lib/types';
+import { wsClient, type SessionStateMessage, type WsStatus } from '../lib/ws';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const COLLAPSED_GROUPS_KEY = 'bodhilander:collapsedGroups';
+const UNGROUPED_KEY = '__ungrouped__';
+const PULL_TO_REFRESH_THRESHOLD = 70; // px the user must drag past
+
+const STATE_PILL: Record<SessionState, { label: string; className: string }> = {
+  waiting: {
+    label: 'Waiting',
+    className: 'bg-amber-500/20 text-amber-300',
+  },
+  working: {
+    label: 'Working',
+    className: 'bg-blue-500/20 text-blue-300',
+  },
+  idle: {
+    label: 'Idle',
+    className: 'bg-neutral-700/40 text-neutral-300',
+  },
+  error: {
+    label: 'Error',
+    className: 'bg-red-500/20 text-red-300',
+  },
+  stopped: {
+    label: 'Stopped',
+    className: 'bg-neutral-800 text-neutral-500',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 export function SessionList() {
   const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const sessionsQuery = useQuery({
+    queryKey: ['sessions'],
+    queryFn: fetchSessions,
+  });
+  const groupsQuery = useQuery({
+    queryKey: ['groups'],
+    queryFn: fetchGroups,
+  });
+
+  // ---- WS live updates -------------------------------------------------
+  useEffect(() => {
+    const unsubSessionsUpdated = wsClient.on('sessions:updated', () => {
+      void qc.invalidateQueries({ queryKey: ['sessions'] });
+    });
+    const unsubGroupsUpdated = wsClient.on('groups:updated', () => {
+      void qc.invalidateQueries({ queryKey: ['groups'] });
+    });
+
+    // session:state — surgical patch. Avoids a full list refetch every time
+    // a single session flips between waiting/working/idle (which can happen
+    // many times per second during an active turn).
+    const unsubSessionState = wsClient.on(
+      'session:state',
+      (msg: SessionStateMessage) => {
+        qc.setQueryData<Session[] | undefined>(['sessions'], (prev) => {
+          if (!prev) return prev;
+          const nextState = msg.payload.state as SessionState;
+          let changed = false;
+          const next = prev.map((s) => {
+            if (s.id !== msg.sessionId) return s;
+            if (s.state === nextState) return s;
+            changed = true;
+            return { ...s, state: nextState };
+          });
+          return changed ? next : prev;
+        });
+      },
+    );
+
+    return () => {
+      unsubSessionsUpdated();
+      unsubGroupsUpdated();
+      unsubSessionState();
+    };
+  }, [qc]);
+
+  // ---- WS status (for the dot) ----------------------------------------
+  const [wsStatus, setWsStatus] = useState<WsStatus>(wsClient.status);
+  useEffect(() => wsClient.onStatusChange(setWsStatus), []);
+
+  // ---- Collapsed-group persistence ------------------------------------
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => {
+    try {
+      const raw = localStorage.getItem(COLLAPSED_GROUPS_KEY);
+      if (!raw) return new Set();
+      const parsed = JSON.parse(raw) as unknown;
+      if (Array.isArray(parsed)) return new Set(parsed as string[]);
+      return new Set();
+    } catch {
+      return new Set();
+    }
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        COLLAPSED_GROUPS_KEY,
+        JSON.stringify(Array.from(collapsed)),
+      );
+    } catch {
+      // localStorage can throw in private-browsing — non-fatal.
+    }
+  }, [collapsed]);
+  const toggleCollapsed = useCallback((groupId: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+  }, []);
+
+  // ---- Group sessions --------------------------------------------------
+  const grouped = useMemo(
+    () => groupSessions(sessionsQuery.data ?? [], groupsQuery.data ?? []),
+    [sessionsQuery.data, groupsQuery.data],
+  );
+
+  // ---- Pull-to-refresh ------------------------------------------------
+  const containerRef = useRef<HTMLDivElement>(null);
+  const pullStateRef = useRef<{ startY: number; pulling: boolean }>({
+    startY: 0,
+    pulling: false,
+  });
+  const [pullOffset, setPullOffset] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const onTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    // Only engage when scrolled to the very top — otherwise we're competing
+    // with native scroll which is jankier than just yielding.
+    if ((containerRef.current?.scrollTop ?? 0) > 0) return;
+    pullStateRef.current = { startY: e.touches[0].clientY, pulling: true };
+  };
+  const onTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+    if (!pullStateRef.current.pulling) return;
+    const delta = e.touches[0].clientY - pullStateRef.current.startY;
+    if (delta <= 0) {
+      setPullOffset(0);
+      return;
+    }
+    // Apply a rubber-band so the indicator feels weighted past the threshold.
+    setPullOffset(Math.min(delta * 0.5, PULL_TO_REFRESH_THRESHOLD * 1.5));
+  };
+  const onTouchEnd = async () => {
+    if (!pullStateRef.current.pulling) return;
+    pullStateRef.current.pulling = false;
+    const triggered = pullOffset >= PULL_TO_REFRESH_THRESHOLD;
+    setPullOffset(0);
+    if (!triggered) return;
+    setRefreshing(true);
+    try {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['sessions'] }),
+        qc.invalidateQueries({ queryKey: ['groups'] }),
+      ]);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  // ---- Unpair ---------------------------------------------------------
+  const [menuOpen, setMenuOpen] = useState(false);
   const [unpairing, setUnpairing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [unpairError, setUnpairError] = useState<string | null>(null);
 
   async function handleUnpair() {
-    setError(null);
+    setMenuOpen(false);
+    setUnpairError(null);
     setUnpairing(true);
     try {
       const auth = await getAuth();
       if (!auth) {
-        // Nothing to unpair — just bounce.
         navigate('/pair', { replace: true });
         return;
       }
-
       await apiFetch(`/pairing/devices/${encodeURIComponent(auth.device.id)}`, {
         method: 'DELETE',
       });
-
+      // Close the WS BEFORE clearing auth so the server sees a clean 1000.
+      wsClient.disconnect();
       await clearAuth();
       navigate('/pair', { replace: true });
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setUnpairError(err instanceof Error ? err.message : String(err));
     } finally {
       setUnpairing(false);
     }
   }
 
+  // ---- Render ---------------------------------------------------------
   return (
-    <main className="mx-auto max-w-md p-4">
-      <nav className="mb-4 text-sm text-neutral-400">
-        <span className="text-neutral-200">Sessions</span>
-      </nav>
-      <h1 className="text-2xl font-semibold">Sessions</h1>
-      <p className="mt-2 text-neutral-300">
-        Session list lands in BDHLNDR-55.
-      </p>
-      <div className="mt-6 space-y-2 text-sm">
-        <Link
-          to="/sessions/example"
-          className="block rounded-md bg-neutral-800 px-4 py-2 hover:bg-neutral-700"
+    <main
+      ref={containerRef}
+      onTouchStart={onTouchStart}
+      onTouchMove={onTouchMove}
+      onTouchEnd={onTouchEnd}
+      className="mx-auto min-h-screen max-w-md overflow-y-auto"
+    >
+      {/* Pull-to-refresh indicator */}
+      {(pullOffset > 0 || refreshing) && (
+        <div
+          className="flex items-center justify-center text-xs text-neutral-500"
+          style={{ height: refreshing ? PULL_TO_REFRESH_THRESHOLD : pullOffset }}
         >
-          Open example session
-        </Link>
-      </div>
+          {refreshing
+            ? 'Refreshing…'
+            : pullOffset >= PULL_TO_REFRESH_THRESHOLD
+              ? 'Release to refresh'
+              : 'Pull to refresh'}
+        </div>
+      )}
 
-      <div className="mt-8 border-t border-neutral-800 pt-4">
-        <button
-          type="button"
-          onClick={handleUnpair}
-          disabled={unpairing}
-          className="w-full rounded-md border border-red-700/60 bg-red-900/20 px-4 py-2 text-sm text-red-200 transition-colors hover:bg-red-900/40 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {unpairing ? 'Unpairing…' : 'Unpair this device'}
-        </button>
-        {error && (
-          <p role="alert" className="mt-2 text-xs text-red-300">
-            {error}
-          </p>
+      <header className="sticky top-0 z-10 flex items-center justify-between border-b border-neutral-800 bg-neutral-900/95 px-4 py-3 backdrop-blur">
+        <div className="flex items-center gap-2">
+          <h1 className="text-lg font-semibold">Sessions</h1>
+          <ConnectionDot status={wsStatus} />
+        </div>
+        <OverflowMenu
+          open={menuOpen}
+          onOpenChange={setMenuOpen}
+          items={[
+            {
+              label: unpairing ? 'Unpairing…' : 'Unpair this device',
+              onSelect: handleUnpair,
+              disabled: unpairing,
+              danger: true,
+            },
+          ]}
+        />
+      </header>
+
+      {unpairError && (
+        <p role="alert" className="px-4 pt-2 text-xs text-red-300">
+          {unpairError}
+        </p>
+      )}
+
+      <div className="p-4">
+        {sessionsQuery.isLoading || groupsQuery.isLoading ? (
+          <SessionListSkeleton />
+        ) : sessionsQuery.isError ? (
+          <ErrorState
+            message={
+              sessionsQuery.error instanceof Error
+                ? sessionsQuery.error.message
+                : 'Failed to load sessions'
+            }
+            onRetry={() => {
+              void sessionsQuery.refetch();
+              void groupsQuery.refetch();
+            }}
+          />
+        ) : grouped.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <div className="space-y-4">
+            {grouped.map((g) => (
+              <GroupBlock
+                key={g.group?.id ?? UNGROUPED_KEY}
+                group={g.group}
+                sessions={g.sessions}
+                collapsed={collapsed.has(g.group?.id ?? UNGROUPED_KEY)}
+                onToggle={() =>
+                  toggleCollapsed(g.group?.id ?? UNGROUPED_KEY)
+                }
+                onOpen={(id) => navigate(`/sessions/${id}`)}
+              />
+            ))}
+          </div>
         )}
       </div>
     </main>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pieces
+// ---------------------------------------------------------------------------
+
+interface GroupedRow {
+  /** null for sessions whose groupId doesn't match any known group. */
+  group: Group | null;
+  sessions: Session[];
+}
+
+/**
+ * Bucket sessions by their `groupId`, ordered by group `order` then session
+ * `order`. Sessions referencing an unknown group fall into a single
+ * "Ungrouped" bucket rendered last so they're not lost.
+ */
+function groupSessions(sessions: Session[], groups: Group[]): GroupedRow[] {
+  const groupsById = new Map(groups.map((g) => [g.id, g]));
+  const buckets = new Map<string, Session[]>();
+  for (const s of sessions) {
+    const key = groupsById.has(s.groupId) ? s.groupId : UNGROUPED_KEY;
+    const list = buckets.get(key) ?? [];
+    list.push(s);
+    buckets.set(key, list);
+  }
+
+  const rows: GroupedRow[] = [];
+  // Known groups in their declared order.
+  const orderedGroups = [...groups].sort((a, b) => a.order - b.order);
+  for (const g of orderedGroups) {
+    const list = buckets.get(g.id);
+    if (!list || list.length === 0) continue;
+    rows.push({ group: g, sessions: list.sort((a, b) => a.order - b.order) });
+  }
+  // Ungrouped last.
+  const orphans = buckets.get(UNGROUPED_KEY);
+  if (orphans && orphans.length > 0) {
+    rows.push({ group: null, sessions: orphans.sort((a, b) => a.order - b.order) });
+  }
+  return rows;
+}
+
+function GroupBlock({
+  group,
+  sessions,
+  collapsed,
+  onToggle,
+  onOpen,
+}: {
+  group: Group | null;
+  sessions: Session[];
+  collapsed: boolean;
+  onToggle: () => void;
+  onOpen: (id: string) => void;
+}) {
+  const label = group?.name ?? 'Ungrouped';
+  const color = group?.color ?? '#525252';
+
+  return (
+    <section>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center justify-between rounded-md px-1 py-1 text-left text-sm text-neutral-300 hover:bg-neutral-800/40"
+        aria-expanded={!collapsed}
+      >
+        <span className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className="inline-block h-2.5 w-2.5 rounded-full"
+            style={{ backgroundColor: color }}
+          />
+          <span className="font-medium">{label}</span>
+          <span className="text-xs text-neutral-500">{sessions.length}</span>
+        </span>
+        <span
+          aria-hidden
+          className={`transition-transform ${collapsed ? '' : 'rotate-90'}`}
+        >
+          ›
+        </span>
+      </button>
+      {!collapsed && (
+        <ul className="mt-2 space-y-1.5">
+          {sessions.map((s) => (
+            <li key={s.id}>
+              <SessionRow session={s} onOpen={onOpen} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function SessionRow({
+  session,
+  onOpen,
+}: {
+  session: Session;
+  onOpen: (id: string) => void;
+}) {
+  const pill = STATE_PILL[session.state] ?? STATE_PILL.idle;
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(session.id)}
+      className="flex w-full items-center justify-between gap-3 rounded-md border border-neutral-800 bg-neutral-900 px-3 py-2.5 text-left transition-colors hover:bg-neutral-800/60 active:bg-neutral-800"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-neutral-100">
+          {session.name || '(unnamed)'}
+        </div>
+        <div className="mt-0.5 truncate text-xs text-neutral-500">
+          {session.workingDir}
+        </div>
+      </div>
+      <span
+        className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${pill.className}`}
+      >
+        {pill.label}
+      </span>
+    </button>
+  );
+}
+
+function ConnectionDot({ status }: { status: WsStatus }) {
+  const tone =
+    status === 'connected'
+      ? { color: 'bg-emerald-500', label: 'Connected' }
+      : status === 'connecting' || status === 'reconnecting'
+        ? { color: 'bg-amber-400 animate-pulse', label: 'Reconnecting' }
+        : { color: 'bg-red-500', label: 'Disconnected' };
+  return (
+    <span
+      role="status"
+      aria-label={tone.label}
+      title={tone.label}
+      className={`inline-block h-2 w-2 rounded-full ${tone.color}`}
+    />
+  );
+}
+
+interface MenuItem {
+  label: string;
+  onSelect: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+}
+
+/**
+ * Tiny 3-dot overflow menu. Inline rather than a standalone component
+ * because right now SessionList is the only consumer; when SessionDetail
+ * (BDHLNDR-56) needs the same menu we'll lift it to
+ * `src/pwa/src/components/OverflowMenu.tsx` and parameterize the items.
+ */
+function OverflowMenu({
+  open,
+  onOpenChange,
+  items,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  items: MenuItem[];
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) onOpenChange(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open, onOpenChange]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        aria-label="Open menu"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => onOpenChange(!open)}
+        className="flex h-9 w-9 items-center justify-center rounded-md text-neutral-300 hover:bg-neutral-800"
+      >
+        <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor" aria-hidden>
+          <circle cx="12" cy="5" r="1.6" />
+          <circle cx="12" cy="12" r="1.6" />
+          <circle cx="12" cy="19" r="1.6" />
+        </svg>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-20 mt-1 w-48 overflow-hidden rounded-md border border-neutral-800 bg-neutral-900 shadow-lg"
+        >
+          {items.map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              role="menuitem"
+              disabled={item.disabled}
+              onClick={item.onSelect}
+              className={`block w-full px-3 py-2 text-left text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                item.danger
+                  ? 'text-red-300 hover:bg-red-900/30'
+                  : 'text-neutral-200 hover:bg-neutral-800'
+              }`}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SessionListSkeleton() {
+  return (
+    <div className="space-y-3" aria-hidden>
+      {[0, 1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="h-14 animate-pulse rounded-md border border-neutral-800 bg-neutral-900"
+        />
+      ))}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-md border border-dashed border-neutral-800 p-6 text-center">
+      <p className="text-sm font-medium text-neutral-200">No sessions yet</p>
+      <p className="mt-1 text-xs text-neutral-500">
+        Create a session in the Bodhilander desktop app — it&apos;ll show up
+        here automatically.
+      </p>
+    </div>
+  );
+}
+
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="rounded-md border border-red-900/60 bg-red-950/30 p-4">
+      <p className="text-sm text-red-200">Couldn&apos;t load sessions.</p>
+      <p className="mt-1 text-xs text-red-300/80">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-3 rounded-md border border-red-800 bg-red-900/40 px-3 py-1 text-xs text-red-100 hover:bg-red-900/60"
+      >
+        Try again
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Replaces `/sessions` placeholder with the real session list — fetches sessions + groups, renders grouped state pills, live updates via WS. **Introduces `src/pwa/src/lib/ws.ts`** — the foundational WS client module that BDHLNDR-56 (chat view), BDHLNDR-57 (raw fallback), and BDHLNDR-59 (offline) will all consume.

**Closes:** [BDHLNDR-55](https://gobodhi.atlassian.net/browse/BDHLNDR-55) · Parent Epic: [BDHLNDR-50](https://gobodhi.atlassian.net/browse/BDHLNDR-50)

## Commits

- `50ec90b` WS client + typed REST helpers for PWA
- `5b51a69` real session list view with live updates

## WsClient contract (downstream consumers — DO NOT BREAK)

```ts
interface WsClient {
  readonly status: WsStatus;
  onStatusChange(handler: (status: WsStatus) => void): () => void;
  connect(): Promise<void>;                              // idempotent; resolves on 'connected' ack
  disconnect(): void;                                    // explicit close, no reconnect
  on<T extends WsMessageType>(
    type: T,
    handler: (msg: ServerMessage<T>) => void,
  ): () => void;                                         // returns unsubscribe
  send(msg: ClientMessage): void;                        // queued if not yet connected
  subscribeSession(sessionId: string): () => void;       // ref-counted; auto re-issued on reconnect
}
type WsStatus = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'closed';
export const wsClient: WsClient
```

`ServerMessage` discriminated union: `connected`, `sessions:updated`, `groups:updated`, `session:state`, `terminal:output`, `terminal:exit`, `terminal:subscribed`, `chat:event`, `error`, `pong`.
`ClientMessage`: `ping`, `terminal:subscribe`/`unsubscribe`, `terminal:input`, `terminal:resize`.

## Files

- **Added:** `src/pwa/src/lib/ws.ts`, `src/pwa/src/lib/types.ts` (narrow PWA-local Session/Group/SessionState — does NOT import from main's `src/shared/types.ts` to avoid pulling Electron deps into the PWA bundle)
- **Modified:** `src/pwa/src/lib/api.ts` (added `fetchSessions()` / `fetchGroups()`), `src/pwa/src/App.tsx` (`wsClient.connect()` inside `<RequireAuth>`), `src/pwa/src/pages/SessionList.tsx` (full rewrite)

## Decisions

- **Dev proxy kept.** WS opens to path `/ws` so existing `vite.config.ts` proxy matches in dev; production accepts any upgrade path.
- **No idle disconnect.** Phone-in-pocket wants instant live updates.
- **WS lifecycle: hybrid.** `<RequireAuth>` connects on mount; `ws.ts` lazy-connects on first `on()`/`send()`/`subscribeSession()`. Unpair is the only explicit teardown.
- **Pull-to-refresh:** inline ~30 LOC touch handler with rubber-band — no new dep.
- **Connection-status indicator:** small dot in sticky header. Green/amber-pulse/red.
- **Overflow menu:** inline in `SessionList.tsx` for now, with extraction TODO to `src/pwa/src/components/OverflowMenu.tsx` for BDHLNDR-56 reuse.

## Test plan

- [x] `bunx tsc --noEmit -p tsconfig.pwa.json` clean
- [x] `bun run build:pwa` succeeds — 287.31 kB JS / 82.40 kB gz (+19.15 raw / +6.20 gz vs prior), 18.28 kB CSS / 3.46 kB gz (+8.27 raw / +1.42 gz), precache 304 KiB / 12 entries
- [ ] Manual: paired phone visits `/sessions`, sees grouped sessions with live state
- [ ] Manual: kill a session on desktop → mobile state pill updates in <1s without refresh
- [ ] Manual: WS disconnect (e.g., desktop restart) → reconnect indicator shows + recovers

## Flagged

- `groups:updated` WS message added to discriminated union — server emits it (`api/index.ts:255`) but wasn't in the original ticket spec
- `chat:event` payload typed as `unknown`; BDHLNDR-56 will narrow at use site (chat-parser types stay in `src/main` to avoid PWA bloat)
- Pull-to-refresh may compete with iOS Safari standalone PWA native overscroll on some devices — acceptable for v1

## Coordination

- BDHLNDR-61 also touches `App.tsx` (mounts `<InstallPrompt />` after `</Routes>` at line 53). Different scope from this PR's `<RequireAuth>` change — merge should be clean.
- BDHLNDR-14 only touches `Pair.tsx` + `package.json` (qr-scanner dep). No overlap.

Built by a parallel subagent alongside BDHLNDR-61 and BDHLNDR-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-55]: https://gobodhi.atlassian.net/browse/BDHLNDR-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-50]: https://gobodhi.atlassian.net/browse/BDHLNDR-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ