### PR TITLE
feat(BDHLNDR-75): ChatParser v3 — ※ glyph, dedupe TTL, bubble grouping

### DIFF
--- a/src/main/api/chat-parser/__tests__/parser.test.ts
+++ b/src/main/api/chat-parser/__tests__/parser.test.ts
@@ -267,6 +267,44 @@ describe('ChatParser classifier tuning (BDHLNDR-73)', () => {
   });
 });
 
+describe('ChatParser classifier v3 (BDHLNDR-75)', () => {
+  test('drops "※ Churned for 37s" — ※ glyph used by Claude Code', async () => {
+    const events = await runFixture('※ Churned for 37s\n');
+    expect(events).toEqual([]);
+  });
+
+  test('drops "※ recap: ..." status lines', async () => {
+    const events = await runFixture('※ recap: doing a thing\n');
+    expect(events).toEqual([]);
+  });
+
+  test('drops bare ※ glyphs (glyph-only line)', async () => {
+    const events = await runFixture('※\n');
+    expect(events).toEqual([]);
+  });
+
+  test('drops "※ Distilling…" by shape (※ in spinner-shape charset)', async () => {
+    const events = await runFixture('※ Distilling…\n');
+    expect(events).toEqual([]);
+  });
+
+  test('dedupe holds across >16 interleaved unique events', async () => {
+    // Synthesise: 25 unique lines, then a repeat of the FIRST one. The old
+    // 16-entry ring would have already evicted "line 0" by event #25, so
+    // the repeat would slip through. New dedupe should remember it.
+    let input = '';
+    for (let i = 0; i < 25; i++) input += `unique line ${i}\n`;
+    input += 'unique line 0\n'; // duplicate of the very first line
+    const events = await runFixture(input);
+    const texts = events
+      .filter((e) => e.type === 'assistant_text')
+      .map((e) => (e as { payload: { text: string } }).payload.text);
+    // Should see each unique line exactly once — 25 events, not 26.
+    expect(texts.length).toBe(25);
+    expect(texts.filter((t) => t === 'unique line 0').length).toBe(1);
+  });
+});
+
 describe('ChatParser wrap-space recovery (BDHLNDR-73 #40)', () => {
   /** Run with a narrow terminal so wraps trigger on small inputs. */
   async function runNarrow(input: string, cols = 10): Promise<ChatEvent[]> {

--- a/src/main/api/chat-parser/parser.ts
+++ b/src/main/api/chat-parser/parser.ts
@@ -111,12 +111,17 @@ const LONE_PROMPT_RE = /^\s*[>❯]\s*$/;
 // short padding intact.
 const TRAILING_DECORATION_RE = /[─━═]{20,}\s*$/;
 
+// BDHLNDR-75: Claude Code uses ※ exclusively as a chrome leader — recap
+// banners, status timings ("※ Churned for 37s"), summaries. Never seen in
+// prose. Drop any line whose first non-space char is ※.
+const REFERENCE_MARK_LEADER_RE = /^\s*※/;
+
 const ERROR_PREFIX_RE = /^(?:\s*)(?:API\s+)?Error[:\s]/i;
 
 const YES_NO_RE = /\(\s*y\s*\/\s*n\s*\)|\[\s*[Yy]\s*\/\s*[Nn]\s*\]/;
 
 const SPINNER_GLYPH_ONLY_RE =
-  /^[\s✶✻✽✢●○◌◍◐◑◒◓◔◕✱✦✧*·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]+$/;
+  /^[\s✶✻✽✢●○◌◍◐◑◒◓◔◕✱✦✧※*·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]+$/;
 
 /**
  * Loading-status / "what claude is doing now" lines. Claude Code rotates a
@@ -128,7 +133,7 @@ const SPINNER_GLYPH_ONLY_RE =
  * that shape rather than an unbounded verb list.
  */
 const LOADING_STATUS_RE =
-  /^[\s✶✻✽✢●○◌◍◐◑◒◓◔◕✱✦✧*·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][^.!?\n]*?\s*(?:\(\s*\d+[ms](?:\s|·)|\d+\s*shell|tokens|thinking|loading|generating|reasoning|pondering|musing|cogitat|deliberat|razzle[-\s]?dazzl|rewrit|sauté|brew|stew|simmer|whisk|knead)/i;
+  /^[\s✶✻✽✢●○◌◍◐◑◒◓◔◕✱✦✧※*·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][^.!?\n]*?\s*(?:\(\s*\d+[ms](?:\s|·)|\d+\s*shell|tokens|thinking|loading|generating|reasoning|pondering|musing|cogitat|deliberat|razzle[-\s]?dazzl|rewrit|sauté|brew|stew|simmer|whisk|knead)/i;
 
 /**
  * BDHLNDR-73: shape-only catch for novel spinner verbs. Claude Code rotates
@@ -140,7 +145,7 @@ const LOADING_STATUS_RE =
  * The leading-glyph requirement keeps it from eating prose.
  */
 const LOADING_STATUS_SHAPE_RE =
-  /^\s*[✶✻✽✢●○◌◍◐◑◒◓◔◕✱✦✧·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][^.!?\n]{0,80}(?:…|\.\.\.)\s*$/;
+  /^\s*[✶✻✽✢●○◌◍◐◑◒◓◔◕✱✦✧※·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏][^.!?\n]{0,80}(?:…|\.\.\.)\s*$/;
 
 /**
  * Claude Code's TUI task-list rows (decorative): "◼ Title" / "✓ Title" /
@@ -217,17 +222,18 @@ export class ChatParser {
   private readonly settleMs: number;
   private readonly maxSettleMs: number;
   /**
-   * Ring buffer of the last N emitted event texts — used to dedupe
-   * near-consecutive duplicates. Claude Code's TUI does periodic
-   * full-screen repaints (e.g. when a status row at the bottom updates,
-   * the entire viewport redraws), which causes xterm to push the same
-   * content into scrollback twice: once as the original paint and again
-   * after the repaint. A simple "equals previous" guard misses cases
-   * where a few interleaved rows (an input prompt `❯`, a status update)
-   * appear between the duplicates, so we keep a small ring instead.
+   * Recent emit map for dedupe. Keys are event texts, values are emit
+   * timestamps (ms). Claude Code's TUI does periodic full-screen repaints
+   * which push the same content into scrollback twice. The previous
+   * implementation was a 16-entry ring (BDHLNDR-72), but BDHLNDR-75 found
+   * cases where >16 unique events interleave between a duplicate pair —
+   * the ring evicted the first instance before the second arrived. TTL
+   * approach: dedupe within `DEDUPE_TTL_MS`, allow re-emit after that.
+   * Hard size cap prevents unbounded growth in long sessions.
    */
-  private recentTexts: string[] = [];
-  private static readonly DEDUPE_RING_SIZE = 16;
+  private recentTexts = new Map<string, number>();
+  private static readonly DEDUPE_TTL_MS = 30_000;
+  private static readonly DEDUPE_MAX_SIZE = 512;
 
   constructor(
     private readonly onEvents: ChatEventsCallback,
@@ -348,11 +354,22 @@ export class ChatParser {
         const event = classifyLine(logical, hasRed);
         if (event) {
           const text = eventText(event);
-          if (!this.recentTexts.includes(text)) {
+          const now = Date.now();
+          const prevTs = this.recentTexts.get(text);
+          if (prevTs === undefined || now - prevTs >= ChatParser.DEDUPE_TTL_MS) {
             events.push(event);
-            this.recentTexts.push(text);
-            if (this.recentTexts.length > ChatParser.DEDUPE_RING_SIZE) {
-              this.recentTexts.shift();
+            this.recentTexts.set(text, now);
+            if (this.recentTexts.size > ChatParser.DEDUPE_MAX_SIZE) {
+              // Purge expired entries; if still too big, drop the oldest.
+              const cutoff = now - ChatParser.DEDUPE_TTL_MS;
+              for (const [k, ts] of this.recentTexts) {
+                if (ts < cutoff) this.recentTexts.delete(k);
+              }
+              while (this.recentTexts.size > ChatParser.DEDUPE_MAX_SIZE) {
+                const oldestKey = this.recentTexts.keys().next().value;
+                if (oldestKey === undefined) break;
+                this.recentTexts.delete(oldestKey);
+              }
             }
           }
         }
@@ -421,6 +438,7 @@ function classifyLine(line: string, hasRed: boolean): ChatEvent | null {
   if (BARE_TIMING_RE.test(trimmed)) return null;
   if (LONE_PROMPT_RE.test(trimmed)) return null;
   if (TRAILING_DECORATION_RE.test(trimmed)) return null;
+  if (REFERENCE_MARK_LEADER_RE.test(trimmed)) return null;
 
   // 1. User input echo. Claude Code prefixes with `>` (older versions) or
   //    `❯` (newer). Both signal "user typed this".

--- a/src/pwa/src/pages/SessionDetail.tsx
+++ b/src/pwa/src/pages/SessionDetail.tsx
@@ -189,6 +189,47 @@ function makeSynthId(): string {
   return `ws-${Date.now()}-${synthIdCounter}`;
 }
 
+/**
+ * BDHLNDR-75: collapse consecutive `assistant_text` events that arrive
+ * within a short window into one display event. The parser emits one event
+ * per terminal row, so a single Claude paragraph painted across 3-6 rows
+ * shows up as 3-6 separate bubbles. Within a single turn the timestamps
+ * are tightly clustered (Claude renders the whole paragraph in <1s), so a
+ * 2s window cleanly groups one paragraph without ever merging across
+ * separate turns (which always have a user input + assistant response
+ * cycle separating them by several seconds).
+ *
+ * Non-`assistant_text` events (tool calls, errors, prompts, responses)
+ * break any in-progress group so they keep their own bubble.
+ */
+const ASSISTANT_GROUP_WINDOW_MS = 2_000;
+
+function groupAssistantTexts(events: DisplayEvent[]): DisplayEvent[] {
+  const result: DisplayEvent[] = [];
+  for (const e of events) {
+    const last = result[result.length - 1];
+    if (
+      e.event.type === 'assistant_text' &&
+      last?.event.type === 'assistant_text' &&
+      e.timestamp - last.timestamp <= ASSISTANT_GROUP_WINDOW_MS
+    ) {
+      result[result.length - 1] = {
+        ...last,
+        timestamp: e.timestamp,
+        event: {
+          type: 'assistant_text',
+          payload: {
+            text: last.event.payload.text + '\n' + e.event.payload.text,
+          },
+        },
+      };
+    } else {
+      result.push(e);
+    }
+  }
+  return result;
+}
+
 function persistedToDisplay(p: PersistedChatEvent): DisplayEvent {
   // The REST snapshot returns rows where { type, payload } already match the
   // ChatEvent union — we just rewrap into the discriminated shape so the
@@ -728,15 +769,18 @@ function SessionDetailInner({
               <EmptyChat />
             ) : (
               <ul className="space-y-2">
-                {events.map((e, idx) => (
-                  <li key={e.id}>
-                    <EventRenderer
-                      display={e}
-                      onTapResponse={handleTapResponse}
-                      isLatest={idx === events.length - 1}
-                    />
-                  </li>
-                ))}
+                {(() => {
+                  const grouped = groupAssistantTexts(events);
+                  return grouped.map((e, idx) => (
+                    <li key={e.id}>
+                      <EventRenderer
+                        display={e}
+                        onTapResponse={handleTapResponse}
+                        isLatest={idx === grouped.length - 1}
+                      />
+                    </li>
+                  ));
+                })()}
               </ul>
             )}
           </div>


### PR DESCRIPTION
## Summary

Four issues from BDHLNDR-73 live smoke testing on mobile.

### Parser

| issue | fix |
|---|---|
| `※ Churned for 37s` / `※ recap:` leak as chat events | Added `※` to spinner charsets; new `REFERENCE_MARK_LEADER_RE` drops any line starting with `※` (Claude uses it exclusively as chrome) |
| Duplicate `※ recap:` escaped 16-entry dedupe ring | Ring → `Map<text, timestamp>` with 30s TTL + 512-entry hard cap. Survives >16-event interleavings |

### Wrap-split investigation — NOT a parser bug

The reported \`BSAE-198 to\` / \`start design and planning.\` split is Claude painting multi-row paragraphs as independent rows (each with cursor positioning, no autowrap). The parser correctly emits one event per row. The user-visible split is a render concern, fixed below.

### PWA: bubble grouping

\`groupAssistantTexts()\` collapses consecutive \`assistant_text\` events within a 2s window into one bubble (joined with \`\n\`). Non-assistant events break the group so they keep their own bubble.

2s window is wide enough for one paragraph paint (typically <1s), well under the gap between turns (always >5s because user input is required between).

## Test plan

- [x] \`bun test src/main/api/chat-parser\` — 41/41 pass (4 new ※ tests + 1 dedupe-interleaving test)
- [x] \`bunx tsc --noEmit -p tsconfig.pwa.json\` — clean
- [x] \`bunx tsc --noEmit -p tsconfig.main.json\` — clean
- [ ] Smoke on phone: ※-prefixed lines gone, multi-row Claude paragraphs render as one bubble

## Related

- Parent epic: BDHLNDR-50
- Parent: BDHLNDR-73 (classifier rewrite)
- Discovered during: BDHLNDR-73 live smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)