### PR TITLE
Arena mode — multi-agent prompt fan-out with streaming metrics

### DIFF
--- a/src/main/arena/__tests__/engine-ollama.test.ts
+++ b/src/main/arena/__tests__/engine-ollama.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Arena engine — Ollama contestant tests (#100). global.fetch is stubbed per
+ * test, covering: happy-path NDJSON streaming with token counts, the
+ * no-models-pulled and HTTP-error branches, daemon-unreachable, and
+ * abort-on-timeout.
+ *
+ * Run with: bun test src/main/arena
+ */
+import { describe, expect, test, mock, afterEach } from 'bun:test';
+import type { ArenaUpdate } from '../../../shared/types';
+
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
+}));
+mock.module('../../repositories/preferences', () => ({
+  getPreference: () => '',
+}));
+
+const finalized: any[] = [];
+mock.module('../../repositories/arena', () => ({
+  createRun: () => undefined,
+  createResponse: () => undefined,
+  finalizeResponse: (id: string, final: any) => finalized.push({ id, ...final }),
+  getRun: (id: string) => ({ id, prompt: 'p', createdAt: new Date(0), responses: [] }),
+  listRuns: () => [],
+}));
+mock.module('../../providers', () => ({
+  getProvider: () => {
+    throw new Error('CLI providers not used in these tests');
+  },
+}));
+
+const { ArenaEngine } = await import('../engine');
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  finalized.length = 0;
+});
+
+function ndjsonStream(lines: object[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(JSON.stringify(line) + '\n'));
+      }
+      controller.close();
+    },
+  });
+}
+
+function runOllamaAndSettle(engine: InstanceType<typeof ArenaEngine>): Promise<ArenaUpdate[]> {
+  const updates: ArenaUpdate[] = [];
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error('never settled')), 10_000);
+    engine.on('update', (u: ArenaUpdate) => {
+      updates.push(u);
+      if (u.status !== 'running') {
+        clearTimeout(t);
+        resolve(updates);
+      }
+    });
+    const run = engine.prepare('ollama-prompt', ['ollama']);
+    engine.launch(run.id);
+  });
+}
+
+describe('ArenaEngine — Ollama contestant', () => {
+  test('streams NDJSON chunks and reports token counts', async () => {
+    globalThis.fetch = (async (url: any) => {
+      if (String(url).endsWith('/api/tags')) {
+        return new Response(JSON.stringify({ models: [{ name: 'llama3' }] }), { status: 200 });
+      }
+      return new Response(
+        ndjsonStream([
+          { message: { content: 'hel' }, done: false },
+          { message: { content: 'lo' }, done: false },
+          { message: { content: '' }, done: true, prompt_eval_count: 9, eval_count: 14 },
+        ]),
+        { status: 200 }
+      );
+    }) as typeof fetch;
+
+    const updates = await runOllamaAndSettle(new ArenaEngine());
+    const final = updates[updates.length - 1];
+    expect(final.status).toBe('done');
+    expect(updates.map(u => u.chunk).join('')).toBe('hello');
+    expect(final.inputTokens).toBe(9);
+    expect(final.outputTokens).toBe(14);
+    expect(final.ttftMs).toBeGreaterThanOrEqual(0);
+    expect(finalized[0].text).toBe('hello');
+  });
+
+  test('reports a clear error when no models are pulled', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ models: [] }), { status: 200 })) as typeof fetch;
+
+    const updates = await runOllamaAndSettle(new ArenaEngine());
+    const final = updates[updates.length - 1];
+    expect(final.status).toBe('error');
+    expect(final.error).toContain('no models pulled');
+    // totalMs is measured from the launch attempt, not run creation.
+    expect(final.totalMs!).toBeLessThan(5_000);
+  });
+
+  test('reports the HTTP status when /api/chat fails', async () => {
+    globalThis.fetch = (async (url: any) => {
+      if (String(url).endsWith('/api/tags')) {
+        return new Response(JSON.stringify({ models: [{ name: 'llama3' }] }), { status: 200 });
+      }
+      return new Response('busy', { status: 503 });
+    }) as typeof fetch;
+
+    const updates = await runOllamaAndSettle(new ArenaEngine());
+    expect(updates[updates.length - 1].error).toContain('HTTP 503');
+  });
+
+  test('reports unreachable when the daemon is down', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as typeof fetch;
+
+    const updates = await runOllamaAndSettle(new ArenaEngine());
+    const final = updates[updates.length - 1];
+    expect(final.status).toBe('error');
+    expect(final.error).toContain('not reachable');
+  });
+
+  test('aborts a hung stream at the contestant timeout', async () => {
+    globalThis.fetch = (async (url: any, init?: RequestInit) => {
+      if (String(url).endsWith('/api/tags')) {
+        return new Response(JSON.stringify({ models: [{ name: 'llama3' }] }), { status: 200 });
+      }
+      // A stream that never produces data and never closes; reject on abort.
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            init?.signal?.addEventListener('abort', () => {
+              controller.error(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+            });
+          },
+        }),
+        { status: 200 }
+      );
+    }) as typeof fetch;
+
+    const updates = await runOllamaAndSettle(new ArenaEngine(400));
+    const final = updates[updates.length - 1];
+    expect(final.status).toBe('error');
+    expect(final.totalMs!).toBeLessThan(5_000);
+  }, 10_000);
+});

--- a/src/main/arena/__tests__/engine-ollama.test.ts
+++ b/src/main/arena/__tests__/engine-ollama.test.ts
@@ -38,6 +38,17 @@ afterEach(() => {
   finalized.length = 0;
 });
 
+/** A stream that never produces data and never closes; errors with AbortError on abort. */
+function hungStream(signal: AbortSignal | null | undefined): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      signal?.addEventListener('abort', () => {
+        controller.error(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+      });
+    },
+  });
+}
+
 function ndjsonStream(lines: object[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   return new ReadableStream({
@@ -132,17 +143,7 @@ describe('ArenaEngine — Ollama contestant', () => {
       if (String(url).endsWith('/api/tags')) {
         return new Response(JSON.stringify({ models: [{ name: 'llama3' }] }), { status: 200 });
       }
-      // A stream that never produces data and never closes; reject on abort.
-      return new Response(
-        new ReadableStream({
-          start(controller) {
-            init?.signal?.addEventListener('abort', () => {
-              controller.error(Object.assign(new Error('aborted'), { name: 'AbortError' }));
-            });
-          },
-        }),
-        { status: 200 }
-      );
+      return new Response(hungStream(init?.signal), { status: 200 });
     }) as typeof fetch;
 
     const updates = await runOllamaAndSettle(new ArenaEngine(400));

--- a/src/main/arena/__tests__/engine.test.ts
+++ b/src/main/arena/__tests__/engine.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Arena engine tests (#100): the concurrency-sensitive paths — two-phase
+ * prepare/launch, streaming + TTFT measurement, non-zero exit, timeout
+ * kill, cancel, and the no-double-finalize guard. Contestants are fake
+ * providers whose "CLI" is plain shell (printf/sleep), spawned through the
+ * real shell-launch wrapper, so the spawn → readline → parser path is
+ * exercised for real without any agent CLI installed.
+ *
+ * Run with: bun test src/main/arena
+ */
+import { describe, expect, test, mock } from 'bun:test';
+import type { ArenaUpdate } from '../../../shared/types';
+
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
+}));
+mock.module('../../repositories/preferences', () => ({
+  getPreference: () => '',
+}));
+
+const finalized: any[] = [];
+mock.module('../../repositories/arena', () => ({
+  createRun: () => undefined,
+  createResponse: () => undefined,
+  finalizeResponse: (id: string, final: any) => finalized.push({ id, ...final }),
+  getRun: (id: string) => ({ id, prompt: 'p', createdAt: new Date(0), responses: [] }),
+  listRuns: () => [],
+}));
+
+const { textParser } = await import('../parsers');
+
+// Fake contestants: ordinary shell commands standing in for agent CLIs.
+const FAKE_PROVIDERS: Record<string, any> = {
+  echoer: {
+    id: 'echoer',
+    arena: {
+      buildCommand: (ref: string) => `echo hello; echo ${ref}`,
+      createParser: textParser,
+    },
+  },
+  failer: {
+    id: 'failer',
+    arena: {
+      buildCommand: () => 'echo oops >&2; exit 3',
+      createParser: textParser,
+    },
+  },
+  sleeper: {
+    id: 'sleeper',
+    arena: {
+      buildCommand: () => 'sleep 30',
+      createParser: textParser,
+    },
+  },
+};
+mock.module('../../providers', () => ({
+  getProvider: (id: string) => {
+    const p = FAKE_PROVIDERS[id];
+    if (!p) throw new Error(`Unknown session provider: ${id}`);
+    return p;
+  },
+}));
+
+const { ArenaEngine } = await import('../engine');
+
+function collectUntilSettled(engine: InstanceType<typeof ArenaEngine>, expectedFinals: number, timeoutMs = 20_000) {
+  const updates: ArenaUpdate[] = [];
+  let settled = 0;
+  const done = new Promise<ArenaUpdate[]>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`settled ${settled}/${expectedFinals}`)), timeoutMs);
+    engine.on('update', (u: ArenaUpdate) => {
+      updates.push(u);
+      if (u.status !== 'running') {
+        settled += 1;
+        if (settled >= expectedFinals) {
+          clearTimeout(t);
+          resolve(updates);
+        }
+      }
+    });
+  });
+  return done;
+}
+
+describe('ArenaEngine', () => {
+  test('prepare creates the run without launching; launch streams and finishes', async () => {
+    finalized.length = 0;
+    const engine = new ArenaEngine();
+    const settled = collectUntilSettled(engine, 1);
+
+    const run = engine.prepare('arena-prompt-text', ['echoer']);
+    expect(run.id.length).toBeGreaterThan(0);
+
+    // Nothing spawned yet: give the loop a beat and confirm silence.
+    await new Promise((r) => setTimeout(r, 150));
+    expect(finalized.length).toBe(0);
+
+    engine.launch(run.id);
+    const updates = await settled;
+
+    const final = updates[updates.length - 1];
+    expect(final.status).toBe('done');
+    expect(final.totalMs).toBeGreaterThan(0);
+    expect(final.ttftMs).toBeGreaterThan(0);
+    expect(final.ttftMs!).toBeLessThanOrEqual(final.totalMs!);
+
+    const text = updates.map((u) => u.chunk).join('');
+    expect(text).toContain('hello');
+    // The prompt reached the CLI through the environment, not the command string.
+    expect(text).toContain('arena-prompt-text');
+    expect(finalized.length).toBe(1);
+    expect(finalized[0].status).toBe('done');
+  }, 25_000);
+
+  test('non-zero exit surfaces stderr as an error column', async () => {
+    finalized.length = 0;
+    const engine = new ArenaEngine();
+    const settled = collectUntilSettled(engine, 1);
+    const run = engine.prepare('p', ['failer']);
+    engine.launch(run.id);
+    const updates = await settled;
+    const final = updates[updates.length - 1];
+    expect(final.status).toBe('error');
+    expect(final.error).toContain('oops');
+    expect(finalized[0].status).toBe('error');
+  }, 25_000);
+
+  test('timeout kills the process tree and settles as error', async () => {
+    finalized.length = 0;
+    const engine = new ArenaEngine(500); // 0.5s contestant timeout
+    const settled = collectUntilSettled(engine, 1);
+    const run = engine.prepare('p', ['sleeper']);
+    engine.launch(run.id);
+    const updates = await settled;
+    const final = updates[updates.length - 1];
+    expect(final.status).toBe('error');
+    expect(final.totalMs!).toBeLessThan(10_000);
+    expect(finalized.length).toBe(1);
+  }, 25_000);
+
+  test('cancelRun settles as Cancelled and never double-finalizes', async () => {
+    finalized.length = 0;
+    const engine = new ArenaEngine();
+    const settled = collectUntilSettled(engine, 1);
+    const run = engine.prepare('p', ['sleeper']);
+    engine.launch(run.id);
+    await new Promise((r) => setTimeout(r, 300)); // let it spawn
+    engine.cancelRun(run.id);
+    const updates = await settled;
+    const final = updates[updates.length - 1];
+    expect(final.status).toBe('error');
+    expect(final.error).toBe('Cancelled');
+    // The killed child's close event must not finalize a second time.
+    await new Promise((r) => setTimeout(r, 500));
+    expect(finalized.length).toBe(1);
+  }, 25_000);
+
+  test('unknown contestant fails fast without spawning', async () => {
+    finalized.length = 0;
+    const engine = new ArenaEngine();
+    const settled = collectUntilSettled(engine, 1);
+    const run = engine.prepare('p', ['nope']);
+    engine.launch(run.id);
+    const updates = await settled;
+    expect(updates[updates.length - 1].error).toContain('Unknown contestant');
+  }, 10_000);
+});

