### PR TITLE
Settings → Providers with CLI detection and setup guidance

### DIFF
--- a/src/main/__tests__/provider-detector.test.ts
+++ b/src/main/__tests__/provider-detector.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Provider CLI detection tests (#97).
+ *
+ * Asserts the machine-independent contract (one status per registered
+ * provider, fully populated fields); whether a given CLI is actually
+ * installed depends on the machine, so `installed` is only type-checked.
+ *
+ * Run with: bun test src/main/__tests__
+ */
+import { describe, expect, test, mock } from 'bun:test';
+
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
+}));
+// preferences pulls in better-sqlite3 via the database module — stub it.
+mock.module('../repositories/preferences', () => ({
+  getPreference: () => '',
+}));
+
+const { detectProviders } = await import('../provider-detector');
+const { listProviders } = await import('../providers');
+
+describe('detectProviders', () => {
+  test('returns a fully-populated status for every registered provider', async () => {
+    const statuses = await detectProviders();
+    const registry = listProviders();
+
+    expect(statuses.map((s) => s.id).sort()).toEqual(registry.map((p) => p.id).sort());
+
+    for (const s of statuses) {
+      expect(typeof s.installed).toBe('boolean');
+      expect(s.name.length).toBeGreaterThan(0);
+      expect(s.command.length).toBeGreaterThan(0);
+      expect(s.installHint.length).toBeGreaterThan(0);
+      expect(s.docsUrl.startsWith('https://')).toBe(true);
+      expect(s.loginHint.length).toBeGreaterThan(0);
+      if (!s.installed) {
+        expect(s.version).toBeNull();
+      }
+    }
+  }, 30_000);
+});

--- a/src/main/__tests__/provider-detector.test.ts
+++ b/src/main/__tests__/provider-detector.test.ts
@@ -1,13 +1,18 @@
 /**
  * Provider CLI detection tests (#97).
  *
- * Asserts the machine-independent contract (one status per registered
- * provider, fully populated fields); whether a given CLI is actually
- * installed depends on the machine, so `installed` is only type-checked.
+ * - Contract test: one fully-populated status per registered provider
+ *   (machine-independent; whether a CLI is installed depends on the machine).
+ * - buildProbe unit tests: the three platform branches (POSIX login shell,
+ *   native Windows, WSL) can't all execute on one machine, so their argv
+ *   construction is asserted directly with process.platform / detectShell
+ *   stubbed.
  *
  * Run with: bun test src/main/__tests__
  */
