### PR TITLE
feat(BDHLNDR-73): TERM_COLS=220 + shape-based spinner suppression

### DIFF
--- a/src/main/api/chat-parser/__tests__/parser.test.ts
+++ b/src/main/api/chat-parser/__tests__/parser.test.ts
@@ -228,10 +228,116 @@ describe('ChatParser classifier tuning (BDHLNDR-73)', () => {
     expect(events[0].type).toBe('assistant_text');
   });
 
+  test('drops spinner + present-progressive verb + ellipsis with no trailing timing', async () => {
+    // Bare `· Rewriting…` (no `(Ns · ↓tokens)` tail) is still a spinner
+    // status — earlier observations showed these leak through. Narrow shape:
+    // leading spinner glyph as the only leader, single capitalized -ing verb,
+    // trailing ellipsis.
+    const events = await runFixture('· Rewriting…\n');
+    expect(events).toEqual([]);
+  });
+
+  test('drops "✶ Pondering…" (spinner + verb + ellipsis)', async () => {
+    const events = await runFixture('✶ Pondering…\n');
+    expect(events).toEqual([]);
+  });
+
+  test('drops novel-verb spinner statuses by shape (glyph + word + ellipsis)', async () => {
+    // Claude rotates verbs continuously; the verb-alternation list will
+    // always lag. A spinner glyph + short text + ellipsis is the durable
+    // shape signal. Tested with two synthesized verbs not in the alternation.
+    const events1 = await runFixture('✶ Distilling…\n');
+    expect(events1).toEqual([]);
+    const events2 = await runFixture('✻ Crystallizing the response…\n');
+    expect(events2).toEqual([]);
+  });
+
+  test('does NOT drop prose "Rewriting the parser for clarity"', async () => {
+    // No leading spinner glyph, no ellipsis — real prose, must survive.
+    const events = await runFixture('Rewriting the parser for clarity\n');
+    expect(events.length).toBe(1);
+    expect(events[0].type).toBe('assistant_text');
+  });
+
   test('does NOT drop real user input "❯ run tests"', async () => {
     const events = await runFixture('❯ run tests\n');
     expect(events).toEqual([
       { type: 'response', payload: { text: 'run tests' } },
+    ]);
+  });
+});
+
+describe('ChatParser wrap-space recovery (BDHLNDR-73 #40)', () => {
+  /** Run with a narrow terminal so wraps trigger on small inputs. */
+  async function runNarrow(input: string, cols = 10): Promise<ChatEvent[]> {
+    const events: ChatEvent[] = [];
+    const parser = new ChatParser((evs) => events.push(...evs), {
+      settleMs: 0,
+      cols,
+    });
+    await parser.parse(input);
+    await new Promise((r) => setTimeout(r, 5));
+    parser.flush();
+    parser.dispose();
+    return events;
+  }
+
+  test('preserves space at wrap boundary (Claude wrote "memory usage")', async () => {
+    // 10-col terminal. "memory usage" is 12 chars — wraps between "memory" + space.
+    // Without recovery: "memoryusage". With recovery: "memory usage".
+    const events = await runNarrow('memory usage\n', 10);
+    expect(events).toEqual([
+      { type: 'assistant_text', payload: { text: 'memory usage' } },
+    ]);
+  });
+
+  test('preserves space at wrap boundary (longer phrase)', async () => {
+    // "Slack and Discord" — 17 chars, wraps mid-phrase. Expect spaces preserved.
+    const events = await runNarrow('Slack and Discord\n', 10);
+    expect(events).toEqual([
+      { type: 'assistant_text', payload: { text: 'Slack and Discord' } },
+    ]);
+  });
+
+  test('does NOT insert a space mid-token when no original space existed', async () => {
+    // A 15-char single identifier (no spaces). 10-col wrap. Must NOT become "abc...def xyz".
+    const ident = 'abcdefghijklmno';
+    const events = await runNarrow(ident + '\n', 10);
+    expect(events).toEqual([
+      { type: 'assistant_text', payload: { text: ident } },
+    ]);
+  });
+
+  test('preserves Claude-Code cursor-positioned text wider than 120 cols', async () => {
+    // Real-corpus pattern: Claude paints with absolute cursor positioning
+    // (`ESC[NG` = cursor to col N). The captured corpus contains instructions
+    // up to col 197+. With TERM_COLS=120, `ESC[121G` clamps to col 120 and
+    // xterm autowraps, fusing "memory" + "usage" into "memoryusage".
+    //
+    // Synthesises the exact corpus byte pattern around "memory usage".
+    const ESC = '\x1b';
+    const input =
+      `${ESC}[110Gand${ESC}[114Gmemory${ESC}[121Gusage${ESC}[127Gis\r\n`;
+    // Use default cols (no override) — this is the production scenario.
+    const events: ChatEvent[] = [];
+    const parser = new ChatParser((e) => events.push(...e), { settleMs: 0 });
+    await parser.parse(input);
+    await new Promise((r) => setTimeout(r, 5));
+    parser.flush();
+    parser.dispose();
+    // The full logical text should preserve word boundaries.
+    const allText = events
+      .filter((e) => e.type === 'assistant_text')
+      .map((e) => (e as { payload: { text: string } }).payload.text)
+      .join(' ');
+    expect(allText).toContain('memory usage');
+  });
+
+  test('preserves space when wrap falls between word and punctuation', async () => {
+    // "concerns (windows," — space + paren is the natural break.
+    const events = await runNarrow('concerns (windows)\n', 10);
+    expect(events).toEqual([
+      { type: 'assistant_text', payload: { text: 'concerns (windows)' } },
     ]);
   });
 });
@@ -303,5 +409,16 @@ describe('ChatParser real-corpus regression (BDHLNDR-72)', () => {
         return false;
       });
     expect(leakers).toEqual([]);
