### PR TITLE
BDHLNDR-62: session controls (Restart / Kill) in chat-view overflow menu

### DIFF
--- a/src/pwa/src/lib/api.ts
+++ b/src/pwa/src/lib/api.ts
@@ -156,3 +156,36 @@ export async function sendTerminalInput(sessionId: string, data: string): Promis
   );
 }
 
+// ---------------------------------------------------------------------------
+// Session control (BDHLNDR-62)
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /api/v1/sessions/:id/stop — kill the PTY for an active session.
+ * Requires the device's `canControl` permission server-side; surfaces 403 as
+ * ApiError so the caller can render an inline "no permission" banner. The
+ * server returns 400 if the session is not currently running — also bubbled
+ * up as ApiError for the caller to message.
+ */
+export async function stopSession(sessionId: string): Promise<void> {
+  await apiFetch<{ success: true }>(
+    `/sessions/${encodeURIComponent(sessionId)}/stop`,
+    { method: 'POST' },
+  );
+}
+
+/**
+ * POST /api/v1/sessions/:id/start — start a fresh PTY for an existing session.
+ * `launchClaude` defaults to false on the server. Caller decides whether to
+ * relaunch Claude vs. spawn a plain shell. Requires `canControl`.
+ */
+export async function startSession(
+  sessionId: string,
+  opts?: { launchClaude?: boolean },
+): Promise<void> {
+  await apiFetch<{ success: true }>(
+    `/sessions/${encodeURIComponent(sessionId)}/start`,
+    { method: 'POST', body: opts ?? {} },
+  );
+}
+

