### PR TITLE
BDHLNDR-69: unpack dist/pwa from asar (PWA white-screen hotfix)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -15,6 +15,12 @@ asarUnpack:
   - dist/mcp-server/**/*
   - dist/hooks/**/*
   - dist/main/vector-search/**/*
+  # BDHLNDR-69: the PWA bundle is served at runtime by express.static, which
+  # streams files via fs.createReadStream — that path doesn't work reliably
+  # inside an asar archive (sendFile errors propagate, and static handler
+  # falls through to the SPA fallback returning JSON-typed errors). Unpacking
+  # gives us real on-disk paths for express to serve cleanly.
+  - dist/pwa/**/*
   - node_modules/node-pty/**/*
   - node_modules/better-sqlite3/**/*
   - node_modules/sodium-native/**/*


### PR DESCRIPTION
## Summary

Hotfix for the PWA white-screen on packaged builds. `dist/pwa/**/*` added to `asarUnpack` in `electron-builder.yml`.

**Closes:** [BDHLNDR-69](https://gobodhi.atlassian.net/browse/BDHLNDR-69)

## Root cause (from BDHLNDR-69)

\`express.static\` streams via \`fs.createReadStream\`, which doesn't work reliably on asar paths. In the packaged \`3.4.0-beta.0\` build, \`/m/assets/*\` requests fall through to the SPA fallback, which returns:
- **500** when \`sendFile\` errors propagate via \`next(err)\` → default error handler
- **404 with \`application/json\` MIME** when \`fs.existsSync\` returns false on asar (the fallback's own JSON error)

Browser refuses to apply CSS with \`application/json\` MIME → white screen.

Console from the affected build:

\`\`\`
index-BqDTC0ps.js:1  Failed to load resource: the server responded with a status of 500 (Internal Server Error)
m/:1 Refused to apply style from 'http://192.168.1.78:8443/m/assets/index-CC3_BKul.css' because its MIME type ('application/json') is not a supported stylesheet MIME type, and strict MIME checking is enabled.
\`\`\`

## Fix

\`\`\`yaml
asarUnpack:
  - dist/mcp-server/**/*
  - dist/hooks/**/*
  - dist/main/vector-search/**/*
  - dist/pwa/**/*   # NEW
\`\`\`

Same treatment as the existing entries — each one is content that needs filesystem-level access from packaged mode (stream / spawn / require / serve).

## Test plan

- [x] No code changes — only \`electron-builder.yml\`
- [ ] After merge: cut \`3.4.0-beta.1\` on development, install, hit \`/m/\` from a phone — see the PWA shell, not a white screen
- [ ] Manual: verify \`/m/assets/index-*.js\` returns 200 with \`application/javascript\` MIME and \`/m/assets/index-*.css\` returns 200 with \`text/css\`

## Severity

**High** — blocks the entire mobile companion PWA on the just-cut \`3.4.0-beta.0\` beta. Trivial fix; next beta cut picks it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BDHLNDR-69]: https://gobodhi.atlassian.net/browse/BDHLNDR-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