-import { describe, expect, test, mock } from 'bun:test';
+import { describe, expect, test, mock, afterEach } from 'bun:test';
+// Type-only import — erased at runtime, so it doesn't load the mocked module.
+import type { ShellInfo } from '../shell-detector';
 
 mock.module('electron', () => ({
   app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
@@ -17,8 +22,29 @@ mock.module('../repositories/preferences', () => ({
   getPreference: () => '',
 }));
 
-const { detectProviders } = await import('../provider-detector');
+// Stub the shell detector: importing the real module AND mock.module-ing the
+// same specifier deadlocks bun's loader, so tests use a platform-plausible
+// default (matching what detectShell would return) plus per-test overrides.
+const defaultShellInfo: ShellInfo = process.platform === 'win32'
+  ? { shell: process.env.ComSpec ?? 'cmd.exe', args: [], isWSL: false }
+  : { shell: process.env.SHELL ?? '/bin/zsh', args: ['-l', '-i'], isWSL: false };
+let shellInfoOverride: ShellInfo | null = null;
+mock.module('../shell-detector', () => ({
+  detectShell: () => shellInfoOverride ?? defaultShellInfo,
+}));
+
+const { detectProviders, buildProbe, extractVersion } = await import('../provider-detector');
 const { listProviders } = await import('../providers');
+
+const realPlatform = process.platform;
+function setPlatform(platform: string): void {
+  Object.defineProperty(process, 'platform', { value: platform });
+}
+
+afterEach(() => {
+  setPlatform(realPlatform);
+  shellInfoOverride = null;
+});
 
 describe('detectProviders', () => {
   test('returns a fully-populated status for every registered provider', async () => {
@@ -39,4 +65,53 @@ describe('detectProviders', () => {
       }
     }
   }, 30_000);
+});
+
+describe('buildProbe platform branches', () => {
+  test('POSIX: probes through the login shell (-l -c)', () => {
+    setPlatform('darwin');
+    shellInfoOverride = { shell: '/bin/zsh', args: ['-l', '-i'], isWSL: false };
+
+    const probe = buildProbe('claude');
+    expect(probe.lookup).toEqual(['/bin/zsh', ['-l', '-c', 'command -v claude']]);
+    expect(probe.version).toEqual(['/bin/zsh', ['-l', '-c', 'claude --version']]);
+  });
+
+  test('native Windows: where.exe lookup, cmd.exe version', () => {
+    setPlatform('win32');
+    shellInfoOverride = {
+      shell: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+      args: [],
+      isWSL: false,
+    };
+
+    const probe = buildProbe('codex');
+    expect(probe.lookup).toEqual(['where.exe', ['codex']]);
+    expect(probe.version).toEqual(['cmd.exe', ['/c', 'codex --version']]);
+  });
+
+  test('WSL: wraps through wsl.exe bash -lc with the configured distro args', () => {
+    setPlatform('win32');
+    shellInfoOverride = { shell: 'wsl.exe', args: ['-d', 'Ubuntu'], isWSL: true };
+
+    const probe = buildProbe('gemini');
+    expect(probe.lookup).toEqual(['wsl.exe', ['-d', 'Ubuntu', '--', 'bash', '-lc', 'command -v gemini']]);
+    expect(probe.version).toEqual(['wsl.exe', ['-d', 'Ubuntu', '--', 'bash', '-lc', 'gemini --version']]);
+  });
+});
+
+describe('extractVersion', () => {
+  test('picks the first line with a semver-looking token', () => {
+    expect(extractVersion('2.1.207 (Claude Code)\n')).toBe('2.1.207 (Claude Code)');
+    expect(extractVersion('codex-cli 0.48.2')).toBe('codex-cli 0.48.2');
+  });
+
+  test('skips plain-text banner lines without version tokens', () => {
+    expect(extractVersion('Welcome to the CLI!\n\nv1.2.3')).toBe('v1.2.3');
+  });
+
+  test('returns null when nothing version-like appears', () => {
+    expect(extractVersion('command not found')).toBeNull();
+    expect(extractVersion('')).toBeNull();
+  });
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, ipcMain, dialog, shell, crashReporter } from 'elect
 import * as path from 'path';
 import { ptyManager } from './pty-manager';
 import { DEFAULT_PROVIDER_ID } from './providers';
+import { detectProviders } from './provider-detector';
 import { getDatabase, closeDatabase } from './database';
 import * as groupsRepo from './repositories/groups';
 import * as sessionsRepo from './repositories/sessions';
@@ -1170,6 +1171,10 @@ safeHandle('editor:open', async (filePath: string, line?: number, column?: numbe
 
 safeHandle('editor:detectAvailable', async () => {
   return detectAvailableEditors();
+});
+
+safeHandle('providers:detect', async () => {
+  return detectProviders();
 });
 
 safeHandle('editor:getOptions', () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -184,6 +184,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Shell
   openExternal: (url: string) => ipcRenderer.invoke('shell:openExternal', url),
+  detectProviders: (): Promise<ProviderStatus[]> => ipcRenderer.invoke('providers:detect'),
 
   // Sound notifications
   testSound: (event: 'waiting' | 'error' | 'start' | 'complete') =>

--- a/src/main/provider-detector.ts
+++ b/src/main/provider-detector.ts
@@ -1,0 +1,89 @@
+/**
+ * Provider CLI detection (#97).
+ *
+ * Probes each registered provider's CLI the same way sessions launch it:
+ * through the user's login shell on macOS/Linux (GUI-launched Electron does
+ * not inherit shell PATH additions), via `wsl.exe bash` when the configured
+ * shell is WSL, and via `where.exe` on native Windows. Command names come
+ * from the static provider registry, never from user input.
+ */
+import { execFile } from 'child_process';
+import { listProviders } from './providers';
+import { detectShell } from './shell-detector';
+import { getPreference } from './repositories/preferences';
+import { ProviderStatus } from '../shared/types';
+
+const PROBE_TIMEOUT_MS = 10_000;
+
+interface Probe {
+  /** argv to check the command exists (exit 0 = installed). */
+  lookup: [string, string[]];
+  /** argv to fetch the version string (best effort). */
+  version: [string, string[]];
+}
+
+function buildProbe(command: string): Probe {
+  const shellInfo = detectShell(getPreference('customShellPath') ?? '');
+
+  if (shellInfo.isWSL) {
+    const wrap = (cmd: string): [string, string[]] =>
+      ['wsl.exe', [...shellInfo.args, '--', 'bash', '-lc', cmd]];
+    return { lookup: wrap(`command -v ${command}`), version: wrap(`${command} --version`) };
+  }
+  if (process.platform === 'win32') {
+    return {
+      lookup: ['where.exe', [command]],
+      version: ['cmd.exe', ['/c', `${command} --version`]],
+    };
+  }
+  // Login (non-interactive) shell: picks up PATH from the user's profile
+  // without interactive-rc noise on stdout.
+  const wrap = (cmd: string): [string, string[]] => [shellInfo.shell, ['-l', '-c', cmd]];
+  return { lookup: wrap(`command -v ${command}`), version: wrap(`${command} --version`) };
+}
+
+function run([file, args]: [string, string[]]): Promise<{ ok: boolean; stdout: string }> {
+  return new Promise((resolve) => {
+    execFile(file, args, { timeout: PROBE_TIMEOUT_MS, windowsHide: true }, (err, stdout) => {
+      resolve({ ok: !err, stdout: stdout?.toString() ?? '' });
+    });
+  });
+}
+
+/** Pick the first output line that looks like a version (contains a digit). */
+function extractVersion(stdout: string): string | null {
+  const line = stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l && /\d/.test(l));
+  return line ? line.slice(0, 100) : null;
+}
+
+async function probeCommand(command: string): Promise<{ installed: boolean; version: string | null }> {
+  const probe = buildProbe(command);
+  const lookup = await run(probe.lookup);
+  if (!lookup.ok) {
+    return { installed: false, version: null };
+  }
+  const version = await run(probe.version);
+  return { installed: true, version: version.ok ? extractVersion(version.stdout) : null };
+}
+
+/** Probe every registered provider concurrently. */
+export function detectProviders(): Promise<ProviderStatus[]> {
+  return Promise.all(
+    listProviders().map(async (p): Promise<ProviderStatus> => {
+      const { installed, version } = await probeCommand(p.command);
+      return {
+        id: p.id,
+        name: p.name,
+        command: p.command,
+        installed,
+        version,
+        installHint: p.setup.installHint,
+        docsUrl: p.setup.docsUrl,
+        loginHint: p.setup.loginHint,
+      };
+    })
+  );
+}

--- a/src/main/provider-detector.ts
+++ b/src/main/provider-detector.ts
@@ -22,7 +22,8 @@ interface Probe {
   version: [string, string[]];
 }
 
-function buildProbe(command: string): Probe {
+/** Exported for tests — platform branches can't all run on one machine. */
+export function buildProbe(command: string): Probe {
   const shellInfo = detectShell(getPreference('customShellPath') ?? '');
 
   if (shellInfo.isWSL) {
@@ -50,12 +51,20 @@ function run([file, args]: [string, string[]]): Promise<{ ok: boolean; stdout: s
   });
 }
 
-/** Pick the first output line that looks like a version (contains a digit). */
-function extractVersion(stdout: string): string | null {
+/** Matches a semver-looking token (1.2, v1.2.3, 2.1.207) — not just any digit. */
+const VERSION_TOKEN = /\bv?\d+\.\d+(\.\d+)?\b/;
+
+/**
+ * Pick the first output line containing a semver-looking token. Best effort:
+ * a pre-version banner that itself contains a version string (update nag,
+ * runtime version) can still win, but plain text banners are skipped.
+ * Exported for tests.
+ */
+export function extractVersion(stdout: string): string | null {
   const line = stdout
     .split('\n')
     .map((l) => l.trim())
-    .find((l) => l && /\d/.test(l));
+    .find((l) => VERSION_TOKEN.test(l));
   return line ? line.slice(0, 100) : null;
 }
 

--- a/src/main/providers/claude.ts
+++ b/src/main/providers/claude.ts
@@ -34,6 +34,11 @@ export const claudeProvider: ProviderDefinition = {
   },
   systemPromptFlag: '--append-system-prompt',
   waitingPatterns: CLAUDE_WAITING_PATTERNS,
+  setup: {
+    installHint: 'npm install -g @anthropic-ai/claude-code',
+    docsUrl: 'https://docs.anthropic.com/en/docs/claude-code/setup',
+    loginHint: 'Run `claude` and complete /login in the browser',
+  },
 
   buildCommand(config: ProviderLaunchConfig): ProviderCommand {
     const hookScriptPath = getHookScriptPath();

--- a/src/main/providers/codex.ts
+++ b/src/main/providers/codex.ts
@@ -10,4 +10,9 @@ export const codexProvider = passthroughProvider({
   id: 'codex',
   name: 'Codex (OpenAI)',
   command: 'codex',
+  setup: {
+    installHint: 'npm install -g @openai/codex',
+    docsUrl: 'https://developers.openai.com/codex/cli',
+    loginHint: 'Run `codex login` (ChatGPT account) or set OPENAI_API_KEY',
+  },
 });

--- a/src/main/providers/gemini.ts
+++ b/src/main/providers/gemini.ts
@@ -9,4 +9,9 @@ export const geminiProvider = passthroughProvider({
   id: 'gemini',
   name: 'Gemini CLI (Google)',
   command: 'gemini',
+  setup: {
+    installHint: 'npm install -g @google/gemini-cli',
+    docsUrl: 'https://github.com/google-gemini/gemini-cli',
+    loginHint: 'Run `gemini` and sign in with your Google account, or set GEMINI_API_KEY',
+  },
 });

--- a/src/main/providers/grok.ts
+++ b/src/main/providers/grok.ts
@@ -9,4 +9,9 @@ export const grokProvider = passthroughProvider({
   id: 'grok',
   name: 'Grok Build (xAI)',
   command: 'grok',
+  setup: {
+    installHint: 'curl -fsSL https://x.ai/cli/install.sh | bash',
+    docsUrl: 'https://docs.x.ai/build/overview',
+    loginHint: 'Run `grok-build login` (requires SuperGrok or X Premium+)',
+  },
 });

--- a/src/main/providers/grok.ts
+++ b/src/main/providers/grok.ts
@@ -12,6 +12,6 @@ export const grokProvider = passthroughProvider({
   setup: {
     installHint: 'curl -fsSL https://x.ai/cli/install.sh | bash',
     docsUrl: 'https://docs.x.ai/build/overview',
-    loginHint: 'Run `grok-build login` (requires SuperGrok or X Premium+)',
+    loginHint: 'Run `grok` — the first launch prompts sign-in with your X/xAI account (requires SuperGrok or X Premium+)',
   },
 });

--- a/src/main/providers/passthrough.ts
+++ b/src/main/providers/passthrough.ts
@@ -20,7 +20,7 @@ export function baseSessionEnv(config: ProviderLaunchConfig): NodeJS.ProcessEnv 
  * management stay entirely inside the CLI itself.
  */
 export function passthroughProvider(
-  opts: Pick<ProviderDefinition, 'id' | 'name' | 'command'>
+  opts: Pick<ProviderDefinition, 'id' | 'name' | 'command' | 'setup'>
 ): ProviderDefinition {
   return {
     ...opts,

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -75,6 +75,15 @@ export interface ProviderDefinition {
    * merged with the generic pattern set by the pty state detector.
    */
   waitingPatterns?: readonly RegExp[];
+  /** Setup guidance surfaced in Settings → Providers when the CLI is missing (#97). */
+  setup: {
+    /** Install command or instruction, shown as copyable text. */
+    installHint: string;
+    /** Official installation/authentication documentation URL. */
+    docsUrl: string;
+    /** How to authenticate after installing. */
+    loginHint: string;
+  };
   /** Build the command, args, and env for launching a session. */
   buildCommand(config: ProviderLaunchConfig): ProviderCommand;
 }

--- a/src/renderer/components/ProviderSettings.tsx
+++ b/src/renderer/components/ProviderSettings.tsx
@@ -1,59 +1,78 @@
-import React from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { ProviderStatus } from '../../shared/types';
 
-interface ProviderSettingsProps {
-  statuses: ProviderStatus[] | null;
-  loading: boolean;
-  onRefresh: () => void;
-}
+/**
+ * Settings → Providers panel: provider CLI detection status + setup guidance
+ * (#97). Self-contained — detects on mount (each time the tab is opened) and
+ * re-detects via the Refresh button, no app restart needed.
+ */
+export const ProviderSettings: React.FC = () => {
+  const [statuses, setStatuses] = useState<ProviderStatus[] | null>(null);
+  const [loading, setLoading] = useState(false);
 
-/** Settings → Providers panel: provider CLI detection status + setup guidance (#97). */
-export const ProviderSettings: React.FC<ProviderSettingsProps> = ({ statuses, loading, onRefresh }) => (
-  <div className="settings-section">
-    <h3>Session Providers</h3>
-    <p className="settings-description">
-      Agent CLIs available for new sessions. Detection runs through your
-      login shell, matching how sessions launch.
-    </p>
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      setStatuses(await window.electronAPI.detectProviders());
+    } catch (error) {
+      console.error('Provider detection failed:', error);
+      setStatuses([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
-    <div className="settings-group">
-      <div className="settings-row">
-        <span className="settings-hint">
-          {loading && 'Detecting installed CLIs…'}
-          {!loading && statuses &&
-            `${statuses.filter(p => p.installed).length} of ${statuses.length} providers detected`}
-        </span>
-        <button className="settings-button" onClick={onRefresh} disabled={loading}>
-          {loading ? 'Detecting…' : 'Refresh'}
-        </button>
-      </div>
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
 
-      {(statuses ?? []).map(p => (
-        <div key={p.id} className="provider-status-row">
-          <div className="provider-status-header">
-            <span className={`provider-status-dot ${p.installed ? 'installed' : 'missing'}`} />
-            <span className="provider-status-name">{p.name}</span>
-            <code className="provider-status-command">{p.command}</code>
-            {p.installed ? (
-              <span className="provider-status-version">{p.version ?? 'detected'}</span>
-            ) : (
-              <span className="provider-status-missing">not found</span>
+  return (
+    <div className="settings-section">
+      <h3>Session Providers</h3>
+      <p className="settings-description">
+        Agent CLIs available for new sessions. Detection runs through your
+        login shell, matching how sessions launch.
+      </p>
+
+      <div className="settings-group">
+        <div className="settings-row">
+          <span className="settings-hint">
+            {loading && 'Detecting installed CLIs…'}
+            {!loading && statuses &&
+              `${statuses.filter(p => p.installed).length} of ${statuses.length} providers detected`}
+          </span>
+          <button className="settings-button" onClick={refresh} disabled={loading}>
+            {loading ? 'Detecting…' : 'Refresh'}
+          </button>
+        </div>
+
+        {(statuses ?? []).map(p => (
+          <div key={p.id} className="provider-status-row">
+            <div className="provider-status-header">
+              <span className={`provider-status-dot ${p.installed ? 'installed' : 'missing'}`} />
+              <span className="provider-status-name">{p.name}</span>
+              <code className="provider-status-command">{p.command}</code>
+              {p.installed ? (
+                <span className="provider-status-version">{p.version ?? 'detected'}</span>
+              ) : (
+                <span className="provider-status-missing">not found</span>
+              )}
+            </div>
+            {!p.installed && (
+              <div className="provider-status-setup">
+                <div>Install: <code>{p.installHint}</code></div>
+                <div>Sign in: {p.loginHint}</div>
+                <button
+                  className="settings-link-button"
+                  onClick={() => window.electronAPI.openExternal(p.docsUrl)}
+                >
+                  Documentation ↗
+                </button>
+              </div>
             )}
           </div>
-          {!p.installed && (
-            <div className="provider-status-setup">
-              <div>Install: <code>{p.installHint}</code></div>
-              <div>Sign in: {p.loginHint}</div>
-              <button
-                className="settings-link-button"
-                onClick={() => window.electronAPI.openExternal(p.docsUrl)}
-              >
-                Documentation ↗
-              </button>
-            </div>
-          )}
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/renderer/components/ProviderSettings.tsx
+++ b/src/renderer/components/ProviderSettings.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { ProviderStatus } from '../../shared/types';
+
+interface ProviderSettingsProps {
+  statuses: ProviderStatus[] | null;
+  loading: boolean;
+  onRefresh: () => void;
+}
+
+/** Settings → Providers panel: provider CLI detection status + setup guidance (#97). */
+export const ProviderSettings: React.FC<ProviderSettingsProps> = ({ statuses, loading, onRefresh }) => (
+  <div className="settings-section">
+    <h3>Session Providers</h3>
+    <p className="settings-description">
+      Agent CLIs available for new sessions. Detection runs through your
+      login shell, matching how sessions launch.
+    </p>
+
+    <div className="settings-group">
+      <div className="settings-row">
+        <span className="settings-hint">
+          {loading && 'Detecting installed CLIs…'}
+          {!loading && statuses &&
+            `${statuses.filter(p => p.installed).length} of ${statuses.length} providers detected`}
+        </span>
+        <button className="settings-button" onClick={onRefresh} disabled={loading}>
+          {loading ? 'Detecting…' : 'Refresh'}
+        </button>
+      </div>
+
+      {(statuses ?? []).map(p => (
+        <div key={p.id} className="provider-status-row">
+          <div className="provider-status-header">
+            <span className={`provider-status-dot ${p.installed ? 'installed' : 'missing'}`} />
+            <span className="provider-status-name">{p.name}</span>
+            <code className="provider-status-command">{p.command}</code>
+            {p.installed ? (
+              <span className="provider-status-version">{p.version ?? 'detected'}</span>
+            ) : (
+              <span className="provider-status-missing">not found</span>
+            )}
+          </div>
+          {!p.installed && (
+            <div className="provider-status-setup">
+              <div>Install: <code>{p.installHint}</code></div>
+              <div>Sign in: {p.loginHint}</div>
+              <button
+                className="settings-link-button"
+                onClick={() => window.electronAPI.openExternal(p.docsUrl)}
+              >
+                Documentation ↗
+              </button>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  </div>
+);

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -10,6 +10,8 @@ interface SettingsModalProps {
 export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
   type SettingsTab = 'general' | 'appearance' | 'terminal' | 'sound' | 'integrations' | 'providers' | 'mobile' | 'updates';
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
+  const navClass = (tab: SettingsTab) =>
+    `settings-nav-item ${activeTab === tab ? 'active' : ''}`;
 
   // Update channel state (BDHLNDR-32)
   const [updateChannel, setUpdateChannelState] = useState<'stable' | 'beta'>('stable');
@@ -388,49 +390,49 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
         <div className="settings-layout">
           <nav className="settings-nav">
             <button
-              className={`settings-nav-item ${activeTab === 'general' ? 'active' : ''}`}
+              className={navClass('general')}
               onClick={() => setActiveTab('general')}
             >
               General
             </button>
             <button
-              className={`settings-nav-item ${activeTab === 'appearance' ? 'active' : ''}`}
+              className={navClass('appearance')}
               onClick={() => setActiveTab('appearance')}
             >
               Appearance
             </button>
             <button
-              className={`settings-nav-item ${activeTab === 'terminal' ? 'active' : ''}`}
+              className={navClass('terminal')}
               onClick={() => setActiveTab('terminal')}
             >
               Terminal
             </button>
             <button
-              className={`settings-nav-item ${activeTab === 'mobile' ? 'active' : ''}`}
+              className={navClass('mobile')}
               onClick={() => setActiveTab('mobile')}
             >
               Mobile App
             </button>
             <button
-              className={`settings-nav-item ${activeTab === 'sound' ? 'active' : ''}`}
+              className={navClass('sound')}
               onClick={() => setActiveTab('sound')}
             >
               Sound
             </button>
             <button
-              className={`settings-nav-item ${activeTab === 'integrations' ? 'active' : ''}`}
+              className={navClass('integrations')}
               onClick={() => setActiveTab('integrations')}
             >
               Integrations
             </button>
             <button
-              className={`settings-nav-item ${activeTab === 'providers' ? 'active' : ''}`}
+              className={navClass('providers')}
               onClick={() => setActiveTab('providers')}
             >
               Providers
             </button>
             <button
-              className={`settings-nav-item ${activeTab === 'updates' ? 'active' : ''}`}
+              className={navClass('updates')}
               onClick={() => setActiveTab('updates')}
             >
               Updates

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { ApiServerStatus, PairedDevice, PairingCode, ProviderStatus } from '../../shared/types';
+import { ApiServerStatus, PairedDevice, PairingCode } from '../../shared/types';
 import { ProviderSettings } from './ProviderSettings';
 
 interface SettingsModalProps {
@@ -15,29 +15,6 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
   const [updateChannel, setUpdateChannelState] = useState<'stable' | 'beta'>('stable');
   const [updateChannelLoading, setUpdateChannelLoading] = useState(false);
 
-  // Provider CLI detection state (#97)
-  const [providerStatuses, setProviderStatuses] = useState<ProviderStatus[] | null>(null);
-  const [providersLoading, setProvidersLoading] = useState(false);
-
-  const refreshProviders = useCallback(async () => {
-    setProvidersLoading(true);
-    try {
-      setProviderStatuses(await window.electronAPI.detectProviders());
-    } catch (error) {
-      console.error('Provider detection failed:', error);
-      setProviderStatuses([]);
-    } finally {
-      setProvidersLoading(false);
-    }
-  }, []);
-
-  // Detect provider CLIs the first time the Providers tab is opened (#97);
-  // the Refresh button re-runs detection on demand without an app restart.
-  useEffect(() => {
-    if (isOpen && activeTab === 'providers' && providerStatuses === null && !providersLoading) {
-      refreshProviders();
-    }
-  }, [isOpen, activeTab, providerStatuses, providersLoading, refreshProviders]);
 
   // Mobile API state
   const [apiStatus, setApiStatus] = useState<ApiServerStatus>({ running: false });
@@ -788,13 +765,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
               </div>
             )}
 
-            {activeTab === 'providers' && (
-              <ProviderSettings
-                statuses={providerStatuses}
-                loading={providersLoading}
-                onRefresh={refreshProviders}
-              />
-            )}
+            {activeTab === 'providers' && <ProviderSettings />}
 
             {activeTab === 'mobile' && (
               <div className="settings-section">

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { ApiServerStatus, PairedDevice, PairingCode } from '../../shared/types';
+import { ApiServerStatus, PairedDevice, PairingCode, ProviderStatus } from '../../shared/types';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -7,12 +7,36 @@ interface SettingsModalProps {
 }
 
 export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
-  type SettingsTab = 'general' | 'appearance' | 'terminal' | 'sound' | 'integrations' | 'mobile' | 'updates';
+  type SettingsTab = 'general' | 'appearance' | 'terminal' | 'sound' | 'integrations' | 'providers' | 'mobile' | 'updates';
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
 
   // Update channel state (BDHLNDR-32)
   const [updateChannel, setUpdateChannelState] = useState<'stable' | 'beta'>('stable');
   const [updateChannelLoading, setUpdateChannelLoading] = useState(false);
+
+  // Provider CLI detection state (#97)
+  const [providerStatuses, setProviderStatuses] = useState<ProviderStatus[] | null>(null);
+  const [providersLoading, setProvidersLoading] = useState(false);
+
+  const refreshProviders = useCallback(async () => {
+    setProvidersLoading(true);
+    try {
+      setProviderStatuses(await window.electronAPI.detectProviders());
+    } catch (error) {
+      console.error('Provider detection failed:', error);
+      setProviderStatuses([]);
+    } finally {
+      setProvidersLoading(false);
+    }
+  }, []);
+
+  // Detect provider CLIs the first time the Providers tab is opened (#97);
+  // the Refresh button re-runs detection on demand without an app restart.
+  useEffect(() => {
+    if (isOpen && activeTab === 'providers' && providerStatuses === null && !providersLoading) {
+      refreshProviders();
+    }
+  }, [isOpen, activeTab, providerStatuses, providersLoading, refreshProviders]);
 
   // Mobile API state
   const [apiStatus, setApiStatus] = useState<ApiServerStatus>({ running: false });
@@ -422,6 +446,12 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
               Integrations
             </button>
             <button
+              className={`settings-nav-item ${activeTab === 'providers' ? 'active' : ''}`}
+              onClick={() => setActiveTab('providers')}
+            >
+              Providers
+            </button>
+            <button
               className={`settings-nav-item ${activeTab === 'updates' ? 'active' : ''}`}
               onClick={() => setActiveTab('updates')}
             >
@@ -753,6 +783,60 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                       current beta will auto-install.
                     </p>
                   )}
+                </div>
+              </div>
+            )}
+
+            {activeTab === 'providers' && (
+              <div className="settings-section">
+                <h3>Session Providers</h3>
+                <p className="settings-description">
+                  Agent CLIs available for new sessions. Detection runs through your
+                  login shell, matching how sessions launch.
+                </p>
+
+                <div className="settings-group">
+                  <div className="settings-row">
+                    <span className="settings-hint">
+                      {providersLoading && 'Detecting installed CLIs…'}
+                      {!providersLoading && providerStatuses &&
+                        `${providerStatuses.filter(p => p.installed).length} of ${providerStatuses.length} providers detected`}
+                    </span>
+                    <button
+                      className="settings-button"
+                      onClick={refreshProviders}
+                      disabled={providersLoading}
+                    >
+                      {providersLoading ? 'Detecting…' : 'Refresh'}
+                    </button>
+                  </div>
+
+                  {(providerStatuses ?? []).map(p => (
+                    <div key={p.id} className="provider-status-row">
+                      <div className="provider-status-header">
+                        <span className={`provider-status-dot ${p.installed ? 'installed' : 'missing'}`} />
+                        <span className="provider-status-name">{p.name}</span>
+                        <code className="provider-status-command">{p.command}</code>
+                        {p.installed ? (
+                          <span className="provider-status-version">{p.version ?? 'detected'}</span>
+                        ) : (
+                          <span className="provider-status-missing">not found</span>
+                        )}
+                      </div>
+                      {!p.installed && (
+                        <div className="provider-status-setup">
+                          <div>Install: <code>{p.installHint}</code></div>
+                          <div>Sign in: {p.loginHint}</div>
+                          <button
+                            className="settings-link-button"
+                            onClick={() => window.electronAPI.openExternal(p.docsUrl)}
+                          >
+                            Documentation ↗
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  ))}
                 </div>
               </div>
             )}

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { ApiServerStatus, PairedDevice, PairingCode, ProviderStatus } from '../../shared/types';
+import { ProviderSettings } from './ProviderSettings';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -788,57 +789,11 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
             )}
 
             {activeTab === 'providers' && (
-              <div className="settings-section">
-                <h3>Session Providers</h3>
-                <p className="settings-description">
-                  Agent CLIs available for new sessions. Detection runs through your
-                  login shell, matching how sessions launch.
-                </p>
-
-                <div className="settings-group">
-                  <div className="settings-row">
-                    <span className="settings-hint">
-                      {providersLoading && 'Detecting installed CLIs…'}
-                      {!providersLoading && providerStatuses &&
-                        `${providerStatuses.filter(p => p.installed).length} of ${providerStatuses.length} providers detected`}
-                    </span>
-                    <button
-                      className="settings-button"
-                      onClick={refreshProviders}
-                      disabled={providersLoading}
-                    >
-                      {providersLoading ? 'Detecting…' : 'Refresh'}
-                    </button>
-                  </div>
-
-                  {(providerStatuses ?? []).map(p => (
-                    <div key={p.id} className="provider-status-row">
-                      <div className="provider-status-header">
-                        <span className={`provider-status-dot ${p.installed ? 'installed' : 'missing'}`} />
-                        <span className="provider-status-name">{p.name}</span>
-                        <code className="provider-status-command">{p.command}</code>
-                        {p.installed ? (
-                          <span className="provider-status-version">{p.version ?? 'detected'}</span>
-                        ) : (
-                          <span className="provider-status-missing">not found</span>
-                        )}
-                      </div>
-                      {!p.installed && (
-                        <div className="provider-status-setup">
-                          <div>Install: <code>{p.installHint}</code></div>
-                          <div>Sign in: {p.loginHint}</div>
-                          <button
-                            className="settings-link-button"
-                            onClick={() => window.electronAPI.openExternal(p.docsUrl)}
-                          >
-                            Documentation ↗
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
+              <ProviderSettings
+                statuses={providerStatuses}
+                loading={providersLoading}
+                onRefresh={refreshProviders}
+              />
             )}
 
             {activeTab === 'mobile' && (

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -83,6 +83,7 @@ interface ElectronAPI {
 
   // Shell
   openExternal: (url: string) => Promise<void>;
+  detectProviders: () => Promise<ProviderStatus[]>;
 
   // Sound notifications
   testSound: (event: 'waiting' | 'error' | 'start' | 'complete') => Promise<void>;

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -478,6 +478,91 @@ body {
   flex-shrink: 0;
 }
 
+/* Settings → Providers CLI detection (#97) */
+.provider-status-row {
+  padding: 10px 0;
+  border-bottom: 1px solid #333;
+}
+
+.provider-status-row:last-child {
+  border-bottom: none;
+}
+
+.provider-status-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.provider-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.provider-status-dot.installed {
+  background: #4caf50;
+}
+
+.provider-status-dot.missing {
+  background: #757575;
+}
+
+.provider-status-name {
+  font-weight: 500;
+}
+
+.provider-status-command {
+  font-size: 11px;
+  color: #999;
+  background: #2a2a2a;
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+
+.provider-status-version {
+  margin-left: auto;
+  font-size: 11px;
+  color: #4caf50;
+}
+
+.provider-status-missing {
+  margin-left: auto;
+  font-size: 11px;
+  color: #999;
+}
+
+.provider-status-setup {
+  margin: 8px 0 0 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #bbb;
+}
+
+.provider-status-setup code {
+  background: #2a2a2a;
+  padding: 1px 5px;
+  border-radius: 4px;
+  user-select: all;
+}
+
+.settings-link-button {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: #6ab0f3;
+  cursor: pointer;
+  padding: 0;
+  font-size: 12px;
+}
+
+.settings-link-button:hover {
+  text-decoration: underline;
+}
+
 /* Provider label on non-Claude agent sessions (#96) */
 .session-provider-badge {
   font-size: 10px;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -33,6 +33,20 @@ export interface Session {
   provider: string;
 }
 
+/** Result of probing one provider CLI's availability (#97). */
+export interface ProviderStatus {
+  id: string;
+  name: string;
+  /** CLI binary probed for. */
+  command: string;
+  installed: boolean;
+  /** First version-looking line of `<command> --version`, when available. */
+  version: string | null;
+  installHint: string;
+  docsUrl: string;
+  loginHint: string;
+}
+
 /** Display labels for session providers (registry ids → short names). */
 export const PROVIDER_LABELS: Record<string, string> = {
   claude: 'Claude',


### PR DESCRIPTION
## Description
Third slice of the multi-provider epic (#94): a Providers tab in Settings showing which agent CLIs are installed, with self-service setup guidance for the missing ones.

- **Detection matches how sessions launch**: probes run through the user's login shell on macOS/Linux (GUI-launched Electron doesn't inherit shell PATH), via `wsl.exe bash -lc` when the configured shell is WSL, and via `where.exe` on native Windows. Command names come from the static provider registry only.
- **Per-provider status row**: green/grey dot, CLI command, detected version (best-effort first version-looking line of `--version`); missing providers expand with a copyable install command, sign-in hint, and a docs link (existing `shell:openExternal` bridge).
- **Refresh** re-runs detection on demand — no app restart (acceptance criterion).
- Setup metadata (`installHint`/`docsUrl`/`loginHint`) lives on each `ProviderDefinition`, so #98's picker can reuse it for disabled entries.
- New `providers:detect` IPC via the existing `safeHandle` wrapper + `detectProviders()` preload method.

## Related issue
Closes #97

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Hotfix
- [ ] Refactor / chore
- [ ] Docs

## How was this tested?
- `bun test`: 12 pass, including a machine-independent contract test for `detectProviders` (one fully-populated status per registered provider)
- Real detection exercised on macOS: `claude` found through the login shell with version `2.1.207 (Claude Code)`; codex/gemini/grok correctly reported missing
- `tsc --noEmit` clean on main and renderer configs
- SonarQube preflight on the new detector: one minor (`??` vs `||`) found and fixed pre-push
- Manual QA worth doing: open Settings → Providers on Windows/WSL to confirm the platform branches

## Checklist
- [ ] Tests pass locally (bun test, 12 pass)
- [x] Self-reviewed the changes
- [x] Docs updated where needed (none required)
- [x] Linked the related issue above

🤖 Generated with [Claude Code](https://claude.com/claude-code)