### PR TITLE
BDHLNDR-70 follow-up: ErrorCard + aggressive wrap-anywhere + flex min-w-0

### DIFF
--- a/src/pwa/src/pages/SessionDetail.tsx
+++ b/src/pwa/src/pages/SessionDetail.tsx
@@ -958,9 +958,16 @@ function EventRenderer({
   }
 }
 
+// BDHLNDR-70 follow-up: wrap-anywhere (Tailwind 4 → `overflow-wrap: anywhere`)
+// instead of break-words, because break-words only breaks at word boundaries
+// and the parser emits payloads with long unbreakable runs (URLs, paths,
+// ANSI sequences that the renderer treats as raw chars). The flex wrapper
+// on ResponseBubble also gets `min-w-0` — without it, flex items don't
+// shrink below their content's intrinsic width, which defeats max-w on the
+// inner bubble.
 function AssistantBubble({ text }: { text: string }) {
   return (
-    <div className="max-w-[85%] break-words rounded-2xl rounded-tl-sm bg-neutral-800 px-3 py-2 text-sm text-neutral-100">
+    <div className="max-w-[85%] wrap-anywhere rounded-2xl rounded-tl-sm bg-neutral-800 px-3 py-2 text-sm text-neutral-100">
       <PlainTextWithBreaks text={text} />
     </div>
   );
@@ -968,8 +975,8 @@ function AssistantBubble({ text }: { text: string }) {
 
 function ResponseBubble({ text }: { text: string }) {
   return (
-    <div className="flex justify-end">
-      <div className="max-w-[85%] break-words rounded-2xl rounded-tr-sm bg-blue-600/30 px-3 py-2 text-sm text-blue-100">
+    <div className="flex min-w-0 justify-end">
+      <div className="max-w-[85%] wrap-anywhere rounded-2xl rounded-tr-sm bg-blue-600/30 px-3 py-2 text-sm text-blue-100">
         <PlainTextWithBreaks text={text} />
       </div>
     </div>
@@ -978,7 +985,7 @@ function ResponseBubble({ text }: { text: string }) {
 
 function ToolCallRow({ tool, argsBrief }: { tool: string; argsBrief: string }) {
   return (
-    <div className="break-all rounded-md bg-neutral-800/40 px-3 py-1 font-mono text-xs text-neutral-400">
+    <div className="wrap-anywhere rounded-md bg-neutral-800/40 px-3 py-1 font-mono text-xs text-neutral-400">
       <span className="text-neutral-500">⏺ </span>
       <span className="text-neutral-300">{tool}</span>
       <span className="text-neutral-500">({argsBrief})</span>
@@ -988,7 +995,7 @@ function ToolCallRow({ tool, argsBrief }: { tool: string; argsBrief: string }) {
 
 function ErrorCard({ text }: { text: string }) {
   return (
-    <div className="max-w-[85%] rounded-md border border-red-900/60 bg-red-950/30 px-3 py-2 text-sm text-red-200">
+    <div className="max-w-[85%] wrap-anywhere rounded-md border border-red-900/60 bg-red-950/30 px-3 py-2 text-sm text-red-200">
       {text}
     </div>
   );


### PR DESCRIPTION
## Summary

Real-phone testing of \`3.4.0-beta.4\` confirmed the CR-not-LF fix unblocked sending (Claude actually processes the input now), but **text still overshoots bubble boxes** despite the \`break-words\` added in PR #85.

Three root causes:

1. **ErrorCard had no overflow-wrap class at all.** Most likely the visible "overshooting" — error messages are often long unwrapped strings (stack traces, tool errors with paths).
2. **\`break-words\` only breaks at word boundaries.** Parser payloads frequently contain long unbreakable runs (URLs, file paths, ANSI sequences treated as raw chars). Tailwind 4's \`wrap-anywhere\` (CSS \`overflow-wrap: anywhere\`) breaks aggressively mid-token when needed.
3. **ResponseBubble's flex parent missing \`min-w-0\`.** Classic flexbox gotcha: flex items don't shrink below their content's intrinsic width, which defeats \`max-w-[85%]\` on the inner bubble whenever content is unbreakable.

## Changes

\`src/pwa/src/pages/SessionDetail.tsx\`:
- \`AssistantBubble\`: \`break-words\` → \`wrap-anywhere\`
- \`ResponseBubble\`: \`break-words\` → \`wrap-anywhere\`, parent gains \`min-w-0\`
- \`ToolCallRow\`: \`break-all\` → \`wrap-anywhere\` (consistency; \`break-all\` was over-aggressive on shorter rows)
- \`ErrorCard\`: gains \`wrap-anywhere\`

## Verified

- \`bunx tsc --noEmit -p tsconfig.pwa.json\` clean
- \`bun run build:pwa\` succeeds; verified \`wrap-anywhere\` and \`overflow-wrap:anywhere\` present in the built CSS

## Out of scope

- **"Random text along with values"** (the parser noise the user also reported) is BDHLNDR-72 work — needs real Claude captures via the script shipped in beta.4 (\`scripts/capture-claude-pty.cjs\`) to tune the parser against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)