### PR TITLE
Encrypted provider API-key vault (Electron safeStorage)

### DIFF
--- a/src/main/__tests__/key-vault.test.ts
+++ b/src/main/__tests__/key-vault.test.ts
@@ -26,8 +26,12 @@ mock.module('electron', () => ({
 const prefs = new Map<string, string>();
 mock.module('../repositories/preferences', () => ({
   getPreference: (k: string) => prefs.get(k) ?? null,
-  setPreference: (k: string, v: string) => void prefs.set(k, v),
-  deletePreference: (k: string) => void prefs.delete(k),
+  setPreference: (k: string, v: string) => {
+    prefs.set(k, v);
+  },
+  deletePreference: (k: string) => {
+    prefs.delete(k);
+  },
 }));
 
 const vault = await import('../key-vault');

--- a/src/main/__tests__/key-vault.test.ts
+++ b/src/main/__tests__/key-vault.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Provider API-key vault tests (#99). Electron's safeStorage is stubbed with
+ * a reversible transform and preferences with an in-memory map, so the whole
+ * store/opt-in/inject/test/delete lifecycle is exercised without an OS
+ * keychain. The subscription-preservation invariant — a stored key changes
+ * nothing until the per-provider toggle is enabled — is asserted explicitly.
+ *
+ * Run with: bun test src/main/__tests__
+ */
+import { describe, expect, test, mock, beforeEach, afterEach } from 'bun:test';
+
+let encryptionAvailable = true;
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
+  safeStorage: {
+    isEncryptionAvailable: () => encryptionAvailable,
+    encryptString: (s: string) => Buffer.from(`enc:${s}`, 'utf8'),
+    decryptString: (b: Buffer) => {
+      const raw = b.toString('utf8');
+      if (!raw.startsWith('enc:')) throw new Error('bad ciphertext');
+      return raw.slice(4);
+    },
+  },
+}));
+
+const prefs = new Map<string, string>();
+mock.module('../repositories/preferences', () => ({
+  getPreference: (k: string) => prefs.get(k) ?? null,
+  setPreference: (k: string, v: string) => void prefs.set(k, v),
+  deletePreference: (k: string) => void prefs.delete(k),
+}));
+
+const vault = await import('../key-vault');
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  prefs.clear();
+  encryptionAvailable = true;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('key storage', () => {
+  test('stores keys encrypted — plaintext never reaches preferences', () => {
+    vault.setKey('claude', 'sk-ant-secret');
+    expect(vault.hasKey('claude')).toBe(true);
+    for (const value of prefs.values()) {
+      expect(value.includes('sk-ant-secret')).toBe(false);
+    }
+  });
+
+  test('rejects empty keys and unknown providers', () => {
+    expect(() => vault.setKey('claude', '   ')).toThrow(/empty/);
+    expect(() => vault.setKey('nope', 'sk-x')).toThrow(/Unknown session provider/);
+  });
+
+  test('throws when encryption is unavailable, and reports it in statuses', () => {
+    encryptionAvailable = false;
+    expect(() => vault.setKey('claude', 'sk-x')).toThrow(/not available/);
+    expect(vault.listVaultStatuses().every(s => !s.available)).toBe(true);
+  });
+
+  test('deleteKey removes the key and the opt-in flag', () => {
+    vault.setKey('grok', 'xai-key');
+    vault.setUseKey('grok', true);
+    vault.deleteKey('grok');
+    expect(vault.hasKey('grok')).toBe(false);
+    expect(vault.useKey('grok')).toBe(false);
+  });
+});
+
+describe('subscription-preservation invariant', () => {
+  test('a stored key injects NOTHING until the toggle is enabled', () => {
+    vault.setKey('claude', 'sk-ant-secret');
+    expect(vault.vaultEnvFor('claude')).toEqual({});
+  });
+
+  test('opt-in injects the provider env var; opt-out reverts', () => {
+    vault.setKey('claude', 'sk-ant-secret');
+    vault.setUseKey('claude', true);
+    expect(vault.vaultEnvFor('claude')).toEqual({ ANTHROPIC_API_KEY: 'sk-ant-secret' });
+    vault.setUseKey('claude', false);
+    expect(vault.vaultEnvFor('claude')).toEqual({});
+  });
+
+  test('cannot enable the toggle without a stored key', () => {
+    expect(() => vault.setUseKey('codex', true)).toThrow(/No API key/);
+  });
+
+  test('providers without keys always inject nothing', () => {
+    expect(vault.vaultEnvFor('gemini')).toEqual({});
+  });
+});
+
+describe('testKey', () => {
+  test('valid key hits the provider models endpoint with its auth header', async () => {
+    vault.setKey('claude', 'sk-ant-valid');
+    let seenUrl = '';
+    let seenHeaders: Record<string, string> = {};
+    globalThis.fetch = (async (url: any, init: any) => {
+      seenUrl = String(url);
+      seenHeaders = init.headers;
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    const result = await vault.testKey('claude');
+    expect(result.ok).toBe(true);
+    expect(seenUrl).toBe('https://api.anthropic.com/v1/models');
+    expect(seenHeaders['x-api-key']).toBe('sk-ant-valid');
+    expect(seenHeaders['anthropic-version']).toBe('2023-06-01');
+  });
+
+  test('401 reports a rejected key', async () => {
+    vault.setKey('codex', 'sk-bad');
+    globalThis.fetch = (async () => new Response('', { status: 401 })) as typeof fetch;
+    const result = await vault.testKey('codex');
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Key rejected');
+  });
+
+  test('network failure reports unreachable', async () => {
+    vault.setKey('grok', 'xai-x');
+    globalThis.fetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as typeof fetch;
+    const result = await vault.testKey('grok');
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('unreachable');
+  });
+
+  test('no stored key short-circuits without a network call', async () => {
+    const result = await vault.testKey('gemini');
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('No API key');
+  });
+});

--- a/src/main/__tests__/redact-env.test.ts
+++ b/src/main/__tests__/redact-env.test.ts
@@ -1,0 +1,31 @@
+/**
+ * redactEnv tests (#99): every provider API-key env var the vault can inject
+ * must be scrubbed before an env map is ever logged.
+ *
+ * Run with: bun test src/main/__tests__
+ */
+import { describe, expect, test } from 'bun:test';
+import { redactEnv } from '../redact-env';
+
+describe('redactEnv', () => {
+  test('scrubs every vault-injectable provider key env var', () => {
+    const redacted = redactEnv({
+      ANTHROPIC_API_KEY: 'sk-ant-live',
+      OPENAI_API_KEY: 'sk-live',
+      GEMINI_API_KEY: 'g-live',
+      XAI_API_KEY: 'xai-live',
+      PATH: '/usr/bin',
+    })!;
+    expect(redacted.ANTHROPIC_API_KEY).toBe('[REDACTED]');
+    expect(redacted.OPENAI_API_KEY).toBe('[REDACTED]');
+    expect(redacted.GEMINI_API_KEY).toBe('[REDACTED]');
+    expect(redacted.XAI_API_KEY).toBe('[REDACTED]');
+    expect(redacted.PATH).toBe('/usr/bin');
+  });
+
+  test('scrubs generic credential naming and passes undefined through', () => {
+    const redacted = redactEnv({ MY_SECRET: 'x', AUTH_TOKEN: 'y', DB_PASSWORD: 'z' })!;
+    expect(Object.values(redacted).every(v => v === '[REDACTED]')).toBe(true);
+    expect(redactEnv(undefined)).toBeUndefined();
+  });
+});

--- a/src/main/arena/__tests__/engine.test.ts
+++ b/src/main/arena/__tests__/engine.test.ts
@@ -27,6 +27,12 @@ mock.module('../../repositories/arena', () => ({
   listRuns: () => [],
 }));
 
+// Vault stub (#99): only the 'keyed' contestant gets an injected env var.
+mock.module('../../key-vault', () => ({
+  vaultEnvFor: (id: string) =>
+    id === 'keyed' ? { FAKE_PROVIDER_KEY: 'sekret-123' } : {},
+}));
+
 const { textParser } = await import('../parsers');
 
 // Fake contestants: ordinary shell commands standing in for agent CLIs.
@@ -35,6 +41,13 @@ const FAKE_PROVIDERS: Record<string, any> = {
     id: 'echoer',
     arena: {
       buildCommand: (ref: string) => `echo hello; echo ${ref}`,
+      createParser: textParser,
+    },
+  },
+  keyed: {
+    id: 'keyed',
+    arena: {
+      buildCommand: () => 'echo "key=$FAKE_PROVIDER_KEY"',
       createParser: textParser,
     },
   },
@@ -153,6 +166,34 @@ describe('ArenaEngine', () => {
     // The killed child's close event must not finalize a second time.
     await new Promise((r) => setTimeout(r, 500));
     expect(finalized.length).toBe(1);
+  }, 25_000);
+
+  test('vault env is merged into the contestant spawn and wins over ambient env (#99)', async () => {
+    finalized.length = 0;
+    // An ambient value must lose to the vault-injected one (merge order).
+    process.env.FAKE_PROVIDER_KEY = 'ambient-value';
+    try {
+      const engine = new ArenaEngine();
+      const settled = collectUntilSettled(engine, 1);
+      const run = engine.prepare('p', ['keyed']);
+      engine.launch(run.id);
+      const updates = await settled;
+      const text = updates.map((u) => u.chunk).join('');
+      expect(text).toContain('key=sekret-123');
+    } finally {
+      delete process.env.FAKE_PROVIDER_KEY;
+    }
+  }, 25_000);
+
+  test('contestants without vault opt-in get no injected env (#99)', async () => {
+    finalized.length = 0;
+    const engine = new ArenaEngine();
+    const settled = collectUntilSettled(engine, 1);
+    const run = engine.prepare('p', ['echoer']);
+    engine.launch(run.id);
+    const updates = await settled;
+    const text = updates.map((u) => u.chunk).join('');
+    expect(text.includes('sekret-123')).toBe(false);
   }, 25_000);
 
   test('unknown contestant fails fast without spawning', async () => {

--- a/src/main/arena/engine.ts
+++ b/src/main/arena/engine.ts
@@ -29,6 +29,7 @@ import { detectShell } from '../shell-detector';
 import { getPreference } from '../repositories/preferences';
 import * as arenaRepo from '../repositories/arena';
 import { vaultEnvFor } from '../key-vault';
+import { redactEnv } from '../redact-env';
 import { ArenaStreamParser, ollamaParser } from './parsers';
 import { ArenaRun, ArenaUpdate, ArenaResponseStatus } from '../../shared/types';
 
@@ -158,10 +159,15 @@ export class ArenaEngine extends EventEmitter {
     const cmd = provider.arena.buildCommand(shellLaunch.envRef('ARENA_PROMPT'));
     const parser = provider.arena.createParser();
 
+    // vaultEnvFor is empty unless the user opted this provider into
+    // API-key auth (#99) — subscription/CLI login stays the default.
+    const vaultEnv = vaultEnvFor(providerId);
+    if (Object.keys(vaultEnv).length > 0) {
+      // Visibility that key auth is active; values scrubbed via redactEnv.
+      log.info(`[Arena] API-key auth enabled for '${providerId}':`, redactEnv(vaultEnv));
+    }
     const child = spawn(shellLaunch.shell, shellLaunch.wrap(cmd), {
-      // vaultEnvFor is empty unless the user opted this provider into
-      // API-key auth (#99) — subscription/CLI login stays the default.
-      env: { ...process.env, ARENA_PROMPT: prompt, ...vaultEnvFor(providerId) },
+      env: { ...process.env, ARENA_PROMPT: prompt, ...vaultEnv },
       windowsHide: true,
       // Own process group on POSIX so killTree can signal the whole tree.
       detached: process.platform !== 'win32',

--- a/src/main/arena/engine.ts
+++ b/src/main/arena/engine.ts
@@ -28,6 +28,7 @@ import { getShellLaunch } from '../shell-launch';
 import { detectShell } from '../shell-detector';
 import { getPreference } from '../repositories/preferences';
 import * as arenaRepo from '../repositories/arena';
+import { vaultEnvFor } from '../key-vault';
 import { ArenaStreamParser, ollamaParser } from './parsers';
 import { ArenaRun, ArenaUpdate, ArenaResponseStatus } from '../../shared/types';
 
@@ -158,7 +159,9 @@ export class ArenaEngine extends EventEmitter {
     const parser = provider.arena.createParser();
 
     const child = spawn(shellLaunch.shell, shellLaunch.wrap(cmd), {
-      env: { ...process.env, ARENA_PROMPT: prompt },
+      // vaultEnvFor is empty unless the user opted this provider into
+      // API-key auth (#99) — subscription/CLI login stays the default.
+      env: { ...process.env, ARENA_PROMPT: prompt, ...vaultEnvFor(providerId) },
       windowsHide: true,
       // Own process group on POSIX so killTree can signal the whole tree.
       detached: process.platform !== 'win32',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { ptyManager } from './pty-manager';
 import { resolveLaunchProviderId } from './providers';
 import { detectProviders } from './provider-detector';
+import * as keyVault from './key-vault';
 import { getDatabase, closeDatabase } from './database';
 import * as groupsRepo from './repositories/groups';
 import * as sessionsRepo from './repositories/sessions';
@@ -1184,6 +1185,24 @@ safeHandle('editor:detectAvailable', async () => {
 
 safeHandle('providers:detect', async () => {
   return detectProviders();
+});
+
+// Provider API-key vault (#99). Keys go in and are tested; they are never
+// returned to the renderer.
+safeHandle('vault:list', async () => {
+  return keyVault.listVaultStatuses();
+});
+safeHandle('vault:setKey', async (providerId: string, key: string) => {
+  keyVault.setKey(providerId, key);
+});
+safeHandle('vault:deleteKey', async (providerId: string) => {
+  keyVault.deleteKey(providerId);
+});
+safeHandle('vault:setUseKey', async (providerId: string, use: boolean) => {
+  keyVault.setUseKey(providerId, use);
+});
+safeHandle('vault:testKey', async (providerId: string) => {
+  return keyVault.testKey(providerId);
 });
 
 // Arena mode (#100). Two-phase: 'start' only creates the run so the renderer

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1188,21 +1188,31 @@ safeHandle('providers:detect', async () => {
 });
 
 // Provider API-key vault (#99). Keys go in and are tested; they are never
-// returned to the renderer.
+// returned to the renderer. IPC is a trust boundary — validate argument
+// types at runtime rather than relying on the preload's TS types.
+function requireIpcString(value: unknown, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Invalid ${name}`);
+  }
+  return value;
+}
 safeHandle('vault:list', async () => {
   return keyVault.listVaultStatuses();
 });
-safeHandle('vault:setKey', async (providerId: string, key: string) => {
-  keyVault.setKey(providerId, key);
+safeHandle('vault:setKey', async (providerId: unknown, key: unknown) => {
+  keyVault.setKey(requireIpcString(providerId, 'providerId'), requireIpcString(key, 'key'));
 });
-safeHandle('vault:deleteKey', async (providerId: string) => {
-  keyVault.deleteKey(providerId);
+safeHandle('vault:deleteKey', async (providerId: unknown) => {
+  keyVault.deleteKey(requireIpcString(providerId, 'providerId'));
 });
-safeHandle('vault:setUseKey', async (providerId: string, use: boolean) => {
-  keyVault.setUseKey(providerId, use);
+safeHandle('vault:setUseKey', async (providerId: unknown, use: unknown) => {
+  if (typeof use !== 'boolean') {
+    throw new Error('Invalid use flag');
+  }
+  keyVault.setUseKey(requireIpcString(providerId, 'providerId'), use);
 });
-safeHandle('vault:testKey', async (providerId: string) => {
-  return keyVault.testKey(providerId);
+safeHandle('vault:testKey', async (providerId: unknown) => {
+  return keyVault.testKey(requireIpcString(providerId, 'providerId'));
 });
 
 // Arena mode (#100). Two-phase: 'start' only creates the run so the renderer

--- a/src/main/key-vault.ts
+++ b/src/main/key-vault.ts
@@ -13,12 +13,23 @@
 import { safeStorage } from 'electron';
 import log from 'electron-log';
 import { getPreference, setPreference, deletePreference } from './repositories/preferences';
-import { getProvider, listProviders } from './providers';
+import { getProvider, listProviders, ProviderDefinition } from './providers';
 import { KeyVaultStatus } from '../shared/types';
 
 const KEY_PREF_PREFIX = 'providerApiKey.';
 const USE_PREF_PREFIX = 'providerApiKeyUse.';
 const TEST_TIMEOUT_MS = 10_000;
+
+type ApiKeyConfig = NonNullable<ProviderDefinition['apiKey']>;
+
+/** Resolve a provider that supports API keys; throws for unknown ids or key-less providers. */
+function requireApiKeyConfig(providerId: string): ApiKeyConfig {
+  const config = getProvider(providerId).apiKey;
+  if (!config) {
+    throw new Error(`Provider '${providerId}' does not support API keys`);
+  }
+  return config;
+}
 
 export function isVaultAvailable(): boolean {
   return safeStorage.isEncryptionAvailable();
@@ -33,7 +44,7 @@ export function useKey(providerId: string): boolean {
 }
 
 export function setKey(providerId: string, key: string): void {
-  getProvider(providerId); // throws on unknown ids
+  requireApiKeyConfig(providerId);
   if (!isVaultAvailable()) {
     throw new Error('Secure key storage is not available on this system');
   }
@@ -46,11 +57,13 @@ export function setKey(providerId: string, key: string): void {
 }
 
 export function deleteKey(providerId: string): void {
+  getProvider(providerId); // throws on unknown ids
   deletePreference(KEY_PREF_PREFIX + providerId);
   deletePreference(USE_PREF_PREFIX + providerId);
 }
 
 export function setUseKey(providerId: string, use: boolean): void {
+  requireApiKeyConfig(providerId);
   if (use && !hasKey(providerId)) {
     throw new Error('No API key stored for this provider');
   }
@@ -81,8 +94,9 @@ export function vaultEnvFor(providerId: string): Record<string, string> {
   const key = decryptKey(providerId);
   if (key === null) return {};
   try {
-    return { [getProvider(providerId).apiKey.envVar]: key };
+    return { [requireApiKeyConfig(providerId).envVar]: key };
   } catch {
+    // Unknown provider or one without API-key support — inject nothing.
     return {};
   }
 }
@@ -96,7 +110,7 @@ export interface KeyTestResult {
 
 /** Validate the stored key against the provider's cheap models endpoint. */
 export async function testKey(providerId: string): Promise<KeyTestResult> {
-  const provider = getProvider(providerId);
+  const config = requireApiKeyConfig(providerId);
   const key = decryptKey(providerId);
   if (key === null) {
     return { ok: false, status: null, error: 'No API key stored' };
@@ -104,8 +118,8 @@ export async function testKey(providerId: string): Promise<KeyTestResult> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TEST_TIMEOUT_MS);
   try {
-    const res = await fetch(provider.apiKey.test.url, {
-      headers: provider.apiKey.test.headers(key),
+    const res = await fetch(config.test.url, {
+      headers: config.test.headers(key),
       signal: controller.signal,
     });
     if (res.ok) return { ok: true, status: res.status, error: null };
@@ -121,10 +135,13 @@ export async function testKey(providerId: string): Promise<KeyTestResult> {
 
 export function listVaultStatuses(): KeyVaultStatus[] {
   const available = isVaultAvailable();
-  return listProviders().map((p) => ({
-    providerId: p.id,
-    available,
-    hasKey: hasKey(p.id),
-    useKey: useKey(p.id),
-  }));
+  // Providers without apiKey support are not applicable and don't appear.
+  return listProviders()
+    .filter((p) => p.apiKey !== undefined)
+    .map((p) => ({
+      providerId: p.id,
+      available,
+      hasKey: hasKey(p.id),
+      useKey: useKey(p.id),
+    }));
 }

--- a/src/main/key-vault.ts
+++ b/src/main/key-vault.ts
@@ -1,0 +1,130 @@
+/**
+ * Provider API-key vault (#99).
+ *
+ * Keys are encrypted with Electron's safeStorage (OS keychain: Keychain on
+ * macOS, DPAPI on Windows, libsecret on Linux) and persisted as base64 blobs
+ * in the existing preferences table. Plaintext keys never touch the DB, logs,
+ * or the renderer — the IPC surface only reports whether a key is stored.
+ *
+ * A stored key does nothing by itself: it is injected into a provider's
+ * launch environment only when the user flips the per-provider "use API key"
+ * toggle. CLI login/subscription remains the default (issue #100 decision).
+ */
+import { safeStorage } from 'electron';
+import log from 'electron-log';
+import { getPreference, setPreference, deletePreference } from './repositories/preferences';
+import { getProvider, listProviders } from './providers';
+import { KeyVaultStatus } from '../shared/types';
+
+const KEY_PREF_PREFIX = 'providerApiKey.';
+const USE_PREF_PREFIX = 'providerApiKeyUse.';
+const TEST_TIMEOUT_MS = 10_000;
+
+export function isVaultAvailable(): boolean {
+  return safeStorage.isEncryptionAvailable();
+}
+
+export function hasKey(providerId: string): boolean {
+  return getPreference(KEY_PREF_PREFIX + providerId) !== null;
+}
+
+export function useKey(providerId: string): boolean {
+  return getPreference(USE_PREF_PREFIX + providerId) === 'true';
+}
+
+export function setKey(providerId: string, key: string): void {
+  getProvider(providerId); // throws on unknown ids
+  if (!isVaultAvailable()) {
+    throw new Error('Secure key storage is not available on this system');
+  }
+  const trimmed = key.trim();
+  if (!trimmed) {
+    throw new Error('API key is empty');
+  }
+  const encrypted = safeStorage.encryptString(trimmed).toString('base64');
+  setPreference(KEY_PREF_PREFIX + providerId, encrypted);
+}
+
+export function deleteKey(providerId: string): void {
+  deletePreference(KEY_PREF_PREFIX + providerId);
+  deletePreference(USE_PREF_PREFIX + providerId);
+}
+
+export function setUseKey(providerId: string, use: boolean): void {
+  if (use && !hasKey(providerId)) {
+    throw new Error('No API key stored for this provider');
+  }
+  setPreference(USE_PREF_PREFIX + providerId, use ? 'true' : 'false');
+}
+
+/** Decrypt a stored key. Main-process only — never exposed over IPC. */
+function decryptKey(providerId: string): string | null {
+  const blob = getPreference(KEY_PREF_PREFIX + providerId);
+  if (blob === null || !isVaultAvailable()) return null;
+  try {
+    return safeStorage.decryptString(Buffer.from(blob, 'base64'));
+  } catch {
+    // Wrong OS-keychain state (e.g. restored DB on another machine). Detail
+    // deliberately not logged — nothing key-adjacent goes to logs.
+    log.error(`[KeyVault] Failed to decrypt key for '${providerId}'`);
+    return null;
+  }
+}
+
+/**
+ * Env vars to merge into a provider launch: the provider's API-key env var
+ * when — and only when — a key is stored AND the user opted in for this
+ * provider. Empty otherwise, leaving CLI login/subscription auth untouched.
+ */
+export function vaultEnvFor(providerId: string): Record<string, string> {
+  if (!useKey(providerId)) return {};
+  const key = decryptKey(providerId);
+  if (key === null) return {};
+  try {
+    return { [getProvider(providerId).apiKey.envVar]: key };
+  } catch {
+    return {};
+  }
+}
+
+export interface KeyTestResult {
+  ok: boolean;
+  /** HTTP status from the provider's validation endpoint, when reached. */
+  status: number | null;
+  error: string | null;
+}
+
+/** Validate the stored key against the provider's cheap models endpoint. */
+export async function testKey(providerId: string): Promise<KeyTestResult> {
+  const provider = getProvider(providerId);
+  const key = decryptKey(providerId);
+  if (key === null) {
+    return { ok: false, status: null, error: 'No API key stored' };
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(provider.apiKey.test.url, {
+      headers: provider.apiKey.test.headers(key),
+      signal: controller.signal,
+    });
+    if (res.ok) return { ok: true, status: res.status, error: null };
+    const reason = res.status === 401 || res.status === 403 ? 'Key rejected' : 'Unexpected response';
+    return { ok: false, status: res.status, error: `${reason} (HTTP ${res.status})` };
+  } catch (e: any) {
+    const message = e?.name === 'AbortError' ? 'Timed out' : 'Endpoint unreachable';
+    return { ok: false, status: null, error: message };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function listVaultStatuses(): KeyVaultStatus[] {
+  const available = isVaultAvailable();
+  return listProviders().map((p) => ({
+    providerId: p.id,
+    available,
+    hasKey: hasKey(p.id),
+    useKey: useKey(p.id),
+  }));
+}

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus, ArenaRun, ArenaUpdate } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus, ArenaRun, ArenaUpdate, KeyVaultStatus } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -185,6 +185,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Shell
   openExternal: (url: string) => ipcRenderer.invoke('shell:openExternal', url),
   detectProviders: (): Promise<ProviderStatus[]> => ipcRenderer.invoke('providers:detect'),
+
+  // Provider API-key vault (#99) — keys go in, never come back out.
+  vaultList: (): Promise<KeyVaultStatus[]> => ipcRenderer.invoke('vault:list'),
+  vaultSetKey: (providerId: string, key: string): Promise<void> =>
+    ipcRenderer.invoke('vault:setKey', providerId, key),
+  vaultDeleteKey: (providerId: string): Promise<void> =>
+    ipcRenderer.invoke('vault:deleteKey', providerId),
+  vaultSetUseKey: (providerId: string, use: boolean): Promise<void> =>
+    ipcRenderer.invoke('vault:setUseKey', providerId, use),
+  vaultTestKey: (providerId: string): Promise<{ ok: boolean; status: number | null; error: string | null }> =>
+    ipcRenderer.invoke('vault:testKey', providerId),
 
   // Arena mode (#100)
   arenaStart: (prompt: string, contestants: string[]): Promise<ArenaRun> =>

--- a/src/main/providers/claude.ts
+++ b/src/main/providers/claude.ts
@@ -35,6 +35,13 @@ export const claudeProvider: ProviderDefinition = {
   },
   systemPromptFlag: '--append-system-prompt',
   waitingPatterns: CLAUDE_WAITING_PATTERNS,
+  apiKey: {
+    envVar: 'ANTHROPIC_API_KEY',
+    test: {
+      url: 'https://api.anthropic.com/v1/models',
+      headers: (key) => ({ 'x-api-key': key, 'anthropic-version': '2023-06-01' }),
+    },
+  },
   arena: {
     // --max-turns 1 keeps the arena chat-shaped (no agentic tool loops);
     // stream-json requires --verbose. Verified live: the result event

--- a/src/main/providers/codex.ts
+++ b/src/main/providers/codex.ts
@@ -11,6 +11,13 @@ export const codexProvider = passthroughProvider({
   id: 'codex',
   name: 'Codex (OpenAI)',
   command: 'codex',
+  apiKey: {
+    envVar: 'OPENAI_API_KEY',
+    test: {
+      url: 'https://api.openai.com/v1/models',
+      headers: (key) => ({ authorization: `Bearer ${key}` }),
+    },
+  },
   arena: {
     // JSONL events; turn.completed carries token usage (OpenAI headless docs).
     buildCommand: (promptRef) => `codex exec --json ${promptRef}`,

--- a/src/main/providers/gemini.ts
+++ b/src/main/providers/gemini.ts
@@ -10,6 +10,13 @@ export const geminiProvider = passthroughProvider({
   id: 'gemini',
   name: 'Gemini CLI (Google)',
   command: 'gemini',
+  apiKey: {
+    envVar: 'GEMINI_API_KEY',
+    test: {
+      url: 'https://generativelanguage.googleapis.com/v1beta/models',
+      headers: (key) => ({ 'x-goog-api-key': key }),
+    },
+  },
   arena: {
     // Single JSON document with response + per-model token stats
     // (Gemini CLI headless docs); no streaming.

--- a/src/main/providers/grok.ts
+++ b/src/main/providers/grok.ts
@@ -10,6 +10,13 @@ export const grokProvider = passthroughProvider({
   id: 'grok',
   name: 'Grok Build (xAI)',
   command: 'grok',
+  apiKey: {
+    envVar: 'XAI_API_KEY',
+    test: {
+      url: 'https://api.x.ai/v1/models',
+      headers: (key) => ({ authorization: `Bearer ${key}` }),
+    },
+  },
   arena: {
     // Plain-text headless output; no documented JSON/usage reporting yet.
     buildCommand: (promptRef) => `grok -p ${promptRef}`,

--- a/src/main/providers/passthrough.ts
+++ b/src/main/providers/passthrough.ts
@@ -20,7 +20,7 @@ export function baseSessionEnv(config: ProviderLaunchConfig): NodeJS.ProcessEnv 
  * management stay entirely inside the CLI itself.
  */
 export function passthroughProvider(
-  opts: Pick<ProviderDefinition, 'id' | 'name' | 'command' | 'setup' | 'arena'>
+  opts: Pick<ProviderDefinition, 'id' | 'name' | 'command' | 'setup' | 'arena' | 'apiKey'>
 ): ProviderDefinition {
   return {
     ...opts,

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -78,6 +78,19 @@ export interface ProviderDefinition {
    */
   waitingPatterns?: readonly RegExp[];
   /**
+   * Direct-API credential support (#99). A stored key is used only when the
+   * user explicitly enables it per provider — CLI login/subscription remains
+   * the default (issue #100 decision). The CLI reads the key from envVar;
+   * `test` names a cheap authenticated endpoint for validating a stored key.
+   */
+  apiKey: {
+    envVar: string;
+    test: {
+      url: string;
+      headers(key: string): Record<string, string>;
+    };
+  };
+  /**
    * Headless invocation for arena mode (#100). promptRef is the
    * shell-appropriate env-var reference for the prompt (e.g.
    * `"$ARENA_PROMPT"`), so the prompt text itself never touches the command

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -78,12 +78,15 @@ export interface ProviderDefinition {
    */
   waitingPatterns?: readonly RegExp[];
   /**
-   * Direct-API credential support (#99). A stored key is used only when the
-   * user explicitly enables it per provider — CLI login/subscription remains
-   * the default (issue #100 decision). The CLI reads the key from envVar;
-   * `test` names a cheap authenticated endpoint for validating a stored key.
+   * Direct-API credential support (#99), for providers whose CLI can
+   * authenticate via an API-key env var. Absent = API keys don't apply
+   * (e.g. a purely local provider) and the vault treats the provider as
+   * not applicable. A stored key is used only when the user explicitly
+   * enables it per provider — CLI login/subscription remains the default
+   * (issue #100 decision). `test` names a cheap authenticated endpoint
+   * for validating a stored key.
    */
-  apiKey: {
+  apiKey?: {
     envVar: string;
     test: {
       url: string;

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -23,6 +23,7 @@ import {
 import { resolveAccountForSession, touchAccount } from './repositories/accounts';
 import { writeMemoryFile, getMemoryInjectionContent } from './memory/injector';
 import { vaultEnvFor } from './key-vault';
+import { redactEnv } from './redact-env';
 import log from 'electron-log';
 
 interface PtySession {
@@ -372,7 +373,12 @@ export class PtyManager extends EventEmitter {
     let agentCmd = `${launch.command}${sessionFlag}`;
     // vaultEnvFor is empty unless the user explicitly opted this provider
     // into API-key auth (#99) — CLI login/subscription stays the default.
-    const processEnv = { ...process.env, ...launch.env, ...vaultEnvFor(provider.id) } as { [key: string]: string };
+    const vaultEnv = vaultEnvFor(provider.id);
+    if (Object.keys(vaultEnv).length > 0) {
+      // Visibility that key auth is active; values scrubbed via redactEnv.
+      log.info(`[PTY] API-key auth enabled for '${provider.id}':`, redactEnv(vaultEnv));
+    }
+    const processEnv = { ...process.env, ...launch.env, ...vaultEnv } as { [key: string]: string };
 
     const supportsSystemPrompt = provider.capabilities.systemPrompt && !!provider.systemPromptFlag;
     if (groupId && supportsSystemPrompt) {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -25,16 +25,6 @@ import { writeMemoryFile, getMemoryInjectionContent } from './memory/injector';
 import { vaultEnvFor } from './key-vault';
 import log from 'electron-log';
 
-function redactEnv(env: Record<string, string> | undefined): Record<string, string> | undefined {
-  if (!env) return undefined;
-  return Object.fromEntries(
-    Object.entries(env).map(([k, v]) => [
-      k,
-      /key|secret|token|password|auth/i.test(k) ? '[REDACTED]' : v,
-    ])
-  );
-}
-
 interface PtySession {
   id: string;
   pty: pty.IPty;

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -22,6 +22,7 @@ import {
 } from './repositories/sessions';
 import { resolveAccountForSession, touchAccount } from './repositories/accounts';
 import { writeMemoryFile, getMemoryInjectionContent } from './memory/injector';
+import { vaultEnvFor } from './key-vault';
 import log from 'electron-log';
 
 function redactEnv(env: Record<string, string> | undefined): Record<string, string> | undefined {
@@ -379,7 +380,9 @@ export class PtyManager extends EventEmitter {
     // Get memory content for system prompt injection
     // Pass via environment variable to avoid shell escaping issues with newlines
     let agentCmd = `${launch.command}${sessionFlag}`;
-    const processEnv = { ...process.env, ...launch.env } as { [key: string]: string };
+    // vaultEnvFor is empty unless the user explicitly opted this provider
+    // into API-key auth (#99) — CLI login/subscription stays the default.
+    const processEnv = { ...process.env, ...launch.env, ...vaultEnvFor(provider.id) } as { [key: string]: string };
 
     const supportsSystemPrompt = provider.capabilities.systemPrompt && !!provider.systemPromptFlag;
     if (groupId && supportsSystemPrompt) {

--- a/src/main/redact-env.ts
+++ b/src/main/redact-env.ts
@@ -1,0 +1,18 @@
+/**
+ * Redact secret-bearing entries from an environment map before it goes
+ * anywhere observable (logs, diagnostics). The pattern covers generic
+ * credential naming — including every provider API-key env var the vault
+ * can inject (#99): ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY,
+ * XAI_API_KEY all match /key/i.
+ *
+ * (Lives outside pty-manager so it stays importable without node-pty.)
+ */
+export function redactEnv(env: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (!env) return undefined;
+  return Object.fromEntries(
+    Object.entries(env).map(([k, v]) => [
+      k,
+      /key|secret|token|password|auth/i.test(k) ? '[REDACTED]' : v,
+    ])
+  );
+}

--- a/src/main/repositories/preferences.ts
+++ b/src/main/repositories/preferences.ts
@@ -22,6 +22,11 @@ export function setPreference(key: string, value: string): void {
   `).run(key, value);
 }
 
+export function deletePreference(key: string): void {
+  const db = getDatabase();
+  db.prepare('DELETE FROM preferences WHERE key = ?').run(key);
+}
+
 export function getWindowBounds(): WindowBounds | null {
   const value = getPreference('windowBounds');
   if (!value) return null;

--- a/src/renderer/components/ProviderKeyVault.tsx
+++ b/src/renderer/components/ProviderKeyVault.tsx
@@ -1,0 +1,139 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { KeyVaultStatus, PROVIDER_LABELS } from '../../shared/types';
+
+interface KeyRowProps {
+  status: KeyVaultStatus;
+  onChanged: () => void;
+}
+
+function describeTest(result: { ok: boolean; error: string | null } | null): string {
+  if (result === null) return '';
+  return result.ok ? 'Key is valid ✓' : `Test failed: ${result.error}`;
+}
+
+const ProviderKeyRow: React.FC<KeyRowProps> = ({ status, onChanged }) => {
+  const [draft, setDraft] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const run = useCallback(async (action: () => Promise<string>) => {
+    setBusy(true);
+    try {
+      setMessage(await action());
+      onChanged();
+    } catch (error: any) {
+      setMessage(error?.message ?? 'Operation failed');
+    } finally {
+      setBusy(false);
+    }
+  }, [onChanged]);
+
+  const saveKey = () => run(async () => {
+    await window.electronAPI.vaultSetKey(status.providerId, draft);
+    setDraft('');
+    return 'Key stored (encrypted via OS keychain)';
+  });
+
+  const testKey = () => run(async () => {
+    const result = await window.electronAPI.vaultTestKey(status.providerId);
+    return describeTest(result);
+  });
+
+  const deleteKey = () => run(async () => {
+    await window.electronAPI.vaultDeleteKey(status.providerId);
+    return 'Key deleted';
+  });
+
+  const toggleUse = (use: boolean) => run(async () => {
+    await window.electronAPI.vaultSetUseKey(status.providerId, use);
+    return use ? 'Launches for this provider now use the API key' : 'Back to CLI login / subscription';
+  });
+
+  const label = PROVIDER_LABELS[status.providerId] ?? status.providerId;
+
+  return (
+    <div className="vault-row">
+      <div className="vault-row-header">
+        <span className="provider-status-name">{label}</span>
+        <span className={`vault-key-state ${status.hasKey ? 'stored' : ''}`}>
+          {status.hasKey ? 'key stored' : 'no key'}
+        </span>
+      </div>
+      <div className="vault-row-controls">
+        <input
+          type="password"
+          className="settings-text-input vault-key-input"
+          placeholder={status.hasKey ? 'Replace key…' : 'Paste API key…'}
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          disabled={busy}
+        />
+        <button className="settings-button" onClick={saveKey} disabled={busy || !draft.trim()}>
+          Save
+        </button>
+        <button className="settings-button" onClick={testKey} disabled={busy || !status.hasKey}>
+          Test
+        </button>
+        <button className="settings-button" onClick={deleteKey} disabled={busy || !status.hasKey}>
+          Delete
+        </button>
+      </div>
+      <label className="vault-use-toggle">
+        <input
+          type="checkbox"
+          checked={status.useKey}
+          disabled={busy || !status.hasKey}
+          onChange={e => toggleUse(e.target.checked)}
+        />
+        Use API key for launches — bills your API account; off = CLI login / subscription (default)
+      </label>
+      {message && <span className="vault-message">{message}</span>}
+    </div>
+  );
+};
+
+/**
+ * Settings → Providers: encrypted API-key vault (#99). Keys are stored via
+ * Electron safeStorage and never displayed back; a stored key only affects
+ * launches after the per-provider opt-in toggle is enabled.
+ */
+export const ProviderKeyVault: React.FC = () => {
+  const [statuses, setStatuses] = useState<KeyVaultStatus[] | null>(null);
+
+  const refresh = useCallback(() => {
+    window.electronAPI.vaultList().then(setStatuses).catch(() => setStatuses([]));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  if (statuses === null) return null;
+
+  if (statuses.length > 0 && !statuses[0].available) {
+    return (
+      <div className="settings-group">
+        <h4>API Keys (optional)</h4>
+        <span className="settings-hint">
+          Secure key storage isn't available on this system (OS keychain
+          encryption unavailable), so API keys can't be stored. Provider CLIs
+          keep working with their own logins.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-group">
+      <h4>API Keys (optional)</h4>
+      <span className="settings-hint">
+        Stored encrypted in your OS keychain and never shown again. By default
+        everything runs on each CLI's own login/subscription — a key is used
+        only for providers where you enable the toggle.
+      </span>
+      {statuses.map(s => (
+        <ProviderKeyRow key={s.providerId} status={s} onChanged={refresh} />
+      ))}
+    </div>
+  );
+};

--- a/src/renderer/components/ProviderKeyVault.tsx
+++ b/src/renderer/components/ProviderKeyVault.tsx
@@ -15,6 +15,7 @@ const ProviderKeyRow: React.FC<KeyRowProps> = ({ status, onChanged }) => {
   const [draft, setDraft] = useState('');
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState('');
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   const run = useCallback(async (action: () => Promise<string>) => {
     setBusy(true);
@@ -39,10 +40,20 @@ const ProviderKeyRow: React.FC<KeyRowProps> = ({ status, onChanged }) => {
     return describeTest(result);
   });
 
-  const deleteKey = () => run(async () => {
-    await window.electronAPI.vaultDeleteKey(status.providerId);
-    return 'Key deleted';
-  });
+  // Delete is irreversible (the key is never displayed again), so require a
+  // second click to confirm.
+  const deleteKey = () => {
+    if (!confirmingDelete) {
+      setConfirmingDelete(true);
+      setMessage('Click again to permanently delete the stored key');
+      return;
+    }
+    setConfirmingDelete(false);
+    run(async () => {
+      await window.electronAPI.vaultDeleteKey(status.providerId);
+      return 'Key deleted';
+    });
+  };
 
   const toggleUse = (use: boolean) => run(async () => {
     await window.electronAPI.vaultSetUseKey(status.providerId, use);
@@ -64,6 +75,7 @@ const ProviderKeyRow: React.FC<KeyRowProps> = ({ status, onChanged }) => {
       <div className="vault-row-controls">
         <input
           type="password"
+          autoComplete="off"
           className="settings-text-input vault-key-input"
           placeholder={status.hasKey ? 'Replace key…' : 'Paste API key…'}
           value={draft}
@@ -77,7 +89,7 @@ const ProviderKeyRow: React.FC<KeyRowProps> = ({ status, onChanged }) => {
           Test
         </button>
         <button className="settings-button" onClick={deleteKey} disabled={!canTouchKey}>
-          Delete
+          {confirmingDelete ? 'Confirm delete' : 'Delete'}
         </button>
       </div>
       <label className="vault-use-toggle">

--- a/src/renderer/components/ProviderKeyVault.tsx
+++ b/src/renderer/components/ProviderKeyVault.tsx
@@ -50,6 +50,8 @@ const ProviderKeyRow: React.FC<KeyRowProps> = ({ status, onChanged }) => {
   });
 
   const label = PROVIDER_LABELS[status.providerId] ?? status.providerId;
+  const canSave = !busy && draft.trim().length > 0;
+  const canTouchKey = !busy && status.hasKey;
 
   return (
     <div className="vault-row">
@@ -68,13 +70,13 @@ const ProviderKeyRow: React.FC<KeyRowProps> = ({ status, onChanged }) => {
           onChange={e => setDraft(e.target.value)}
           disabled={busy}
         />
-        <button className="settings-button" onClick={saveKey} disabled={busy || !draft.trim()}>
+        <button className="settings-button" onClick={saveKey} disabled={!canSave}>
           Save
         </button>
-        <button className="settings-button" onClick={testKey} disabled={busy || !status.hasKey}>
+        <button className="settings-button" onClick={testKey} disabled={!canTouchKey}>
           Test
         </button>
-        <button className="settings-button" onClick={deleteKey} disabled={busy || !status.hasKey}>
+        <button className="settings-button" onClick={deleteKey} disabled={!canTouchKey}>
           Delete
         </button>
       </div>
@@ -82,10 +84,12 @@ const ProviderKeyRow: React.FC<KeyRowProps> = ({ status, onChanged }) => {
         <input
           type="checkbox"
           checked={status.useKey}
-          disabled={busy || !status.hasKey}
+          disabled={!canTouchKey}
           onChange={e => toggleUse(e.target.checked)}
         />
-        Use API key for launches — bills your API account; off = CLI login / subscription (default)
+        <span>
+          Use API key for launches — bills your API account; off = CLI login / subscription (default)
+        </span>
       </label>
       {message && <span className="vault-message">{message}</span>}
     </div>

--- a/src/renderer/components/ProviderSettings.tsx
+++ b/src/renderer/components/ProviderSettings.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { ProviderStatus } from '../../shared/types';
+import { ProviderKeyVault } from './ProviderKeyVault';
 
 /**
  * Settings → Providers panel: provider CLI detection status + setup guidance
@@ -73,6 +74,8 @@ export const ProviderSettings: React.FC = () => {
           </div>
         ))}
       </div>
+
+      <ProviderKeyVault />
     </div>
   );
 };

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus, ArenaRun, ArenaUpdate } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus, ArenaRun, ArenaUpdate, KeyVaultStatus } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -84,6 +84,11 @@ interface ElectronAPI {
   // Shell
   openExternal: (url: string) => Promise<void>;
   detectProviders: () => Promise<ProviderStatus[]>;
+  vaultList: () => Promise<KeyVaultStatus[]>;
+  vaultSetKey: (providerId: string, key: string) => Promise<void>;
+  vaultDeleteKey: (providerId: string) => Promise<void>;
+  vaultSetUseKey: (providerId: string, use: boolean) => Promise<void>;
+  vaultTestKey: (providerId: string) => Promise<{ ok: boolean; status: number | null; error: string | null }>;
   arenaStart: (prompt: string, contestants: string[]) => Promise<ArenaRun>;
   arenaLaunch: (runId: string) => Promise<void>;
   arenaCancel: (runId: string) => Promise<void>;

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1628,3 +1628,55 @@ body {
   max-width: 420px;
   text-align: center;
 }
+
+/* Provider API-key vault (#99) */
+.vault-row {
+  padding: 10px 0;
+  border-bottom: 1px solid #333;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.vault-row:last-child {
+  border-bottom: none;
+}
+
+.vault-row-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.vault-key-state {
+  font-size: 11px;
+  color: #999;
+}
+
+.vault-key-state.stored {
+  color: #4caf50;
+}
+
+.vault-row-controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.vault-key-input {
+  flex: 1;
+}
+
+.vault-use-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #bbb;
+  cursor: pointer;
+}
+
+.vault-message {
+  font-size: 11px;
+  color: #9fc3f0;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -86,6 +86,22 @@ export interface ArenaUpdate {
   error: string | null;
 }
 
+/**
+ * Renderer-facing state of one provider's API-key vault entry (#99). The key
+ * itself is never returned to the renderer — only whether one is stored.
+ */
+export interface KeyVaultStatus {
+  providerId: string;
+  /** Whether OS-keychain-backed encryption is available on this platform. */
+  available: boolean;
+  hasKey: boolean;
+  /**
+   * Whether the stored key is injected into launches for this provider.
+   * Defaults to false — CLI login/subscription stays the default.
+   */
+  useKey: boolean;
+}
+
 /** Result of probing one provider CLI's availability (#97). */
 export interface ProviderStatus {
   id: string;


### PR DESCRIPTION
## Description
Final slice of the multi-provider epic (#94): optional API-key support for users who run on API keys instead of subscriptions.

**The subscription guarantee holds by construction**: a stored key does nothing until the user flips a per-provider "use API key" toggle (default off, cannot be enabled without a stored key). CLI login/subscription remains the default auth everywhere — sessions and arena alike. This is asserted by a dedicated test ("a stored key injects NOTHING until the toggle is enabled").

- **Vault** (`src/main/key-vault.ts`): keys encrypted via Electron `safeStorage` (OS keychain), persisted as base64 blobs in the preferences table. Plaintext never reaches the DB, logs, or the renderer — the IPC surface is write/test/delete/toggle only; there is no read-back.
- **Injection**: `vaultEnvFor(provider)` merges the provider's key env var (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / `XAI_API_KEY`) into session spawns and arena contestants — empty object unless opted in, so the default path is byte-identical to before.
- **Validation**: "Test" performs a cheap authenticated call to each provider's models endpoint (Anthropic endpoint + headers confirmed against current API docs) with a 10s timeout; 401/403 reports "key rejected", network failure "unreachable".
- **UI**: Settings → Providers gains an "API Keys (optional)" section — masked input, Save/Test/Delete, the opt-in toggle with an explicit billing warning, and a graceful message when OS-keychain encryption is unavailable (acceptance criterion).

## Related issue
Closes #99

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Hotfix
- [ ] Refactor / chore
- [ ] Docs

## How was this tested?
- `bun test`: 61 pass across the repo, including 12 new vault tests (encrypted-at-rest, empty/unknown-provider rejection, unavailable-keychain error + status reporting, delete clears the opt-in flag, the subscription-preservation invariant, opt-in/opt-out round-trip, testKey against stubbed endpoints incl. 401 and network failure)
- `tsc --noEmit` clean on main + renderer configs; SonarQube preflight on the vault module clean
- Manual QA worth doing: store a real key on a machine with a keychain, Test it, enable the toggle, and confirm the CLI picks up the env var (and that disabling reverts to login auth)

## Checklist
- [ ] Tests pass locally (bun test, 61 pass)
- [x] Self-reviewed the changes
- [x] Docs updated where needed (none required)
- [x] Linked the related issue above

🤖 Generated with [Claude Code](https://claude.com/claude-code)