### PR TITLE
feat(BDHLNDR-73): ChatParser classifier tuning — tool calls + chrome filters

### DIFF
--- a/src/main/api/chat-parser/__tests__/parser.test.ts
+++ b/src/main/api/chat-parser/__tests__/parser.test.ts
@@ -153,6 +153,89 @@ describe('ChatParser streaming + terminal-emulator behaviour', () => {
   });
 });
 
+describe('ChatParser classifier tuning (BDHLNDR-73)', () => {
+  test('classifies "Reading N file…" as a Read tool call', async () => {
+    const events = await runFixture('Reading 1 file… (ctrl+o to expand)\n');
+    expect(events).toEqual([
+      { type: 'tool_call', payload: { tool: 'Read', argsBrief: '1 file' } },
+    ]);
+  });
+
+  test('classifies "Read N file (ctrl+o to expand)" as a Read tool call', async () => {
+    const events = await runFixture('Read 1 file (ctrl+o to expand)\n');
+    expect(events).toEqual([
+      { type: 'tool_call', payload: { tool: 'Read', argsBrief: '1 file' } },
+    ]);
+  });
+
+  test('classifies "Searching for N pattern…" as a Grep tool call', async () => {
+    const events = await runFixture('Searching for 1 pattern… (ctrl+o to expand)\n');
+    expect(events).toEqual([
+      { type: 'tool_call', payload: { tool: 'Grep', argsBrief: '1 pattern' } },
+    ]);
+  });
+
+  test('classifies "Searched for N pattern" as a Grep tool call', async () => {
+    const events = await runFixture('Searched for 1 pattern (ctrl+o to expand)\n');
+    expect(events).toEqual([
+      { type: 'tool_call', payload: { tool: 'Grep', argsBrief: '1 pattern' } },
+    ]);
+  });
+
+  test('drops decorative tool-result header "──Read package.json"', async () => {
+    const events = await runFixture('──Read package.json\n');
+    expect(events).toEqual([]);
+  });
+
+  test('drops decorative tool-result header with quoted arg', async () => {
+    const events = await runFixture('──── "src/main/api/**/*"\n');
+    expect(events).toEqual([]);
+  });
+
+  test('drops bare timing "(3s)"', async () => {
+    const events = await runFixture('(3s)\n');
+    expect(events).toEqual([]);
+  });
+
+  test('drops bare timing "(1m 30s)"', async () => {
+    const events = await runFixture('(1m 30s)\n');
+    expect(events).toEqual([]);
+  });
+
+  test('drops lone prompt indicator "❯"', async () => {
+    const events = await runFixture('❯\n');
+    expect(events).toEqual([]);
+  });
+
+  test('drops lone prompt indicator ">"', async () => {
+    const events = await runFixture('>\n');
+    expect(events).toEqual([]);
+  });
+
+  test('drops "Shell details" header with long trailing decoration', async () => {
+    const events = await runFixture(
+      'Shell details' + '─'.repeat(75) + '\n',
+    );
+    expect(events).toEqual([]);
+  });
+
+  test('keeps tree-render lines with short trailing padding', async () => {
+    // Real content — a few trailing dashes shouldn't trigger the filter.
+    const events = await runFixture(
+      '├── parser.ts          ← The new state machine\n',
+    );
+    expect(events.length).toBe(1);
+    expect(events[0].type).toBe('assistant_text');
+  });
+
+  test('does NOT drop real user input "❯ run tests"', async () => {
+    const events = await runFixture('❯ run tests\n');
+    expect(events).toEqual([
+      { type: 'response', payload: { text: 'run tests' } },
+    ]);
+  });
+});
+
 describe('ChatParser real-corpus regression (BDHLNDR-72)', () => {
   test('5-min real Claude session captures: extracts real content, suppresses noise', async () => {
     // Real PTY capture from one of @Will Long's Bodhilander sessions on
@@ -195,5 +278,30 @@ describe('ChatParser real-corpus regression (BDHLNDR-72)', () => {
 
     // At least one user-input echo correctly classified.
     expect(events.some((e) => e.type === 'response')).toBe(true);
+
+    // BDHLNDR-73: real-corpus tool-call recovery — at least one of the
+    // Read/Glob tool calls in the corpus should now classify correctly.
+    expect(events.some((e) => e.type === 'tool_call')).toBe(true);
+
+    // BDHLNDR-73: leaker regressions — none of these chrome patterns
+    // should survive classification.
+    const text = (e: ChatEvent) =>
+      e.type === 'assistant_text' || e.type === 'error' || e.type === 'response'
+        ? e.payload.text
+        : '';
+    const leakers = events
+      .map(text)
+      .filter((t) => {
+        const s = t.trim();
+        if (!s) return false;
+        // Lone prompt indicator
+        if (/^[>❯]$/.test(s)) return true;
+        // Bare timing
+        if (/^\(\s*\d+\s*[smh]\s*(?:\d+\s*[smh]\s*)?\)$/i.test(s)) return true;
+        // Decorative header (line starts with 2+ box-drawing dashes)
+        if (/^[─━]{2,}\s*\S/.test(s)) return true;
+        return false;
+      });
+    expect(leakers).toEqual([]);
   });
 });

--- a/src/main/api/chat-parser/parser.ts
+++ b/src/main/api/chat-parser/parser.ts
@@ -77,6 +77,35 @@ const MAX_SETTLE_MS = 1500;
 const TOOL_CALL_RE =
   /^\s*[●⏺*•◦]?\s*([A-Z][A-Za-z0-9_]+)\s*\(([^)]*)\)\s*$/;
 
+// BDHLNDR-73: Claude Code's real TUI renders Read tool calls as
+// `Reading 1 file… (ctrl+o to expand)` (pre-result) or `Read 1 file
+// (ctrl+o to expand)` (post-result). Neither matches TOOL_CALL_RE.
+const TOOL_CALL_READ_RE =
+  /^\s*Read(?:ing)?\s+(\d+)\s+(files?)(?:\s*[…]|\s*\.\.\.)?\s*(?:\(.*\))?\s*$/;
+
+// BDHLNDR-73: Grep/Glob render as `Searching for 1 pattern…` and
+// `Searched for 1 pattern (ctrl+o to expand)`.
+const TOOL_CALL_SEARCH_RE =
+  /^\s*Search(?:ing|ed)\s+(?:for\s+)?(\d+)\s+(patterns?|files?)(?:\s*[…]|\s*\.\.\.)?\s*(?:\(.*\))?\s*$/;
+
+// BDHLNDR-73: decorative tool-result header line, e.g. `──Read package.json`
+// or `──── "src/main/api/**/*"──────...`. Two-or-more leading box-drawing
+// chars followed by content — drop as chrome.
+const DECORATIVE_HEADER_RE = /^\s*[─━]{2,}\s*\S/;
+
+// BDHLNDR-73: bare timing line like `(3s)`, `( 12s )`, `(1m 30s)`.
+const BARE_TIMING_RE =
+  /^\s*\(\s*\d+\s*[smh]\s*(?:\d+\s*[smh]\s*)?\)\s*$/i;
+
+// BDHLNDR-73: lone prompt indicator with no input after it.
+const LONE_PROMPT_RE = /^\s*[>❯]\s*$/;
+
+// BDHLNDR-73: line ending in a long run of box-drawing chars — TUI section
+// header like `Shell details─────────...` (Bash tool result label expanded
+// across the full pane width). Threshold of 20 keeps tree-render lines with
+// short padding intact.
+const TRAILING_DECORATION_RE = /[─━═]{20,}\s*$/;
+
 const ERROR_PREFIX_RE = /^(?:\s*)(?:API\s+)?Error[:\s]/i;
 
 const YES_NO_RE = /\(\s*y\s*\/\s*n\s*\)|\[\s*[Yy]\s*\/\s*[Nn]\s*\]/;
@@ -370,6 +399,10 @@ function classifyLine(line: string, hasRed: boolean): ChatEvent | null {
   if (LOADING_STATUS_RE.test(trimmed)) return null;
   if (TASK_LIST_CHROME_RE.test(trimmed)) return null;
   if (HELP_HINT_CHROME_RE.test(trimmed)) return null;
+  if (DECORATIVE_HEADER_RE.test(trimmed)) return null;
+  if (BARE_TIMING_RE.test(trimmed)) return null;
+  if (LONE_PROMPT_RE.test(trimmed)) return null;
+  if (TRAILING_DECORATION_RE.test(trimmed)) return null;
 
   // 1. User input echo. Claude Code prefixes with `>` (older versions) or
   //    `❯` (newer). Both signal "user typed this".
@@ -378,12 +411,26 @@ function classifyLine(line: string, hasRed: boolean): ChatEvent | null {
     if (text) return { type: 'response', payload: { text } };
   }
 
-  // 2. Tool call.
+  // 2. Tool call (multiple render shapes).
   const toolMatch = TOOL_CALL_RE.exec(trimmed);
   if (toolMatch) {
     return {
       type: 'tool_call',
       payload: { tool: toolMatch[1], argsBrief: toolMatch[2].trim() },
+    };
+  }
+  const readMatch = TOOL_CALL_READ_RE.exec(trimmed);
+  if (readMatch) {
+    return {
+      type: 'tool_call',
+      payload: { tool: 'Read', argsBrief: `${readMatch[1]} ${readMatch[2]}` },
+    };
+  }
+  const searchMatch = TOOL_CALL_SEARCH_RE.exec(trimmed);
+  if (searchMatch) {
+    return {
+      type: 'tool_call',
+      payload: { tool: 'Grep', argsBrief: `${searchMatch[1]} ${searchMatch[2]}` },
     };
   }
 


### PR DESCRIPTION
## Summary

Follow-up to BDHLNDR-72 (parser rewrite). The new terminal-emulator parser extracted clean prose but missed several Claude Code TUI-specific patterns. This pass closes the most impactful gaps.

**Wins**
- Tool-call recognition for the real render shapes — `Reading N file…`, `Read N file`, `Searching for N pattern…`, `Searched for N pattern`
- Drop decorative tool-result headers — `──Read package.json`, `──── \"src/main/api/**/*\"`
- Drop bare timing — `(3s)`, `(1m 30s)`
- Drop lone prompt indicators — `❯` / `>` alone on a line
- Drop section headers with long trailing decoration — `Shell details────...`

Tree-render output (`├── parser.ts          ← The new state machine`) is explicitly preserved by a 20-char threshold on the trailing-decoration filter.

## Real-corpus impact (5-min capture in tests/fixtures)

| | before | after |
|---|---|---|
| total events | 111 | 98 |
| tool_calls recovered | 0 | 2 (Read + Glob/Grep) |
| bare-timing leakers | yes | 0 |
| lone-prompt leakers | yes | 0 |
| decorative-header leakers | yes | 0 |

The strengthened regression test (`5-min real Claude session captures: extracts real content, suppresses noise`) now asserts at least one `tool_call` and zero leakers of each class.

## Still on the BDHLNDR-73 backlog (separate work)

- **Wrap-space recovery** — `memoryusage` → `memory usage`. Needs a wrap-boundary heuristic that only inserts a space if both sides are word chars. Will be its own commit / sub-task because it touches the harvest loop, not the classifier.
- **Xterm repaint-overlap corruption** — strings like `Read it.LQuick2highlights:hatParser with real ANSI state machine` arise when Claude Code paints new shorter text over old longer text and we harvest mid-frame. Architectural fix (longer settle window or row-stability detection), not a regex.

## Test plan

- [x] `bun test src/main/api/chat-parser` — 27/27 pass
- [x] `bunx tsc --noEmit -p tsconfig.main.json` — clean
- [x] Real-corpus regression dump inspected — tree content preserved, leakers gone
- [ ] Phone-side smoke once merged into beta

🤖 Generated with [Claude Code](https://claude.com/claude-code)