### PR TITLE
Session provider persistence and launch-path threading

### DIFF
--- a/src/main/api/routes/sessions.ts
+++ b/src/main/api/routes/sessions.ts
@@ -195,6 +195,7 @@ export function createSessionsRouter(): Router {
           endedAt: null,
           durationSeconds: 0,
           claudeAccountId: null,
+          provider: 'claude',
         };
 
         sessionsRepo.createSession(session);
@@ -208,7 +209,7 @@ export function createSessionsRouter(): Router {
 
         // Start PTY if requested
         if (launchClaude) {
-          ptyManager.createSession(id, session.workingDir, true, groupId);
+          ptyManager.createSession(id, session.workingDir, true, groupId, session.provider);
         }
 
         log.info(`[SessionsAPI] Created session: ${id}`);
@@ -305,7 +306,7 @@ export function createSessionsRouter(): Router {
           return;
         }
 
-        ptyManager.createSession(id, session.workingDir, launchClaude ?? false, session.groupId);
+        ptyManager.createSession(id, session.workingDir, launchClaude ?? false, session.groupId, session.provider);
 
         log.info(`[SessionsAPI] Started session: ${id}`);
         res.json({ success: true });

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -143,6 +143,13 @@ function initializeTables(database: Database.Database): void {
     database.exec("ALTER TABLE sessions ADD COLUMN claude_account_id TEXT DEFAULT NULL");
   }
 
+  // Migration: Add provider column to sessions (#96, epic #94).
+  // Which agent provider the session runs (providers registry id). Existing
+  // rows are Claude sessions by definition, so they default to 'claude'.
+  if (!sessionColsBdhlndr17.includes('provider')) {
+    database.exec("ALTER TABLE sessions ADD COLUMN provider TEXT NOT NULL DEFAULT 'claude'");
+  }
+
   // Migration: Create session_events table (BDHLNDR-17)
   database.exec(`
     CREATE TABLE IF NOT EXISTS session_events (

--- a/src/main/group-import-export.ts
+++ b/src/main/group-import-export.ts
@@ -40,6 +40,8 @@ interface PortableSession {
   order: number;
   createdAt: string;
   lastActivityAt: string;
+  /** Agent provider registry id (#96); absent in exports from older versions. */
+  provider?: string;
 }
 
 interface PortableData {
@@ -100,6 +102,7 @@ export async function exportGroupsAndSessions(): Promise<ExportResult> {
         order: s.order,
         createdAt: s.createdAt instanceof Date ? s.createdAt.toISOString() : String(s.createdAt),
         lastActivityAt: s.lastActivityAt instanceof Date ? s.lastActivityAt.toISOString() : String(s.lastActivityAt),
+        provider: s.provider ?? 'claude',
       })),
     };
 
@@ -225,6 +228,7 @@ export async function importGroupsAndSessions(): Promise<ImportResult> {
         endedAt: null,
         durationSeconds: 0,
         claudeAccountId: null,
+        provider: s.provider ?? 'claude',
       });
       sessionCount++;
     }
@@ -363,6 +367,7 @@ export async function importFromClaudeLander(): Promise<ImportResult> {
         endedAt: null,
         durationSeconds: 0,
         claudeAccountId: null,
+        provider: row.provider ?? 'claude',
       });
       sessionCount++;
     }

--- a/src/main/group-import-export.ts
+++ b/src/main/group-import-export.ts
@@ -13,7 +13,23 @@ import { randomUUID } from 'crypto';
 import Database from 'better-sqlite3';
 import * as groupsRepo from './repositories/groups';
 import * as sessionsRepo from './repositories/sessions';
+import { isKnownProvider, DEFAULT_PROVIDER_ID } from './providers';
 import log from 'electron-log';
+
+/**
+ * Validate an imported provider id at import time (#96). Unknown ids — e.g.
+ * an export written by a newer app version — are logged and defaulted here so
+ * they never land in the DB, rather than relying solely on the launch-path
+ * fallback. Exported for tests.
+ */
+export function sanitizeImportedProvider(provider: string | null | undefined): string {
+  const id = provider ?? DEFAULT_PROVIDER_ID;
+  if (!isKnownProvider(id)) {
+    log.warn(`[Import/Export] Unknown provider '${id}' in imported session; defaulting to '${DEFAULT_PROVIDER_ID}'`);
+    return DEFAULT_PROVIDER_ID;
+  }
+  return id;
+}
 
 // ---------------------------------------------------------------------------
 // Portable format types
@@ -228,7 +244,7 @@ export async function importGroupsAndSessions(): Promise<ImportResult> {
         endedAt: null,
         durationSeconds: 0,
         claudeAccountId: null,
-        provider: s.provider ?? 'claude',
+        provider: sanitizeImportedProvider(s.provider),
       });
       sessionCount++;
     }
@@ -367,7 +383,7 @@ export async function importFromClaudeLander(): Promise<ImportResult> {
         endedAt: null,
         durationSeconds: 0,
         claudeAccountId: null,
-        provider: row.provider ?? 'claude',
+        provider: sanitizeImportedProvider(row.provider),
       });
       sessionCount++;
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, ipcMain, dialog, shell, crashReporter } from 'electron';
 import * as path from 'path';
 import { ptyManager } from './pty-manager';
-import { DEFAULT_PROVIDER_ID, isKnownProvider } from './providers';
+import { DEFAULT_PROVIDER_ID } from './providers';
 import { getDatabase, closeDatabase } from './database';
 import * as groupsRepo from './repositories/groups';
 import * as sessionsRepo from './repositories/sessions';
@@ -661,16 +661,9 @@ ipcMain.handle('pty:create', async (_, id: string, cwd: string, launchClaude: bo
     const session = sessions.find(s => s.id === id);
     const groupId = session?.groupId || null;
 
-    // Resolve the session's provider from its stored row (#96). Fall back to
-    // the default when the row references a provider this app version doesn't
-    // know (e.g. written by a newer version) instead of failing the launch.
-    let providerId = session?.provider ?? DEFAULT_PROVIDER_ID;
-    if (!isKnownProvider(providerId)) {
-      log.warn(`[Main] Unknown provider '${providerId}' on session ${id}; falling back to '${DEFAULT_PROVIDER_ID}'`);
-      providerId = DEFAULT_PROVIDER_ID;
-    }
-
-    ptyManager.createSession(id, cwd, launchClaude, groupId, providerId);
+    // The session's stored provider drives the launch (#96); unknown ids are
+    // degraded to the default inside PtyManager.createSession (resolveProvider).
+    ptyManager.createSession(id, cwd, launchClaude, groupId, session?.provider ?? DEFAULT_PROVIDER_ID);
     // Play session start sound
     soundManager.playStartSound();
   } catch (error) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain, dialog, shell, crashReporter } from 'electron';
 import * as path from 'path';
 import { ptyManager } from './pty-manager';
+import { DEFAULT_PROVIDER_ID, isKnownProvider } from './providers';
 import { getDatabase, closeDatabase } from './database';
 import * as groupsRepo from './repositories/groups';
 import * as sessionsRepo from './repositories/sessions';
@@ -660,7 +661,16 @@ ipcMain.handle('pty:create', async (_, id: string, cwd: string, launchClaude: bo
     const session = sessions.find(s => s.id === id);
     const groupId = session?.groupId || null;
 
-    ptyManager.createSession(id, cwd, launchClaude, groupId);
+    // Resolve the session's provider from its stored row (#96). Fall back to
+    // the default when the row references a provider this app version doesn't
+    // know (e.g. written by a newer version) instead of failing the launch.
+    let providerId = session?.provider ?? DEFAULT_PROVIDER_ID;
+    if (!isKnownProvider(providerId)) {
+      log.warn(`[Main] Unknown provider '${providerId}' on session ${id}; falling back to '${DEFAULT_PROVIDER_ID}'`);
+      providerId = DEFAULT_PROVIDER_ID;
+    }
+
+    ptyManager.createSession(id, cwd, launchClaude, groupId, providerId);
     // Play session start sound
     soundManager.playStartSound();
   } catch (error) {

--- a/src/main/providers/__tests__/resolve.test.ts
+++ b/src/main/providers/__tests__/resolve.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Provider resolution tests (#96).
+ *
+ * Run with: bun test src/main/providers
+ */
+import { describe, expect, test, mock } from 'bun:test';
+
+// providers/claude.ts calls electron's app.getPath at buildCommand time only,
+// but the module import chain still pulls in 'electron' — stub it.
+mock.module('electron', () => ({
+  app: { getPath: () => '/tmp/bodhilander-test-userdata' },
+}));
+
+const providers = await import('../index');
+
+describe('provider registry resolution', () => {
+  test('isKnownProvider reflects the registry', () => {
+    expect(providers.isKnownProvider('claude')).toBe(true);
+    expect(providers.isKnownProvider('codex')).toBe(true);
+    expect(providers.isKnownProvider('gemini')).toBe(true);
+    expect(providers.isKnownProvider('grok')).toBe(true);
+    expect(providers.isKnownProvider('nope')).toBe(false);
+    expect(providers.isKnownProvider('')).toBe(false);
+  });
+
+  test('resolveProvider returns the matching definition for known ids', () => {
+    for (const id of ['claude', 'codex', 'gemini', 'grok']) {
+      expect(providers.resolveProvider(id).id).toBe(id);
+    }
+  });
+
+  test('resolveProvider degrades unknown ids to the default provider', () => {
+    expect(providers.resolveProvider('from-a-newer-version').id).toBe(providers.DEFAULT_PROVIDER_ID);
+  });
+
+  test('resolveProvider treats null/undefined/empty as the default', () => {
+    expect(providers.resolveProvider(undefined).id).toBe(providers.DEFAULT_PROVIDER_ID);
+    expect(providers.resolveProvider(null).id).toBe(providers.DEFAULT_PROVIDER_ID);
+    expect(providers.resolveProvider('').id).toBe(providers.DEFAULT_PROVIDER_ID);
+  });
+
+  test('getProvider still throws for unknown ids (programming errors)', () => {
+    expect(() => providers.getProvider('nope')).toThrow(/Unknown session provider/);
+  });
+});

--- a/src/main/providers/__tests__/resolve.test.ts
+++ b/src/main/providers/__tests__/resolve.test.ts
@@ -6,9 +6,10 @@
 import { describe, expect, test, mock } from 'bun:test';
 
 // providers/claude.ts calls electron's app.getPath at buildCommand time only,
-// but the module import chain still pulls in 'electron' — stub it.
+// but the module import chain still pulls in 'electron' — stub it. The path
+// is never dereferenced by these tests (buildCommand is not exercised here).
 mock.module('electron', () => ({
-  app: { getPath: () => '/tmp/bodhilander-test-userdata' },
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
 }));
 
 const providers = await import('../index');

--- a/src/main/providers/index.ts
+++ b/src/main/providers/index.ts
@@ -16,6 +16,10 @@ const REGISTRY: ReadonlyMap<string, ProviderDefinition> = new Map(
   [claudeProvider, codexProvider, geminiProvider, grokProvider].map((p) => [p.id, p])
 );
 
+export function isKnownProvider(id: string): boolean {
+  return REGISTRY.has(id);
+}
+
 export function getProvider(id: string): ProviderDefinition {
   const provider = REGISTRY.get(id);
   if (!provider) {

--- a/src/main/providers/index.ts
+++ b/src/main/providers/index.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as os from 'os';
 import * as crypto from 'crypto';
+import log from 'electron-log';
 import { ProviderDefinition } from './types';
 import { claudeProvider } from './claude';
 import { codexProvider } from './codex';
@@ -18,6 +19,25 @@ const REGISTRY: ReadonlyMap<string, ProviderDefinition> = new Map(
 
 export function isKnownProvider(id: string): boolean {
   return REGISTRY.has(id);
+}
+
+/**
+ * Resolve a provider id to its definition, falling back to the default with
+ * a logged warning when the id is unknown — e.g. a session row or import
+ * written by a newer app version (#96). Every launch path goes through this
+ * so an unrecognized id degrades to a Claude session instead of a failed
+ * launch. Use getProvider() instead where an unknown id is a programming
+ * error that should throw.
+ */
+export function resolveProvider(id: string | null | undefined, context?: string): ProviderDefinition {
+  if (id && isKnownProvider(id)) {
+    return REGISTRY.get(id)!;
+  }
+  if (id) {
+    const where = context ? ` (${context})` : '';
+    log.warn(`[Providers] Unknown provider '${id}'${where}; falling back to '${DEFAULT_PROVIDER_ID}'`);
+  }
+  return claudeProvider;
 }
 
 export function getProvider(id: string): ProviderDefinition {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import { execFile } from 'child_process';
 import { EventEmitter } from 'events';
 import {
-  getProvider,
+  resolveProvider,
   getSocketPath,
   generateAgentSessionId,
   claudeProvider,
@@ -230,8 +230,10 @@ export class PtyManager extends EventEmitter {
       throw new Error(errorMsg);
     }
 
-    // Track agent resume state for early-exit fallback (BDHLNDR-9)
-    const provider = launchClaude ? getProvider(providerId) : null;
+    // Track agent resume state for early-exit fallback (BDHLNDR-9).
+    // resolveProvider degrades unknown ids (e.g. rows written by a newer app
+    // version) to the default provider instead of failing the launch (#96).
+    const provider = launchClaude ? resolveProvider(providerId, `session ${id}`) : null;
     let resumeAttempted = false;
 
     if (provider) {

--- a/src/main/repositories/__tests__/sessions.test.ts
+++ b/src/main/repositories/__tests__/sessions.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Sessions repository tests (#96) — provider persistence and the
+ * resume-UUID invalidation that fires when a session's provider changes.
+ *
+ * Uses bun:sqlite (API-compatible with better-sqlite3 for the statements the
+ * repo issues) so no native build is required to run the suite.
+ *
+ * Run with: bun test src/main/repositories
+ */
+import { describe, expect, test, beforeEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { Session } from '../../../shared/types';
+
+let db: Database;
+
+mock.module('../../database', () => ({
+  getDatabase: () => db,
+}));
+
+const sessionsRepo = await import('../sessions');
+
+function freshDb(): Database {
+  const d = new Database(':memory:');
+  // Post-migration sessions schema (subset ordering irrelevant)
+  d.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      group_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      working_dir TEXT,
+      state TEXT,
+      shell_type TEXT DEFAULT 'bash',
+      "order" INTEGER DEFAULT 0,
+      created_at TEXT,
+      last_activity_at TEXT,
+      claude_session_id TEXT DEFAULT NULL,
+      ended_at TEXT DEFAULT NULL,
+      duration_seconds REAL DEFAULT 0,
+      claude_account_id TEXT DEFAULT NULL,
+      provider TEXT NOT NULL DEFAULT 'claude'
+    )
+  `);
+  return d;
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 's1',
+    groupId: 'g1',
+    name: 'test',
+    workingDir: '/tmp',
+    state: 'idle',
+    shellType: 'claude',
+    order: 0,
+    createdAt: new Date('2026-07-13T00:00:00Z'),
+    lastActivityAt: new Date('2026-07-13T00:00:00Z'),
+    claudeSessionId: null,
+    endedAt: null,
+    durationSeconds: 0,
+    claudeAccountId: null,
+    provider: 'claude',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  db = freshDb();
+});
+
+describe('provider persistence', () => {
+  test('createSession/getAllSessions round-trips the provider', () => {
+    sessionsRepo.createSession(makeSession({ id: 'grok-1', provider: 'grok' }));
+    sessionsRepo.createSession(makeSession({ id: 'claude-1', provider: 'claude' }));
+
+    const byId = new Map(sessionsRepo.getAllSessions().map((s) => [s.id, s]));
+    expect(byId.get('grok-1')?.provider).toBe('grok');
+    expect(byId.get('claude-1')?.provider).toBe('claude');
+  });
+
+  test('rows without a provider value read back as claude (pre-migration data)', () => {
+    db.exec(`
+      INSERT INTO sessions (id, group_id, name, created_at, last_activity_at, provider)
+      VALUES ('legacy', 'g1', 'old', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'claude')
+    `);
+    expect(sessionsRepo.getAllSessions()[0].provider).toBe('claude');
+  });
+});
+
+describe('updateSession provider change invalidates the stored resume UUID', () => {
+  beforeEach(() => {
+    sessionsRepo.createSession(makeSession());
+    sessionsRepo.setClaudeSessionId('s1', 'uuid-belonging-to-claude');
+  });
+
+  test('changing provider clears claude_session_id in the same statement', () => {
+    sessionsRepo.updateSession('s1', { provider: 'codex' });
+    const s = sessionsRepo.getAllSessions()[0];
+    expect(s.provider).toBe('codex');
+    expect(s.claudeSessionId).toBeNull();
+  });
+
+  test('setting provider to its current value preserves the UUID', () => {
+    sessionsRepo.updateSession('s1', { provider: 'claude' });
+    const s = sessionsRepo.getAllSessions()[0];
+    expect(s.provider).toBe('claude');
+    expect(s.claudeSessionId).toBe('uuid-belonging-to-claude');
+  });
+
+  test('updates without a provider field never touch the UUID', () => {
+    sessionsRepo.updateSession('s1', { name: 'renamed', state: 'working' });
+    const s = sessionsRepo.getAllSessions()[0];
+    expect(s.name).toBe('renamed');
+    expect(s.claudeSessionId).toBe('uuid-belonging-to-claude');
+  });
+
+  test('switching back to the original provider does not resurrect the UUID', () => {
+    sessionsRepo.updateSession('s1', { provider: 'codex' });
+    sessionsRepo.updateSession('s1', { provider: 'claude' });
+    const s = sessionsRepo.getAllSessions()[0];
+    expect(s.provider).toBe('claude');
+    expect(s.claudeSessionId).toBeNull();
+  });
+});

