### PR TITLE
Pin Windows release runner to windows-2022 (node-gyp vs VS 2026)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,14 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: linux
-          - os: windows-latest
+          # Pinned to windows-2022 (VS 2022) deliberately (#109). GitHub moved
+          # the `windows-latest` label to windows-2025-vs2026 (Visual Studio
+          # 2026), which the project's node-gyp doesn't yet detect — the
+          # postinstall electron-rebuild fails with "Could not find any Visual
+          # Studio installation to use". Same build-reproducibility reasoning as
+          # the pinned macOS runners below. Revisit when node-gyp/node-pty gain
+          # VS 2026 support (or if windows-2022 is retired).
+          - os: windows-2022
             platform: win
           # BDHLNDR-38: build each Mac arch on its native runner so postinstall
           # (electron-rebuild) and sharp's optional-dep resolution produce


### PR DESCRIPTION
## Description
The `Build and Release` Windows job broke on the `3.4.0-beta.10` cut — `electron-rebuild` (postinstall) failed with *"Could not find any Visual Studio installation to use"*, so `node-pty` never rebuilt and the `.exe` was never produced.

**Root cause** (not a code regression): GitHub rolled the `windows-latest` label from Server 2022 / VS 2022 to the **`windows-2025-vs2026`** image (Visual Studio 2026). The project's `node-gyp@12.4.0` detects VS through 2022 (major 17) but not VS 2026's new major version. The last release (3.3.4, May) built fine because `windows-latest` was still VS 2022.

**Fix**: pin the Windows matrix runner to `windows-2022` — the known-good image — mirroring how the macOS runners are already pinned for build reproducibility, with a comment so it isn't reverted. Longer-term (noted on #109): move to a node-gyp that supports VS 2026 once the toolchain catches up.

## Related issue
Closes #109

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Hotfix
- [ ] Refactor / chore
- [ ] Docs

## How was this tested?
- YAML validated (js-yaml)
- Real verification is the workflow run itself — this is a CI-runner config change with no unit-testable surface. After merge to `development`, re-running "Build and Release" should complete the Windows job and emit the installer. (The macOS legs still need the separate Apple Program License Agreement re-signed — tracked outside this PR.)

## Checklist
- [x] Self-reviewed the changes
- [x] Docs updated where needed (rationale documented in-workflow)
- [x] Linked the related issue above

🤖 Generated with [Claude Code](https://claude.com/claude-code)