### PR TITLE
BDHLNDR-59: offline IndexedDB cache (session list + chat events)

### DIFF
--- a/src/pwa/src/components/RelativeTime.tsx
+++ b/src/pwa/src/components/RelativeTime.tsx
@@ -1,0 +1,49 @@
+/**
+ * Self-updating "X seconds/minutes/hours ago" timestamp (BDHLNDR-59).
+ *
+ * Used by the stale-cache indicators in `SessionList` and `SessionDetail` —
+ * the user is looking at cached data and we want them to know roughly how
+ * stale it is. The component re-renders itself on an interval so the label
+ * doesn't get stuck at "just now" for ten minutes.
+ *
+ * Tick cadence is adaptive: every 15s for the first minute, every minute
+ * after that. Past an hour we tick every 15 minutes (the label rounds to
+ * the hour anyway). This keeps the wakeups cheap on a backgrounded tab.
+ */
+
+import { useEffect, useState } from 'react';
+
+export interface RelativeTimeProps {
+  /** ms-epoch of the reference instant. */
+  ts: number;
+}
+
+function formatRelative(deltaMs: number): string {
+  const sec = Math.max(0, Math.floor(deltaMs / 1000));
+  if (sec < 5) return 'just now';
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
+}
+
+function nextTickMs(deltaMs: number): number {
+  if (deltaMs < 60_000) return 15_000;
+  if (deltaMs < 3_600_000) return 60_000;
+  return 15 * 60_000;
+}
+
+export function RelativeTime({ ts }: RelativeTimeProps) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const delta = now - ts;
+    const handle = setTimeout(() => setNow(Date.now()), nextTickMs(delta));
+    return () => clearTimeout(handle);
+  }, [now, ts]);
+
+  return <span>{formatRelative(now - ts)}</span>;
+}

--- a/src/pwa/src/lib/auth.ts
+++ b/src/pwa/src/lib/auth.ts
@@ -18,16 +18,27 @@
 
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
 
+import { clearAllCaches } from './cache';
+
 const DB_NAME = 'bodhilander';
-// BDHLNDR-61: bumped 1 → 2 to add the `install_prompt` store. The schema
-// change itself is owned by `install-prompt.ts` (this file's upgrade callback
-// only creates the `auth` store at v1); the version number just has to agree
+// BDHLNDR-59: bumped 2 → 3 to add `sessions_cache` + `chat_events_cache`.
+// BDHLNDR-61: bumped 1 → 2 to add the `install_prompt` store.
+// Schema changes for v2/v3 are owned by their respective modules
+// (`install-prompt.ts`, `cache.ts`); this file's upgrade callback only
+// creates the `auth` store at v1. The version number just has to agree
 // across every module that opens the DB, otherwise the second `openDB` call
 // throws a `VersionError`. If you bump again, mirror the new version in
-// `install-prompt.ts:DB_VERSION`.
-const DB_VERSION = 2;
+// `install-prompt.ts:DB_VERSION` AND `cache.ts:DB_VERSION`, and extend the
+// defensive upgrade callbacks in both peer files to cover the new schema.
+const DB_VERSION = 3;
 const STORE_NAME = 'auth';
 const ROW_ID = 'current';
+// New cache stores added in v3 (BDHLNDR-59). We defensively create them
+// here too so whichever module wins the open-DB race lands at the same
+// final shape.
+const SESSIONS_CACHE_STORE = 'sessions_cache';
+const CHAT_EVENTS_CACHE_STORE = 'chat_events_cache';
+const PROMPT_STORE = 'install_prompt';
 
 /**
  * Subset of the device payload the desktop returns from
@@ -55,6 +66,13 @@ interface BodhilanderDB extends DBSchema {
     key: string;
     value: AuthRecord;
   };
+  // Peer stores — typed as `unknown` so we don't reach into other modules'
+  // row shapes from here. Each owner module declares its own DBSchema with
+  // the proper types; idb tolerates the loose declaration as long as the
+  // names match.
+  [PROMPT_STORE]: { key: string; value: unknown };
+  [SESSIONS_CACHE_STORE]: { key: string; value: unknown };
+  [CHAT_EVENTS_CACHE_STORE]: { key: string; value: unknown };
 }
 
 let dbPromise: Promise<IDBPDatabase<BodhilanderDB>> | null = null;
@@ -62,9 +80,25 @@ let dbPromise: Promise<IDBPDatabase<BodhilanderDB>> | null = null;
 function getDB(): Promise<IDBPDatabase<BodhilanderDB>> {
   if (!dbPromise) {
     dbPromise = openDB<BodhilanderDB>(DB_NAME, DB_VERSION, {
-      upgrade(db) {
-        if (!db.objectStoreNames.contains(STORE_NAME)) {
+      // Defensive upgrade — handles v0→v3 (fresh install after v3 ships),
+      // v1→v3 (user on the original BDHLNDR-54 build), v2→v3 (user on the
+      // BDHLNDR-61 build). Whichever module wins the open-DB race runs an
+      // identical upgrade path; the `if (!contains)` guards make every
+      // createObjectStore idempotent.
+      upgrade(db, oldVersion) {
+        if (oldVersion < 1 && !db.objectStoreNames.contains(STORE_NAME)) {
           db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        }
+        if (oldVersion < 2 && !db.objectStoreNames.contains(PROMPT_STORE)) {
+          db.createObjectStore(PROMPT_STORE, { keyPath: 'id' });
+        }
+        if (oldVersion < 3) {
+          if (!db.objectStoreNames.contains(SESSIONS_CACHE_STORE)) {
+            db.createObjectStore(SESSIONS_CACHE_STORE, { keyPath: 'id' });
+          }
+          if (!db.objectStoreNames.contains(CHAT_EVENTS_CACHE_STORE)) {
+            db.createObjectStore(CHAT_EVENTS_CACHE_STORE, { keyPath: 'sessionId' });
+          }
         }
       },
     });
@@ -108,8 +142,15 @@ export async function getAuth(): Promise<AuthRecord | null> {
 /**
  * Wipe the auth row. Called after the desktop confirms unpair so the PWA
  * forgets the (now-invalid) token and bounces back to /pair.
+ *
+ * Also drops the offline session/event caches (BDHLNDR-59) — a re-pair on
+ * a shared device must not leak the previous user's sessions or chat log.
+ * Cache clear runs after auth delete and is best-effort (own try/catch
+ * inside `clearAllCaches`), so a cache failure can't leave the auth row
+ * stranded.
  */
 export async function clearAuth(): Promise<void> {
   const db = await getDB();
   await db.delete(STORE_NAME, ROW_ID);
+  await clearAllCaches();
 }