--- a/src/main/repositories/sessions.ts
+++ b/src/main/repositories/sessions.ts
@@ -25,14 +25,15 @@ export function getAllSessions(): Session[] {
     endedAt: row.ended_at ? new Date(row.ended_at) : null,
     durationSeconds: row.duration_seconds ?? 0,
     claudeAccountId: row.claude_account_id ?? null,
+    provider: row.provider ?? 'claude',
   }));
 }
 
 export function createSession(session: Session): void {
   const db = getDatabase();
   db.prepare(`
-    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at, claude_session_id, ended_at, duration_seconds, claude_account_id)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at, claude_session_id, ended_at, duration_seconds, claude_account_id, provider)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     session.id,
     session.groupId,
@@ -46,7 +47,8 @@ export function createSession(session: Session): void {
     session.claudeSessionId ?? null,
     session.endedAt ? session.endedAt.toISOString() : null,
     session.durationSeconds ?? 0,
-    session.claudeAccountId ?? null
+    session.claudeAccountId ?? null,
+    session.provider ?? 'claude'
   );
 }
 
@@ -115,6 +117,16 @@ export function updateSession(id: string, updates: Partial<Session>): void {
   if (updates.claudeAccountId !== undefined) {
     fields.push('claude_account_id = ?');
     values.push(updates.claudeAccountId);
+  }
+  if (updates.provider !== undefined) {
+    // Changing provider invalidates any stored conversation UUID — it belongs
+    // to the previous provider's CLI and must never be replayed as another
+    // provider's resume flag (#96). SET expressions evaluate against the
+    // pre-update row, so `provider` here is the old value.
+    fields.push('claude_session_id = CASE WHEN provider IS ? THEN claude_session_id ELSE NULL END');
+    values.push(updates.provider);
+    fields.push('provider = ?');
+    values.push(updates.provider);
   }
 
   if (fields.length > 0) {

--- a/src/pwa/src/lib/types.ts
+++ b/src/pwa/src/lib/types.ts
@@ -39,6 +39,8 @@ export interface Session {
   endedAt: string | null;
   durationSeconds: number;
   claudeAccountId: string | null;
+  /** Agent provider registry id (#96); absent from older API versions. */
+  provider?: string;
 }
 
 export interface Group {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,7 +10,7 @@ import AnalyticsPanel from './components/panels/AnalyticsPanel';
 import { SessionStatsBadge } from './components/SessionStatsBadge';
 import { CodeSearchModal } from './components/CodeSearchModal';
 import { ClaudeAccountsModal } from './components/ClaudeAccountsModal';
-import { ClaudeAccount } from '../shared/types';
+import { ClaudeAccount, PROVIDER_LABELS } from '../shared/types';
 import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -1099,6 +1099,15 @@ const App: React.FC = () => {
                       )}
                       <SessionStatsBadge sessionId={session.id} />
                     </div>
+                    {session.shellType === 'claude' && session.provider !== 'claude' && (
+                      <span
+                        className="session-provider-badge"
+                        title={`Provider: ${PROVIDER_LABELS[session.provider] ?? session.provider}`}
+                        draggable={false}
+                      >
+                        {PROVIDER_LABELS[session.provider] ?? session.provider}
+                      </span>
+                    )}
                     <span className={`status-pill ${session.state}`} draggable={false}>{session.state}</span>
                     <button
                       className="session-close"

--- a/src/renderer/store/sessions.ts
+++ b/src/renderer/store/sessions.ts
@@ -45,7 +45,8 @@ export function useSessions() {
     groupId: string,
     name: string,
     workingDir: string,
-    launchClaude: boolean = true
+    launchClaude: boolean = true,
+    provider: string = 'claude'
   ): Promise<Session> => {
     return new Promise((resolve, reject) => {
       setSessions(prev => {
@@ -63,6 +64,7 @@ export function useSessions() {
           endedAt: null,
           durationSeconds: 0,
           claudeAccountId: null,
+          provider,
         };
 
         // Activate immediately so the Terminal mounts in a visible container.

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -478,6 +478,17 @@ body {
   flex-shrink: 0;
 }
 
+/* Provider label on non-Claude agent sessions (#96) */
+.session-provider-badge {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 10px;
+  font-weight: 500;
+  flex-shrink: 0;
+  background: #2d3a4d;
+  color: #9fc3f0;
+}
+
 .status-pill.idle {
   background: #3c3c3c;
   color: #888;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -25,7 +25,21 @@ export interface Session {
    * to the global default account, then to the legacy ~/.claude config).
    */
   claudeAccountId: string | null;
+  /**
+   * Agent provider this session runs (providers registry id: 'claude',
+   * 'codex', 'gemini', 'grok') (#96). Only meaningful when shellType is
+   * 'claude'; plain shell sessions keep the default.
+   */
+  provider: string;
 }
+
+/** Display labels for session providers (registry ids → short names). */
+export const PROVIDER_LABELS: Record<string, string> = {
+  claude: 'Claude',
+  codex: 'Codex',
+  gemini: 'Gemini',
+  grok: 'Grok',
+};
 
 export interface Group {
   id: string;


### PR DESCRIPTION
## Description
Second slice of the multi-provider epic (#94): sessions now remember which provider they run.

- **Migration**: `sessions.provider` column, `TEXT NOT NULL DEFAULT 'claude'` — existing rows migrate as Claude sessions with no behavior change.
- **Threading**: `Session` type → repo mapper/insert/update → `pty:create` (resolves provider from the stored row, so the preload/renderer signatures are unchanged) → `PtyManager.createSession`. Mobile API create/start and group import/export carry the field; PWA type gains it as optional.
- **Deferred findings from #95 closed out**: updating a session's provider clears its stored conversation UUID in the same SQL statement (one provider's resume id is never replayed against another CLI), and `pty:create` falls back to the default provider with a logged warning when a row references an unknown provider id instead of failing the launch.
- **UI**: sidebar session rows show a small provider badge when an agent session runs a non-Claude provider; Claude sessions look exactly as before.
- Renderer store `createSession` accepts an optional `provider` argument as groundwork for the #98 picker (a persistence/mount race relevant to that picker is documented on #98).

## Related issue
Closes #96

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Hotfix
- [ ] Refactor / chore
- [ ] Docs

## How was this tested?
- `tsc` clean on main, base (renderer), and pwa tsconfigs
- SQL semantics verified against real SQLite: migration backfills `claude` on existing rows; same-provider updates preserve the stored UUID; provider changes clear it; explicit-provider inserts round-trip
- SonarQube preflight on the repo file with the new logic: clean
- Manual QA still worth doing: launch the app, confirm existing sessions open and resume exactly as before after the migration runs

## Checklist
- [ ] Tests pass locally (no test suite; SQL semantics + typecheck verification above)
- [x] Self-reviewed the changes
- [x] Docs updated where needed (none required)
- [x] Linked the related issue above

🤖 Generated with [Claude Code](https://claude.com/claude-code)