### PR TITLE
BDHLNDR-61: iOS install prompt + Android beforeinstallprompt primer

### DIFF
--- a/src/pwa/src/App.tsx
+++ b/src/pwa/src/App.tsx
@@ -17,6 +17,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import { Pair } from './pages/Pair';
 import { SessionList } from './pages/SessionList';
 import { SessionDetail } from './pages/SessionDetail';
+import { InstallPrompt } from './components/InstallPrompt';
 import { getAuth } from './lib/auth';
 
 export function App() {
@@ -45,6 +46,11 @@ export function App() {
             from the desktop never lands on a blank screen. */}
         <Route path="*" element={<Navigate to="/sessions" replace />} />
       </Routes>
+      {/* BDHLNDR-61: always-mounted install walkthrough. Self-gates on
+          platform + standalone state + paired_at; renders nothing until
+          conditions are met. Placed as a <Routes> sibling so it stays up
+          across navigation. */}
+      <InstallPrompt />
     </div>
   );
 }

--- a/src/pwa/src/components/InstallPrompt.tsx
+++ b/src/pwa/src/components/InstallPrompt.tsx
@@ -1,0 +1,437 @@
+/**
+ * <InstallPrompt /> — first-pair install walkthrough (BDHLNDR-61).
+ *
+ * Mounted as an always-on sibling of <Routes> in App.tsx. Renders nothing
+ * until the user has successfully paired (BDHLNDR-54 wrote `paired_at`),
+ * then shows a platform-specific modal:
+ *
+ *   - iOS Safari: full-screen "Add to Home Screen" walkthrough with
+ *     inline SVG step icons. Safari doesn't expose a programmatic install
+ *     API so we have to teach the user the manual gesture; this is the
+ *     only path to working Web Push on iOS (BDHLNDR-49).
+ *
+ *   - Android Chrome: a one-screen primer that, on tap, fires the
+ *     captured `beforeinstallprompt` event. We *don't* fire it as soon as
+ *     Chrome offers it — Chrome's mini-infobar is way out of context and
+ *     gets dismissed reflexively. Showing it right after pair, framed
+ *     around notifications, gets far better acceptance.
+ *
+ * On install (detected via `appinstalled` event OR display-mode change),
+ * we show a one-time toast confirming push will work, then mark
+ * `installed_at` so the prompt never re-appears.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { getAuth } from '../lib/auth';
+import { detectPlatform, type Platform } from '../lib/platform';
+import {
+  isStandalone,
+  markDismissed,
+  markInstalled,
+  markShown,
+  shouldShowPrompt,
+} from '../lib/install-prompt';
+
+/**
+ * The `beforeinstallprompt` event isn't in the standard lib.dom types yet
+ * (Chrome-only API). Minimal local shim covering what we actually call.
+ */
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: ReadonlyArray<string>;
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+  prompt(): Promise<void>;
+}
+
+type Mode = 'hidden' | 'ios' | 'android' | 'installed-toast';
+
+export function InstallPrompt() {
+  const [mode, setMode] = useState<Mode>('hidden');
+  const [platform] = useState<Platform>(() => detectPlatform());
+  const deferredPromptRef = useRef<BeforeInstallPromptEvent | null>(null);
+
+  // Re-evaluate the gating condition. Called on mount, when auth changes
+  // (best-effort: focus/visibility), and after the user pairs.
+  const reevaluate = useCallback(async () => {
+    const auth = await getAuth();
+    const show = await shouldShowPrompt(auth?.paired_at ?? null);
+    if (!show) {
+      setMode((m) => (m === 'installed-toast' ? m : 'hidden'));
+      return;
+    }
+    if (platform === 'ios') {
+      setMode('ios');
+      void markShown();
+    } else if (platform === 'android') {
+      // Don't surface the Android modal until we've actually captured a
+      // `beforeinstallprompt` event — otherwise tapping "Install" does
+      // nothing. If the event hasn't fired yet, wait for it (handled by
+      // the listener below, which calls reevaluate() again).
+      if (deferredPromptRef.current) {
+        setMode('android');
+        void markShown();
+      }
+    }
+  }, [platform]);
+
+  // Capture `beforeinstallprompt` so we can fire it on user gesture.
+  // Chrome dispatches this once, eagerly; we must call preventDefault to
+  // stop the mini-infobar and stash the event for later.
+  useEffect(() => {
+    function onBeforeInstallPrompt(e: Event) {
+      e.preventDefault();
+      deferredPromptRef.current = e as BeforeInstallPromptEvent;
+      // If gating already wanted us to show but we were waiting for the
+      // event, this is our cue.
+      void reevaluate();
+    }
+    function onAppInstalled() {
+      deferredPromptRef.current = null;
+      void markInstalled();
+      setMode('installed-toast');
+    }
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+    window.addEventListener('appinstalled', onAppInstalled);
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', onAppInstalled);
+    };
+  }, [reevaluate]);
+
+  // Watch the standalone media query — on iOS there's no `appinstalled`
+  // event, the only signal we get is the next launch happening in
+  // standalone mode. We still want to fire the toast that first time.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(display-mode: standalone)');
+    function onChange(e: MediaQueryListEvent) {
+      if (e.matches) {
+        void markInstalled();
+        setMode('installed-toast');
+      }
+    }
+    mq.addEventListener?.('change', onChange);
+    return () => {
+      mq.removeEventListener?.('change', onChange);
+    };
+  }, []);
+
+  // Initial gating check + re-check when the user returns to the tab.
+  // The latter catches the common case of pairing in another tab / via
+  // the desktop and then switching back here.
+  useEffect(() => {
+    void reevaluate();
+    function onVisibility() {
+      if (document.visibilityState === 'visible') void reevaluate();
+    }
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('focus', onVisibility);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('focus', onVisibility);
+    };
+  }, [reevaluate]);
+
+  // If we became standalone between reads (e.g. user installed via
+  // browser menu while a modal was up), hide the modal proactively.
+  useEffect(() => {
+    if (mode === 'ios' || mode === 'android') {
+      if (isStandalone()) setMode('installed-toast');
+    }
+  }, [mode]);
+
+  const handleDismiss = useCallback(async () => {
+    await markDismissed();
+    setMode('hidden');
+  }, []);
+
+  const handleIosGotIt = useCallback(() => {
+    // "Got it" acknowledges the walkthrough without snoozing — we already
+    // called markShown() when we opened the modal, so just close.
+    setMode('hidden');
+  }, []);
+
+  const handleAndroidInstall = useCallback(async () => {
+    const ev = deferredPromptRef.current;
+    if (!ev) {
+      // Shouldn't happen — we only surface the Android modal once the
+      // event is captured. Belt-and-braces: dismiss so the user isn't
+      // stuck looking at a no-op button.
+      await markDismissed();
+      setMode('hidden');
+      return;
+    }
+    try {
+      await ev.prompt();
+      const choice = await ev.userChoice;
+      deferredPromptRef.current = null;
+      if (choice.outcome === 'accepted') {
+        // `appinstalled` will fire and handle the toast + markInstalled.
+        setMode('hidden');
+      } else {
+        await markDismissed();
+        setMode('hidden');
+      }
+    } catch (err) {
+      console.error('[InstallPrompt] beforeinstallprompt.prompt() failed:', err);
+      setMode('hidden');
+    }
+  }, []);
+
+  // Auto-hide the success toast after a few seconds. Cheap and non-modal.
+  useEffect(() => {
+    if (mode !== 'installed-toast') return;
+    const t = window.setTimeout(() => setMode('hidden'), 5000);
+    return () => window.clearTimeout(t);
+  }, [mode]);
+
+  if (mode === 'hidden') return null;
+
+  if (mode === 'installed-toast') {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="pointer-events-none fixed inset-x-0 bottom-4 z-50 flex justify-center px-4"
+      >
+        <div className="pointer-events-auto max-w-sm rounded-lg border border-emerald-700/60 bg-emerald-900/90 px-4 py-3 text-sm text-emerald-100 shadow-lg backdrop-blur">
+          Bodhilander installed — push notifications will work now.
+        </div>
+      </div>
+    );
+  }
+
+  if (mode === 'ios') {
+    return <IosWalkthrough onDismiss={handleDismiss} onGotIt={handleIosGotIt} />;
+  }
+
+  // android
+  return <AndroidPrimer onDismiss={handleDismiss} onInstall={handleAndroidInstall} />;
+}
+
+// --------------------------------------------------------------------------
+// iOS walkthrough
+// --------------------------------------------------------------------------
+
+interface IosProps {
+  onDismiss: () => void;
+  onGotIt: () => void;
+}
+
+function IosWalkthrough({ onDismiss, onGotIt }: IosProps) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="install-prompt-title"
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/70 p-4 sm:items-center"
+    >
+      <div className="w-full max-w-md rounded-2xl bg-neutral-900 p-6 shadow-2xl ring-1 ring-white/10">
+        <h2 id="install-prompt-title" className="text-xl font-semibold text-neutral-50">
+          Install Bodhilander on your home screen
+        </h2>
+        <p className="mt-1 text-sm text-neutral-400">
+          Required for push notifications when Claude needs your input.
+        </p>
+
+        <ol className="mt-5 space-y-4">
+          <Step
+            number={1}
+            icon={<ShareIcon />}
+            text={
+              <>
+                Tap the <span className="font-medium text-neutral-100">Share</span> button at
+                the bottom of Safari.
+              </>
+            }
+          />
+          <Step
+            number={2}
+            icon={<AddIcon />}
+            text={
+              <>
+                Scroll and tap{' '}
+                <span className="font-medium text-neutral-100">Add to Home Screen</span>.
+              </>
+            }
+          />
+          <Step
+            number={3}
+            icon={<TapIcon />}
+            text={
+              <>
+                Tap <span className="font-medium text-neutral-100">Add</span> in the top-right
+                corner.
+              </>
+            }
+          />
+        </ol>
+
+        <div className="mt-6 flex flex-col gap-2 sm:flex-row-reverse">
+          <button
+            type="button"
+            onClick={onGotIt}
+            className="rounded-md bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+          >
+            Got it
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded-md border border-neutral-700 bg-transparent px-4 py-2.5 text-sm font-medium text-neutral-200 transition-colors hover:bg-neutral-800"
+          >
+            Maybe later
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Step({
+  number,
+  icon,
+  text,
+}: {
+  number: number;
+  icon: React.ReactNode;
+  text: React.ReactNode;
+}) {
+  return (
+    <li className="flex items-start gap-3">
+      <span
+        aria-hidden
+        className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-800 text-xs font-semibold text-neutral-300"
+      >
+        {number}
+      </span>
+      <div className="flex-1 text-sm text-neutral-200">
+        <p>{text}</p>
+      </div>
+      <span aria-hidden className="mt-0.5 text-neutral-400">
+        {icon}
+      </span>
+    </li>
+  );
+}
+
+// --------------------------------------------------------------------------
+// Inline SVG icons (matching Apple's iOS share / add affordances closely
+// enough to be recognizable, without shipping their proprietary glyphs).
+// All 24x24, `currentColor`-based so they inherit Tailwind text color.
+// --------------------------------------------------------------------------
+
+function ShareIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label="Share"
+    >
+      {/* Up arrow */}
+      <path d="M12 3v13" />
+      <path d="M7 8l5-5 5 5" />
+      {/* Box bottom */}
+      <path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-7" />
+    </svg>
+  );
+}
+
+function AddIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label="Add"
+    >
+      <rect x="3" y="3" width="18" height="18" rx="4" />
+      <path d="M12 8v8" />
+      <path d="M8 12h8" />
+    </svg>
+  );
+}
+
+function TapIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label="Tap"
+    >
+      {/* Finger tap glyph: small circle inside ripple */}
+      <circle cx="12" cy="12" r="3" />
+      <path d="M12 5V3" />
+      <path d="M12 21v-2" />
+      <path d="M5 12H3" />
+      <path d="M21 12h-2" />
+      <path d="M6.34 6.34 4.93 4.93" />
+      <path d="M19.07 19.07l-1.41-1.41" />
+    </svg>
+  );
+}
+
+// --------------------------------------------------------------------------
+// Android primer
+// --------------------------------------------------------------------------
+
+interface AndroidProps {
+  onDismiss: () => void;
+  onInstall: () => void;
+}
+
+function AndroidPrimer({ onDismiss, onInstall }: AndroidProps) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="install-prompt-title"
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/70 p-4 sm:items-center"
+    >
+      <div className="w-full max-w-md rounded-2xl bg-neutral-900 p-6 shadow-2xl ring-1 ring-white/10">
+        <h2 id="install-prompt-title" className="text-xl font-semibold text-neutral-50">
+          Install Bodhilander
+        </h2>
+        <p className="mt-2 text-sm text-neutral-300">
+          Add Bodhilander to your home screen for faster access and notifications.
+        </p>
+        <div className="mt-6 flex flex-col gap-2 sm:flex-row-reverse">
+          <button
+            type="button"
+            onClick={onInstall}
+            className="rounded-md bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+          >
+            Install
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded-md border border-neutral-700 bg-transparent px-4 py-2.5 text-sm font-medium text-neutral-200 transition-colors hover:bg-neutral-800"
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pwa/src/lib/auth.ts
+++ b/src/pwa/src/lib/auth.ts
@@ -19,7 +19,13 @@
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
 
 const DB_NAME = 'bodhilander';
