### PR TITLE
Route cmd.exe agent launches through PowerShell (env-ref injection)

### DIFF
--- a/src/main/__tests__/shell-launch.test.ts
+++ b/src/main/__tests__/shell-launch.test.ts
@@ -5,15 +5,26 @@
  *
  * Run with: bun test src/main/__tests__
  */
-import { describe, expect, test, afterEach } from 'bun:test';
-import { getShellLaunch } from '../shell-launch';
+import { describe, expect, test, afterEach, mock } from 'bun:test';
 import type { ShellInfo } from '../shell-detector';
+
+// The cmd→PowerShell reroute resolves an absolute powershell.exe on disk;
+// stub fs.existsSync so that path is testable on a POSIX runner.
+let powershellExists = true;
+mock.module('fs', () => ({
+  existsSync: () => powershellExists,
+}));
+
+const { getShellLaunch } = await import('../shell-launch');
 
 const realPlatform = process.platform;
 function setPlatform(platform: string): void {
   Object.defineProperty(process, 'platform', { value: platform });
 }
-afterEach(() => setPlatform(realPlatform));
+afterEach(() => {
+  setPlatform(realPlatform);
+  powershellExists = true;
+});
 
 const shell = (overrides: Partial<ShellInfo>): ShellInfo => ({
   shell: '/bin/zsh',
@@ -22,10 +33,12 @@ const shell = (overrides: Partial<ShellInfo>): ShellInfo => ({
   ...overrides,
 });
 
+const ENV_REF = { needsEnvRef: true };
+
 describe('getShellLaunch branches', () => {
   test('POSIX: login shell, quoted-$ env refs', () => {
     setPlatform('darwin');
-    const launch = getShellLaunch(shell({ shell: '/bin/zsh', args: ['-l', '-i'] }));
+    const launch = getShellLaunch(shell({ shell: '/bin/zsh', args: ['-l', '-i'] }), ENV_REF);
     expect(launch.shell).toBe('/bin/zsh');
     expect(launch.wrap('claude')).toEqual(['-l', '-i', '-c', 'claude']);
     expect(launch.envRef('ARENA_PROMPT')).toBe('"$ARENA_PROMPT"');
@@ -33,7 +46,7 @@ describe('getShellLaunch branches', () => {
 
   test('WSL: wraps through wsl.exe bash with distro args', () => {
     setPlatform('win32');
-    const launch = getShellLaunch(shell({ shell: 'wsl.exe', args: ['-d', 'Ubuntu'], isWSL: true }));
+    const launch = getShellLaunch(shell({ shell: 'wsl.exe', args: ['-d', 'Ubuntu'], isWSL: true }), ENV_REF);
     expect(launch.wrap('claude')).toEqual(['-d', 'Ubuntu', '--', 'bash', '-c', 'claude']);
     expect(launch.envRef('X')).toBe('"$X"');
   });
@@ -41,15 +54,32 @@ describe('getShellLaunch branches', () => {
   test('Windows PowerShell: -Command wrap, $env: refs', () => {
     setPlatform('win32');
     const launch = getShellLaunch(
-      shell({ shell: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' })
+      shell({ shell: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' }),
+      ENV_REF
     );
     expect(launch.wrap('claude')).toEqual(['-NoLogo', '-Command', 'claude']);
     expect(launch.envRef('ARENA_PROMPT')).toBe('$env:ARENA_PROMPT');
   });
 
-  test('cmd.exe reroutes to PowerShell at an absolute path (#106)', () => {
+  test('Git Bash on Windows: bash -c wrap', () => {
     setPlatform('win32');
-    const launch = getShellLaunch(shell({ shell: 'C:\\Windows\\System32\\cmd.exe' }));
+    const launch = getShellLaunch(shell({ shell: 'C:\\Program Files\\Git\\bin\\bash.exe' }), ENV_REF);
+    expect(launch.wrap('claude')).toEqual(['-c', 'claude']);
+    expect(launch.envRef('X')).toBe('"$X"');
+  });
+
+  test('cmd.exe WITHOUT env-ref keeps the user shell; envRef throws if misused (#106)', () => {
+    setPlatform('win32');
+    const launch = getShellLaunch(shell({ shell: 'C:\\Windows\\System32\\cmd.exe' }), { needsEnvRef: false });
+    // Login-pty case: cmd.exe is preserved, no PowerShell reroute.
+    expect(launch.shell).toBe('C:\\Windows\\System32\\cmd.exe');
+    expect(launch.wrap('claude')).toEqual(['/c', 'claude']);
+    expect(() => launch.envRef('X')).toThrow(/needsEnvRef/);
+  });
+
+  test('cmd.exe WITH env-ref reroutes to PowerShell at an absolute path (#106)', () => {
+    setPlatform('win32');
+    const launch = getShellLaunch(shell({ shell: 'C:\\Windows\\System32\\cmd.exe' }), ENV_REF);
     // Never /c through cmd — %VAR% expansion is textual and injectable.
     expect(launch.shell.toLowerCase()).toContain('powershell.exe');
     expect(path_isAbsoluteWin(launch.shell)).toBe(true);
@@ -57,14 +87,14 @@ describe('getShellLaunch branches', () => {
     expect(launch.envRef('ARENA_PROMPT')).toBe('$env:ARENA_PROMPT');
   });
 
-  test('Git Bash on Windows: bash -c wrap', () => {
+  test('cmd.exe env-ref reroute throws a clear error when PowerShell is absent', () => {
     setPlatform('win32');
-    const launch = getShellLaunch(shell({ shell: 'C:\\Program Files\\Git\\bin\\bash.exe' }));
-    expect(launch.wrap('claude')).toEqual(['-c', 'claude']);
-    expect(launch.envRef('X')).toBe('"$X"');
+    powershellExists = false;
+    expect(() => getShellLaunch(shell({ shell: 'C:\\Windows\\System32\\cmd.exe' }), ENV_REF))
+      .toThrow(/PowerShell not found/);
   });
 
-  test('invariant: no branch produces cmd-style %VAR% env refs', () => {
+  test('env-ref invariant: no branch produces cmd-style %VAR% refs', () => {
     const cases: Array<[string, ShellInfo]> = [
       ['darwin', shell({})],
       ['win32', shell({ shell: 'wsl.exe', args: ['-d', 'Ubuntu'], isWSL: true })],
@@ -74,7 +104,7 @@ describe('getShellLaunch branches', () => {
     ];
     for (const [platform, info] of cases) {
       setPlatform(platform);
-      expect(getShellLaunch(info).envRef('VAR').includes('%')).toBe(false);
+      expect(getShellLaunch(info, ENV_REF).envRef('VAR').includes('%')).toBe(false);
     }
   });
 });

--- a/src/main/__tests__/shell-launch.test.ts
+++ b/src/main/__tests__/shell-launch.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Shell-launch tests (#106): argv construction per platform branch, and the
+ * env-ref safety invariant — no branch may reference an env var with
+ * cmd.exe-style `%VAR%` textual expansion, which cannot be quoted safely.
+ *
+ * Run with: bun test src/main/__tests__
+ */
+import { describe, expect, test, afterEach } from 'bun:test';
+import { getShellLaunch } from '../shell-launch';
+import type { ShellInfo } from '../shell-detector';
+
+const realPlatform = process.platform;
+function setPlatform(platform: string): void {
+  Object.defineProperty(process, 'platform', { value: platform });
+}
+afterEach(() => setPlatform(realPlatform));
+
+const shell = (overrides: Partial<ShellInfo>): ShellInfo => ({
+  shell: '/bin/zsh',
+  args: [],
+  isWSL: false,
+  ...overrides,
+});
+
+describe('getShellLaunch branches', () => {
+  test('POSIX: login shell, quoted-$ env refs', () => {
+    setPlatform('darwin');
+    const launch = getShellLaunch(shell({ shell: '/bin/zsh', args: ['-l', '-i'] }));
+    expect(launch.shell).toBe('/bin/zsh');
+    expect(launch.wrap('claude')).toEqual(['-l', '-i', '-c', 'claude']);
+    expect(launch.envRef('ARENA_PROMPT')).toBe('"$ARENA_PROMPT"');
+  });
+
+  test('WSL: wraps through wsl.exe bash with distro args', () => {
+    setPlatform('win32');
+    const launch = getShellLaunch(shell({ shell: 'wsl.exe', args: ['-d', 'Ubuntu'], isWSL: true }));
+    expect(launch.wrap('claude')).toEqual(['-d', 'Ubuntu', '--', 'bash', '-c', 'claude']);
+    expect(launch.envRef('X')).toBe('"$X"');
+  });
+
+  test('Windows PowerShell: -Command wrap, $env: refs', () => {
+    setPlatform('win32');
+    const launch = getShellLaunch(
+      shell({ shell: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' })
+    );
+    expect(launch.wrap('claude')).toEqual(['-NoLogo', '-Command', 'claude']);
+    expect(launch.envRef('ARENA_PROMPT')).toBe('$env:ARENA_PROMPT');
+  });
+
+  test('cmd.exe reroutes to PowerShell at an absolute path (#106)', () => {
+    setPlatform('win32');
+    const launch = getShellLaunch(shell({ shell: 'C:\\Windows\\System32\\cmd.exe' }));
+    // Never /c through cmd — %VAR% expansion is textual and injectable.
+    expect(launch.shell.toLowerCase()).toContain('powershell.exe');
+    expect(path_isAbsoluteWin(launch.shell)).toBe(true);
+    expect(launch.wrap('claude')).toEqual(['-NoLogo', '-Command', 'claude']);
+    expect(launch.envRef('ARENA_PROMPT')).toBe('$env:ARENA_PROMPT');
+  });
+
+  test('Git Bash on Windows: bash -c wrap', () => {
+    setPlatform('win32');
+    const launch = getShellLaunch(shell({ shell: 'C:\\Program Files\\Git\\bin\\bash.exe' }));
+    expect(launch.wrap('claude')).toEqual(['-c', 'claude']);
+    expect(launch.envRef('X')).toBe('"$X"');
+  });
+
+  test('invariant: no branch produces cmd-style %VAR% env refs', () => {
+    const cases: Array<[string, ShellInfo]> = [
+      ['darwin', shell({})],
+      ['win32', shell({ shell: 'wsl.exe', args: ['-d', 'Ubuntu'], isWSL: true })],
+      ['win32', shell({ shell: 'powershell.exe' })],
+      ['win32', shell({ shell: 'cmd.exe' })],
+      ['win32', shell({ shell: 'bash.exe' })],
+    ];
+    for (const [platform, info] of cases) {
+      setPlatform(platform);
+      expect(getShellLaunch(info).envRef('VAR').includes('%')).toBe(false);
+    }
+  });
+});
+
+/** Windows-style absolute path check that works when running tests on POSIX. */
+function path_isAbsoluteWin(p: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(p);
+}

--- a/src/main/arena/__tests__/engine.test.ts
+++ b/src/main/arena/__tests__/engine.test.ts
@@ -196,6 +196,22 @@ describe('ArenaEngine', () => {
     expect(text.includes('sekret-123')).toBe(false);
   }, 25_000);
 
+  test('shell metacharacters in the prompt are never executed (#106)', async () => {
+    finalized.length = 0;
+    const engine = new ArenaEngine();
+    const settled = collectUntilSettled(engine, 1);
+    // If the env-ref path ever re-parsed the prompt, the substitution would
+    // run and the literal `$(echo ...)` wrapper would vanish from output.
+    const hostile = 'hi"; $(echo EXECUTED_MARKER); `echo BACKTICK_MARKER`; & echo AMP "bye';
+    const run = engine.prepare(hostile, ['echoer']);
+    engine.launch(run.id);
+    const updates = await settled;
+    const text = updates.map((u) => u.chunk).join('');
+    expect(updates[updates.length - 1].status).toBe('done');
+    expect(text).toContain('$(echo EXECUTED_MARKER)');
+    expect(text).toContain('`echo BACKTICK_MARKER`');
+  }, 25_000);
+
   test('unknown contestant fails fast without spawning', async () => {
     finalized.length = 0;
     const engine = new ArenaEngine();

--- a/src/main/arena/engine.ts
+++ b/src/main/arena/engine.ts
@@ -155,7 +155,7 @@ export class ArenaEngine extends EventEmitter {
     }
 
     const shellInfo = detectShell(getPreference('customShellPath') ?? '');
-    const shellLaunch = getShellLaunch(shellInfo);
+    const shellLaunch = getShellLaunch(shellInfo, { needsEnvRef: true });
     const cmd = provider.arena.buildCommand(shellLaunch.envRef('ARENA_PROMPT'));
     const parser = provider.arena.createParser();
 

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -392,7 +392,7 @@ export class PtyManager extends EventEmitter {
     // var, using the shell-appropriate variable reference syntax. Gated on
     // capability so an inherited BODHILANDER_SYSTEM_PROMPT in the parent
     // environment can't produce a bogus flag for providers without one.
-    const shellLaunch = getShellLaunch(shellInfo);
+    const shellLaunch = getShellLaunch(shellInfo, { needsEnvRef: true });
     if (supportsSystemPrompt && processEnv.BODHILANDER_SYSTEM_PROMPT) {
       agentCmd = `${launch.command} ${provider.systemPromptFlag} ${shellLaunch.envRef('BODHILANDER_SYSTEM_PROMPT')}${sessionFlag}`;
     }
@@ -428,7 +428,9 @@ export class PtyManager extends EventEmitter {
     };
     const agentCmd = claudeProvider.command;
 
-    const shellLaunch = getShellLaunch(shellInfo);
+    // The login pty just runs `claude` — no env-ref interpolation — so it
+    // keeps the user's cmd.exe shell rather than rerouting to PowerShell (#106).
+    const shellLaunch = getShellLaunch(shellInfo, { needsEnvRef: false });
     const shell = shellLaunch.shell;
     const args = shellLaunch.wrap(agentCmd);
 

--- a/src/main/shell-launch.ts
+++ b/src/main/shell-launch.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import { ShellInfo } from './shell-detector';
 
@@ -7,12 +8,16 @@ import { ShellInfo } from './shell-detector';
  * referencing an environment variable inside that command string. Single
  * source of truth for agent sessions, login ptys, and arena contestants.
  *
- * Env-ref safety invariant (#106): every branch's envRef must expand AFTER
- * the shell parses the command, so the value is never re-parsed as shell
- * syntax. bash `"$VAR"` and PowerShell `$env:VAR` both satisfy this.
- * cmd.exe `%VAR%` does NOT — its expansion is textual and pre-parse, so a
- * value containing `"` or `&` breaks out of any quoting. Agent launches
- * from cmd.exe shells therefore route through PowerShell instead.
+ * Env-ref safety invariant (#106): a launch's envRef must expand AFTER the
+ * shell parses the command, so the value is never re-parsed as shell syntax.
+ * bash `"$VAR"` and PowerShell `$env:VAR` both satisfy this. cmd.exe `%VAR%`
+ * does NOT — its expansion is textual and pre-parse, so a value containing
+ * `"` or `&` breaks out of any quoting.
+ *
+ * Callers declare via `needsEnvRef` whether they will interpolate a value
+ * with envRef. When true, cmd.exe cannot host the launch safely and it is
+ * rerouted through PowerShell. When false (e.g. the login pty, which just
+ * runs `claude`), cmd.exe is used unchanged and envRef throws if misused.
  *
  * (Lives outside pty-manager so consumers that don't need node-pty — like
  * the arena engine and its tests — don't drag the native module in.)
@@ -23,6 +28,14 @@ export interface ShellLaunch {
   envRef(name: string): string;
 }
 
+export interface ShellLaunchOptions {
+  /**
+   * Whether the caller will build the command with envRef (interpolating a
+   * possibly-untrusted value). Gates the cmd.exe→PowerShell reroute (#106).
+   */
+  needsEnvRef: boolean;
+}
+
 function powershellLaunch(shell: string): ShellLaunch {
   return {
     shell,
@@ -31,7 +44,28 @@ function powershellLaunch(shell: string): ShellLaunch {
   };
 }
 
-export function getShellLaunch(shellInfo: ShellInfo): ShellLaunch {
+/**
+ * Absolute path to Windows PowerShell 5.1 (bundled with Windows). Absolute so
+ * a poisoned PATH can't substitute the binary. Throws a clear error rather
+ * than spawning an ENOENT if it is somehow absent (e.g. a pwsh-only image).
+ */
+function windowsPowershellPath(): string {
+  // SystemRoot can be set-but-empty in some sandboxed processes; an empty or
+  // whitespace value would make path.join produce a relative (PATH-relative)
+  // path, so fall back to the default whenever it isn't a usable string.
+  const raw = process.env.SystemRoot;
+  const systemRoot = raw && raw.trim().length > 0 ? raw : 'C:\\Windows';
+  const candidate = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+  if (!fs.existsSync(candidate)) {
+    throw new Error(
+      `Windows PowerShell not found at ${candidate}. Agent launches from a cmd.exe ` +
+      `shell require it; set your Bodhilander shell to PowerShell or Git Bash instead.`
+    );
+  }
+  return candidate;
+}
+
+export function getShellLaunch(shellInfo: ShellInfo, options: ShellLaunchOptions): ShellLaunch {
   if (shellInfo.isWSL) {
     // Launch the agent inside WSL
     return {
@@ -46,15 +80,20 @@ export function getShellLaunch(shellInfo: ShellInfo): ShellLaunch {
       return powershellLaunch(shellInfo.shell);
     }
     if (shellName.includes('cmd')) {
-      // cmd.exe cannot host env-ref launches safely (#106) — see the module
-      // doc. Route through Windows PowerShell at its absolute path (always
-      // present; PATH-poisoning-proof). Only agent/arena launches use this
-      // wrapper; the user's plain cmd shell sessions are unaffected.
-      const powershell = path.join(
-        process.env.SystemRoot ?? 'C:\\Windows',
-        'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'
-      );
-      return powershellLaunch(powershell);
+      // cmd.exe %VAR% expansion is textual and pre-parse (#106) — see the
+      // module doc. When the caller interpolates a value via envRef, reroute
+      // through PowerShell whose $env: expansion is parse-safe. Otherwise
+      // (login pty), keep cmd.exe and make envRef throw so misuse is caught.
+      if (options.needsEnvRef) {
+        return powershellLaunch(windowsPowershellPath());
+      }
+      return {
+        shell: shellInfo.shell,
+        wrap: (cmd) => ['/c', cmd],
+        envRef: () => {
+          throw new Error('cmd.exe env-ref launch must set needsEnvRef (#106)');
+        },
+      };
     }
     // Assume bash-like shell (Git Bash, etc.)
     return {

--- a/src/main/shell-launch.ts
+++ b/src/main/shell-launch.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { ShellInfo } from './shell-detector';
 
 /**
@@ -6,6 +7,13 @@ import { ShellInfo } from './shell-detector';
  * referencing an environment variable inside that command string. Single
  * source of truth for agent sessions, login ptys, and arena contestants.
  *
+ * Env-ref safety invariant (#106): every branch's envRef must expand AFTER
+ * the shell parses the command, so the value is never re-parsed as shell
+ * syntax. bash `"$VAR"` and PowerShell `$env:VAR` both satisfy this.
+ * cmd.exe `%VAR%` does NOT — its expansion is textual and pre-parse, so a
+ * value containing `"` or `&` breaks out of any quoting. Agent launches
+ * from cmd.exe shells therefore route through PowerShell instead.
+ *
  * (Lives outside pty-manager so consumers that don't need node-pty — like
  * the arena engine and its tests — don't drag the native module in.)
  */
@@ -13,6 +21,14 @@ export interface ShellLaunch {
   shell: string;
   wrap(cmd: string): string[];
   envRef(name: string): string;
+}
+
+function powershellLaunch(shell: string): ShellLaunch {
+  return {
+    shell,
+    wrap: (cmd) => ['-NoLogo', '-Command', cmd],
+    envRef: (name) => `$env:${name}`,
+  };
 }
 
 export function getShellLaunch(shellInfo: ShellInfo): ShellLaunch {
@@ -27,18 +43,18 @@ export function getShellLaunch(shellInfo: ShellInfo): ShellLaunch {
   if (process.platform === 'win32') {
     const shellName = shellInfo.shell.toLowerCase();
     if (shellName.includes('powershell')) {
-      return {
-        shell: shellInfo.shell,
-        wrap: (cmd) => ['-NoLogo', '-Command', cmd],
-        envRef: (name) => `$env:${name}`,
-      };
+      return powershellLaunch(shellInfo.shell);
     }
     if (shellName.includes('cmd')) {
-      return {
-        shell: shellInfo.shell,
-        wrap: (cmd) => ['/c', cmd],
-        envRef: (name) => `"%${name}%"`,
-      };
+      // cmd.exe cannot host env-ref launches safely (#106) — see the module
+      // doc. Route through Windows PowerShell at its absolute path (always
+      // present; PATH-poisoning-proof). Only agent/arena launches use this
+      // wrapper; the user's plain cmd shell sessions are unaffected.
+      const powershell = path.join(
+        process.env.SystemRoot ?? 'C:\\Windows',
+        'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'
+      );
+      return powershellLaunch(powershell);
     }
     // Assume bash-like shell (Git Bash, etc.)
     return {


### PR DESCRIPTION
## Description
Hardens the follow-up from #105's review: cmd.exe `%VAR%` expansion is **textual and pre-parse**, so a value containing `"` or `&` escapes any quoting — meaning arena prompts (arbitrary pasted text) and memory-injected system prompts could inject commands for users whose configured shell is cmd.exe. This class isn't fixable by escaping; the safe expansions are the post-parse kind (`bash "$VAR"`, PowerShell `$env:VAR`).

- `getShellLaunch`'s cmd.exe branch now routes env-ref launches through **Windows PowerShell at its absolute SystemRoot path** (always present, PATH-poisoning-proof). The module doc states the invariant every future branch must satisfy.
- Scope is exactly the agent/arena wrapper — a user's plain interactive cmd sessions never touch `getShellLaunch` and are unchanged. Behavior note for cmd users: their *agent* launches now run under a PowerShell wrapper (env and system PATH carry over; agent CLIs don't rely on cmd autorun).

## Related issue
Closes #106

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Hotfix
- [ ] Refactor / chore
- [ ] Docs

## How was this tested?
- `bun test`: 72 pass — new per-branch argv tests (incl. the cmd→PowerShell reroute and absolute-path assertion), an invariant test that **no branch emits `%VAR%` refs**, and an engine-level regression that spawns a real contestant with a hostile prompt (`$(…)`, backticks, `&`, quote-breaks) and proves it round-trips literally without execution
- `tsc --noEmit` clean; SonarQube preflight on the changed module clean
- Manual QA worth doing on Windows: set shell to cmd.exe, launch a Claude session and an arena run, confirm both work under the PowerShell wrapper

## Checklist
- [ ] Tests pass locally (bun test, 72 pass)
- [x] Self-reviewed the changes
- [x] Docs updated where needed (invariant documented in the module)
- [x] Linked the related issue above

🤖 Generated with [Claude Code](https://claude.com/claude-code)