### PR TITLE
BDHLNDR-69 follow-up: resolve PWA dir through app.asar.unpacked explicitly

### DIFF
--- a/src/main/api/http-server.ts
+++ b/src/main/api/http-server.ts
@@ -130,7 +130,19 @@ export async function createHttpServer(config: HttpServerConfig): Promise<HttpSe
   // /m/* path so client-side routing works on hard refresh. No auth is
   // required here — auth happens inside the PWA after pairing, exactly
   // like the /api/v1/pairing initiation endpoints.
-  const pwaDistDir = path.join(__dirname, '..', '..', 'pwa');
+  //
+  // BDHLNDR-69 follow-up: in packaged builds dist/pwa is asarUnpacked (see
+  // electron-builder.yml), so the real files live under app.asar.unpacked/.
+  // Electron's fs wrapper auto-redirects asar paths for most calls, but the
+  // `send` package that express.static uses internally resolves paths in
+  // ways that don't always trigger the redirect — the result was 500s on
+  // asset requests that fell through to the SPA fallback. Substituting the
+  // unpacked path here means express.static gets a real on-disk path. In
+  // dev mode the substitution is a no-op (the path doesn't contain
+  // `app.asar`), so the same code works in both modes.
+  const pwaDistDir = path
+    .join(__dirname, '..', '..', 'pwa')
+    .replace(`${path.sep}app.asar${path.sep}`, `${path.sep}app.asar.unpacked${path.sep}`);
   const pwaIndexHtml = path.join(pwaDistDir, 'index.html');
   app.use(
     '/m',


### PR DESCRIPTION
## Summary

The previous BDHLNDR-69 hotfix (#82, added \`dist/pwa\` to \`asarUnpack\`) was necessary but not sufficient. \`express.static\` still failed to serve PWA assets in packaged mode because the path it received resolved INTO the asar archive — where the files no longer live, since asarUnpack moved them out.

**Verified against the installed 3.4.0-beta.1 layout on this machine before pushing this PR.**

## Diagnosis (the real root cause)

In packaged mode, \`__dirname\` for the compiled \`http-server.js\` is:
\`\`\`
.../resources/app.asar/dist/main/api
\`\`\`

\`path.join(__dirname, '..', '..', 'pwa')\` resolves to:
\`\`\`
.../resources/app.asar/dist/pwa
\`\`\`

But after asarUnpack, the actual files live at:
\`\`\`
.../resources/app.asar.unpacked/dist/pwa
\`\`\`

Electron's fs wrapper auto-redirects asar paths for direct \`fs.*\` calls, but the \`send\` package that \`express.static\` uses internally resolves paths through a sequence of \`path.normalize\` / \`path.resolve\` / \`fs.stat\` calls in ways that don't reliably trigger the redirect. Result: the static handler can't find the asset, falls through to the SPA fallback, which returns either a 500 (sendFile errors propagate) or a 404 with \`application/json\` MIME (the JSON error response).

Confirmed empirically: \`fs.existsSync('.../resources/app.asar/dist/pwa')\` returns **false** under Node (no asar wrapper), while \`fs.existsSync('.../resources/app.asar.unpacked/dist/pwa')\` returns **true**.

## Fix

Substitute the path explicitly:

\`\`\`ts
const pwaDistDir = path
  .join(__dirname, '..', '..', 'pwa')
  .replace(\`\${path.sep}app.asar\${path.sep}\`, \`\${path.sep}app.asar.unpacked\${path.sep}\`);
\`\`\`

Behavior:
- **Packaged Windows**: \`...\app.asar\dist\pwa\` → \`...\app.asar.unpacked\dist\pwa\` ✓
- **Packaged macOS**: \`.../app.asar/dist/pwa\` → \`.../app.asar.unpacked/dist/pwa\` ✓
- **Dev mode**: \`dist/pwa\` (no \`app.asar\` substring) → unchanged ✓

Standard Electron pattern. \`path.sep\` makes it cross-platform.

## Verified before pushing

Test methodology (per "actually verify locally before pushing more fixes" feedback on the previous attempt):

1. Inspected the installed beta.1 — confirmed \`dist/pwa\` IS at \`app.asar.unpacked/dist/pwa\` (BDHLNDR-69 hotfix #82 worked) but Node's native \`existsSync\` confirmed the un-substituted path resolves to a non-existent dir.

2. Wrote a throwaway Express server (\`scripts/test-pwa-serve.cjs\`, deleted after verification) that mirrored the production mount strategy and pointed at the installed beta.1's \`app.asar.unpacked/dist/pwa\` directly. All asset MIMEs + statuses correct:

\`\`\`
PASS  /m/                                            200  text/html
PASS  /m/index.html                                  200  text/html
PASS  /m/assets/index-BqDTC0ps.js                    200  text/javascript
PASS  /m/assets/index-CC3_BKul.css                   200  text/css
PASS  /m/sw.js                                       200  text/javascript
PASS  /m/manifest.webmanifest                        200  application/manifest+json
PASS  /m/sessions/foo                                200  text/html  (SPA fallback)
\`\`\`

3. Verified the path-substitution logic produces correct paths for packaged Windows, packaged macOS, and dev mode at the corresponding \`path.sep\` runtimes.

\`bunx tsc --noEmit -p tsconfig.main.json\` clean.

## Severity

**High** — beta.1 was the hotfix attempt that didn't work; PWA still white-screens in 3.4.0-beta.1. This is the real fix. Cut 3.4.0-beta.2 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)