--- a/src/main/arena/__tests__/parsers.test.ts
+++ b/src/main/arena/__tests__/parsers.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Arena parser tests (#100). The claude fixture lines are from a real
+ * `claude -p --output-format stream-json --verbose --max-turns 1` run;
+ * codex/gemini/ollama fixtures follow their documented output contracts.
+ *
+ * Run with: bun test src/main/arena
+ */
+import { describe, expect, test } from 'bun:test';
+import { claudeParser, codexParser, geminiParser, textParser, ollamaParser } from '../parsers';
+
+describe('claudeParser', () => {
+  test('extracts assistant text and result metrics from stream-json', () => {
+    const p = claudeParser();
+    expect(p.onLine(JSON.stringify({ type: 'system', subtype: 'init' }))).toBe('');
+    expect(
+      p.onLine(JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'thinking', thinking: 'hmm' }, { type: 'text', text: 'pong' }] },
+      }))
+    ).toBe('pong');
+    expect(
+      p.onLine(JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        duration_ms: 5973,
+        ttft_ms: 5423,
+        result: 'pong',
+        total_cost_usd: 0.194027,
+        usage: { input_tokens: 2, output_tokens: 21 },
+      }))
+    ).toBe('');
+    expect(p.finalize()).toEqual({
+      inputTokens: 2,
+      outputTokens: 21,
+      costUsd: 0.194027,
+      reportedTtftMs: 5423,
+      trailingText: '',
+    });
+  });
+
+  test('ignores garbage and non-JSON lines', () => {
+    const p = claudeParser();
+    expect(p.onLine('not json')).toBe('');
+    expect(p.onLine('{broken')).toBe('');
+    expect(p.finalize().costUsd).toBeNull();
+  });
+});
+
+describe('codexParser', () => {
+  test('extracts agent messages and turn usage from exec --json', () => {
+    const p = codexParser();
+    expect(p.onLine(JSON.stringify({ type: 'turn.started' }))).toBe('');
+    expect(
+      p.onLine(JSON.stringify({
+        type: 'item.completed',
+        item: { item_type: 'agent_message', text: 'hello from codex' },
+      }))
+    ).toBe('hello from codex');
+    expect(
+      p.onLine(JSON.stringify({
+        type: 'turn.completed',
+        usage: { input_tokens: 120, output_tokens: 45 },
+      }))
+    ).toBe('');
+    const final = p.finalize();
+    expect(final.inputTokens).toBe(120);
+    expect(final.outputTokens).toBe(45);
+  });
+
+  test('accepts item.type as an alternative to item_type', () => {
+    const p = codexParser();
+    expect(
+      p.onLine(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'alt' } }))
+    ).toBe('alt');
+  });
+});
+
+describe('geminiParser', () => {
+  test('parses the single JSON document with response and model stats', () => {
+    const doc = {
+      response: 'hello from gemini',
+      stats: {
+        models: {
+          'gemini-2.5-pro': { tokens: { prompt: 10, candidates: 30, total: 40 } },
+          'gemini-2.5-flash': { tokens: { prompt: 5, candidates: 7, total: 12 } },
+        },
+      },
+    };
+    const p = geminiParser();
+    for (const line of JSON.stringify(doc, null, 2).split('\n')) {
+      expect(p.onLine(line)).toBe('');
+    }
+    expect(p.finalize()).toEqual({
+      inputTokens: 15,
+      outputTokens: 37,
+      costUsd: null,
+      reportedTtftMs: null,
+      trailingText: 'hello from gemini',
+    });
+  });
+
+  test('falls back to raw text when output is not JSON', () => {
+    const p = geminiParser();
+    p.onLine('plain output');
+    expect(p.finalize().trailingText).toBe('plain output');
+  });
+});
+
+describe('textParser', () => {
+  test('passes lines through with newlines', () => {
+    const p = textParser();
+    expect(p.onLine('line one')).toBe('line one\n');
+    expect(p.finalize().inputTokens).toBeNull();
+  });
+});
+
+describe('ollamaParser', () => {
+  test('streams message content and captures eval counts at done', () => {
+    const p = ollamaParser();
+    expect(p.onLine(JSON.stringify({ message: { content: 'hel' }, done: false }))).toBe('hel');
+    expect(p.onLine(JSON.stringify({ message: { content: 'lo' }, done: false }))).toBe('lo');
+    expect(
+      p.onLine(JSON.stringify({ message: { content: '' }, done: true, prompt_eval_count: 8, eval_count: 22 }))
+    ).toBe('');
+    const final = p.finalize();
+    expect(final.inputTokens).toBe(8);
+    expect(final.outputTokens).toBe(22);
+  });
+});

--- a/src/main/arena/engine.ts
+++ b/src/main/arena/engine.ts
@@ -36,28 +36,44 @@ const OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
 /** Generous default cap so a hung CLI can't leave a column spinning forever. */
 const DEFAULT_CONTESTANT_TIMEOUT_MS = 5 * 60 * 1000;
 