-const DB_VERSION = 1;
+// BDHLNDR-61: bumped 1 → 2 to add the `install_prompt` store. The schema
+// change itself is owned by `install-prompt.ts` (this file's upgrade callback
+// only creates the `auth` store at v1); the version number just has to agree
+// across every module that opens the DB, otherwise the second `openDB` call
+// throws a `VersionError`. If you bump again, mirror the new version in
+// `install-prompt.ts:DB_VERSION`.
+const DB_VERSION = 2;
 const STORE_NAME = 'auth';
 const ROW_ID = 'current';
 

--- a/src/pwa/src/lib/install-prompt.ts
+++ b/src/pwa/src/lib/install-prompt.ts
@@ -20,6 +20,8 @@
 
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
 
+import { detectPlatform } from './platform';
+
 const DB_NAME = 'bodhilander';
 /**
  * v2 = added `install_prompt` store (BDHLNDR-61).
@@ -193,9 +195,6 @@ export async function shouldShowPrompt(pairedAt: number | null): Promise<boolean
   if (isStandalone()) return false;
   if (!isTouchDevice()) return false;
 
-  // Lazy-import to avoid pulling platform.ts into modules that don't need
-  // it — and to keep the gating logic self-contained.
-  const { detectPlatform } = await import('./platform');
   const platform = detectPlatform();
   if (platform !== 'ios' && platform !== 'android') return false;
 

--- a/src/pwa/src/lib/install-prompt.ts
+++ b/src/pwa/src/lib/install-prompt.ts
@@ -1,0 +1,223 @@
+/**
+ * Install-prompt state store + gating logic for the mobile PWA (BDHLNDR-61).
+ *
+ * iOS Web Push (BDHLNDR-49) only works for PWAs *installed* to the home
+ * screen — Safari refuses to register push for ordinary tabs. Android Chrome
+ * is more forgiving but installing still significantly improves UX
+ * (full-screen, persistent notifications, faster launch).
+ *
+ * After a successful first pair (BDHLNDR-54 wrote a `paired_at` timestamp
+ * into the auth row), we show a platform-specific walkthrough. The user can
+ * dismiss it; we snooze for 7 days. Once the PWA is actually installed
+ * (detected via `display-mode: standalone` matching or the `appinstalled`
+ * event), we mark `installed_at` and never show again.
+ *
+ * State lives in IndexedDB so it survives reloads. We share the existing
+ * `bodhilander` database created by `auth.ts` — this module is responsible
+ * for bumping the schema to v2 (adding the `install_prompt` store). The
+ * `auth` store created at v1 is left untouched.
+ */
+
+import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
+
+const DB_NAME = 'bodhilander';
+/**
+ * v2 = added `install_prompt` store (BDHLNDR-61).
+ * v1 = `auth` store (BDHLNDR-54).
+ *
+ * If you bump this further, mirror the new version in `auth.ts:DB_VERSION`
+ * — both modules must agree on which version they're opening at, otherwise
+ * one of them triggers a `VersionError` on `openDB`.
+ */
+const DB_VERSION = 2;
+const AUTH_STORE = 'auth';
+const PROMPT_STORE = 'install_prompt';
+const PROMPT_ROW_ID = 'state';
+
+/** 7 days in ms — how long "Maybe later" snoozes the iOS prompt. */
+const DISMISS_SNOOZE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * The single row we persist in `install_prompt`. All timestamps are
+ * `Date.now()` epoch ms, or `null` if the corresponding event hasn't
+ * happened yet.
+ */
+export interface InstallState {
+  id: typeof PROMPT_ROW_ID;
+  dismissed_at: number | null;
+  installed_at: number | null;
+  last_shown_at: number | null;
+}
+
+interface BodhilanderDB extends DBSchema {
+  [AUTH_STORE]: {
+    key: string;
+    // We don't read auth here, so leave the value type open. The real
+    // shape is owned by `auth.ts:AuthRecord`.
+    value: unknown;
+  };
+  [PROMPT_STORE]: {
+    key: string;
+    value: InstallState;
+  };
+}
+
+let dbPromise: Promise<IDBPDatabase<BodhilanderDB>> | null = null;
+
+function getDB(): Promise<IDBPDatabase<BodhilanderDB>> {
+  if (!dbPromise) {
+    dbPromise = openDB<BodhilanderDB>(DB_NAME, DB_VERSION, {
+      upgrade(db, oldVersion) {
+        // v1: create the auth store (BDHLNDR-54). Safe to re-run defensively
+        // in case this module wins the race to open the DB before auth.ts.
+        if (oldVersion < 1 && !db.objectStoreNames.contains(AUTH_STORE)) {
+          db.createObjectStore(AUTH_STORE, { keyPath: 'id' });
+        }
+        // v2: install-prompt state (this ticket).
+        if (oldVersion < 2 && !db.objectStoreNames.contains(PROMPT_STORE)) {
+          db.createObjectStore(PROMPT_STORE, { keyPath: 'id' });
+        }
+      },
+    });
+  }
+  return dbPromise;
+}
+
+function emptyState(): InstallState {
+  return {
+    id: PROMPT_ROW_ID,
+    dismissed_at: null,
+    installed_at: null,
+    last_shown_at: null,
+  };
+}
+
+/**
+ * Read the install-prompt row. Returns a zeroed-out state if the row hasn't
+ * been written yet (first run) or if IndexedDB throws (private browsing,
+ * locked-down contexts) — the gating logic then falls back to
+ * "act as if we've never shown it", which is the desired UX.
+ */
+export async function getInstallState(): Promise<InstallState> {
+  try {
+    const db = await getDB();
+    const row = await db.get(PROMPT_STORE, PROMPT_ROW_ID);
+    return row ?? emptyState();
+  } catch (err) {
+    console.error('[install-prompt] Failed to read IndexedDB:', err);
+    return emptyState();
+  }
+}
+
+async function patchState(patch: Partial<InstallState>): Promise<void> {
+  try {
+    const db = await getDB();
+    const current = (await db.get(PROMPT_STORE, PROMPT_ROW_ID)) ?? emptyState();
+    const next: InstallState = { ...current, ...patch, id: PROMPT_ROW_ID };
+    await db.put(PROMPT_STORE, next);
+  } catch (err) {
+    // Non-fatal — at worst we re-prompt next session.
+    console.error('[install-prompt] Failed to write IndexedDB:', err);
+  }
+}
+
+/**
+ * User tapped "Maybe later" / "Not now". Snoozes for ~7 days via the
+ * gating logic in `shouldShowPrompt`.
+ */
+export async function markDismissed(): Promise<void> {
+  await patchState({ dismissed_at: Date.now() });
+}
+
+/**
+ * User tapped "Got it" (iOS) without dismissing — they've seen the
+ * walkthrough but might come back. We don't snooze, we just record that
+ * the prompt has been displayed at least once so we don't re-pop it
+ * aggressively on every reload.
+ */
+export async function markShown(): Promise<void> {
+  await patchState({ last_shown_at: Date.now() });
+}
+
+/**
+ * The PWA is now installed (display-mode flipped to standalone OR the
+ * Android `appinstalled` event fired). Persist so we never prompt again.
+ */
+export async function markInstalled(): Promise<void> {
+  await patchState({ installed_at: Date.now() });
+}
+
+/**
+ * True if the PWA is currently running as an installed app. Checks both
+ * the standard `display-mode: standalone` media query and the legacy iOS
+ * `navigator.standalone` boolean (Safari < 17 doesn't expose
+ * display-mode for PWAs).
+ */
+export function isStandalone(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (window.matchMedia?.('(display-mode: standalone)').matches) return true;
+  const legacy = (navigator as Navigator & { standalone?: boolean }).standalone;
+  return legacy === true;
+}
+
+/**
+ * True if this looks like a touch device — used to skip the prompt on
+ * desktop browsers where PWA install is either unsupported (Safari) or
+ * better handled by the browser's own install affordance (Chrome's URL
+ * bar icon). The pointer-coarse query is the most reliable cross-browser
+ * touch check; `'ontouchstart' in window` is gameable by emulators.
+ */
+function isTouchDevice(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia?.('(pointer: coarse)').matches === true;
+}
+
+/**
+ * Gating decision for `<InstallPrompt />`.
+ *
+ *   Show if:
+ *     - we're not already standalone
+ *     - we're on iOS or Android (the only platforms we have a UX for)
+ *     - we're on a touch device (skip desktop browsers — see above)
+ *     - the user has paired at least once (`paired_at` exists on auth row)
+ *     - AND either
+ *         - we've never shown it, OR
+ *         - the user last dismissed it more than 7 days ago, OR
+ *         - the user paired *after* their last dismissal (re-pair = reset)
+ *
+ * `pairedAt` is passed in by the caller (`InstallPrompt`) so the gating
+ * logic stays pure / testable and so we don't reach into auth.ts from here
+ * (avoiding a circular IndexedDB-open race between the two modules).
+ */
+export async function shouldShowPrompt(pairedAt: number | null): Promise<boolean> {
+  if (isStandalone()) return false;
+  if (!isTouchDevice()) return false;
+
+  // Lazy-import to avoid pulling platform.ts into modules that don't need
+  // it — and to keep the gating logic self-contained.
+  const { detectPlatform } = await import('./platform');
+  const platform = detectPlatform();
+  if (platform !== 'ios' && platform !== 'android') return false;
+
+  if (pairedAt == null) return false;
+
+  const state = await getInstallState();
+  if (state.installed_at != null) return false;
+
+  // Never shown before → show.
+  if (state.last_shown_at == null && state.dismissed_at == null) return true;
+
+  const now = Date.now();
+  // Re-pair after a previous dismissal resets the snooze.
+  if (state.dismissed_at != null && pairedAt > state.dismissed_at) return true;
+  // Snooze expired.
+  if (state.dismissed_at != null && now - state.dismissed_at > DISMISS_SNOOZE_MS) {
+    return true;
+  }
+  // User saw the prompt before but never dismissed it → re-show on first
+  // load after a fresh pair (i.e. pair happened after the last show).
+  if (state.dismissed_at == null && state.last_shown_at != null && pairedAt > state.last_shown_at) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Adds an Add-to-Home-Screen walkthrough that fires after the user's first successful pair. Critical for iOS because **Web Push (BDHLNDR-49) only works on installed PWAs** — without this, push silently fails on iOS Safari. Pre-mortem item PM-1 from the BDHLNDR-50 design session.

**Closes:** [BDHLNDR-61](https://gobodhi.atlassian.net/browse/BDHLNDR-61) · Parent Epic: [BDHLNDR-50](https://gobodhi.atlassian.net/browse/BDHLNDR-50)

## Commits

- `9ef3237` BDHLNDR-61: bump bodhilander IndexedDB version to 2
- `4f3d17b` BDHLNDR-61: add install-prompt IndexedDB module + gating logic
- `f48a25a` BDHLNDR-61: add <InstallPrompt /> component (iOS + Android)
- `6ba4542` BDHLNDR-61: mount <InstallPrompt /> in App.tsx

## Files

- **Added:** `src/pwa/src/lib/install-prompt.ts`, `src/pwa/src/components/InstallPrompt.tsx`
- **Modified:** `src/pwa/src/lib/auth.ts` (DB_VERSION 1→2 + comment block), `src/pwa/src/App.tsx` (import + `<InstallPrompt />` mount at line 53)

## InstallState contract

```ts
export interface InstallState {
  id: typeof PROMPT_ROW_ID;        // literal 'state'
  dismissed_at: number | null;
  installed_at: number | null;
  last_shown_at: number | null;
}
```

Stored in the existing `bodhilander` IndexedDB (now version 2), new `install_prompt` store.

## Gating logic (should-show pseudocode)

```
if isStandalone() return false               // already installed
if !isTouchDevice() return false             // matchMedia('(pointer: coarse)')
if platform !in ['ios', 'android'] return false
if pairedAt == null return false             // wait for commitment
if state.installed_at != null return false   // already installed
if state.last_shown_at == null && state.dismissed_at == null return true
if state.dismissed_at != null && pairedAt > state.dismissed_at return true     // re-pair resets snooze
if state.dismissed_at != null && (now - state.dismissed_at) > 7d return true
if state.dismissed_at == null && state.last_shown_at != null && pairedAt > state.last_shown_at return true
return false
```

## Platform variants

- **iOS Safari (non-standalone)**: full-screen overlay with 3-step visual walkthrough (Share → Add to Home Screen → Add). Inline SVG icons (no external assets, no proprietary glyphs).
- **Android Chrome (non-standalone)**: simpler modal. On "Install" tap, fires the captured `beforeinstallprompt` event's `prompt()`. Falls back gracefully if event wasn't captured.
- **Already standalone**: skipped.
- **Desktop browsers (non-touch)**: out of scope.

## `beforeinstallprompt` capture

`useRef<BeforeInstallPromptEvent | null>` set in a `useEffect`-registered `window.addEventListener('beforeinstallprompt', ...)`. Companion `appinstalled` listener clears the ref + calls `markInstalled()`. Event type defined as a small local interface (DOM lib doesn't ship it).

## DB version bump details

`auth.ts` had `DB_VERSION = 1` inline — had to be touched. Kept minimal: only the `1 → 2` change + a 6-line comment block explaining that the `install_prompt` store creation lives in `install-prompt.ts` and future bumps must mirror across both files. The `auth.ts` upgrade callback was NOT changed. `install-prompt.ts` is defensive: its upgrade callback also re-creates the `auth` store if absent, so a fresh install hitting install-prompt.ts first still works.

## Test plan

- [x] `bunx tsc --noEmit -p tsconfig.pwa.json` clean
- [x] `bun run build:pwa` succeeds in 962ms, 98 modules, no warnings
- [ ] Manual on iOS Safari: pair → modal appears with 3-step instructions
- [ ] Manual: tap "Maybe later" → don't re-show for 7 days
- [ ] Manual on Android Chrome: native `beforeinstallprompt` deferred + fires on Install tap
- [ ] Manual: install → standalone detected → confirmation toast → no re-show

## Flagged / decisions

- `shouldShowPrompt(pairedAt)` takes `pairedAt` as a parameter rather than reaching into `auth.ts` — keeps the gating pure and avoids a second IndexedDB-open race. Caller passes `auth?.paired_at`. Small contract divergence from the original spec but cleaner.
- The "re-pair after dismissal resets the snooze" rule is interpretation of spec's "shown more than 7 days ago AND user just paired". One-line tweak if product wants stricter (never re-show within 7d even on re-pair).
- Converted a previously-dynamic `import('./platform')` to static import in `install-prompt.ts` to silence a vite warning. Bundle size unchanged in practice.

## Coordination

- BDHLNDR-55 also touches `App.tsx` — that PR edits `<RequireAuth>` (different scope from this PR's `<InstallPrompt />` mount after `</Routes>`). Should merge clean.
- BDHLNDR-14 touches `Pair.tsx` + `package.json`. Zero overlap.
- All three siblings touched `package.json`/`bun.lock` (this PR doesn't add deps, but DB version coordinates with auth.ts). Resolve in merge order: #55 (no deps) → #14 (qr-scanner) → this one.

Built by a parallel subagent alongside BDHLNDR-55 and BDHLNDR-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-61]: https://gobodhi.atlassian.net/browse/BDHLNDR-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-50]: https://gobodhi.atlassian.net/browse/BDHLNDR-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