### PR TITLE
BDHLNDR-68: prompt-on-gesture push + unpair-clears-subscriptions

### DIFF
--- a/src/main/api/pairing/pairing-manager.ts
+++ b/src/main/api/pairing/pairing-manager.ts
@@ -275,6 +275,23 @@ export class PairingManager {
 
     if (success) {
       log.info(`[PairingManager] Device unpaired: ${deviceId}`);
+      // BDHLNDR-68: also clear the device's Web Push subscriptions so we
+      // don't keep firing pushes at a now-unauthenticated endpoint. Lazy
+      // 410-driven cleanup in the dispatcher still works as a fallback, but
+      // hitting it on unpair avoids the dead-row window. Lazy-required to
+      // dodge an import cycle (pairing-manager ↔ push-subscriptions repo
+      // both touch the database singleton).
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { deleteSubscriptionsForDevice } = require('../../repositories/push-subscriptions');
+        const removed: number = deleteSubscriptionsForDevice(deviceId);
+        if (removed > 0) {
+          log.info(`[PairingManager] Cleaned ${removed} push subscription(s) for ${deviceId}`);
+        }
+      } catch (error) {
+        // Non-fatal — the dispatcher's 410-cleanup path catches any leftovers.
+        log.warn('[PairingManager] Push subscription cleanup failed:', error);
+      }
     }
 
     return success;