--- a/src/pwa/src/pages/SessionDetail.tsx
+++ b/src/pwa/src/pages/SessionDetail.tsx
@@ -86,7 +86,14 @@ import {
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 
-import { ApiError, fetchChatEvents, sendTerminalInput } from '../lib/api';
+import {
+  ApiError,
+  fetchChatEvents,
+  sendTerminalInput,
+  startSession,
+  stopSession,
+} from '../lib/api';
+import { getAuth } from '../lib/auth';
 import { maybePromptAndSubscribe } from '../lib/push';
 import {
   narrowChatEvent,
@@ -381,6 +388,91 @@ function SessionDetailInner({
   // ---- Header bits -----------------------------------------------------
   const [menuOpen, setMenuOpen] = useState(false);
 
+  // ---- Session control (BDHLNDR-62) ------------------------------------
+  // Restart / Kill buttons live in the header overflow menu. Server enforces
+  // canControl on /sessions/:id/start and /stop; we additionally hide the
+  // items client-side so read-only devices don't see disabled affordances
+  // they can't use. Defensive default: assume false until getAuth() resolves
+  // — better to flicker an item IN than show it to a device that turns out
+  // not to have permission.
+  const [canControl, setCanControl] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    void getAuth()
+      .then((auth) => {
+        if (!cancelled) setCanControl(auth?.device.canControl === true);
+      })
+      .catch(() => {
+        if (!cancelled) setCanControl(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  /** Modal state for the Kill confirmation. Null when closed. */
+  const [killConfirmOpen, setKillConfirmOpen] = useState(false);
+  /**
+   * In-flight tracker for the two control actions. We disable BOTH buttons
+   * while either is firing — they're mutually-exclusive operations on the
+   * same PTY and racing them server-side would just produce a 400 anyway.
+   */
+  const [controlBusy, setControlBusy] = useState<null | 'restarting' | 'stopping'>(null);
+  const [controlError, setControlError] = useState<string | null>(null);
+  const [controlFlash, setControlFlash] = useState<string | null>(null);
+  // Auto-dismiss the success banner so the chat view goes back to normal.
+  useEffect(() => {
+    if (!controlFlash) return;
+    const handle = window.setTimeout(() => setControlFlash(null), 2000);
+    return () => window.clearTimeout(handle);
+  }, [controlFlash]);
+
+  const runControlAction = useCallback(
+    async (
+      kind: 'restarting' | 'stopping',
+      action: () => Promise<void>,
+      successMessage: string,
+    ) => {
+      setControlBusy(kind);
+      setControlError(null);
+      setControlFlash(null);
+      try {
+        await action();
+        setControlFlash(successMessage);
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 403) {
+          setControlError("Read-only — this device can't control sessions.");
+        } else if (err instanceof ApiError && err.status === 400) {
+          // Server-side "already running" / "not running" lands here. The
+          // error body usually has a useful `error` field, but we don't want
+          // to render arbitrary server text — keep it generic.
+          setControlError(
+            kind === 'restarting'
+              ? 'Could not start session (already running?).'
+              : 'Could not stop session (not running?).',
+          );
+        } else {
+          setControlError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        setControlBusy(null);
+      }
+    },
+    [],
+  );
+
+  const handleRestart = useCallback(() => {
+    setMenuOpen(false);
+    void runControlAction('restarting', () => startSession(sessionId), 'Session restarted');
+  }, [runControlAction, sessionId]);
+
+  const handleConfirmKill = useCallback(() => {
+    setKillConfirmOpen(false);
+    void runControlAction('stopping', () => stopSession(sessionId), 'Session stopped');
+  }, [runControlAction, sessionId]);
+
+  const shortSessionId = useMemo(() => sessionId.slice(0, 8), [sessionId]);
+
   // ---- Render ----------------------------------------------------------
   // TODO(BDHLNDR-56-followup): "Load older" pagination using
   //   fetchChatEvents(sessionId, { since: oldestTs - 1, limit: 500 })
@@ -396,7 +488,35 @@ function SessionDetailInner({
         menuOpen={menuOpen}
         onMenuOpenChange={setMenuOpen}
         onBack={() => navigate('/sessions')}
+        canControl={canControl}
+        controlBusy={controlBusy}
+        onRestart={handleRestart}
+        onRequestKill={() => {
+          setMenuOpen(false);
+          setKillConfirmOpen(true);
+        }}
       />
+
+      {/* BDHLNDR-62: session-control feedback. The flash auto-dismisses
+          (success); the error banner persists until the user takes another
+          action so they can read it. Matches the inline sendError pattern
+          used by Compose to keep the UX consistent. */}
+      {controlError && (
+        <div
+          role="alert"
+          className="border-b border-red-900/50 bg-red-950/40 px-3 py-2 text-xs text-red-200"
+        >
+          {controlError}
+        </div>
+      )}
+      {controlFlash && (
+        <div
+          role="status"
+          className="border-b border-emerald-900/40 bg-emerald-950/30 px-3 py-2 text-xs text-emerald-200"
+        >
+          {controlFlash}
+        </div>
+      )}
 
       <div
         ref={scrollRef}
@@ -456,6 +576,18 @@ function SessionDetailInner({
         readOnly={readOnly}
         error={sendError}
       />
+
+      {/* BDHLNDR-62: Kill-session confirmation. Controlled JSX overlay
+          (no native <dialog> to avoid the platform inconsistencies in
+          mobile Safari, which still has incomplete <dialog> support). */}
+      {killConfirmOpen && (
+        <KillConfirmDialog
+          shortSessionId={shortSessionId}
+          stopping={controlBusy === 'stopping'}
+          onCancel={() => setKillConfirmOpen(false)}
+          onConfirm={handleConfirmKill}
+        />
+      )}
     </main>
   );
 }
@@ -470,12 +602,22 @@ function Header({
   menuOpen,
   onMenuOpenChange,
   onBack,
+  canControl,
+  controlBusy,
+  onRestart,
+  onRequestKill,
 }: {
   sessionId: string;
   wsStatus: WsStatus;
   menuOpen: boolean;
   onMenuOpenChange: (open: boolean) => void;
   onBack: () => void;
+  /** BDHLNDR-62: only render control items when the device may use them. */
+  canControl: boolean;
+  /** Which control action (if any) is currently in flight — disables both. */
+  controlBusy: null | 'restarting' | 'stopping';
+  onRestart: () => void;
+  onRequestKill: () => void;
 }) {
   // We don't fetch the session here just for the name — the session list
   // shows it on the row the user tapped to get here, and the URL id is the
@@ -525,6 +667,36 @@ function Header({
               onBack();
             },
           },
+          // BDHLNDR-62: session control items, appended at the BOTTOM of the
+          // menu by coordination with BDHLNDR-57 (which inserts its "Show
+          // raw terminal" toggle at the TOP). Only rendered when the device
+          // has canControl — the server enforces the same gate, so this is
+          // purely UX clutter reduction for read-only viewers.
+          ...(canControl
+            ? [
+                {
+                  label:
+                    controlBusy === 'restarting'
+                      ? 'Restarting…'
+                      : 'Restart session',
+                  disabled: controlBusy !== null,
+                  onSelect: () => {
+                    if (controlBusy !== null) return;
+                    onRestart();
+                  },
+                },
+                {
+                  label:
+                    controlBusy === 'stopping' ? 'Stopping…' : 'Kill session',
+                  danger: true,
+                  disabled: controlBusy !== null,
+                  onSelect: () => {
+                    if (controlBusy !== null) return;
+                    onRequestKill();
+                  },
+                },
+              ]
+            : []),
         ]}
       />
     </header>
@@ -863,6 +1035,72 @@ function ChatLoadError({ message, onRetry }: { message: string; onRetry: () => v
       >
         Try again
       </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Kill confirmation modal (BDHLNDR-62)
+// ---------------------------------------------------------------------------
+
+/**
+ * Tiny controlled-JSX confirm modal for the destructive "Kill session"
+ * action. We avoid the native `<dialog>` element because mobile Safari's
+ * `<dialog>` implementation still has gaps (focus-trap, backdrop interop)
+ * that aren't worth chasing for a single confirm, and bringing in a modal
+ * lib for one prompt would dwarf the feature. The overlay is fixed-position
+ * with an ARIA-labeled inner card; tapping the dim backdrop cancels.
+ */
+function KillConfirmDialog({
+  shortSessionId,
+  stopping,
+  onCancel,
+  onConfirm,
+}: {
+  shortSessionId: string;
+  stopping: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-30 flex items-center justify-center bg-black/60 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="kill-confirm-title"
+      onClick={(e) => {
+        // Click on backdrop only — taps inside the card shouldn't dismiss.
+        if (e.target === e.currentTarget && !stopping) onCancel();
+      }}
+    >
+      <div className="w-full max-w-sm rounded-lg border border-neutral-800 bg-neutral-900 p-4 shadow-xl">
+        <h2 id="kill-confirm-title" className="text-base font-semibold text-neutral-100">
+          Stop session?
+        </h2>
+        <p className="mt-2 text-sm text-neutral-300">
+          This will kill the PTY for session{' '}
+          <span className="font-mono text-neutral-100">{shortSessionId}</span>.
+          Any unsaved work in the terminal will be lost.
+        </p>
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={stopping}
+            className="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-sm text-neutral-200 hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={stopping}
+            className="rounded-md border border-red-800 bg-red-700/80 px-3 py-1.5 text-sm font-medium text-red-50 hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {stopping ? 'Stopping…' : 'Stop session'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Kill / Restart buttons in the SessionDetail overflow menu. Gated client-side by `canControl` (server enforces the same gate via `requireControlPermission` middleware). Confirmation dialog for the destructive Kill action.

**Closes:** [BDHLNDR-62](https://gobodhi.atlassian.net/browse/BDHLNDR-62) · Parent Epic: [BDHLNDR-50](https://gobodhi.atlassian.net/browse/BDHLNDR-50)

## Commits

- `4309c2f` add stopSession/startSession api helpers
- `d27755e` add Restart/Kill items to chat-view overflow menu

## Files modified

- `src/pwa/src/lib/api.ts` — `stopSession()` + `startSession()` helpers wrapping existing POST routes
- `src/pwa/src/pages/SessionDetail.tsx` — control state/handlers, new Header props, two appended overflow menu items, banners under the header, inline `KillConfirmDialog`

## Overflow menu placement

BOTTOM (after "Back to sessions"), leaving TOP slot for BDHLNDR-57's raw-terminal toggle per wave-6 coordination.

## Confirmation dialog

Controlled JSX (`fixed inset-0` overlay + ARIA-labeled card), NOT the native `<dialog>` element (mobile Safari `<dialog>` has focus-trap / backdrop interop gaps not worth chasing). Backdrop tap cancels; Cancel + Stop session buttons; Stop is destructive red and shows "Stopping…" while in flight.

## Toast/banner UX

Two sticky banners directly under `<Header>`:
- Error banner — red, persists until next action
- Success flash — emerald, auto-dismisses after 2000ms via `setTimeout` cleanup

Matches the existing `sendError` aesthetic from Compose for consistency.

## canControl gate

Client-side **hidden** (items omitted from menu entirely) when `canControl !== true`. `getAuth()` read on mount; defensive default `false` until it resolves or if it throws. Server enforces the same gate; hiding the items is purely UX clutter reduction for read-only viewers.

## Test plan

- [x] `bunx tsc --noEmit -p tsconfig.pwa.json` clean
- [x] `bun run build:pwa` succeeds
- [ ] Manual on canControl device: tap Restart → toast → new PTY spawns
- [ ] Manual on canControl device: tap Kill → confirmation → confirm → PTY stops
- [ ] Manual on read-only device: items NOT visible in menu
- [ ] Manual: cancel the Kill confirmation → no action taken

## Flagged

- Brief said `startSession(sessionId)` (no opts) → translates to `launchClaude: false` server-side. A chat-view restart that spawns bash instead of Claude **may not be what end users expect**. Followed the spec literally; trivial to flip to `{ launchClaude: true }` if product confirms.

## Coordination (wave 6 parallel)

Touches SessionDetail.tsx overflow menu (bottom items) + banner section + dialog. #57 takes top slot in overflow, #15 touches compose, #59 touches hydration effects. Different sections — mechanical merges.

Built by a parallel subagent alongside #57, #59, #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-62]: https://gobodhi.atlassian.net/browse/BDHLNDR-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BDHLNDR-50]: https://gobodhi.atlassian.net/browse/BDHLNDR-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