+/** Grace period between SIGTERM and the SIGKILL escalation. */
+const KILL_GRACE_MS = 3000;
+
 /**
  * Kill the contestant's whole process tree. The CLI runs as a child of the
  * wrapper shell, so signalling just the shell would leave the actual agent
  * process running detached. POSIX contestants are spawned detached (own
- * process group) and killed by group; Windows uses taskkill /T.
+ * process group) and killed by group, escalating to SIGKILL if the tree
+ * ignores SIGTERM — otherwise 'close' never fires and the column would sit
+ * on "running" forever. Windows taskkill /F is already forceful.
  */
 function killTree(child: ChildProcess): void {
-  if (!child.pid) {
+  const pid = child.pid;
+  if (!pid) {
     child.kill();
     return;
   }
   if (process.platform === 'win32') {
     // Absolute path so a poisoned PATH can't substitute the binary (S4036).
     const taskkill = path.join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'taskkill.exe');
-    execFile(taskkill, ['/F', '/T', '/PID', String(child.pid)], () => undefined);
+    execFile(taskkill, ['/F', '/T', '/PID', String(pid)], () => undefined);
     return;
   }
   try {
-    process.kill(-child.pid, 'SIGTERM');
+    process.kill(-pid, 'SIGTERM');
   } catch {
     child.kill();
+    return;
   }
+  const escalation = setTimeout(() => {
+    try {
+      process.kill(-pid, 'SIGKILL');
+    } catch {
+      // Process group already gone — nothing to escalate.
+    }
+  }, KILL_GRACE_MS);
+  escalation.unref?.();
+  child.once('close', () => clearTimeout(escalation));
 }
 
 interface LiveResponse {
@@ -199,6 +215,9 @@ export class ArenaEngine extends EventEmitter {
       clearTimeout(timeout);
       controller.abort();
     };
+    // Clock starts at the launch attempt so error paths (no models, daemon
+    // down) don't inherit the prepare()→launch() gap in totalMs.
+    entry.startedAt = Date.now();
 
     try {
       // Use the first locally available model.
@@ -208,7 +227,6 @@ export class ArenaEngine extends EventEmitter {
         this.finish(responseId, 'error', null, 'Ollama is running but has no models pulled');
         return;
       }
-      entry.startedAt = Date.now();
 
       const res = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
         method: 'POST',

--- a/src/main/arena/engine.ts
+++ b/src/main/arena/engine.ts
@@ -18,6 +18,7 @@
  * a column stuck on "running".
  */
 import { spawn, execFile, ChildProcess } from 'child_process';
+import * as path from 'path';
 import * as readline from 'readline';
 import { randomUUID } from 'crypto';
 import { EventEmitter } from 'events';
@@ -47,7 +48,9 @@ function killTree(child: ChildProcess): void {
     return;
   }
   if (process.platform === 'win32') {
-    execFile('taskkill', ['/F', '/T', '/PID', String(child.pid)], () => undefined);
+    // Absolute path so a poisoned PATH can't substitute the binary (S4036).
+    const taskkill = path.join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'taskkill.exe');
+    execFile(taskkill, ['/F', '/T', '/PID', String(child.pid)], () => undefined);
     return;
   }
   try {

--- a/src/main/arena/engine.ts
+++ b/src/main/arena/engine.ts
@@ -1,0 +1,268 @@
+/**
+ * Arena engine (#100): fans one prompt out to N contestants concurrently,
+ * streams their output as 'update' events, and persists final text + metrics.
+ *
+ * CLI contestants run headless under the user's existing login/subscription
+ * (never an API key — see issue #100's subscription-preservation decision),
+ * spawned through the user's shell exactly like sessions are. The prompt is
+ * passed via the ARENA_PROMPT environment variable and referenced with the
+ * shell's own env syntax, so prompt text never touches the command string.
+ *
+ * Ollama is the one non-CLI contestant: a keyless HTTP call to the local
+ * daemon, streaming /api/chat.
+ */
+import { spawn } from 'child_process';
+import * as readline from 'readline';
+import { randomUUID } from 'crypto';
+import { EventEmitter } from 'events';
+import log from 'electron-log';
+import { getProvider } from '../providers';
+import { getShellLaunch } from '../pty-manager';
+import { detectShell } from '../shell-detector';
+import { getPreference } from '../repositories/preferences';
+import * as arenaRepo from '../repositories/arena';
+import { ArenaStreamParser, ollamaParser } from './parsers';
+import { ArenaRun, ArenaUpdate, ArenaResponseStatus } from '../../shared/types';
+
+export const OLLAMA_CONTESTANT_ID = 'ollama';
+const OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
+/** Generous cap so a hung CLI can't leave a column spinning forever. */
+const CONTESTANT_TIMEOUT_MS = 5 * 60 * 1000;
+
+interface LiveResponse {
+  runId: string;
+  provider: string;
+  text: string;
+  startedAt: number;
+  ttftMs: number | null;
+  kill: (() => void) | null;
+}
+
+export class ArenaEngine extends EventEmitter {
+  private readonly live: Map<string, LiveResponse> = new Map();
+
+  /** Create the run + response rows and launch every contestant. */
+  start(prompt: string, contestants: string[]): ArenaRun {
+    const runId = randomUUID();
+    arenaRepo.createRun(runId, prompt);
+
+    for (const provider of contestants) {
+      const responseId = randomUUID();
+      arenaRepo.createResponse(responseId, runId, provider);
+      this.live.set(responseId, {
+        runId,
+        provider,
+        text: '',
+        startedAt: Date.now(),
+        ttftMs: null,
+        kill: null,
+      });
+      if (provider === OLLAMA_CONTESTANT_ID) {
+        void this.runOllama(responseId, prompt);
+      } else {
+        this.runCli(responseId, provider, prompt);
+      }
+    }
+
+    const run = arenaRepo.getRun(runId);
+    if (!run) throw new Error('Arena run vanished immediately after creation');
+    return run;
+  }
+
+  cancelRun(runId: string): void {
+    for (const [responseId, entry] of this.live) {
+      if (entry.runId === runId) {
+        entry.kill?.();
+        this.finish(responseId, 'error', null, 'Cancelled');
+      }
+    }
+  }
+
+  private runCli(responseId: string, providerId: string, prompt: string): void {
+    const entry = this.live.get(responseId);
+    if (!entry) return;
+    let provider: ReturnType<typeof getProvider>;
+    try {
+      provider = getProvider(providerId);
+    } catch {
+      this.finish(responseId, 'error', null, `Unknown contestant: ${providerId}`);
+      return;
+    }
+
+    const shellInfo = detectShell(getPreference('customShellPath') ?? '');
+    const shellLaunch = getShellLaunch(shellInfo);
+    const cmd = provider.arena.buildCommand(shellLaunch.envRef('ARENA_PROMPT'));
+    const parser = provider.arena.createParser();
+
+    const child = spawn(shellLaunch.shell, shellLaunch.wrap(cmd), {
+      env: { ...process.env, ARENA_PROMPT: prompt },
+      windowsHide: true,
+    });
+    entry.startedAt = Date.now();
+
+    const timeout = setTimeout(() => {
+      log.warn(`[Arena] ${providerId} timed out after ${CONTESTANT_TIMEOUT_MS}ms`);
+      child.kill();
+    }, CONTESTANT_TIMEOUT_MS);
+    entry.kill = () => {
+      clearTimeout(timeout);
+      child.kill();
+    };
+
+    let stderrTail = '';
+    child.stderr?.on('data', (data: Buffer) => {
+      stderrTail = (stderrTail + data.toString()).slice(-2000);
+    });
+
+    const rl = readline.createInterface({ input: child.stdout! });
+    rl.on('line', (line) => {
+      this.appendChunk(responseId, parser.onLine(line));
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timeout);
+      this.finish(responseId, 'error', null, `Failed to launch: ${err.message}`);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      if (!this.live.has(responseId)) return; // already finished (error/cancel)
+      const final = parser.finalize();
+      this.appendChunk(responseId, final.trailingText);
+      if (code === 0) {
+        this.finish(responseId, 'done', final, null);
+      } else {
+        const detail = stderrTail.trim() || `exit code ${code}`;
+        this.finish(responseId, 'error', final, detail.slice(0, 500));
+      }
+    });
+  }
+
+  private async runOllama(responseId: string, prompt: string): Promise<void> {
+    const entry = this.live.get(responseId);
+    if (!entry) return;
+    const parser = ollamaParser();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), CONTESTANT_TIMEOUT_MS);
+    entry.kill = () => {
+      clearTimeout(timeout);
+      controller.abort();
+    };
+
+    try {
+      // Use the first locally available model.
+      const tags = await fetch(`${OLLAMA_BASE_URL}/api/tags`, { signal: controller.signal });
+      const model: string | undefined = (await tags.json())?.models?.[0]?.name;
+      if (!model) {
+        this.finish(responseId, 'error', null, 'Ollama is running but has no models pulled');
+        return;
+      }
+      entry.startedAt = Date.now();
+
+      const res = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
+        method: 'POST',
+        signal: controller.signal,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model, messages: [{ role: 'user', content: prompt }], stream: true }),
+      });
+      if (!res.ok || !res.body) {
+        this.finish(responseId, 'error', null, `Ollama returned HTTP ${res.status}`);
+        return;
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffered = '';
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffered += decoder.decode(value, { stream: true });
+        const lines = buffered.split('\n');
+        buffered = lines.pop() ?? '';
+        for (const line of lines) {
+          this.appendChunk(responseId, parser.onLine(line));
+        }
+      }
+      if (buffered) this.appendChunk(responseId, parser.onLine(buffered));
+      this.finish(responseId, 'done', parser.finalize(), null);
+    } catch (err: any) {
+      const message = err?.name === 'AbortError'
+        ? 'Timed out'
+        : `Ollama not reachable at ${OLLAMA_BASE_URL} (${err?.message ?? err})`;
+      this.finish(responseId, 'error', parser.finalize(), message);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private appendChunk(responseId: string, chunk: string): void {
+    if (!chunk) return;
+    const entry = this.live.get(responseId);
+    if (!entry) return;
+    if (entry.ttftMs === null) {
+      entry.ttftMs = Date.now() - entry.startedAt;
+    }
+    entry.text += chunk;
+    this.emitUpdate(responseId, entry, 'running', chunk, null, null);
+  }
+
+  private finish(
+    responseId: string,
+    status: ArenaResponseStatus,
+    final: ReturnType<ArenaStreamParser['finalize']> | null,
+    error: string | null
+  ): void {
+    const entry = this.live.get(responseId);
+    if (!entry) return;
+    this.live.delete(responseId);
+
+    const totalMs = Date.now() - entry.startedAt;
+    // Prefer the CLI's own TTFT measurement when it reports one (claude):
+    // it excludes process startup, ours includes it — theirs is the honest
+    // model-latency number, ours still shows in total.
+    const ttftMs = final?.reportedTtftMs ?? entry.ttftMs;
+
+    try {
+      arenaRepo.finalizeResponse(responseId, {
+        status,
+        text: entry.text,
+        ttftMs,
+        totalMs,
+        inputTokens: final?.inputTokens ?? null,
+        outputTokens: final?.outputTokens ?? null,
+        costUsd: final?.costUsd ?? null,
+        error,
+      });
+    } catch (e) {
+      log.error(`[Arena] Failed to persist response ${responseId}:`, e);
+    }
+    this.emitUpdate(responseId, { ...entry, ttftMs }, status, '', totalMs, final, error);
+  }
+
+  private emitUpdate(
+    responseId: string,
+    entry: Pick<LiveResponse, 'runId' | 'provider' | 'ttftMs'>,
+    status: ArenaResponseStatus,
+    chunk: string,
+    totalMs: number | null,
+    final?: ReturnType<ArenaStreamParser['finalize']> | null,
+    error: string | null = null
+  ): void {
+    const update: ArenaUpdate = {
+      runId: entry.runId,
+      responseId,
+      provider: entry.provider,
+      chunk,
+      status,
+      ttftMs: entry.ttftMs,
+      totalMs,
+      inputTokens: final?.inputTokens ?? null,
+      outputTokens: final?.outputTokens ?? null,
+      costUsd: final?.costUsd ?? null,
+      error,
+    };
+    this.emit('update', update);
+  }
+}
+
+export const arenaEngine = new ArenaEngine();

--- a/src/main/arena/engine.ts
+++ b/src/main/arena/engine.ts
@@ -10,14 +10,20 @@
  *
  * Ollama is the one non-CLI contestant: a keyless HTTP call to the local
  * daemon, streaming /api/chat.
+ *
+ * Two-phase start: prepare() creates the run + response rows WITHOUT
+ * launching anything, so the renderer can learn the run id and subscribe
+ * before launch() spawns the contestants — otherwise a fast-failing CLI
+ * could emit its final update before the renderer knew the run id, leaving
+ * a column stuck on "running".
  */
-import { spawn } from 'child_process';
+import { spawn, execFile, ChildProcess } from 'child_process';
 import * as readline from 'readline';
 import { randomUUID } from 'crypto';
 import { EventEmitter } from 'events';
 import log from 'electron-log';
 import { getProvider } from '../providers';
-import { getShellLaunch } from '../pty-manager';
+import { getShellLaunch } from '../shell-launch';
 import { detectShell } from '../shell-detector';
 import { getPreference } from '../repositories/preferences';
 import * as arenaRepo from '../repositories/arena';
@@ -26,47 +32,85 @@ import { ArenaRun, ArenaUpdate, ArenaResponseStatus } from '../../shared/types';
 
 export const OLLAMA_CONTESTANT_ID = 'ollama';
 const OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