--- a/src/pwa/src/lib/push.ts
+++ b/src/pwa/src/lib/push.ts
@@ -181,6 +181,36 @@ export async function subscribeToPush(): Promise<SubscribeResult> {
 }
 
 /**
+ * BDHLNDR-68: convenience helper meant to be fire-and-forgotten from a user
+ * gesture (chat-view compose send, one-tap response button, etc.) so that
+ * the user is asked for notification permission at the right moment without
+ * the caller having to know all the gating rules.
+ *
+ * Safe to call repeatedly — idempotent across all branches:
+ *   - push not supported (no SW, no Push API) → no-op
+ *   - not installed via Add-to-Home-Screen on iOS → no-op (push won't work
+ *     in browser-tab mode on iOS, so don't waste the user's permission grant)
+ *   - permission already granted + subscription exists → no-op
+ *   - permission denied → no-op
+ *   - permission default + standalone + supported → prompt + subscribe
+ */
+export async function maybePromptAndSubscribe(): Promise<void> {
+  if (!isPushSupported()) return;
+  // Inline matchMedia check rather than importing from install-prompt to
+  // keep push.ts self-contained and avoid an import cycle.
+  const standalone =
+    window.matchMedia?.('(display-mode: standalone)').matches ||
+    (window.navigator as { standalone?: boolean }).standalone === true;
+  if (!standalone) return;
+  if (Notification.permission === 'denied') return;
+  // subscribeToPush internally calls requestPushPermission when the state
+  // is 'default' — the only place that's safe to do so is inside a user-
+  // gesture handler, which is exactly where this helper is meant to be
+  // called from.
+  await subscribeToPush();
+}
+
+/**
  * Best-effort unsubscribe on both ends. Always attempts the browser-side
  * unsubscribe even if the server DELETE fails (orphaning a subscription on
  * the server is far worse than an orphan record — it'd keep pushing to a

--- a/src/pwa/src/pages/SessionDetail.tsx
+++ b/src/pwa/src/pages/SessionDetail.tsx
@@ -87,6 +87,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 
 import { ApiError, fetchChatEvents, sendTerminalInput } from '../lib/api';
+import { maybePromptAndSubscribe } from '../lib/push';
 import {
   narrowChatEvent,
   type ChatEvent,
@@ -321,6 +322,13 @@ function SessionDetailInner({
       if (!text || sending) return;
       setSending(true);
       setSendError(null);
+      // BDHLNDR-68: any send (free-text or one-tap response) is a user
+      // gesture — fire the push subscribe in the background. Idempotent and
+      // self-gating in push.ts, so safe to call on every send. Browser
+      // remembers the permission decision, so the user is prompted at most
+      // once per device (and never on iOS until installed via Add to Home
+      // Screen, where push is supported).
+      void maybePromptAndSubscribe();
       try {
         await sendTerminalInput(sessionId, text);
         return true;


### PR DESCRIPTION
## Summary

Two follow-ups from BDHLNDR-49 (Web Push) and BDHLNDR-56 (chat view) running in parallel. Neither agent could close the loop on the other's contract; this PR closes both gaps.

**Closes:** [BDHLNDR-68](https://gobodhi.atlassian.net/browse/BDHLNDR-68) · Followup to BDHLNDR-49 + BDHLNDR-56.

## Problems addressed

### 1. New users never asked for notification permission

BDHLNDR-49's `<PushBootstrap />` silently re-binds when `Notification.permission === 'granted'` but never *requests* it. The intent was for BDHLNDR-56 to wire the prompt into the compose-send handler — but #56 ran in parallel with #49 and didn't know about that contract. Net result before this PR: a fresh PWA install would never see a permission dialog, so push notifications were silently broken for any new user.

### 2. Unpaired devices left stale push subscriptions

BDHLNDR-49 shipped `deleteSubscriptionsForDevice(deviceId)` in the push-subscriptions repo but didn't wire it into `PairingManager.unpairDevice()`. Lazy 410-driven cleanup from the dispatcher works as a fallback, but eager cleanup closes the window where pushes keep firing at an unauthenticated endpoint.

## Changes (+55 LOC, 3 files)

### `src/pwa/src/lib/push.ts` (+27)
New `maybePromptAndSubscribe()` helper meant to be fire-and-forgotten from a user gesture. Idempotent and self-gating:
- Push not supported → no-op
- Not standalone (browser tab on iOS) → no-op (iOS push only works on installed PWAs)
- Permission denied → no-op
- Permission default + standalone + supported → prompt + subscribe

Inlined the `matchMedia('(display-mode: standalone)')` check rather than importing from `install-prompt` to keep `push.ts` self-contained and avoid an import cycle.

### `src/pwa/src/pages/SessionDetail.tsx` (+9 -1)
Wired `void maybePromptAndSubscribe()` into the shared `send()` callback. Fires on both free-text compose and one-tap response buttons. Browser remembers the decision, so user is prompted at most once per device.

### `src/main/api/pairing/pairing-manager.ts` (+17)
After successful `unpairDevice()` SQLite delete: lazy-require + call `deleteSubscriptionsForDevice(deviceId)` in try/catch. Lazy `require` to avoid an import cycle (pairing-manager and push-subscriptions both touch the database singleton). Non-fatal — if cleanup fails, the dispatcher's 410-cleanup path catches any leftovers.

## Test plan

- [x] `bunx tsc --noEmit -p tsconfig.main.json` clean
- [x] `bunx tsc --noEmit -p tsconfig.pwa.json` clean
- [ ] Manual: fresh PWA install (Add to Home Screen), pair, tap compose-send → notification permission dialog appears
- [ ] Manual: grant → subscription POSTed to server → desktop sees the row in `push_subscriptions`
- [ ] Manual: deny → no retries, no further dialogs
- [ ] Manual: send a second message → no second prompt (browser remembers)
- [ ] Manual: unpair → `push_subscriptions` row for that device is gone

## Notes

- ESLint disable for the lazy `require()` in pairing-manager.ts — only way to dodge the import cycle without a bigger refactor. Documented in the inline comment.
- Browser remembers permission decisions, so `maybePromptAndSubscribe()` is genuinely idempotent across hundreds of calls. No accumulator or "asked already" flag needed.
- Doesn't fix the dev-mode SW (`devOptions.enabled: false`) — that's still BDHLNDR-49's behavior; push testing requires a production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-68]: https://gobodhi.atlassian.net/browse/BDHLNDR-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