--- a/src/pwa/src/lib/cache.ts
+++ b/src/pwa/src/lib/cache.ts
@@ -1,0 +1,322 @@
+/**
+ * Offline cache for sessions + chat events (BDHLNDR-59).
+ *
+ * Mom-and-Dad's iPhone is going to be on subway WiFi, in the car, in airplane
+ * mode, etc. The PWA needs to render *something* the moment they open it,
+ * not a spinner with a "Failed to load" error five seconds later. So we
+ * persist the last-known session list and the last N chat events per session
+ * into IndexedDB; on open, the views seed React Query / local state from the
+ * cache and then refresh from the network in the background.
+ *
+ * Two stores in the shared `bodhilander` IndexedDB:
+ *
+ *   - `sessions_cache` — single row (`id = 'snapshot'`) holding the last
+ *     session list + group list. Single-row because the desktop returns both
+ *     as one logical unit per render, and there's no per-session row to
+ *     update independently.
+ *
+ *   - `chat_events_cache` — one row per `sessionId`, holding the most recent
+ *     events for that session. Capped at `EVENTS_CAP_PER_SESSION` so a noisy
+ *     session can't blow out the device's quota (Safari is notoriously stingy
+ *     with PWA IDB quota).
+ *
+ * Eviction (LRU-ish, capped):
+ *   - `chat_events_cache` is trimmed to the last `EVENTS_CAP_PER_SESSION`
+ *     events on every write (eager, cheap).
+ *   - The number of sessions cached is capped at `SESSIONS_CAP` via
+ *     `evictOldSessions()`, called opportunistically after writes (cheap
+ *     count → only does work when over cap).
+ *
+ * Invalidation:
+ *   - `clearAllCaches()` is called from `auth.ts:clearAuth()`. Re-pairing on
+ *     a shared device must not leak the previous user's sessions.
+ *
+ * Schema bump (DB v2 → v3): owned here. Both `auth.ts` and `install-prompt.ts`
+ * mirror `DB_VERSION = 3` so whichever module wins the race to open the DB
+ * triggers the same upgrade path. The upgrade callback handles every
+ * starting version (0, 1, 2 → 3) defensively so a fresh install that arrives
+ * after v3 ships gets all four stores in one shot.
+ */
+
+import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
+
+import type { Group, PersistedChatEvent, Session } from './types';
+
+const DB_NAME = 'bodhilander';
+/**
+ * v3 = added `sessions_cache` + `chat_events_cache` (BDHLNDR-59).
+ * v2 = added `install_prompt` (BDHLNDR-61).
+ * v1 = `auth` (BDHLNDR-54).
+ *
+ * Mirrored in `auth.ts:DB_VERSION` and `install-prompt.ts:DB_VERSION`.
+ */
+const DB_VERSION = 3;
+
+const AUTH_STORE = 'auth';
+const PROMPT_STORE = 'install_prompt';
+const SESSIONS_STORE = 'sessions_cache';
+const EVENTS_STORE = 'chat_events_cache';
+
+const SESSIONS_ROW_ID = 'snapshot';
+
+/** Most-recent events kept per session. Phones get unhappy past a few hundred. */
+const EVENTS_CAP_PER_SESSION = 200;
+/** Max number of sessions we cache events for. LRU by `fetched_at`. */
+const SESSIONS_CAP = 50;
+
+// ---------------------------------------------------------------------------
+// Row shapes
+// ---------------------------------------------------------------------------
+
+export interface SessionsCacheRow {
+  id: typeof SESSIONS_ROW_ID;
+  sessions: Session[];
+  groups: Group[];
+  /** ms-epoch when this snapshot was written. Used for "Last updated X ago". */
+  fetched_at: number;
+}
+
+export interface ChatEventsCacheRow {
+  sessionId: string;
+  events: PersistedChatEvent[];
+  /**
+   * `timestamp` of the newest cached event (ms-epoch). Used as `since` for
+   * the incremental REST refresh — we never re-fetch events older than this.
+   * Zero when the cached event list is empty.
+   */
+  last_ts: number;
+  /** ms-epoch when this row was last written. Used for LRU eviction. */
+  fetched_at: number;
+}
+
+interface BodhilanderDB extends DBSchema {
+  [AUTH_STORE]: {
+    key: string;
+    // Owned by `auth.ts:AuthRecord`; opaque from this module's POV.
+    value: unknown;
+  };
+  [PROMPT_STORE]: {
+    key: string;
+    // Owned by `install-prompt.ts:InstallState`; opaque from this module's POV.
+    value: unknown;
+  };
+  [SESSIONS_STORE]: {
+    key: string;
+    value: SessionsCacheRow;
+  };
+  [EVENTS_STORE]: {
+    key: string;
+    value: ChatEventsCacheRow;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DB open + upgrade
+// ---------------------------------------------------------------------------
+
+let dbPromise: Promise<IDBPDatabase<BodhilanderDB>> | null = null;
+
+function getDB(): Promise<IDBPDatabase<BodhilanderDB>> {
+  if (!dbPromise) {
+    dbPromise = openDB<BodhilanderDB>(DB_NAME, DB_VERSION, {
+      upgrade(db, oldVersion) {
+        // Stepwise / idempotent. Every `if` guards with `objectStoreNames`
+        // so a fresh-install v0→v3 jump and a v2→v3 upgrade both land in the
+        // same final shape.
+        if (oldVersion < 1 && !db.objectStoreNames.contains(AUTH_STORE)) {
+          db.createObjectStore(AUTH_STORE, { keyPath: 'id' });
+        }
+        if (oldVersion < 2 && !db.objectStoreNames.contains(PROMPT_STORE)) {
+          db.createObjectStore(PROMPT_STORE, { keyPath: 'id' });
+        }
+        if (oldVersion < 3) {
+          if (!db.objectStoreNames.contains(SESSIONS_STORE)) {
+            db.createObjectStore(SESSIONS_STORE, { keyPath: 'id' });
+          }
+          if (!db.objectStoreNames.contains(EVENTS_STORE)) {
+            db.createObjectStore(EVENTS_STORE, { keyPath: 'sessionId' });
+          }
+        }
+      },
+    });
+  }
+  return dbPromise;
+}
+
+// ---------------------------------------------------------------------------
+// Sessions cache
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the cached session-list snapshot, or null if we've never written one
+ * (fresh install) or IndexedDB threw (private browsing / locked-down).
+ * Read failures are swallowed because "no cache" is the correct fallback —
+ * the view will just show a spinner and wait for the network.
+ */
+export async function getCachedSessions(): Promise<SessionsCacheRow | null> {
+  try {
+    const db = await getDB();
+    const row = await db.get(SESSIONS_STORE, SESSIONS_ROW_ID);
+    return row ?? null;
+  } catch (err) {
+    console.error('[cache] Failed to read sessions cache:', err);
+    return null;
+  }
+}
+
+/**
+ * Overwrite the cached session-list snapshot. Called from `SessionList`
+ * after each successful `fetchSessions`/`fetchGroups` pair so the cache
+ * tracks the latest known state.
+ *
+ * Writes are best-effort — if IDB throws we log and continue rather than
+ * surfacing an error into the UI. The next successful write recovers.
+ */
+export async function setCachedSessions(
+  sessions: Session[],
+  groups: Group[],
+): Promise<void> {
+  try {
+    const db = await getDB();
+    const row: SessionsCacheRow = {
+      id: SESSIONS_ROW_ID,
+      sessions,
+      groups,
+      fetched_at: Date.now(),
+    };
+    await db.put(SESSIONS_STORE, row);
+  } catch (err) {
+    console.error('[cache] Failed to write sessions cache:', err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Chat events cache
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the cached event list for one session, or null if no row exists.
+ */
+export async function getCachedChatEvents(
+  sessionId: string,
+): Promise<ChatEventsCacheRow | null> {
+  try {
+    const db = await getDB();
+    const row = await db.get(EVENTS_STORE, sessionId);
+    return row ?? null;
+  } catch (err) {
+    console.error('[cache] Failed to read chat events cache:', err);
+    return null;
+  }
+}
+
+/**
+ * Write the full event list for one session, dedup'd by `id` and capped at
+ * `EVENTS_CAP_PER_SESSION`. The caller passes the *combined* event list (cached
+ * + newly-loaded snapshot + WS frames) — we don't try to merge inside the
+ * cache because the caller already owns the canonical in-memory log.
+ *
+ * Triggers an eviction sweep when the number of cached sessions exceeds
+ * `SESSIONS_CAP`. The sweep is cheap (count + maybe a few deletes) so we
+ * run it eagerly on writes rather than scheduling it.
+ */
+export async function setCachedChatEvents(
+  sessionId: string,
+  events: PersistedChatEvent[],
+): Promise<void> {
+  try {
+    const db = await getDB();
+
+    // Dedup by id, preserving insertion order. The caller's list is supposed
+    // to be deduped already, but a defensive pass here prevents pathological
+    // growth if the contract slips.
+    const seen = new Set<string>();
+    const deduped: PersistedChatEvent[] = [];
+    for (const e of events) {
+      if (seen.has(e.id)) continue;
+      seen.add(e.id);
+      deduped.push(e);
+    }
+
+    // Cap to the last N events. Ordering: chat-events arrive in ascending
+    // chronological order (REST contract + WS append), so we keep the tail.
+    const capped =
+      deduped.length > EVENTS_CAP_PER_SESSION
+        ? deduped.slice(deduped.length - EVENTS_CAP_PER_SESSION)
+        : deduped;
+
+    const lastTs = capped.length > 0 ? capped[capped.length - 1].timestamp : 0;
+
+    const row: ChatEventsCacheRow = {
+      sessionId,
+      events: capped,
+      last_ts: lastTs,
+      fetched_at: Date.now(),
+    };
+    await db.put(EVENTS_STORE, row);
+
+    // Opportunistic eviction. Done after the write so the just-written row
+    // is up-to-date in `fetched_at` and won't be the eviction victim.
+    await evictOldSessions();
+  } catch (err) {
+    console.error('[cache] Failed to write chat events cache:', err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Eviction + invalidation
+// ---------------------------------------------------------------------------
+
+/**
+ * Cap `chat_events_cache` at the most recent `SESSIONS_CAP` sessions by
+ * `fetched_at`. Cheap fast-path: count first, return immediately if under
+ * cap. Only iterates + deletes when we're actually over.
+ *
+ * Lazy in the sense that we don't run on a timer — only after writes that
+ * could plausibly push us over the cap.
+ */
+export async function evictOldSessions(): Promise<void> {
+  try {
+    const db = await getDB();
+    const count = await db.count(EVENTS_STORE);
+    if (count <= SESSIONS_CAP) return;
+
+    // Pull all rows, sort by fetched_at desc, drop everything past the cap.
+    // Cheaper than maintaining a separate index (we only do this when we're
+    // already over the cap, which is uncommon).
+    const all = await db.getAll(EVENTS_STORE);
+    all.sort((a, b) => b.fetched_at - a.fetched_at);
+    const victims = all.slice(SESSIONS_CAP);
+    if (victims.length === 0) return;
+    const tx = db.transaction(EVENTS_STORE, 'readwrite');
+    await Promise.all([
+      ...victims.map((v) => tx.store.delete(v.sessionId)),
+      tx.done,
+    ]);
+  } catch (err) {
+    console.error('[cache] Failed to evict old sessions:', err);
+  }
+}
+
+/**
+ * Drop everything in both caches. Called from `auth.ts:clearAuth()` so a
+ * fresh pair on a shared device (Mom hands her iPhone to Dad) starts from
+ * an empty cache instead of showing the previous account's sessions.
+ *
+ * Uses `clear()` rather than `deleteDatabase()` so the auth + install_prompt
+ * stores (cleared independently by their owners) aren't disturbed and so
+ * the next `openDB()` call doesn't re-trigger the upgrade callback.
+ */
+export async function clearAllCaches(): Promise<void> {
+  try {
+    const db = await getDB();
+    const tx = db.transaction([SESSIONS_STORE, EVENTS_STORE], 'readwrite');
+    await Promise.all([
+      tx.objectStore(SESSIONS_STORE).clear(),
+      tx.objectStore(EVENTS_STORE).clear(),
+      tx.done,
+    ]);
+  } catch (err) {
+    console.error('[cache] Failed to clear caches:', err);
+  }
+}

--- a/src/pwa/src/lib/install-prompt.ts
+++ b/src/pwa/src/lib/install-prompt.ts
@@ -24,17 +24,24 @@ import { detectPlatform } from './platform';
 
 const DB_NAME = 'bodhilander';
 /**
+ * v3 = added `sessions_cache` + `chat_events_cache` stores (BDHLNDR-59).
  * v2 = added `install_prompt` store (BDHLNDR-61).
  * v1 = `auth` store (BDHLNDR-54).
  *
  * If you bump this further, mirror the new version in `auth.ts:DB_VERSION`
- * — both modules must agree on which version they're opening at, otherwise
- * one of them triggers a `VersionError` on `openDB`.
+ * AND `cache.ts:DB_VERSION`, and extend the defensive upgrade callbacks in
+ * each peer file — every module that calls `openDB` must agree on the
+ * version number or the second `openDB` call throws a `VersionError`.
  */
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const AUTH_STORE = 'auth';
 const PROMPT_STORE = 'install_prompt';
 const PROMPT_ROW_ID = 'state';
+// v3 cache stores — owned by `cache.ts`. We defensively create them here
+// too so whichever module wins the open-DB race lands at the same final
+// shape.
+const SESSIONS_CACHE_STORE = 'sessions_cache';
+const CHAT_EVENTS_CACHE_STORE = 'chat_events_cache';
 
 /** 7 days in ms — how long "Maybe later" snoozes the iOS prompt. */
 const DISMISS_SNOOZE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -62,6 +69,12 @@ interface BodhilanderDB extends DBSchema {
     key: string;
     value: InstallState;
   };
+  // Peer cache stores — opaque from this module's POV; real shapes are
+  // owned by `cache.ts`. Declared here so the schema-typed DB handle
+  // doesn't fail typecheck if some future code branched off `getDB()` here
+  // happens to enumerate `db.objectStoreNames`.
+  [SESSIONS_CACHE_STORE]: { key: string; value: unknown };
+  [CHAT_EVENTS_CACHE_STORE]: { key: string; value: unknown };
 }
 
 let dbPromise: Promise<IDBPDatabase<BodhilanderDB>> | null = null;
@@ -70,14 +83,24 @@ function getDB(): Promise<IDBPDatabase<BodhilanderDB>> {
   if (!dbPromise) {
     dbPromise = openDB<BodhilanderDB>(DB_NAME, DB_VERSION, {
       upgrade(db, oldVersion) {
-        // v1: create the auth store (BDHLNDR-54). Safe to re-run defensively
-        // in case this module wins the race to open the DB before auth.ts.
+        // Stepwise + idempotent. Whichever of {auth, install-prompt, cache}
+        // wins the open-DB race runs this and lands at the same final shape.
+        // v1: auth store (BDHLNDR-54).
         if (oldVersion < 1 && !db.objectStoreNames.contains(AUTH_STORE)) {
           db.createObjectStore(AUTH_STORE, { keyPath: 'id' });
         }
-        // v2: install-prompt state (this ticket).
+        // v2: install-prompt state (BDHLNDR-61 — this module's own ticket).
         if (oldVersion < 2 && !db.objectStoreNames.contains(PROMPT_STORE)) {
           db.createObjectStore(PROMPT_STORE, { keyPath: 'id' });
+        }
+        // v3: offline cache stores (BDHLNDR-59 — owned by `cache.ts`).
+        if (oldVersion < 3) {
+          if (!db.objectStoreNames.contains(SESSIONS_CACHE_STORE)) {
+            db.createObjectStore(SESSIONS_CACHE_STORE, { keyPath: 'id' });
+          }
+          if (!db.objectStoreNames.contains(CHAT_EVENTS_CACHE_STORE)) {
+            db.createObjectStore(CHAT_EVENTS_CACHE_STORE, { keyPath: 'sessionId' });
+          }
         }
       },
     });

--- a/src/pwa/src/pages/SessionDetail.tsx
+++ b/src/pwa/src/pages/SessionDetail.tsx
@@ -87,6 +87,10 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 
 import { ApiError, fetchChatEvents, sendTerminalInput } from '../lib/api';
+import {
+  getCachedChatEvents,
+  setCachedChatEvents,
+} from '../lib/cache';
 import { maybePromptAndSubscribe } from '../lib/push';
 import {
   narrowChatEvent,
@@ -97,6 +101,7 @@ import {
 import { wsClient, type ChatEventMessage, type WsStatus } from '../lib/ws';
 import { ConnectionDot } from '../components/ConnectionDot';
 import { OverflowMenu } from '../components/OverflowMenu';
+import { RelativeTime } from '../components/RelativeTime';
 
 // ---------------------------------------------------------------------------
 // Tunables
@@ -151,6 +156,24 @@ function persistedToDisplay(p: PersistedChatEvent): DisplayEvent {
   };
 }
 
+/**
+ * Inverse of `persistedToDisplay` for caching (BDHLNDR-59). We persist the
+ * in-memory display log into IndexedDB so the next cold open can render
+ * immediately. WS-sourced events synthesized their own `id` (no server id
+ * over the wire) — we keep that synth id in the cache; on the next cold
+ * start the snapshot refetch fires with `?since=last_ts` and the server's
+ * `since` is strict (timestamp >), so the same event isn't re-delivered.
+ */
+function displayToPersisted(sessionId: string, d: DisplayEvent): PersistedChatEvent {
+  return {
+    id: d.id,
+    sessionId,
+    type: d.event.type,
+    payload: d.event.payload,
+    timestamp: d.timestamp,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -179,38 +202,95 @@ function SessionDetailInner({
   sessionId: string;
   navigate: ReturnType<typeof useNavigate>;
 }) {
+  // The combined in-memory log. Seeded from cache first, then merged with
+  // the REST snapshot delta, then appended to by WS frames. See the chunks
+  // below for the three sources.
+  const [events, setEvents] = useState<DisplayEvent[]>([]);
+
+  // ---- Cache hydration (BDHLNDR-59) ------------------------------------
+  // Read the offline cache BEFORE firing the snapshot query so:
+  //   1. We can seed `events` immediately and unblock first paint (PWA may
+  //      be offline at this exact moment — last-known events are better
+  //      than a spinner).
+  //   2. The snapshot fetch can use `since=cached.last_ts` for an
+  //      incremental delta instead of re-downloading the full 500-event
+  //      window. Cheaper, and matches the BDHLNDR-58 endpoint contract.
+  //
+  // `cacheReady` gates the snapshot query — we can't pass `since` until
+  // we've read the cache, and we don't want the snapshot to fire with no
+  // `since` and then immediately again with one.
+  const [cacheReady, setCacheReady] = useState(false);
+  const [cacheLastTs, setCacheLastTs] = useState<number>(0);
+  const [cacheHydratedAt, setCacheHydratedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    // Reset hydration state when navigating between sessions — see the
+    // session-id reset effect below; this one runs alongside it.
+    let cancelled = false;
+    void (async () => {
+      const cached = await getCachedChatEvents(sessionId);
+      if (cancelled) return;
+      if (cached && cached.events.length > 0) {
+        setEvents(cached.events.map(persistedToDisplay));
+        setCacheLastTs(cached.last_ts);
+        setCacheHydratedAt(cached.fetched_at);
+      }
+      setCacheReady(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
   // ---- Snapshot ---------------------------------------------------------
+  // Gated on `cacheReady` so the request includes `?since=cached.last_ts`
+  // for an incremental refresh when we have prior data. The server returns
+  // events strictly newer than `since` (BDHLNDR-58 contract), so dedup
+  // against the cached set is unnecessary — but we still id-dedup below as
+  // a defensive belt-and-suspenders.
   const snapshot = useQuery({
-    queryKey: ['chat-events', sessionId],
-    queryFn: () => fetchChatEvents(sessionId, { limit: SNAPSHOT_LIMIT }),
+    queryKey: ['chat-events', sessionId, cacheLastTs],
+    queryFn: () =>
+      fetchChatEvents(sessionId, {
+        limit: SNAPSHOT_LIMIT,
+        ...(cacheLastTs > 0 ? { since: cacheLastTs } : {}),
+      }),
     staleTime: Infinity, // live updates come via WS — don't refetch on focus
+    enabled: cacheReady,
   });
 
   // ---- Combined log -----------------------------------------------------
-  const [events, setEvents] = useState<DisplayEvent[]>([]);
   /** WS frames that arrived before the snapshot resolved — flushed on success. */
   const pendingWsRef = useRef<DisplayEvent[]>([]);
   const snapshotLoadedRef = useRef(false);
 
   // Seed from snapshot when it lands; flush any buffered WS frames.
+  // When `cacheLastTs > 0` the snapshot is an incremental delta — we MERGE
+  // it onto the cached events that `events` was hydrated with. Otherwise
+  // (cold first-ever open) it's a full snapshot and we replace.
   useEffect(() => {
     if (!snapshot.data || snapshotLoadedRef.current) return;
     snapshotLoadedRef.current = true;
     const seeded = snapshot.data.events.map(persistedToDisplay);
-    if (pendingWsRef.current.length > 0) {
-      // Filter out WS frames already present in the snapshot (server-side
-      // race: snapshot fetched right as a WS broadcast went out). Match by
-      // id — persisted events have stable IDs, WS frames have synth IDs, so
-      // collisions are impossible by construction; this just normalizes if
-      // the contract ever changes.
-      const ids = new Set(seeded.map((e) => e.id));
-      const newer = pendingWsRef.current.filter((e) => !ids.has(e.id));
+    setEvents((prev) => {
+      const base = cacheLastTs > 0 ? prev : [];
+      const ids = new Set(base.map((e) => e.id));
+      const merged: DisplayEvent[] = [...base];
+      for (const ev of seeded) {
+        if (ids.has(ev.id)) continue;
+        ids.add(ev.id);
+        merged.push(ev);
+      }
+      // Flush any buffered WS frames that landed during the snapshot fetch.
+      for (const ev of pendingWsRef.current) {
+        if (ids.has(ev.id)) continue;
+        ids.add(ev.id);
+        merged.push(ev);
+      }
       pendingWsRef.current = [];
-      setEvents([...seeded, ...newer]);
-    } else {
-      setEvents(seeded);
-    }
-  }, [snapshot.data]);
+      return merged;
+    });
+  }, [snapshot.data, cacheLastTs]);
 
   // ---- WS subscription --------------------------------------------------
   useEffect(() => {
@@ -242,11 +322,31 @@ function SessionDetailInner({
   }, [sessionId]);
 
   // Reset state when navigating between sessions (sessionId in deps).
+  // Cache-hydration state resets too so the new session can re-hydrate from
+  // its own cache row.
   useEffect(() => {
     snapshotLoadedRef.current = false;
     pendingWsRef.current = [];
     setEvents([]);
+    setCacheReady(false);
+    setCacheLastTs(0);
+    setCacheHydratedAt(null);
   }, [sessionId]);
+
+  // ---- Persist to cache (BDHLNDR-59) -----------------------------------
+  // Write the in-memory event log back to IndexedDB whenever it changes
+  // (snapshot resolves, WS frame appends, one-tap response edits). The
+  // cache module dedups + caps internally, so we can pass the full array
+  // unconditionally. Skipping the empty-array case avoids overwriting a
+  // valid cache row on the brief moment between the sessionId-reset effect
+  // clearing state and the cache-hydration effect re-populating it.
+  useEffect(() => {
+    if (events.length === 0) return;
+    void setCachedChatEvents(
+      sessionId,
+      events.map((d) => displayToPersisted(sessionId, d)),
+    );
+  }, [events, sessionId]);
 
   // ---- WS status (for the header dot) ----------------------------------
   const [wsStatus, setWsStatus] = useState<WsStatus>(wsClient.status);
@@ -398,15 +498,32 @@ function SessionDetailInner({
         onBack={() => navigate('/sessions')}
       />
 
+      {/*
+        Stale-cache indicator (BDHLNDR-59). Surfaced only when the snapshot
+        query is in an error state AND we hydrated from cache — i.e. we're
+        showing the user something but it might be stale. Healthy network →
+        hidden entirely so it doesn't add header noise during normal use.
+      */}
+      {snapshot.isError && cacheHydratedAt != null && (
+        <div className="border-b border-amber-900/40 bg-amber-950/30 px-3 py-1.5 text-xs text-amber-300/90" role="status">
+          Offline — showing cached chat from <RelativeTime ts={cacheHydratedAt} />.
+        </div>
+      )}
+
       <div
         ref={scrollRef}
         className="relative flex-1 overflow-y-auto px-3 py-3"
         aria-live="polite"
         aria-relevant="additions"
       >
-        {snapshot.isLoading ? (
+        {/*
+          Loading / error gates. If we have cached events, render them even
+          while the snapshot is loading or has errored — the stale-cache
+          indicator above tells the user what they're looking at.
+        */}
+        {snapshot.isLoading && events.length === 0 ? (
           <ChatSkeleton />
-        ) : snapshot.isError ? (
+        ) : snapshot.isError && events.length === 0 ? (
           <ChatLoadError
             message={
               snapshot.error instanceof ApiError && snapshot.error.status === 404

--- a/src/pwa/src/pages/SessionList.tsx
+++ b/src/pwa/src/pages/SessionList.tsx
@@ -23,10 +23,15 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { apiFetch, fetchGroups, fetchSessions } from '../lib/api';
 import { clearAuth, getAuth } from '../lib/auth';
+import {
+  getCachedSessions,
+  setCachedSessions,
+} from '../lib/cache';
 import type { Group, Session, SessionState } from '../lib/types';
 import { wsClient, type SessionStateMessage, type WsStatus } from '../lib/ws';
 import { ConnectionDot } from '../components/ConnectionDot';
 import { OverflowMenu } from '../components/OverflowMenu';
+import { RelativeTime } from '../components/RelativeTime';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -67,6 +72,38 @@ export function SessionList() {
   const navigate = useNavigate();
   const qc = useQueryClient();
 
+  // ---- Cache seed (BDHLNDR-59) ----------------------------------------
+  // Hydrate React Query from IndexedDB before the network fetch resolves so
+  // the user sees their last-known session list immediately on PWA open —
+  // critical for offline / spotty-connectivity launches. Network fetch fires
+  // normally below; whichever resolves first wins, and the network response
+  // overwrites the cached snapshot.
+  //
+  // `cacheHydratedAt` powers the "Last updated X ago" indicator below; it
+  // captures the moment we *seeded* from cache, not the moment the cache
+  // was written. We render the indicator only while the network query is
+  // failing AND we have a hydrated value (cached or stale).
+  const [cacheHydratedAt, setCacheHydratedAt] = useState<number | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const cached = await getCachedSessions();
+      if (cancelled || !cached) return;
+      // Only seed if RQ doesn't already have fresher data (e.g. user
+      // navigated away and back within the same session).
+      if (qc.getQueryData<Session[]>(['sessions']) === undefined) {
+        qc.setQueryData<Session[]>(['sessions'], cached.sessions);
+      }
+      if (qc.getQueryData<Group[]>(['groups']) === undefined) {
+        qc.setQueryData<Group[]>(['groups'], cached.groups);
+      }
+      setCacheHydratedAt(cached.fetched_at);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [qc]);
+
   const sessionsQuery = useQuery({
     queryKey: ['sessions'],
     queryFn: fetchSessions,
@@ -75,6 +112,20 @@ export function SessionList() {
     queryKey: ['groups'],
     queryFn: fetchGroups,
   });
+
+  // Persist on every successful fetch — keeps the cache fresh so the next
+  // cold open shows current data. Runs only when *both* succeed so we never
+  // write a partial snapshot (e.g. sessions newer than groups).
+  useEffect(() => {
+    if (!sessionsQuery.isSuccess || !groupsQuery.isSuccess) return;
+    if (!sessionsQuery.data || !groupsQuery.data) return;
+    void setCachedSessions(sessionsQuery.data, groupsQuery.data);
+  }, [
+    sessionsQuery.isSuccess,
+    groupsQuery.isSuccess,
+    sessionsQuery.data,
+    groupsQuery.data,
+  ]);
 
   // ---- WS live updates -------------------------------------------------
   useEffect(() => {
@@ -270,6 +321,19 @@ export function SessionList() {
       {unpairError && (
         <p role="alert" className="px-4 pt-2 text-xs text-red-300">
           {unpairError}
+        </p>
+      )}
+
+      {/*
+        Stale-cache indicator (BDHLNDR-59). Only shown when:
+          - the network query is in an error state (offline / server down), AND
+          - we have a hydrated cache value to display
+        Healthy network → hidden entirely so it doesn't add noise.
+      */}
+      {sessionsQuery.isError && cacheHydratedAt != null && (
+        <p className="px-4 pt-2 text-xs text-amber-300/80" role="status">
+          Showing cached data — last updated{' '}
+          <RelativeTime ts={cacheHydratedAt} />. Reconnecting…
         </p>
       )}
 


### PR DESCRIPTION
## Summary

Cache last session list + last N chat events per session in IndexedDB. On PWA open, render cached state immediately, refresh from network in background. Survives offline / spotty connectivity. Cache invalidated on unpair.

**Closes:** [BDHLNDR-59](https://gobodhi.atlassian.net/browse/BDHLNDR-59) · Parent Epic: [BDHLNDR-50](https://gobodhi.atlassian.net/browse/BDHLNDR-50)

## Commits

- `6b29bb5` add offline cache module + bump IDB schema to v3
- `90d6ef3` wire offline cache into SessionList + SessionDetail

## Files

**Added:** `src/pwa/src/lib/cache.ts`, `src/pwa/src/components/RelativeTime.tsx`

**Modified:**
- `src/pwa/src/lib/auth.ts` — DB_VERSION 2→3, defensive upgrade now covers v0/v1/v2→v3, `clearAuth()` calls `clearAllCaches()` after auth delete
- `src/pwa/src/lib/install-prompt.ts` — DB_VERSION 2→3, mirror defensive upgrade (cache stores too)
- `src/pwa/src/pages/SessionList.tsx` — cache-seed effect + persist-on-success effect + stale indicator
- `src/pwa/src/pages/SessionDetail.tsx` — cache-hydration effect, gated snapshot query with `since=last_ts`, merge logic, persist-on-change effect, stale banner

## Cache schemas (contract)

```
sessions_cache (keyPath: 'id'):
  { id: 'snapshot', sessions: Session[], groups: Group[], fetched_at: number }

chat_events_cache (keyPath: 'sessionId'):
  { sessionId: string, events: PersistedChatEvent[], last_ts: number, fetched_at: number }
```

## Cache module API

```ts
getCachedSessions(): Promise<SessionsCacheRow | null>
setCachedSessions(sessions, groups): Promise<void>
getCachedChatEvents(sessionId): Promise<ChatEventsCacheRow | null>
setCachedChatEvents(sessionId, events): Promise<void>   // applies 200-event cap
clearAllCaches(): Promise<void>                           // called from clearAuth()
evictOldSessions(): Promise<void>                         // 50-session cap
```

## Eviction policy

- **Per-session cap (200 events)**: EAGER on every `setCachedChatEvents` write (cheap `slice`)
- **Sessions cap (50 rows)**: LAZY-on-write — `evictOldSessions()` called after each `setCachedChatEvents`. Fast path `db.count()` returns early when under cap.

## "Last updated X ago" indicator

Shown **only on network failure** (`snapshotQuery.isError && cacheHydratedAt != null`). Healthy network → hidden so it doesn't clutter the header.
- SessionList: subtle amber text below header
- SessionDetail: bordered amber banner above chat scroller
- Uses `RelativeTime` with adaptive timer (15s / 1min / 15min)

## DB upgrade defensive coverage

All three peer files (`auth.ts`, `install-prompt.ts`, `cache.ts`) carry identical `oldVersion`-gated stepwise callbacks. Whichever wins the open-DB race produces the same final shape:
- **v0→v3** (fresh install): creates all 4 stores in one upgrade callback run
- **v1→v3** (#54 user): skips auth create, adds prompt + caches
- **v2→v3** (#61 user): skips auth + prompt creates, adds caches

All `createObjectStore` calls guarded with `!db.objectStoreNames.contains(...)` for idempotency.

## Test plan

- [x] `bunx tsc --noEmit -p tsconfig.pwa.json` clean
- [x] `bun run build:pwa` succeeds — 335KB main bundle, 13 precache entries
- [ ] Manual: open PWA offline → see cached state instantly
- [ ] Manual: reconnect → cache refreshes seamlessly without UI flicker
- [ ] Manual: unpair → IndexedDB caches all cleared

## Flagged

- WS-sourced events get a synth `id` (no server id over the wire). Cached with synth id; on next cold start, snapshot fetch with `?since=last_ts` relies on server returning events strictly newer (`>`) to avoid id-mismatch dupes. **If BDHLNDR-58's `since` semantics ever change from `>` to `>=`, the dedup-by-id in `setCachedChatEvents` won't catch the dupes.** Worth a contract note on #58, but works as specified today.
- Persist-to-cache effect in SessionDetail fires on every `events` change including consumed-key edits — redundant write when user taps one-tap response. Cheap (small array, async IDB) but flagged.

## Coordination (wave 6 parallel)

Cache logic confined to clearly-bounded `useEffect` blocks at the top of SessionList + SessionDetail. Other wave-6 PRs (#57, #62, #15) touch different sections (overflow menu / compose / render switch). Mechanical merge conflicts at worst.

Built by a parallel subagent alongside #57, #62, #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-59]: https://gobodhi.atlassian.net/browse/BDHLNDR-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-50]: https://gobodhi.atlassian.net/browse/BDHLNDR-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