+
+    // BDHLNDR-73 #40: wrap-space recovery — these three corrupted strings
+    // were present in the v1 (TERM_COLS=120) output of the real corpus.
+    // After bumping TERM_COLS to cover Claude's cursor-positioning range,
+    // they should be repaired.
+    const allText = events
+      .map(text)
+      .join('\n');
+    expect(allText).toContain('memory usage');
+    expect(allText).toContain('concerns (windows');
+    expect(allText).toContain('Slack, and Figma');
   });
 });

--- a/src/main/api/chat-parser/parser.ts
+++ b/src/main/api/chat-parser/parser.ts
@@ -64,7 +64,12 @@ import type {
   PromptYesNoEvent,
 } from './types';
 
-const TERM_COLS = 120;
+// BDHLNDR-73 #40: Claude Code paints with absolute cursor positioning
+// (`ESC[NG`). Captured corpora show instructions up to col 209 — clamping
+// at 120 caused autowrap to fuse adjacent words (`memory usage` →
+// `memoryusage`, `concerns (windows,` → `concerns(windows,`). 220 covers
+// observed max + headroom; xterm-headless handles wide buffers fine.
+const TERM_COLS = 220;
 const TERM_ROWS = 40;
 const SCROLLBACK = 10_000;
 /** Debounce window before harvesting (ms). */
@@ -124,6 +129,18 @@ const SPINNER_GLYPH_ONLY_RE =
  */
 const LOADING_STATUS_RE =
   /^[\s✶✻✽✢●○◌◍◐◑◒◓◔◕✱✦✧*·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][^.!?\n]*?\s*(?:\(\s*\d+[ms](?:\s|·)|\d+\s*shell|tokens|thinking|loading|generating|reasoning|pondering|musing|cogitat|deliberat|razzle[-\s]?dazzl|rewrit|sauté|brew|stew|simmer|whisk|knead)/i;
+
+/**
+ * BDHLNDR-73: shape-only catch for novel spinner verbs. Claude Code rotates
+ * its verb list continuously ("Distilling…", "Crystallizing…", new ones
+ * shipping in every Claude Code release) and the alternation in
+ * LOADING_STATUS_RE will always lag. This catches the durable shape:
+ * spinner glyph as the leading non-space char, followed by short content
+ * (under ~80 chars, no terminal punctuation), ending in `…` or `...`.
+ * The leading-glyph requirement keeps it from eating prose.
+ */
+const LOADING_STATUS_SHAPE_RE =
+  /^\s*[✶✻✽✢●○◌◍◐◑◒◓◔◕✱✦✧·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][^.!?\n]{0,80}(?:…|\.\.\.)\s*$/;
 
 /**
  * Claude Code's TUI task-list rows (decorative): "◼ Title" / "✓ Title" /
@@ -397,6 +414,7 @@ function classifyLine(line: string, hasRed: boolean): ChatEvent | null {
   if (BOX_DRAWING_ONLY_RE.test(trimmed)) return null;
   if (SPINNER_GLYPH_ONLY_RE.test(trimmed)) return null;
   if (LOADING_STATUS_RE.test(trimmed)) return null;
+  if (LOADING_STATUS_SHAPE_RE.test(trimmed)) return null;
   if (TASK_LIST_CHROME_RE.test(trimmed)) return null;
   if (HELP_HINT_CHROME_RE.test(trimmed)) return null;
   if (DECORATIVE_HEADER_RE.test(trimmed)) return null;


### PR DESCRIPTION
## Summary

Two follow-up fixes on BDHLNDR-73 that close out tasks #38 and #40.

### 1. Wider terminal emulator (TERM_COLS 120 → 220)

Root cause for the bigger corpus corruption issues. Claude Code paints text with absolute cursor positioning (\`ESC[NG\` = cursor to col N). The captured corpus contains instructions up to col 209. Our 120-col emulator clamped all those positions, autowrapped, and fused adjacent tokens into garbage:

| before | after |
|---|---|
| \`memoryusage\` | \`memory usage\` |
| \`concerns(windows,\` | \`concerns (windows,\` |
| \`Slack,and Figma\` | \`Slack, and Figma\` |
| \`Read it.LQuick2highlights:hatParser with real ANSI state machine + cursor tracking\` | \`Read it. Quick highlights:\` |

The last one was a repaint-over-undersized-buffer corruption — also gone after the bump. Bonus.

xterm-headless handles wide buffers fine; the extra 100 cols × 40 rows × scrollback memory cost is negligible.

### 2. Shape-based spinner suppression

LOADING_STATUS_RE's verb-alternation list will always lag Claude's rotated verb pool ("Distilling…", "Crystallizing…", new ones every release). Added LOADING_STATUS_SHAPE_RE as a durable shape-only catch: leading spinner glyph + short content (≤80 chars, no terminal punctuation) + trailing ellipsis.

## Real-corpus impact

- Prose now extracts as coherent paragraphs (was fragmented + corrupted)
- Three previously-corrupted phrases verified clean by regression assertion
- Event count went 98 → 111 — went UP because previously-fused logical lines now separate properly

## Test plan

- [x] \`bun test src/main/api/chat-parser\` — 36/36 pass
- [x] \`bunx tsc --noEmit -p tsconfig.main.json\` — clean
- [x] Real-corpus regression now asserts \`memory usage\`, \`concerns (windows\`, \`Slack, and Figma\` present
- [ ] Phone-side smoke once merged into beta.7

## Closes

BDHLNDR-73 sub-tasks #38 (spinner-status shape) + #40 (wrap-space recovery, actually wider-cols).

🤖 Generated with [Claude Code](https://claude.com/claude-code)