-/** Generous cap so a hung CLI can't leave a column spinning forever. */
-const CONTESTANT_TIMEOUT_MS = 5 * 60 * 1000;
+/** Generous default cap so a hung CLI can't leave a column spinning forever. */
+const DEFAULT_CONTESTANT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Kill the contestant's whole process tree. The CLI runs as a child of the
+ * wrapper shell, so signalling just the shell would leave the actual agent
+ * process running detached. POSIX contestants are spawned detached (own
+ * process group) and killed by group; Windows uses taskkill /T.
+ */
+function killTree(child: ChildProcess): void {
+  if (!child.pid) {
+    child.kill();
+    return;
+  }
+  if (process.platform === 'win32') {
+    execFile('taskkill', ['/F', '/T', '/PID', String(child.pid)], () => undefined);
+    return;
+  }
+  try {
+    process.kill(-child.pid, 'SIGTERM');
+  } catch {
+    child.kill();
+  }
+}
 
 interface LiveResponse {
   runId: string;
   provider: string;
+  prompt: string;
   text: string;
   startedAt: number;
   ttftMs: number | null;
+  launched: boolean;
   kill: (() => void) | null;
 }
 
 export class ArenaEngine extends EventEmitter {
   private readonly live: Map<string, LiveResponse> = new Map();
+  private readonly timeoutMs: number;
 
-  /** Create the run + response rows and launch every contestant. */
-  start(prompt: string, contestants: string[]): ArenaRun {
+  constructor(timeoutMs: number = DEFAULT_CONTESTANT_TIMEOUT_MS) {
+    super();
+    this.timeoutMs = timeoutMs;
+  }
+
+  /** Phase 1: create the run + response rows; nothing is spawned yet. */
+  prepare(prompt: string, contestants: string[]): ArenaRun {
     const runId = randomUUID();
     arenaRepo.createRun(runId, prompt);
-
     for (const provider of contestants) {
       const responseId = randomUUID();
       arenaRepo.createResponse(responseId, runId, provider);
       this.live.set(responseId, {
         runId,
         provider,
+        prompt,
         text: '',
         startedAt: Date.now(),
         ttftMs: null,
+        launched: false,
         kill: null,
       });
-      if (provider === OLLAMA_CONTESTANT_ID) {
-        void this.runOllama(responseId, prompt);
-      } else {
-        this.runCli(responseId, provider, prompt);
-      }
     }
-
     const run = arenaRepo.getRun(runId);
     if (!run) throw new Error('Arena run vanished immediately after creation');
     return run;
+  }
+
+  /** Phase 2: spawn every contestant of a prepared run. */
+  launch(runId: string): void {
+    for (const [responseId, entry] of this.live) {
+      if (entry.runId !== runId || entry.launched) continue;
+      entry.launched = true;
+      if (entry.provider === OLLAMA_CONTESTANT_ID) {
+        void this.runOllama(responseId, entry.prompt);
+      } else {
+        this.runCli(responseId, entry.provider, entry.prompt);
+      }
+    }
   }
 
   cancelRun(runId: string): void {
@@ -97,16 +141,18 @@ export class ArenaEngine extends EventEmitter {
     const child = spawn(shellLaunch.shell, shellLaunch.wrap(cmd), {
       env: { ...process.env, ARENA_PROMPT: prompt },
       windowsHide: true,
+      // Own process group on POSIX so killTree can signal the whole tree.
+      detached: process.platform !== 'win32',
     });
     entry.startedAt = Date.now();
 
     const timeout = setTimeout(() => {
-      log.warn(`[Arena] ${providerId} timed out after ${CONTESTANT_TIMEOUT_MS}ms`);
-      child.kill();
-    }, CONTESTANT_TIMEOUT_MS);
+      log.warn(`[Arena] ${providerId} timed out after ${this.timeoutMs}ms`);
+      killTree(child);
+    }, this.timeoutMs);
     entry.kill = () => {
       clearTimeout(timeout);
-      child.kill();
+      killTree(child);
     };
 
     let stderrTail = '';
@@ -132,7 +178,9 @@ export class ArenaEngine extends EventEmitter {
       if (code === 0) {
         this.finish(responseId, 'done', final, null);
       } else {
-        const detail = stderrTail.trim() || `exit code ${code}`;
+        // code === null means killed by signal (timeout or cancel).
+        const fallback = code === null ? 'terminated' : `exit code ${code}`;
+        const detail = stderrTail.trim() || fallback;
         this.finish(responseId, 'error', final, detail.slice(0, 500));
       }
     });
@@ -143,7 +191,7 @@ export class ArenaEngine extends EventEmitter {
     if (!entry) return;
     const parser = ollamaParser();
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), CONTESTANT_TIMEOUT_MS);
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     entry.kill = () => {
       clearTimeout(timeout);
       controller.abort();
@@ -199,9 +247,7 @@ export class ArenaEngine extends EventEmitter {
     if (!chunk) return;
     const entry = this.live.get(responseId);
     if (!entry) return;
-    if (entry.ttftMs === null) {
-      entry.ttftMs = Date.now() - entry.startedAt;
-    }
+    entry.ttftMs ??= Date.now() - entry.startedAt;
     entry.text += chunk;
     this.emitUpdate(responseId, entry, 'running', chunk, null, null);
   }

--- a/src/main/arena/parsers.ts
+++ b/src/main/arena/parsers.ts
@@ -1,0 +1,171 @@
+/**
+ * Arena stream parsers (#100): turn each contestant CLI's headless output
+ * into displayable text chunks plus final metrics. Pure — no process or
+ * electron dependencies — so every parser is directly unit-testable.
+ *
+ * Verified output contracts:
+ * - claude: `-p --output-format stream-json --verbose --max-turns 1` emits
+ *   JSONL; `assistant` events carry text content, the final `result` event
+ *   carries usage, total_cost_usd, ttft_ms and duration_ms (verified live).
+ * - codex: `exec --json` emits JSONL; agent_message items carry text,
+ *   `turn.completed` carries token usage (per OpenAI headless docs).
+ * - gemini: `-p --output-format json` emits ONE JSON document at the end
+ *   with `response` + per-model token `stats` (per Gemini CLI headless docs).
+ * - grok: `-p` emits plain text.
+ */
+
+export interface ArenaFinal {
+  inputTokens: number | null;
+  outputTokens: number | null;
+  costUsd: number | null;
+  /** CLI-reported time-to-first-token, when available (claude). */
+  reportedTtftMs: number | null;
+  /** Text only available at finalize time (gemini's single-doc output). */
+  trailingText: string;
+}
+
+export interface ArenaStreamParser {
+  /** Extract displayable text from one stdout line ('' when none). */
+  onLine(line: string): string;
+  /** Final metrics after the process exits. */
+  finalize(): ArenaFinal;
+}
+
+const EMPTY_FINAL: ArenaFinal = {
+  inputTokens: null,
+  outputTokens: null,
+  costUsd: null,
+  reportedTtftMs: null,
+  trailingText: '',
+};
+
+function tryParseJson(line: string): any | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('{')) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/** claude -p --output-format stream-json --verbose */
+export function claudeParser(): ArenaStreamParser {
+  let final: ArenaFinal = { ...EMPTY_FINAL };
+  return {
+    onLine(line) {
+      const event = tryParseJson(line);
+      if (!event) return '';
+      if (event.type === 'assistant') {
+        const parts: unknown[] = event.message?.content ?? [];
+        return parts
+          .map((p: any) => (p?.type === 'text' && typeof p.text === 'string' ? p.text : ''))
+          .join('');
+      }
+      if (event.type === 'result') {
+        final = {
+          inputTokens: asFiniteNumber(event.usage?.input_tokens),
+          outputTokens: asFiniteNumber(event.usage?.output_tokens),
+          costUsd: asFiniteNumber(event.total_cost_usd),
+          reportedTtftMs: asFiniteNumber(event.ttft_ms),
+          trailingText: '',
+        };
+      }
+      return '';
+    },
+    finalize: () => final,
+  };
+}
+
+/** codex exec --json */
+export function codexParser(): ArenaStreamParser {
+  let final: ArenaFinal = { ...EMPTY_FINAL };
+  return {
+    onLine(line) {
+      const event = tryParseJson(line);
+      if (!event) return '';
+      const item = event.item;
+      const itemType = item?.item_type ?? item?.type;
+      if (event.type === 'item.completed' && itemType === 'agent_message' && typeof item?.text === 'string') {
+        return item.text;
+      }
+      if (event.type === 'turn.completed') {
+        const usage = event.usage ?? {};
+        final = {
+          ...final,
+          inputTokens: asFiniteNumber(usage.input_tokens),
+          outputTokens: asFiniteNumber(usage.output_tokens),
+        };
+      }
+      return '';
+    },
+    finalize: () => final,
+  };
+}
+
+/** gemini -p --output-format json — one JSON document, no streaming. */
+export function geminiParser(): ArenaStreamParser {
+  let buffer = '';
+  return {
+    onLine(line) {
+      buffer += line + '\n';
+      return '';
+    },
+    finalize() {
+      const doc = tryParseJson(buffer);
+      if (!doc) {
+        // Not JSON after all (older CLI or plain error text) — show it raw.
+        return { ...EMPTY_FINAL, trailingText: buffer.trim() };
+      }
+      let inputTokens: number | null = null;
+      let outputTokens: number | null = null;
+      const models = doc.stats?.models ?? {};
+      for (const model of Object.values<any>(models)) {
+        const tokens = model?.tokens ?? {};
+        const prompt = asFiniteNumber(tokens.prompt);
+        const candidates = asFiniteNumber(tokens.candidates);
+        if (prompt !== null) inputTokens = (inputTokens ?? 0) + prompt;
+        if (candidates !== null) outputTokens = (outputTokens ?? 0) + candidates;
+      }
+      return {
+        inputTokens,
+        outputTokens,
+        costUsd: null,
+        reportedTtftMs: null,
+        trailingText: typeof doc.response === 'string' ? doc.response : '',
+      };
+    },
+  };
+}
+
+/** Plain-text CLIs (grok -p). */
+export function textParser(): ArenaStreamParser {
+  return {
+    onLine: (line) => line + '\n',
+    finalize: () => ({ ...EMPTY_FINAL }),
+  };
+}
+
+/** Ollama /api/chat streaming lines: {message:{content}, done, eval counts}. */
+export function ollamaParser(): ArenaStreamParser {
+  let final: ArenaFinal = { ...EMPTY_FINAL };
+  return {
+    onLine(line) {
+      const event = tryParseJson(line);
+      if (!event) return '';
+      if (event.done === true) {
+        final = {
+          ...final,
+          inputTokens: asFiniteNumber(event.prompt_eval_count),
+          outputTokens: asFiniteNumber(event.eval_count),
+        };
+      }
+      return typeof event.message?.content === 'string' ? event.message.content : '';
+    },
+    finalize: () => final,
+  };
+}

--- a/src/main/arena/parsers.ts
+++ b/src/main/arena/parsers.ts
@@ -39,7 +39,7 @@ const EMPTY_FINAL: ArenaFinal = {
   trailingText: '',
 };
 
