### PR TITLE
fix(BDHLNDR-74): SW auto-claims on update + textarea send-key hardening

### DIFF
--- a/src/pwa/src/pages/SessionDetail.tsx
+++ b/src/pwa/src/pages/SessionDetail.tsx
@@ -1175,7 +1175,9 @@ function Compose({
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // Enter sends, Shift+Enter inserts a newline. This matches every chat
     // app on every platform — users expect it.
-    if (e.key === 'Enter' && !e.shiftKey) {
+    // BDHLNDR-74: skip Enter that's part of an IME composition (CJK input,
+    // some Android keyboards) so accepting a suggestion doesn't send.
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       if (!sending && draft.trim() && !readOnly) onSend();
     }
@@ -1206,6 +1208,11 @@ function Compose({
           placeholder={readOnly ? 'Read-only device' : 'Message Claude…'}
           disabled={readOnly}
           rows={1}
+          // BDHLNDR-74: enterKeyHint surfaces "Send" on mobile soft keyboards
+          // instead of the default ↵. autoComplete=off blocks browser
+          // autocomplete from injecting events that race onKeyDown.
+          enterKeyHint="send"
+          autoComplete="off"
           className="min-h-[40px] flex-1 resize-none rounded-2xl border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 placeholder:text-neutral-500 focus:border-blue-500 focus:outline-none disabled:opacity-50"
         />
         <button

--- a/src/pwa/src/sw.ts
+++ b/src/pwa/src/sw.ts
@@ -162,8 +162,21 @@ self.addEventListener('notificationclick', (event: NotificationEvent) => {
   );
 });
 
-// Allow the page to immediately activate a fresh SW (matches the
-// `registerType: 'autoUpdate'` config in vite.config.ts).
+// BDHLNDR-74: take over open clients as soon as a new SW activates, so
+// users don't have to close + reopen the PWA to pick up a bug fix. Without
+// these two hooks, `registerType: 'autoUpdate'` only swaps the SW after the
+// last client tab unloads — which most users never do. Symptom we hit:
+// BDHLNDR-70 send fix (CR instead of LF) shipped, but PWAs installed on a
+// prior build kept running cached old JS that used LF.
+self.addEventListener('install', () => {
+  void self.skipWaiting();
+});
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+// Manual SKIP_WAITING channel kept for completeness (vite-plugin-pwa's
+// register snippet can call it when prompting users to refresh).
 self.addEventListener('message', (event) => {
   if ((event.data as { type?: string } | undefined)?.type === 'SKIP_WAITING') {
     void self.skipWaiting();


### PR DESCRIPTION
## Summary

Two fixes for a regression discovered during BDHLNDR-73 smoke testing: the mobile-PWA Send button stopped working on Brave for users who had installed an earlier beta.

### Diagnosis (via Chrome DevTools, this session)

Verified the code is correct in fresh installs:
- Click Send → \`POST /terminal/.../input\` with body \`{\"data\":\"x\r\"}\` ✓
- Press Enter → same ✓
- \`SessionDetail.tsx:501\` is \`text + '\r'\` ✓

So the regression was **stale service-worker cache** — devices that installed the PWA on a pre-BDHLNDR-70 build (when send used \`'\n'\`) kept running cached old JS, even after the desktop shipped fixes.

## Changes

### \`src/pwa/src/sw.ts\` — auto-claim on update

The SW previously only called \`skipWaiting()\` on explicit \`SKIP_WAITING\` messages, and had no \`clients.claim()\`. With \`registerType: 'autoUpdate'\`, the new SW downloaded fine but sat in \"waiting\" state until all PWA windows closed — most users never do this.

Adds:
\`\`\`ts
self.addEventListener('install', () => void self.skipWaiting());
self.addEventListener('activate', e => e.waitUntil(self.clients.claim()));
\`\`\`

### \`src/pwa/src/pages/SessionDetail.tsx\` — textarea hardening

- \`enterKeyHint=\"send\"\` — soft keyboards now show **Send** instead of generic ↵
- \`autoComplete=\"off\"\` — blocks browser autocomplete from injecting events that race onKeyDown
- \`!e.nativeEvent.isComposing\` guard inside the Enter branch — Enter as part of an IME composition (CJK, some Android autocomplete) no longer triggers send

## ⚠️ Caveat for the first install of this fix

The currently-installed SW (without skipWaiting/clients.claim) **won't auto-roll-out beta.8**. Users will need to close+reopen the PWA once for the new SW to activate. **After that, all subsequent betas swap silently.**

Communication: announce \"close and reopen the PWA once for this update; from then on it's automatic\" in the beta.8 notes.

## Test plan

- [x] \`bunx tsc --noEmit -p tsconfig.pwa.json\` — clean
- [x] Built PWA bundle contains \`clients.claim\` + two \`skipWaiting\` occurrences (install + message handler)
- [x] Chrome DevTools confirmed pre-fix Send path uses \`\r\` correctly — this PR addresses *delivery* of that fix, not the send code itself
- [ ] Smoke on Brave mobile after beta.8: close+reopen PWA once, send a message → should submit immediately

## Related
- Parent: BDHLNDR-50 (PWA epic)
- Original send fix: BDHLNDR-70
- Discovered during: BDHLNDR-73 smoke
- Follow-up still open: BDHLNDR-75 (parser v3: ※ glyph, wrap-split, dedupe escapes, bubble grouping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)