### PR TITLE
BDHLNDR-57: raw xterm.js fallback toggle on session detail

### DIFF
--- a/src/pwa/src/components/RawTerminal.tsx
+++ b/src/pwa/src/components/RawTerminal.tsx
@@ -1,0 +1,235 @@
+/**
+ * Raw xterm.js view (BDHLNDR-57) — belt-and-suspenders fallback for the
+ * chat view in `/sessions/:sessionId`.
+ *
+ * Why
+ * ---
+ * The default view (BDHLNDR-56) parses Claude Code's PTY output into
+ * structured chat events. That works great for `claude` sessions but:
+ *   - shell sessions (`bash`, `pwsh`, etc.) have no chat conversation to
+ *     chatify, so the chat view is mostly empty;
+ *   - if the parser ever misses something (new Claude output format,
+ *     unexpected ANSI sequence, etc.) the user has no way to see what's
+ *     actually on the terminal.
+ *
+ * This component bypasses the parser entirely — it just renders raw
+ * `terminal:output` frames into an xterm.js instance, the same way the
+ * desktop renderer does.
+ *
+ * Mobile constraints (PM-5 mitigation)
+ * ------------------------------------
+ * We DO NOT resize the PTY from the PWA. The desktop owns the PTY
+ * dimensions (~80 cols by default). On a phone, fitting the PTY to the
+ * viewport would mangle output on every other open device. Instead, we
+ * let xterm render at whatever width the desktop chose and the container
+ * scrolls horizontally on narrow viewports. The fit-addon is wired up
+ * for future use but `wsClient.send({type: 'terminal:resize', ...})` is
+ * never called from here.
+ *
+ * Input
+ * -----
+ * Tapping the terminal focuses xterm → the mobile virtual keyboard
+ * appears → typed chars (including IME composition output) hit
+ * `xterm.onData(d => wsClient.send(...))`. One WS frame per keystroke —
+ * the desktop's PTY handles batching/echo. If the device is read-only
+ * (no canControl perm), the server emits a generic `error` frame which
+ * we surface as a small banner inside this component.
+ *
+ * Cleanup
+ * -------
+ * On unmount: dispose xterm, unsubscribe the WS handler, drop the
+ * session subscription (ref-counted; the chat view may still be holding
+ * one — but in practice we render EITHER chat or raw, not both, so the
+ * count drops to zero and the desktop sends `terminal:unsubscribe`).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Terminal as XTerm } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+import 'xterm/css/xterm.css';
+
+import {
+  wsClient,
+  type ErrorMessage,
+  type TerminalOutputMessage,
+} from '../lib/ws';
+
+interface RawTerminalProps {
+  sessionId: string;
+}
+
+/**
+ * Dark theme tuned to match the PWA's neutral-900 backdrop. Mirrors the
+ * desktop renderer's palette closely enough that users moving between
+ * devices don't get whiplash.
+ */
+const XTERM_THEME = {
+  background: '#0a0a0a',
+  foreground: '#e5e5e5',
+  cursor: '#e5e5e5',
+  cursorAccent: '#0a0a0a',
+  selectionBackground: 'rgba(255,255,255,0.2)',
+  black: '#000000',
+  red: '#ef4444',
+  green: '#22c55e',
+  yellow: '#eab308',
+  blue: '#3b82f6',
+  magenta: '#a855f7',
+  cyan: '#06b6d4',
+  white: '#e5e5e5',
+  brightBlack: '#525252',
+  brightRed: '#f87171',
+  brightGreen: '#4ade80',
+  brightYellow: '#facc15',
+  brightBlue: '#60a5fa',
+  brightMagenta: '#c084fc',
+  brightCyan: '#22d3ee',
+  brightWhite: '#fafafa',
+} as const;
+
+export function RawTerminal({ sessionId }: RawTerminalProps) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const xtermRef = useRef<XTerm | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const [permError, setPermError] = useState<string | null>(null);
+
+  // ---- Mount xterm + wire WS subscriptions -----------------------------
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    const xterm = new XTerm({
+      theme: XTERM_THEME,
+      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+      fontSize: 13,
+      // Default cursorBlink off — saves a redraw loop on mobile.
+      cursorBlink: true,
+      // Scrollback enough to cover a typical session-end review without
+      // ballooning memory on a phone.
+      scrollback: 5000,
+      // PM-5: do NOT call fit() with the intent of resizing the PTY. We
+      // pre-size xterm with desktop-ish dimensions so output stays
+      // readable; the container will horizontally scroll on narrow
+      // viewports. See file header.
+      cols: 80,
+      rows: 24,
+      // Phones tend to have small viewports; allow text wrapping selection.
+      allowProposedApi: false,
+    });
+    const fitAddon = new FitAddon();
+    xterm.loadAddon(fitAddon);
+    xterm.open(host);
+    xtermRef.current = xterm;
+    fitAddonRef.current = fitAddon;
+
+    // Fit vertically only — we don't propagate cols/rows to the PTY (see
+    // header). Calling fit() makes xterm size its viewport to the host
+    // container; the resulting cols may differ from the PTY's cols, in
+    // which case content wider than the viewport scrolls horizontally
+    // inside xterm's own scroll area. That's the explicit trade-off.
+    try {
+      fitAddon.fit();
+    } catch {
+      // First-paint race with layout — non-fatal, output still renders.
+    }
+
+    // Send typed input through the WS — one frame per keystroke. The
+    // desktop's `terminal:input` handler writes to the PTY; if the device
+    // is read-only, the server replies with an `error` frame which the
+    // error handler below picks up.
+    const inputDisposable = xterm.onData((data) => {
+      wsClient.send({
+        type: 'terminal:input',
+        sessionId,
+        payload: { data },
+      });
+    });
+
+    // Subscribe to terminal:output for THIS session id only.
+    const offOutput = wsClient.on('terminal:output', (msg: TerminalOutputMessage) => {
+      if (msg.sessionId !== sessionId) return;
+      xterm.write(msg.payload.data);
+    });
+
+    // Surface server-side permission failures (read-only paired devices).
+    // The server emits a generic `error` frame, not a 403. We can't
+    // perfectly attribute it to a specific terminal:input call, but the
+    // message text is descriptive enough ("Control permission required").
+    const offError = wsClient.on('error', (msg: ErrorMessage) => {
+      if (typeof msg.payload?.message === 'string' && /control permission/i.test(msg.payload.message)) {
+        setPermError(msg.payload.message);
+      }
+    });
+
+    // Ensure we're subscribed to session-scoped frames. Ref-counted, so
+    // safe even if SessionDetail had its own subscribeSession running.
+    const unsubSession = wsClient.subscribeSession(sessionId);
+
+    return () => {
+      offOutput();
+      offError();
+      unsubSession();
+      inputDisposable.dispose();
+      try {
+        xterm.dispose();
+      } catch {
+        // xterm sometimes throws during dispose if a deferred resize is
+        // still queued — non-fatal, mirrors the desktop renderer guard.
+      }
+      xtermRef.current = null;
+      fitAddonRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId]);
+
+  // ---- Re-fit on viewport changes (orientation, keyboard) --------------
+  // We fit vertically only — see header re: not propagating cols/rows to
+  // the PTY. xterm's own column count won't change since the host width
+  // is bounded by the viewport, but the row count tracks the host height
+  // so the scroll buffer behaves correctly as the keyboard opens/closes.
+  useEffect(() => {
+    const onResize = () => {
+      try {
+        fitAddonRef.current?.fit();
+      } catch {
+        // Layout race — ignore.
+      }
+    };
+    window.addEventListener('resize', onResize);
+    // visualViewport fires when the on-screen keyboard expands/collapses.
+    const vv = window.visualViewport;
+    vv?.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      vv?.removeEventListener('resize', onResize);
+    };
+  }, []);
+
+  // Tapping anywhere on the host focuses xterm so the mobile keyboard
+  // opens. The xterm helper textarea is invisible; without an explicit
+  // focus call iOS sometimes leaves the keyboard down on the first tap.
+  const focusXterm = () => {
+    xtermRef.current?.focus();
+  };
+
+  return (
+    <div className="relative flex flex-1 flex-col overflow-hidden bg-[#0a0a0a]">
+      {permError && (
+        <div
+          role="alert"
+          className="border-b border-red-900/60 bg-red-950/40 px-3 py-2 text-xs text-red-200"
+        >
+          {permError} — this device can view but not control. Re-pair as a
+          control device to type.
+        </div>
+      )}
+      <div
+        ref={hostRef}
+        onClick={focusXterm}
+        className="flex-1 overflow-auto"
+        // The xterm.css handles internal styling; we just provide a
+        // scrollable host that occupies the remaining flex space.
+      />
+    </div>
+  );
+}