-function tryParseJson(line: string): any | null {
+function tryParseJson(line: string): any {
   const trimmed = line.trim();
   if (!trimmed.startsWith('{')) return null;
   try {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -436,6 +436,30 @@ function initializeCodeSearchTables(database: Database.Database): void {
   } catch (e) {
     log.error('Vector table setup error:', e);
   }
+
+  // Migration: Arena mode tables (#100, epic #94). One run = one prompt
+  // fanned out to N contestants; responses persist final text + metrics.
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS arena_runs (
+      id TEXT PRIMARY KEY,
+      prompt TEXT NOT NULL,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS arena_responses (
+      id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES arena_runs(id) ON DELETE CASCADE,
+      provider TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'running',
+      response_text TEXT NOT NULL DEFAULT '',
+      ttft_ms INTEGER DEFAULT NULL,
+      total_ms INTEGER DEFAULT NULL,
+      input_tokens INTEGER DEFAULT NULL,
+      output_tokens INTEGER DEFAULT NULL,
+      cost_usd REAL DEFAULT NULL,
+      error TEXT DEFAULT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_arena_responses_run ON arena_responses(run_id);
+  `);
 }
 
 export function closeDatabase(): void {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -50,6 +50,7 @@ export function getDatabase(): Database.Database {
 
   initializeTables(db);
   initializeCodeSearchTables(db);
+  initializeArenaTables(db);
 
   return db;
 }
@@ -437,8 +438,11 @@ function initializeCodeSearchTables(database: Database.Database): void {
     log.error('Vector table setup error:', e);
   }
 
-  // Migration: Arena mode tables (#100, epic #94). One run = one prompt
-  // fanned out to N contestants; responses persist final text + metrics.
+}
+
+// Arena mode tables (#100, epic #94). One run = one prompt fanned out to N
+// contestants; responses persist final text + metrics.
+function initializeArenaTables(database: Database.Database): void {
   database.exec(`
     CREATE TABLE IF NOT EXISTS arena_runs (
       id TEXT PRIMARY KEY,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1186,12 +1186,16 @@ safeHandle('providers:detect', async () => {
   return detectProviders();
 });
 
-// Arena mode (#100)
+// Arena mode (#100). Two-phase: 'start' only creates the run so the renderer
+// can subscribe with the run id; 'launch' then spawns the contestants.
 safeHandle('arena:start', async (prompt: string, contestants: string[]) => {
   if (!prompt?.trim() || !Array.isArray(contestants) || contestants.length === 0) {
     throw new Error('Arena run needs a prompt and at least one contestant');
   }
-  return arenaEngine.start(prompt, contestants);
+  return arenaEngine.prepare(prompt, contestants);
+});
+safeHandle('arena:launch', async (runId: string) => {
+  arenaEngine.launch(runId);
 });
 safeHandle('arena:cancel', async (runId: string) => {
   arenaEngine.cancelRun(runId);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,8 @@ import * as sessionsRepo from './repositories/sessions';
 import * as prefsRepo from './repositories/preferences';
 import * as memoriesRepo from './repositories/memories';
 import * as sessionEventsRepo from './repositories/session-events';
+import * as arenaRepo from './repositories/arena';
+import { arenaEngine } from './arena/engine';
 import * as chatEventsRepo from './repositories/chat-events';
 import { ChatParser } from './api/chat-parser';
 import * as accountsRepo from './repositories/accounts';
@@ -507,6 +509,11 @@ function createWindow(): void {
 
   vsManager.on('indexing-error', (data) => {
     mainWindow?.webContents.send('vector-search:error', data);
+  });
+
+  // Arena streaming updates (#100)
+  arenaEngine.on('update', (update) => {
+    mainWindow?.webContents.send('arena:update', update);
   });
 
   // PTY data forwarding
@@ -1177,6 +1184,23 @@ safeHandle('editor:detectAvailable', async () => {
 
 safeHandle('providers:detect', async () => {
   return detectProviders();
+});
+
+// Arena mode (#100)
+safeHandle('arena:start', async (prompt: string, contestants: string[]) => {
+  if (!prompt?.trim() || !Array.isArray(contestants) || contestants.length === 0) {
+    throw new Error('Arena run needs a prompt and at least one contestant');
+  }
+  return arenaEngine.start(prompt, contestants);
+});
+safeHandle('arena:cancel', async (runId: string) => {
+  arenaEngine.cancelRun(runId);
+});
+safeHandle('arena:listRuns', async () => {
+  return arenaRepo.listRuns();
+});
+safeHandle('arena:getRun', async (id: string) => {
+  return arenaRepo.getRun(id);
 });
 
 safeHandle('editor:getOptions', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1192,7 +1192,7 @@ safeHandle('arena:start', async (prompt: string, contestants: string[]) => {
   if (!prompt?.trim() || !Array.isArray(contestants) || contestants.length === 0) {
     throw new Error('Arena run needs a prompt and at least one contestant');
   }
-  return arenaEngine.prepare(prompt, contestants);
+  return arenaEngine.prepare(prompt, Array.from(new Set(contestants)));
 });
 safeHandle('arena:launch', async (runId: string) => {
   arenaEngine.launch(runId);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -189,6 +189,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Arena mode (#100)
   arenaStart: (prompt: string, contestants: string[]): Promise<ArenaRun> =>
     ipcRenderer.invoke('arena:start', prompt, contestants),
+  arenaLaunch: (runId: string): Promise<void> =>
+    ipcRenderer.invoke('arena:launch', runId),
   arenaCancel: (runId: string): Promise<void> =>
     ipcRenderer.invoke('arena:cancel', runId),
   arenaListRuns: (): Promise<ArenaRun[]> =>

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus, ArenaRun, ArenaUpdate } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -185,6 +185,23 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Shell
   openExternal: (url: string) => ipcRenderer.invoke('shell:openExternal', url),
   detectProviders: (): Promise<ProviderStatus[]> => ipcRenderer.invoke('providers:detect'),
+
+  // Arena mode (#100)
+  arenaStart: (prompt: string, contestants: string[]): Promise<ArenaRun> =>
+    ipcRenderer.invoke('arena:start', prompt, contestants),
+  arenaCancel: (runId: string): Promise<void> =>
+    ipcRenderer.invoke('arena:cancel', runId),
+  arenaListRuns: (): Promise<ArenaRun[]> =>
+    ipcRenderer.invoke('arena:listRuns'),
+  arenaGetRun: (id: string): Promise<ArenaRun | null> =>
+    ipcRenderer.invoke('arena:getRun', id),
+  onArenaUpdate: (callback: (update: ArenaUpdate) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, update: ArenaUpdate) => callback(update);
+    ipcRenderer.on('arena:update', listener);
+    return () => {
+      ipcRenderer.removeListener('arena:update', listener);
+    };
+  },
 
   // Sound notifications
   testSound: (event: 'waiting' | 'error' | 'start' | 'complete') =>

--- a/src/main/providers/claude.ts
+++ b/src/main/providers/claude.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import { app } from 'electron';
 import { ProviderDefinition, ProviderLaunchConfig, ProviderCommand } from './types';
 import { baseSessionEnv } from './passthrough';
+import { claudeParser as claudeArenaParser } from '../arena/parsers';
 
 /** Env var Claude Code reads its isolated config dir from (BDHLNDR-31). */
 export const CLAUDE_CONFIG_DIR_ENV = 'CLAUDE_CONFIG_DIR';
@@ -34,6 +35,14 @@ export const claudeProvider: ProviderDefinition = {
   },
   systemPromptFlag: '--append-system-prompt',
   waitingPatterns: CLAUDE_WAITING_PATTERNS,
+  arena: {
+    // --max-turns 1 keeps the arena chat-shaped (no agentic tool loops);
+    // stream-json requires --verbose. Verified live: the result event
+    // reports usage, total_cost_usd, ttft_ms.
+    buildCommand: (promptRef) =>
+      `claude -p ${promptRef} --output-format stream-json --verbose --max-turns 1`,
+    createParser: claudeArenaParser,
+  },
   setup: {
     installHint: 'npm install -g @anthropic-ai/claude-code',
     docsUrl: 'https://docs.anthropic.com/en/docs/claude-code/setup',

--- a/src/main/providers/codex.ts
+++ b/src/main/providers/codex.ts
@@ -1,4 +1,5 @@
 import { passthroughProvider } from './passthrough';
+import { codexParser } from '../arena/parsers';
 
 /**
  * OpenAI Codex CLI (`codex`). Auth is handled by the CLI itself
@@ -10,6 +11,11 @@ export const codexProvider = passthroughProvider({
   id: 'codex',
   name: 'Codex (OpenAI)',
   command: 'codex',
+  arena: {
+    // JSONL events; turn.completed carries token usage (OpenAI headless docs).
+    buildCommand: (promptRef) => `codex exec --json ${promptRef}`,
+    createParser: codexParser,
+  },
   setup: {
     installHint: 'npm install -g @openai/codex',
     docsUrl: 'https://developers.openai.com/codex/cli',

--- a/src/main/providers/gemini.ts
+++ b/src/main/providers/gemini.ts
@@ -1,4 +1,5 @@
 import { passthroughProvider } from './passthrough';
+import { geminiParser } from '../arena/parsers';
 
 /**
  * Google Gemini CLI (`gemini`). Auth is handled by the CLI itself
@@ -9,6 +10,12 @@ export const geminiProvider = passthroughProvider({
   id: 'gemini',
   name: 'Gemini CLI (Google)',
   command: 'gemini',
+  arena: {
+    // Single JSON document with response + per-model token stats
+    // (Gemini CLI headless docs); no streaming.
+    buildCommand: (promptRef) => `gemini -p ${promptRef} --output-format json`,
+    createParser: geminiParser,
+  },
   setup: {
     installHint: 'npm install -g @google/gemini-cli',
     docsUrl: 'https://github.com/google-gemini/gemini-cli',

--- a/src/main/providers/grok.ts
+++ b/src/main/providers/grok.ts
@@ -1,4 +1,5 @@
 import { passthroughProvider } from './passthrough';
+import { textParser } from '../arena/parsers';
 
 /**
  * xAI Grok Build (`grok`, per https://docs.x.ai/build/overview). Auth is
@@ -9,6 +10,11 @@ export const grokProvider = passthroughProvider({
   id: 'grok',
   name: 'Grok Build (xAI)',
   command: 'grok',
+  arena: {
+    // Plain-text headless output; no documented JSON/usage reporting yet.
+    buildCommand: (promptRef) => `grok -p ${promptRef}`,
+    createParser: textParser,
+  },
   setup: {
     installHint: 'curl -fsSL https://x.ai/cli/install.sh | bash',
     docsUrl: 'https://docs.x.ai/build/overview',

--- a/src/main/providers/passthrough.ts
+++ b/src/main/providers/passthrough.ts
@@ -20,7 +20,7 @@ export function baseSessionEnv(config: ProviderLaunchConfig): NodeJS.ProcessEnv 
  * management stay entirely inside the CLI itself.
  */
 export function passthroughProvider(
-  opts: Pick<ProviderDefinition, 'id' | 'name' | 'command' | 'setup'>
+  opts: Pick<ProviderDefinition, 'id' | 'name' | 'command' | 'setup' | 'arena'>
 ): ProviderDefinition {
   return {
     ...opts,

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -1,3 +1,5 @@
+import { ArenaStreamParser } from '../arena/parsers';
+
 /**
  * Provider abstraction for agentic CLI sessions (#95).
  *
@@ -75,6 +77,17 @@ export interface ProviderDefinition {
    * merged with the generic pattern set by the pty state detector.
    */
   waitingPatterns?: readonly RegExp[];
+  /**
+   * Headless invocation for arena mode (#100). promptRef is the
+   * shell-appropriate env-var reference for the prompt (e.g.
+   * `"$ARENA_PROMPT"`), so the prompt text itself never touches the command
+   * string — it travels via the environment, immune to shell injection.
+   * Runs under the user's existing CLI login (subscription), never an API key.
+   */
+  arena: {
+    buildCommand(promptRef: string): string;
+    createParser(): ArenaStreamParser;
+  };
   /** Setup guidance surfaced in Settings → Providers when the CLI is missing (#97). */
   setup: {
     /** Install command or instruction, shown as copyable text. */

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -13,6 +13,7 @@ import {
   ProviderDefinition,
 } from './providers';
 import { detectShell, ShellInfo } from './shell-detector';
+import { getShellLaunch } from './shell-launch';
 import { getPreference } from './repositories/preferences';
 import {
   getClaudeSessionId as getStoredClaudeSessionId,
@@ -118,52 +119,6 @@ const GENERIC_WAITING_PATTERNS = [
  * referencing an environment variable inside that command string. Single
  * source of truth for both regular agent sessions and login ptys.
  */
-export interface ShellLaunch {
-  shell: string;
-  wrap(cmd: string): string[];
-  envRef(name: string): string;
-}
-
-export function getShellLaunch(shellInfo: ShellInfo): ShellLaunch {
-  if (shellInfo.isWSL) {
-    // Launch the agent inside WSL
-    return {
-      shell: 'wsl.exe',
-      wrap: (cmd) => [...shellInfo.args, '--', 'bash', '-c', cmd],
-      envRef: (name) => `"$${name}"`,
-    };
-  }
-  if (process.platform === 'win32') {
-    const shellName = shellInfo.shell.toLowerCase();
-    if (shellName.includes('powershell')) {
-      return {
-        shell: shellInfo.shell,
-        wrap: (cmd) => ['-NoLogo', '-Command', cmd],
-        envRef: (name) => `$env:${name}`,
-      };
-    }
-    if (shellName.includes('cmd')) {
-      return {
-        shell: shellInfo.shell,
-        wrap: (cmd) => ['/c', cmd],
-        envRef: (name) => `"%${name}%"`,
-      };
-    }
-    // Assume bash-like shell (Git Bash, etc.)
-    return {
-      shell: shellInfo.shell,
-      wrap: (cmd) => ['-c', cmd],
-      envRef: (name) => `"$${name}"`,
-    };
-  }
-  // macOS/Linux: run through interactive login shell
-  return {
-    shell: shellInfo.shell,
-    wrap: (cmd) => ['-l', '-i', '-c', cmd],
-    envRef: (name) => `"$${name}"`,
-  };
-}
-
 /** Merged generic + provider waiting patterns, computed once per provider id. */
 const mergedWaitingPatterns = new Map<string, readonly RegExp[]>();
 

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -118,13 +118,13 @@ const GENERIC_WAITING_PATTERNS = [
  * referencing an environment variable inside that command string. Single
  * source of truth for both regular agent sessions and login ptys.
  */
-interface ShellLaunch {
+export interface ShellLaunch {
   shell: string;
   wrap(cmd: string): string[];
   envRef(name: string): string;
 }
 
-function getShellLaunch(shellInfo: ShellInfo): ShellLaunch {
+export function getShellLaunch(shellInfo: ShellInfo): ShellLaunch {
   if (shellInfo.isWSL) {
     // Launch the agent inside WSL
     return {

--- a/src/main/repositories/arena.ts
+++ b/src/main/repositories/arena.ts
@@ -111,7 +111,3 @@ export function listRuns(limit: number = 50): ArenaRun[] {
     responses: (responsesStmt.all(run.id) as ResponseRow[]).map(rowToResponse),
   }));
 }
-
-export function deleteRun(id: string): void {
-  getDatabase().prepare('DELETE FROM arena_runs WHERE id = ?').run(id);
-}

--- a/src/main/repositories/arena.ts
+++ b/src/main/repositories/arena.ts
@@ -1,0 +1,117 @@
+import { getDatabase } from '../database';
+import { ArenaRun, ArenaResponse, ArenaResponseStatus } from '../../shared/types';
+
+interface ResponseRow {
+  id: string;
+  run_id: string;
+  provider: string;
+  status: string;
+  response_text: string;
+  ttft_ms: number | null;
+  total_ms: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cost_usd: number | null;
+  error: string | null;
+}
+
+function rowToResponse(row: ResponseRow): ArenaResponse {
+  return {
+    id: row.id,
+    runId: row.run_id,
+    provider: row.provider,
+    status: row.status as ArenaResponseStatus,
+    text: row.response_text,
+    ttftMs: row.ttft_ms,
+    totalMs: row.total_ms,
+    inputTokens: row.input_tokens,
+    outputTokens: row.output_tokens,
+    costUsd: row.cost_usd,
+    error: row.error,
+  };
+}
+
+export function createRun(id: string, prompt: string): void {
+  getDatabase()
+    .prepare('INSERT INTO arena_runs (id, prompt) VALUES (?, ?)')
+    .run(id, prompt);
+}
+
+export function createResponse(id: string, runId: string, provider: string): void {
+  getDatabase()
+    .prepare("INSERT INTO arena_responses (id, run_id, provider, status) VALUES (?, ?, ?, 'running')")
+    .run(id, runId, provider);
+}
+
+export interface FinalizeResponseInput {
+  status: ArenaResponseStatus;
+  text: string;
+  ttftMs: number | null;
+  totalMs: number | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  costUsd: number | null;
+  error: string | null;
+}
+
+/**
+ * Streamed text is held in memory by the engine and written once here at
+ * completion — per-chunk DB writes would hammer sqlite for no benefit since
+ * the renderer receives live text via events, not the DB.
+ */
+export function finalizeResponse(id: string, final: FinalizeResponseInput): void {
+  getDatabase()
+    .prepare(`
+      UPDATE arena_responses
+      SET status = ?, response_text = ?, ttft_ms = ?, total_ms = ?,
+          input_tokens = ?, output_tokens = ?, cost_usd = ?, error = ?
+      WHERE id = ?
+    `)
+    .run(
+      final.status,
+      final.text,
+      final.ttftMs,
+      final.totalMs,
+      final.inputTokens,
+      final.outputTokens,
+      final.costUsd,
+      final.error,
+      id
+    );
+}
+
+export function getRun(id: string): ArenaRun | null {
+  const db = getDatabase();
+  const run = db.prepare('SELECT id, prompt, created_at FROM arena_runs WHERE id = ?').get(id) as
+    | { id: string; prompt: string; created_at: string }
+    | undefined;
+  if (!run) return null;
+  const rows = db
+    .prepare('SELECT * FROM arena_responses WHERE run_id = ? ORDER BY provider')
+    .all(id) as ResponseRow[];
+  return {
+    id: run.id,
+    prompt: run.prompt,
+    createdAt: new Date(run.created_at),
+    responses: rows.map(rowToResponse),
+  };
+}
+
+/** Most-recent-first run summaries (responses included for the history list). */
+export function listRuns(limit: number = 50): ArenaRun[] {
+  const db = getDatabase();
+  const runs = db
+    .prepare('SELECT id, prompt, created_at FROM arena_runs ORDER BY created_at DESC LIMIT ?')
+    .all(limit) as { id: string; prompt: string; created_at: string }[];
+  const responsesStmt = db.prepare('SELECT * FROM arena_responses WHERE run_id = ? ORDER BY provider');
+  return runs.map((run) => ({
+    id: run.id,
+    prompt: run.prompt,
+    createdAt: new Date(run.created_at),
+    responses: (responsesStmt.all(run.id) as ResponseRow[]).map(rowToResponse),
+  }));
+}
+
+export function deleteRun(id: string): void {
+  getDatabase().prepare('DELETE FROM arena_runs WHERE id = ?').run(id);
+}

--- a/src/main/shell-launch.ts
+++ b/src/main/shell-launch.ts
@@ -1,0 +1,56 @@
+import { ShellInfo } from './shell-detector';
+
+/**
+ * How to launch a command string under the user's shell: the executable to
+ * spawn, how to wrap the command into argv, and the shell's syntax for
+ * referencing an environment variable inside that command string. Single
+ * source of truth for agent sessions, login ptys, and arena contestants.
+ *
+ * (Lives outside pty-manager so consumers that don't need node-pty — like
+ * the arena engine and its tests — don't drag the native module in.)
+ */
+export interface ShellLaunch {
+  shell: string;
+  wrap(cmd: string): string[];
+  envRef(name: string): string;
+}
+
+export function getShellLaunch(shellInfo: ShellInfo): ShellLaunch {
+  if (shellInfo.isWSL) {
+    // Launch the agent inside WSL
+    return {
+      shell: 'wsl.exe',
+      wrap: (cmd) => [...shellInfo.args, '--', 'bash', '-c', cmd],
+      envRef: (name) => `"$${name}"`,
+    };
+  }
+  if (process.platform === 'win32') {
+    const shellName = shellInfo.shell.toLowerCase();
+    if (shellName.includes('powershell')) {
+      return {
+        shell: shellInfo.shell,
+        wrap: (cmd) => ['-NoLogo', '-Command', cmd],
+        envRef: (name) => `$env:${name}`,
+      };
+    }
+    if (shellName.includes('cmd')) {
+      return {
+        shell: shellInfo.shell,
+        wrap: (cmd) => ['/c', cmd],
+        envRef: (name) => `"%${name}%"`,
+      };
+    }
+    // Assume bash-like shell (Git Bash, etc.)
+    return {
+      shell: shellInfo.shell,
+      wrap: (cmd) => ['-c', cmd],
+      envRef: (name) => `"$${name}"`,
+    };
+  }
+  // macOS/Linux: run through interactive login shell
+  return {
+    shell: shellInfo.shell,
+    wrap: (cmd) => ['-l', '-i', '-c', cmd],
+    envRef: (name) => `"$${name}"`,
+  };
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,6 +7,7 @@ import { SettingsModal } from './components/SettingsModal';
 import { NewItemChoice } from './components/NewItemChoice';
 import { MemoryPanel } from './components/panels/MemoryPanel';
 import AnalyticsPanel from './components/panels/AnalyticsPanel';
+import { ArenaPanel } from './components/ArenaPanel';
 import { SessionStatsBadge } from './components/SessionStatsBadge';
 import { CodeSearchModal } from './components/CodeSearchModal';
 import { ClaudeAccountsModal } from './components/ClaudeAccountsModal';
@@ -84,6 +85,7 @@ const App: React.FC = () => {
 
   // Analytics view state (BDHLNDR-18)
   const [analyticsViewOpen, setAnalyticsViewOpen] = useState(false);
+  const [arenaViewOpen, setArenaViewOpen] = useState(false);
 
   // Code search modal state
   const [codeSearchOpen, setCodeSearchOpen] = useState(false);
@@ -904,6 +906,14 @@ const App: React.FC = () => {
               📊
             </button>
             <button
+              className={`icon-button ${arenaViewOpen ? 'active' : ''}`}
+              onClick={() => setArenaViewOpen(prev => !prev)}
+              title="Arena — compare agents"
+              aria-label="Arena"
+            >
+              ⚔️
+            </button>
+            <button
               className="icon-button"
               onClick={() => setCodeSearchOpen(true)}
               title="Code Search (Ctrl+Shift+F)"
@@ -1324,7 +1334,8 @@ const App: React.FC = () => {
             activeSessionId={activeSessionId}
           />
         )}
-        <div className="terminal-area" style={{ display: analyticsViewOpen ? 'none' : undefined }}>
+        {arenaViewOpen && <ArenaPanel onClose={() => setArenaViewOpen(false)} />}
+        <div className="terminal-area" style={{ display: analyticsViewOpen || arenaViewOpen ? 'none' : undefined }}>
           {sessions.map(session => (
             <div
               key={session.id}

--- a/src/renderer/components/ArenaPanel.tsx
+++ b/src/renderer/components/ArenaPanel.tsx
@@ -15,6 +15,11 @@ const STATUS_PILL_CLASS: Record<string, string> = {
   error: 'error',
 };
 
+function columnText(text: string, status: string): string {
+  if (text) return text;
+  return status === 'running' ? '…' : '';
+}
+
 function formatMs(ms: number | null): string {
   if (ms === null) return '—';
   return ms >= 10_000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
@@ -59,31 +64,37 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose }) => {
     window.electronAPI.arenaListRuns().then(setHistory).catch(() => setHistory([]));
   }, []);
 
-  // Live streaming updates for the active run.
-  useEffect(() => {
-    const unsubscribe = window.electronAPI.onArenaUpdate((update: ArenaUpdate) => {
-      if (update.runId !== runIdRef.current) return;
-      setRun(prev => {
-        if (!prev) return prev;
-        const next = applyArenaUpdate(prev, update);
-        if (update.status !== 'running' && isRunSettled(next)) {
-          setRunning(false);
-          window.electronAPI.arenaListRuns().then(setHistory).catch(() => undefined);
-        }
-        return next;
-      });
-    });
-    return unsubscribe;
+  const refreshHistory = useCallback(() => {
+    window.electronAPI.arenaListRuns().then(setHistory).catch(() => undefined);
   }, []);
+
+  // Live streaming updates for the active run.
+  const handleUpdate = useCallback((update: ArenaUpdate) => {
+    if (update.runId !== runIdRef.current) return;
+    setRun(prev => (prev ? applyArenaUpdate(prev, update) : prev));
+  }, []);
+
+  useEffect(() => window.electronAPI.onArenaUpdate(handleUpdate), [handleUpdate]);
+
+  // When every column has settled, unlock the Run button and refresh history.
+  useEffect(() => {
+    if (running && run && run.id === runIdRef.current && isRunSettled(run)) {
+      setRunning(false);
+      refreshHistory();
+    }
+  }, [run, running, refreshHistory]);
 
   const startRun = useCallback(async () => {
     const trimmed = prompt.trim();
     if (!trimmed || selected.size === 0 || running) return;
     setRunning(true);
     try {
+      // Two-phase: subscribe with the run id BEFORE contestants launch, so
+      // even an instantly-failing CLI's updates are never dropped.
       const newRun = await window.electronAPI.arenaStart(trimmed, Array.from(selected));
       runIdRef.current = newRun.id;
       setRun(newRun);
+      await window.electronAPI.arenaLaunch(newRun.id);
     } catch (error) {
       console.error('Arena start failed:', error);
       setRunning(false);
@@ -188,7 +199,7 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose }) => {
               <span title="Cost">{formatCost(r.costUsd)}</span>
             </div>
             {r.error && <div className="arena-column-error">{r.error}</div>}
-            <pre className="arena-column-text">{r.text || (r.status === 'running' ? '…' : '')}</pre>
+            <pre className="arena-column-text">{columnText(r.text, r.status)}</pre>
           </div>
         ))}
         {!run && (

--- a/src/renderer/components/ArenaPanel.tsx
+++ b/src/renderer/components/ArenaPanel.tsx
@@ -196,7 +196,9 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose }) => {
               <span title="Time to first token">TTFT {formatMs(r.ttftMs)}</span>
               <span title="Total duration">total {formatMs(r.totalMs)}</span>
               <span title="Token usage">{formatTokens(r.inputTokens, r.outputTokens)}</span>
-              <span title="Cost">{formatCost(r.costUsd)}</span>
+              <span title="Runs bill against the CLI's own subscription — no direct cost. When the CLI reports a figure, it's what the same call would cost on the provider's API.">
+                {formatCost(r.costUsd)}
+              </span>
             </div>
             {r.error && <div className="arena-column-error">{r.error}</div>}
             <pre className="arena-column-text">{columnText(r.text, r.status)}</pre>

--- a/src/renderer/components/ArenaPanel.tsx
+++ b/src/renderer/components/ArenaPanel.tsx
@@ -1,0 +1,203 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { ArenaRun, ArenaUpdate, ProviderStatus } from '../../shared/types';
+import { applyArenaUpdate, isRunSettled } from './arenaUpdates';
+
+interface ArenaPanelProps {
+  onClose: () => void;
+}
+
+const OLLAMA_ID = 'ollama';
+
+/** Reuse the sidebar status-pill palette for arena response states. */
+const STATUS_PILL_CLASS: Record<string, string> = {
+  running: 'working',
+  done: 'idle',
+  error: 'error',
+};
+
+function formatMs(ms: number | null): string {
+  if (ms === null) return '—';
+  return ms >= 10_000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
+}
+
+function formatTokens(input: number | null, output: number | null): string {
+  if (input === null && output === null) return '—';
+  return `${input ?? '?'} in / ${output ?? '?'} out`;
+}
+
+function formatCost(costUsd: number | null): string {
+  // Subscription-backed CLI runs don't bill the user; the CLI-reported figure
+  // is the API-equivalent price of the same call.
+  if (costUsd === null) return 'included';
+  return `included (API-equiv $${costUsd.toFixed(4)})`;
+}
+
+/**
+ * Arena mode (#100): one prompt fanned out to the selected contestants,
+ * streamed side-by-side with latency/token/cost metrics. Runs persist and
+ * can be reloaded from the history dropdown.
+ */
+export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose }) => {
+  const [prompt, setPrompt] = useState('');
+  const [contestants, setContestants] = useState<{ id: string; name: string; available: boolean }[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [run, setRun] = useState<ArenaRun | null>(null);
+  const [running, setRunning] = useState(false);
+  const [history, setHistory] = useState<ArenaRun[]>([]);
+  const runIdRef = useRef<string | null>(null);
+
+  // Contestant list: detected provider CLIs plus the local Ollama daemon.
+  useEffect(() => {
+    window.electronAPI.detectProviders()
+      .then((statuses: ProviderStatus[]) => {
+        const cli = statuses.map(s => ({ id: s.id, name: s.name, available: s.installed }));
+        const all = [...cli, { id: OLLAMA_ID, name: 'Ollama (local)', available: true }];
+        setContestants(all);
+        setSelected(new Set(cli.filter(c => c.available).map(c => c.id)));
+      })
+      .catch(() => setContestants([{ id: OLLAMA_ID, name: 'Ollama (local)', available: true }]));
+    window.electronAPI.arenaListRuns().then(setHistory).catch(() => setHistory([]));
+  }, []);
+
+  // Live streaming updates for the active run.
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.onArenaUpdate((update: ArenaUpdate) => {
+      if (update.runId !== runIdRef.current) return;
+      setRun(prev => {
+        if (!prev) return prev;
+        const next = applyArenaUpdate(prev, update);
+        if (update.status !== 'running' && isRunSettled(next)) {
+          setRunning(false);
+          window.electronAPI.arenaListRuns().then(setHistory).catch(() => undefined);
+        }
+        return next;
+      });
+    });
+    return unsubscribe;
+  }, []);
+
+  const startRun = useCallback(async () => {
+    const trimmed = prompt.trim();
+    if (!trimmed || selected.size === 0 || running) return;
+    setRunning(true);
+    try {
+      const newRun = await window.electronAPI.arenaStart(trimmed, Array.from(selected));
+      runIdRef.current = newRun.id;
+      setRun(newRun);
+    } catch (error) {
+      console.error('Arena start failed:', error);
+      setRunning(false);
+    }
+  }, [prompt, selected, running]);
+
+  const cancelRun = useCallback(() => {
+    if (runIdRef.current) {
+      window.electronAPI.arenaCancel(runIdRef.current).catch(() => undefined);
+    }
+  }, []);
+
+  const loadHistoryRun = useCallback(async (id: string) => {
+    if (!id) return;
+    const loaded = await window.electronAPI.arenaGetRun(id);
+    if (loaded) {
+      runIdRef.current = null; // viewing history — ignore live updates
+      setRun(loaded);
+      setPrompt(loaded.prompt);
+      setRunning(false);
+    }
+  }, []);
+
+  const toggleContestant = useCallback((id: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <div className="arena-panel">
+      <div className="arena-header">
+        <h2>Arena</h2>
+        <span className="arena-subtitle">
+          One prompt, every agent — runs use each CLI's own login/subscription.
+        </span>
+        <select
+          className="arena-history-select"
+          value=""
+          onChange={e => loadHistoryRun(e.target.value)}
+          aria-label="Run history"
+        >
+          <option value="">History…</option>
+          {history.map(h => (
+            <option key={h.id} value={h.id}>
+              {new Date(h.createdAt).toLocaleString()} — {h.prompt.slice(0, 60)}
+            </option>
+          ))}
+        </select>
+        <button className="icon-button" onClick={onClose} aria-label="Close arena">✕</button>
+      </div>
+
+      <div className="arena-controls">
+        <textarea
+          className="arena-prompt"
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+          placeholder="Ask every agent the same thing…"
+          rows={3}
+        />
+        <div className="arena-contestants">
+          {contestants.map(c => (
+            <label key={c.id} className={`arena-contestant ${c.available ? '' : 'unavailable'}`}>
+              <input
+                type="checkbox"
+                checked={selected.has(c.id)}
+                disabled={!c.available}
+                onChange={() => toggleContestant(c.id)}
+              />
+              {c.name}{c.available ? '' : ' (not installed)'}
+            </label>
+          ))}
+          <button
+            className="confirm-btn arena-run-button"
+            onClick={running ? cancelRun : startRun}
+            disabled={!running && (!prompt.trim() || selected.size === 0)}
+          >
+            {running ? 'Cancel' : 'Run'}
+          </button>
+        </div>
+      </div>
+
+      <div className="arena-results">
+        {run?.responses.map(r => (
+          <div key={r.id} className={`arena-column ${r.status}`}>
+            <div className="arena-column-header">
+              <span className="arena-column-name">{r.provider}</span>
+              <span className={`status-pill ${STATUS_PILL_CLASS[r.status]}`}>
+                {r.status}
+              </span>
+            </div>
+            <div className="arena-column-metrics">
+              <span title="Time to first token">TTFT {formatMs(r.ttftMs)}</span>
+              <span title="Total duration">total {formatMs(r.totalMs)}</span>
+              <span title="Token usage">{formatTokens(r.inputTokens, r.outputTokens)}</span>
+              <span title="Cost">{formatCost(r.costUsd)}</span>
+            </div>
+            {r.error && <div className="arena-column-error">{r.error}</div>}
+            <pre className="arena-column-text">{r.text || (r.status === 'running' ? '…' : '')}</pre>
+          </div>
+        ))}
+        {!run && (
+          <div className="arena-empty">
+            Pick contestants, write a prompt, and hit Run to compare responses,
+            latency, tokens, and cost side-by-side.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/components/__tests__/arenaUpdates.test.ts
+++ b/src/renderer/components/__tests__/arenaUpdates.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Arena update merge tests (#100).
+ *
+ * Run with: bun test src/renderer/components/__tests__
+ */
+import { describe, expect, test } from 'bun:test';
+import { applyArenaUpdate, isRunSettled } from '../arenaUpdates';
+import { ArenaRun, ArenaUpdate } from '../../../shared/types';
+
+function makeRun(): ArenaRun {
+  return {
+    id: 'run1',
+    prompt: 'p',
+    createdAt: new Date(0),
+    responses: [
+      {
+        id: 'a', runId: 'run1', provider: 'claude', status: 'running', text: 'he',
+        ttftMs: 100, totalMs: null, inputTokens: null, outputTokens: null, costUsd: null, error: null,
+      },
+      {
+        id: 'b', runId: 'run1', provider: 'grok', status: 'running', text: '',
+        ttftMs: null, totalMs: null, inputTokens: null, outputTokens: null, costUsd: null, error: null,
+      },
+    ],
+  };
+}
+
+function update(overrides: Partial<ArenaUpdate>): ArenaUpdate {
+  return {
+    runId: 'run1', responseId: 'a', provider: 'claude', chunk: '', status: 'running',
+    ttftMs: null, totalMs: null, inputTokens: null, outputTokens: null, costUsd: null, error: null,
+    ...overrides,
+  };
+}
+
+describe('applyArenaUpdate', () => {
+  test('appends chunks to the matching response only', () => {
+    const next = applyArenaUpdate(makeRun(), update({ chunk: 'llo' }));
+    expect(next.responses[0].text).toBe('hello');
+    expect(next.responses[1].text).toBe('');
+  });
+
+  test('null metric fields never overwrite previously-reported values', () => {
+    const next = applyArenaUpdate(makeRun(), update({ chunk: '!' }));
+    expect(next.responses[0].ttftMs).toBe(100);
+  });
+
+  test('final update adopts metrics and status', () => {
+    const next = applyArenaUpdate(
+      makeRun(),
+      update({ status: 'done', totalMs: 900, inputTokens: 2, outputTokens: 27, costUsd: 0.02 })
+    );
+    expect(next.responses[0]).toMatchObject({ status: 'done', totalMs: 900, outputTokens: 27, costUsd: 0.02 });
+  });
+});
+
+describe('isRunSettled', () => {
+  test('false while any response is running, true when all settled', () => {
+    const run = makeRun();
+    expect(isRunSettled(run)).toBe(false);
+    let next = applyArenaUpdate(run, update({ status: 'done' }));
+    expect(isRunSettled(next)).toBe(false);
+    next = applyArenaUpdate(next, update({ responseId: 'b', provider: 'grok', status: 'error', error: 'x' }));
+    expect(isRunSettled(next)).toBe(true);
+  });
+});

--- a/src/renderer/components/arenaUpdates.ts
+++ b/src/renderer/components/arenaUpdates.ts
@@ -1,0 +1,32 @@
+import { ArenaRun, ArenaUpdate } from '../../shared/types';
+
+/**
+ * Merge a streaming ArenaUpdate into the run state (#100): append the chunk
+ * to the matching response and adopt any newly-reported metrics, keeping
+ * previous values where the update carries null. Pure — extracted from
+ * ArenaPanel for direct unit testing.
+ */
+export function applyArenaUpdate(run: ArenaRun, update: ArenaUpdate): ArenaRun {
+  return {
+    ...run,
+    responses: run.responses.map((r) => {
+      if (r.id !== update.responseId) return r;
+      return {
+        ...r,
+        text: r.text + update.chunk,
+        status: update.status,
+        ttftMs: update.ttftMs ?? r.ttftMs,
+        totalMs: update.totalMs ?? r.totalMs,
+        inputTokens: update.inputTokens ?? r.inputTokens,
+        outputTokens: update.outputTokens ?? r.outputTokens,
+        costUsd: update.costUsd ?? r.costUsd,
+        error: update.error ?? r.error,
+      };
+    }),
+  };
+}
+
+/** True when every response in the run has settled (done or error). */
+export function isRunSettled(run: ArenaRun): boolean {
+  return run.responses.every((r) => r.status !== 'running');
+}

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus, ArenaRun, ArenaUpdate } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -84,6 +84,11 @@ interface ElectronAPI {
   // Shell
   openExternal: (url: string) => Promise<void>;
   detectProviders: () => Promise<ProviderStatus[]>;
+  arenaStart: (prompt: string, contestants: string[]) => Promise<ArenaRun>;
+  arenaCancel: (runId: string) => Promise<void>;
+  arenaListRuns: () => Promise<ArenaRun[]>;
+  arenaGetRun: (id: string) => Promise<ArenaRun | null>;
+  onArenaUpdate: (callback: (update: ArenaUpdate) => void) => () => void;
 
   // Sound notifications
   testSound: (event: 'waiting' | 'error' | 'start' | 'complete') => Promise<void>;

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -85,6 +85,7 @@ interface ElectronAPI {
   openExternal: (url: string) => Promise<void>;
   detectProviders: () => Promise<ProviderStatus[]>;
   arenaStart: (prompt: string, contestants: string[]) => Promise<ArenaRun>;
+  arenaLaunch: (runId: string) => Promise<void>;
   arenaCancel: (runId: string) => Promise<void>;
   arenaListRuns: () => Promise<ArenaRun[]>;
   arenaGetRun: (id: string) => Promise<ArenaRun | null>;

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1481,3 +1481,150 @@ body {
   gap: 12px;
   justify-content: center;
 }
+
+/* Arena mode (#100) */
+.arena-panel {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  background: #1e1e1e;
+  z-index: 5;
+  padding: 16px;
+  gap: 12px;
+  overflow: hidden;
+}
+
+.arena-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.arena-header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.arena-subtitle {
+  color: #999;
+  font-size: 12px;
+  flex: 1;
+}
+
+.arena-history-select {
+  max-width: 320px;
+  background: #2a2a2a;
+  color: #ddd;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+  padding: 4px 8px;
+}
+
+.arena-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.arena-prompt {
+  width: 100%;
+  resize: vertical;
+  background: #252525;
+  color: #eee;
+  border: 1px solid #3c3c3c;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-family: inherit;
+  font-size: 13px;
+  box-sizing: border-box;
+}
+
+.arena-contestants {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.arena-contestant {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.arena-contestant.unavailable {
+  color: #777;
+  cursor: default;
+}
+
+.arena-run-button {
+  margin-left: auto;
+  min-width: 90px;
+}
+
+.arena-results {
+  display: flex;
+  gap: 12px;
+  flex: 1;
+  min-height: 0;
+  overflow-x: auto;
+}
+
+.arena-column {
+  flex: 1;
+  min-width: 260px;
+  display: flex;
+  flex-direction: column;
+  background: #252525;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 10px;
+  gap: 6px;
+  min-height: 0;
+}
+
+.arena-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.arena-column-name {
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.arena-column-metrics {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  color: #9fc3f0;
+}
+
+.arena-column-error {
+  color: #f28b82;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+.arena-column-text {
+  flex: 1;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 12.5px;
+  margin: 0;
+  color: #ddd;
+}
+
+.arena-empty {
+  color: #888;
+  margin: auto;
+  font-size: 14px;
+  max-width: 420px;
+  text-align: center;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -33,6 +33,59 @@ export interface Session {
   provider: string;
 }
 
+// ---------------------------------------------------------------------------
+// Arena mode (#100) — one prompt fanned out to multiple agents, compared.
+// ---------------------------------------------------------------------------
+
+export type ArenaResponseStatus = 'running' | 'done' | 'error';
+
+export interface ArenaResponse {
+  id: string;
+  runId: string;
+  /** Arena contestant id: a provider registry id or 'ollama'. */
+  provider: string;
+  status: ArenaResponseStatus;
+  /** Accumulated response text (streamed). */
+  text: string;
+  /** Milliseconds from spawn to first output. Null until first chunk. */
+  ttftMs: number | null;
+  /** Milliseconds from spawn to completion. Null while running. */
+  totalMs: number | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  /**
+   * API-equivalent cost in USD when the CLI reports one (subscription-backed
+   * runs don't bill this; it's shown as "included in subscription"). Null
+   * when the CLI doesn't report cost.
+   */
+  costUsd: number | null;
+  /** Error detail when status === 'error'. */
+  error: string | null;
+}
+
+export interface ArenaRun {
+  id: string;
+  prompt: string;
+  createdAt: Date;
+  responses: ArenaResponse[];
+}
+
+/** Renderer-facing progress event for a streaming arena response. */
+export interface ArenaUpdate {
+  runId: string;
+  responseId: string;
+  provider: string;
+  /** New text appended since the last update (may be empty on status-only updates). */
+  chunk: string;
+  status: ArenaResponseStatus;
+  ttftMs: number | null;
+  totalMs: number | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  costUsd: number | null;
+  error: string | null;
+}
+
 /** Result of probing one provider CLI's availability (#97). */
 export interface ProviderStatus {
   id: string;


### PR DESCRIPTION
## Description
Phase 2 of the multi-provider epic (#94): the competitive arena. One prompt fans out to selected contestants, streamed side-by-side with time-to-first-token, total latency, token counts, and cost.

**Subscription-preservation by design (per the decision on #100):** every CLI contestant runs headless under the user's existing login — `claude -p --output-format stream-json --verbose --max-turns 1`, `codex exec --json`, `gemini -p --output-format json`, `grok -p` — never an API key. Ollama joins as a keyless local-HTTP contestant. Cost shows as "included (API-equiv $X)" when the CLI reports a figure.

- **Prompt safety**: the prompt travels via the `ARENA_PROMPT` env var and is referenced with the shell's own env syntax (same pattern as memory injection), so user text never touches a command string.
- **Engine** (`src/main/arena/engine.ts`): concurrent spawn through the user's shell (reusing `getShellLaunch`), per-line parsing, 5-minute per-contestant timeout, cancel support, single DB write per response at completion.
- **Persistence**: new `arena_runs` / `arena_responses` tables; history is reloadable from the panel's dropdown.
- **UI**: `ArenaPanel` toggled from the toolbar (⚔️), modeled on the analytics panel; contestants come from provider detection (#97), missing CLIs disabled.
- **Parsers** are pure and per-provider (`src/main/arena/parsers.ts`), attached to `ProviderDefinition.arena`.

## Related issue
Closes #100

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Hotfix
- [ ] Refactor / chore
- [ ] Docs

## How was this tested?
- **Live end-to-end** against the real claude CLI: engine spawn → readline → parser → metrics → persistence; response streamed correctly with TTFT 5.2s (CLI-reported), total 10.6s, 27 output tokens, $0.24 API-equivalent
- The claude headless output contract was captured from a real run and is baked into the parser tests as a fixture
- `bun test`: 39 pass (5 parsers, update-merge helpers, plus all prior suites)
- `tsc --noEmit` clean on main + renderer configs; SonarQube preflight on the engine (one `readonly` minor found and fixed)
- Not live-tested: codex/gemini/grok runners (CLIs not installed on this machine — parsers follow their documented contracts and errors surface in-column) and Ollama; worth a manual QA pass

## Checklist
- [ ] Tests pass locally (bun test, 39 pass)
- [x] Self-reviewed the changes
- [x] Docs updated where needed (none required)
- [x] Linked the related issue above

🤖 Generated with [Claude Code](https://claude.com/claude-code)