--- a/src/pwa/src/pages/SessionDetail.tsx
+++ b/src/pwa/src/pages/SessionDetail.tsx
@@ -97,6 +97,42 @@ import {
 import { wsClient, type ChatEventMessage, type WsStatus } from '../lib/ws';
 import { ConnectionDot } from '../components/ConnectionDot';
 import { OverflowMenu } from '../components/OverflowMenu';
+import { RawTerminal } from '../components/RawTerminal';
+
+// ---------------------------------------------------------------------------
+// View mode (BDHLNDR-57)
+// ---------------------------------------------------------------------------
+
+/**
+ * SessionDetail can render the parsed chat view (default, BDHLNDR-56) OR
+ * a raw xterm.js view of `terminal:output` (BDHLNDR-57). The choice is
+ * persisted per-session in localStorage so each session remembers the
+ * user's preference across reloads.
+ */
+type ViewMode = 'chat' | 'raw';
+
+const VIEW_MODE_STORAGE_PREFIX = 'bodhilander.view-mode.';
+
+function viewModeStorageKey(sessionId: string): string {
+  return `${VIEW_MODE_STORAGE_PREFIX}${sessionId}`;
+}
+
+function loadViewMode(sessionId: string): ViewMode {
+  try {
+    const v = localStorage.getItem(viewModeStorageKey(sessionId));
+    return v === 'raw' ? 'raw' : 'chat';
+  } catch {
+    return 'chat';
+  }
+}
+
+function saveViewMode(sessionId: string, mode: ViewMode): void {
+  try {
+    localStorage.setItem(viewModeStorageKey(sessionId), mode);
+  } catch {
+    // Quota or disabled storage — non-fatal; just don't remember.
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Tunables
@@ -381,6 +417,23 @@ function SessionDetailInner({
   // ---- Header bits -----------------------------------------------------
   const [menuOpen, setMenuOpen] = useState(false);
 
+  // ---- View mode (BDHLNDR-57) ------------------------------------------
+  // Persisted per-session in localStorage. Default 'chat'. Toggled via
+  // the overflow-menu item below.
+  const [viewMode, setViewMode] = useState<ViewMode>(() => loadViewMode(sessionId));
+  // Re-read when the session id changes (the inner component is mounted
+  // per-session so this is mostly belt-and-suspenders).
+  useEffect(() => {
+    setViewMode(loadViewMode(sessionId));
+  }, [sessionId]);
+  const toggleViewMode = useCallback(() => {
+    setViewMode((prev) => {
+      const next: ViewMode = prev === 'chat' ? 'raw' : 'chat';
+      saveViewMode(sessionId, next);
+      return next;
+    });
+  }, [sessionId]);
+
   // ---- Render ----------------------------------------------------------
   // TODO(BDHLNDR-56-followup): "Load older" pagination using
   //   fetchChatEvents(sessionId, { since: oldestTs - 1, limit: 500 })
@@ -396,66 +449,78 @@ function SessionDetailInner({
         menuOpen={menuOpen}
         onMenuOpenChange={setMenuOpen}
         onBack={() => navigate('/sessions')}
+        viewMode={viewMode}
+        onToggleViewMode={toggleViewMode}
       />
 
-      <div
-        ref={scrollRef}
-        className="relative flex-1 overflow-y-auto px-3 py-3"
-        aria-live="polite"
-        aria-relevant="additions"
-      >
-        {snapshot.isLoading ? (
-          <ChatSkeleton />
-        ) : snapshot.isError ? (
-          <ChatLoadError
-            message={
-              snapshot.error instanceof ApiError && snapshot.error.status === 404
-                ? 'Session not found.'
-                : snapshot.error instanceof Error
-                  ? snapshot.error.message
-                  : 'Failed to load chat history.'
-            }
-            onRetry={() => void snapshot.refetch()}
+      {/* BDHLNDR-57: render EITHER chat log + compose OR the raw xterm
+          view — never both, to avoid duplicate WS handlers and double
+          render of incoming output. Header (incl. overflow menu) stays
+          identical between modes. */}
+      {viewMode === 'raw' ? (
+        <RawTerminal sessionId={sessionId} />
+      ) : (
+        <>
+          <div
+            ref={scrollRef}
+            className="relative flex-1 overflow-y-auto px-3 py-3"
+            aria-live="polite"
+            aria-relevant="additions"
+          >
+            {snapshot.isLoading ? (
+              <ChatSkeleton />
+            ) : snapshot.isError ? (
+              <ChatLoadError
+                message={
+                  snapshot.error instanceof ApiError && snapshot.error.status === 404
+                    ? 'Session not found.'
+                    : snapshot.error instanceof Error
+                      ? snapshot.error.message
+                      : 'Failed to load chat history.'
+                }
+                onRetry={() => void snapshot.refetch()}
+              />
+            ) : events.length === 0 ? (
+              <EmptyChat />
+            ) : (
+              <ul className="space-y-2">
+                {events.map((e, idx) => (
+                  <li key={e.id}>
+                    <EventRenderer
+                      display={e}
+                      onTapResponse={handleTapResponse}
+                      isLatest={idx === events.length - 1}
+                    />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {/* Floating "↓ new messages" pill */}
+          {!pinnedToBottom && unreadCount > 0 && (
+            <button
+              type="button"
+              onClick={() => {
+                scrollToBottom('smooth');
+                setUnreadCount(0);
+              }}
+              className="absolute bottom-24 left-1/2 z-10 -translate-x-1/2 rounded-full bg-blue-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg shadow-blue-900/40 hover:bg-blue-500"
+            >
+              ↓ {unreadCount} new {unreadCount === 1 ? 'message' : 'messages'}
+            </button>
+          )}
+
+          <Compose
+            draft={draft}
+            onDraftChange={setDraft}
+            onSend={handleSend}
+            sending={sending}
+            readOnly={readOnly}
+            error={sendError}
           />
-        ) : events.length === 0 ? (
-          <EmptyChat />
-        ) : (
-          <ul className="space-y-2">
-            {events.map((e, idx) => (
-              <li key={e.id}>
-                <EventRenderer
-                  display={e}
-                  onTapResponse={handleTapResponse}
-                  isLatest={idx === events.length - 1}
-                />
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-
-      {/* Floating "↓ new messages" pill */}
-      {!pinnedToBottom && unreadCount > 0 && (
-        <button
-          type="button"
-          onClick={() => {
-            scrollToBottom('smooth');
-            setUnreadCount(0);
-          }}
-          className="absolute bottom-24 left-1/2 z-10 -translate-x-1/2 rounded-full bg-blue-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg shadow-blue-900/40 hover:bg-blue-500"
-        >
-          ↓ {unreadCount} new {unreadCount === 1 ? 'message' : 'messages'}
-        </button>
+        </>
       )}
-
-      <Compose
-        draft={draft}
-        onDraftChange={setDraft}
-        onSend={handleSend}
-        sending={sending}
-        readOnly={readOnly}
-        error={sendError}
-      />
     </main>
   );
 }
@@ -470,12 +535,16 @@ function Header({
   menuOpen,
   onMenuOpenChange,
   onBack,
+  viewMode,
+  onToggleViewMode,
 }: {
   sessionId: string;
   wsStatus: WsStatus;
   menuOpen: boolean;
   onMenuOpenChange: (open: boolean) => void;
   onBack: () => void;
+  viewMode: ViewMode;
+  onToggleViewMode: () => void;
 }) {
   // We don't fetch the session here just for the name — the session list
   // shows it on the row the user tapped to get here, and the URL id is the
@@ -518,6 +587,16 @@ function Header({
         open={menuOpen}
         onOpenChange={onMenuOpenChange}
         items={[
+          // BDHLNDR-57: view-mode toggle. Placed at the TOP per the
+          // wave-6 coordination notes — BDHLNDR-62 (Kill / Restart) will
+          // append its items at the BOTTOM, so the merge is mechanical.
+          {
+            label: viewMode === 'chat' ? 'Show raw terminal' : 'Show chat view',
+            onSelect: () => {
+              onMenuOpenChange(false);
+              onToggleViewMode();
+            },
+          },
           {
             label: 'Back to sessions',
             onSelect: () => {


### PR DESCRIPTION
## Summary

Per-session toggle on `/sessions/:sessionId` that switches from the chat view (BDHLNDR-56) to a raw xterm.js view of `terminal:output`. Belt-and-suspenders for shell sessions or chat-parser misses.

**Closes:** [BDHLNDR-57](https://gobodhi.atlassian.net/browse/BDHLNDR-57) · Parent Epic: [BDHLNDR-50](https://gobodhi.atlassian.net/browse/BDHLNDR-50)

## Commits

- `6edb152` add RawTerminal xterm component
- `b2c18bc` wire view-mode toggle in SessionDetail

## Files

- **Added:** `src/pwa/src/components/RawTerminal.tsx`
- **Modified:** `src/pwa/src/pages/SessionDetail.tsx`

## Dep reuse (no new install)

Used existing root deps `xterm@5.3.0` + `xterm-addon-fit@0.8.0` (already declared in `package.json` from the Electron renderer). Did NOT use the `@xterm/*` scope variants to keep the dep aligned with the desktop renderer.

## View-mode persistence

`localStorage` key `bodhilander.view-mode.<sessionId>`, default `'chat'`. Per-session — each session remembers its own preference.

## Overflow menu

Item placed at the TOP of the menu items array per the wave-6 coordination. BDHLNDR-62 appends Kill/Restart at the bottom — mechanical conflict only.

Label flips with current mode: `"Show raw terminal"` (chat mode) ↔ `"Show chat view"` (raw mode).

## PM-5 mitigation: "don't resize PTY from mobile"

xterm created with fixed `cols: 80, rows: 24` (desktop-ish baseline). `FitAddon.fit()` called on mount + `window.resize` / `visualViewport.resize` (keyboard show/hide). **`wsClient.send({type: 'terminal:resize', ...})` is NEVER called** from this component. Content wider than viewport scrolls horizontally inside xterm's viewport — accepted per spec.

## Input handling

`xterm.onData(d => wsClient.send({type: 'terminal:input', sessionId, payload: {data: d}}))` — one WS frame per keystroke. No client-side batching; the desktop PTY echoes back via `terminal:output`.

## Bundle delta — ⚠️ heads-up

```
JS:  330.09 → 617.98 kB raw (+287.89 kB), gzip 103.84 → 176.75 kB (+72.91 kB)
CSS: 27.83 → 31.75 kB raw (+3.92 kB), gzip 5.78 → 7.29 kB (+1.51 kB)
```

xterm adds **+288 KB raw / +73 KB gzip**. Well over the 100 KB threshold the brief called out. Worth a small follow-up to code-split via `React.lazy(() => import('../components/RawTerminal'))` so chat-only users (the default) don't pay the xterm cost. Currently loaded eagerly on every SessionDetail mount.

## Test plan

- [x] `bunx tsc --noEmit -p tsconfig.pwa.json` clean
- [x] `bun run build:pwa` succeeds
- [ ] Manual: toggle chat→raw, verify xterm streams `terminal:output` live
- [ ] Manual: type in raw view, verify input echoes back
- [ ] Manual: reload, verify per-session mode preference persists

## Flagged

- Server emits a generic `error` frame (not 403) for read-only-device `terminal:input` attempts. Matched on `/control permission/i` in the message text — fragile if server wording changes. Could add a dedicated error code in a follow-up.
- xterm bundle weight wants `React.lazy()` in a follow-up.

## Coordination (wave 6 parallel)

Touches SessionDetail.tsx render section + overflow menu (top slot). #62 takes the bottom slot, #15 touches compose, #59 touches hydration effects. Mostly mechanical merges.

Built by a parallel subagent alongside #59, #62, #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-57]: https://gobodhi.atlassian.net/browse/BDHLNDR-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-50]: https://gobodhi.atlassian.net/browse/BDHLNDR-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