### PR TITLE
feat: scope arena runs to a project folder via group working dirs

### DIFF
--- a/src/main/__tests__/shell-launch.test.ts
+++ b/src/main/__tests__/shell-launch.test.ts
@@ -6,12 +6,17 @@
  * Run with: bun test src/main/__tests__
  */
 import { describe, expect, test, afterEach, mock } from 'bun:test';
+import * as realFs from 'node:fs';
 import type { ShellInfo } from '../shell-detector';
 
 // The cmd→PowerShell reroute resolves an absolute powershell.exe on disk;
-// stub fs.existsSync so that path is testable on a POSIX runner.
+// stub fs.existsSync so that path is testable on a POSIX runner. The rest
+// of fs is passed through: mock.module is process-global in bun, so a
+// bare {existsSync} would gut fs for every test file that runs after this
+// one (the real module is grabbed via 'node:fs', which stays unmocked).
 let powershellExists = true;
 mock.module('fs', () => ({
+  ...realFs,
   existsSync: () => powershellExists,
 }));
 

--- a/src/main/arena/__tests__/engine.test.ts
+++ b/src/main/arena/__tests__/engine.test.ts
@@ -65,6 +65,13 @@ const FAKE_PROVIDERS: Record<string, any> = {
       createParser: textParser,
     },
   },
+  pwder: {
+    id: 'pwder',
+    arena: {
+      buildCommand: () => 'pwd',
+      createParser: textParser,
+    },
+  },
 };
 mock.module('../../providers', () => ({
   getProvider: (id: string) => {
@@ -210,6 +217,37 @@ describe('ArenaEngine', () => {
     expect(updates[updates.length - 1].status).toBe('done');
     expect(text).toContain('$(echo EXECUTED_MARKER)');
     expect(text).toContain('`echo BACKTICK_MARKER`');
+  }, 25_000);
+
+  test('a scoped run spawns contestants inside the working directory', async () => {
+    finalized.length = 0;
+    const os = await import('os');
+    const fs = await import('fs');
+    const path = await import('path');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arena-cwd-'));
+    try {
+      const engine = new ArenaEngine();
+      const settled = collectUntilSettled(engine, 1);
+      const run = engine.prepare('p', ['pwder'], dir);
+      engine.launch(run.id);
+      const updates = await settled;
+      expect(updates[updates.length - 1].status).toBe('done');
+      const text = updates.map((u) => u.chunk).join('');
+      // realpath: the shell resolves symlinked tmpdirs (/tmp → /private/tmp).
+      expect(text).toContain(fs.realpathSync(dir));
+    } finally {
+      fs.rmdirSync(dir);
+    }
+  }, 25_000);
+
+  test('an unscoped run keeps the engine process cwd behavior', async () => {
+    finalized.length = 0;
+    const engine = new ArenaEngine();
+    const settled = collectUntilSettled(engine, 1);
+    const run = engine.prepare('p', ['pwder']);
+    engine.launch(run.id);
+    const updates = await settled;
+    expect(updates[updates.length - 1].status).toBe('done');
   }, 25_000);
 
   test('unknown contestant fails fast without spawning', async () => {

--- a/src/main/arena/engine.ts
+++ b/src/main/arena/engine.ts
@@ -82,6 +82,8 @@ interface LiveResponse {
   runId: string;
   provider: string;
   prompt: string;
+  /** Project folder CLI contestants spawn in (null = engine process cwd). */
+  workingDir: string | null;
   text: string;
   startedAt: number;
   ttftMs: number | null;
@@ -98,10 +100,14 @@ export class ArenaEngine extends EventEmitter {
     this.timeoutMs = timeoutMs;
   }
 
-  /** Phase 1: create the run + response rows; nothing is spawned yet. */
-  prepare(prompt: string, contestants: string[]): ArenaRun {
+  /**
+   * Phase 1: create the run + response rows; nothing is spawned yet.
+   * workingDir scopes CLI contestants to a project folder so they answer
+   * with that codebase as context (Ollama, a bare HTTP chat, ignores it).
+   */
+  prepare(prompt: string, contestants: string[], workingDir: string | null = null): ArenaRun {
     const runId = randomUUID();
-    arenaRepo.createRun(runId, prompt);
+    arenaRepo.createRun(runId, prompt, workingDir);
     for (const provider of contestants) {
       const responseId = randomUUID();
       arenaRepo.createResponse(responseId, runId, provider);
@@ -109,6 +115,7 @@ export class ArenaEngine extends EventEmitter {
         runId,
         provider,
         prompt,
+        workingDir,
         text: '',
         startedAt: Date.now(),
         ttftMs: null,
@@ -168,6 +175,10 @@ export class ArenaEngine extends EventEmitter {
     }
     const child = spawn(shellLaunch.shell, shellLaunch.wrap(cmd), {
       env: { ...process.env, ARENA_PROMPT: prompt, ...vaultEnv },
+      // Scoped runs put the CLI inside the project folder, exactly like a
+      // terminal session there. A vanished dir surfaces via the 'error'
+      // handler below (spawn ENOENT), settling the column as an error.
+      cwd: entry.workingDir ?? undefined,
       windowsHide: true,
       // Own process group on POSIX so killTree can signal the whole tree.
       detached: process.platform !== 'win32',

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -447,6 +447,7 @@ function initializeArenaTables(database: Database.Database): void {
     CREATE TABLE IF NOT EXISTS arena_runs (
       id TEXT PRIMARY KEY,
       prompt TEXT NOT NULL,
+      working_dir TEXT DEFAULT NULL,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
     );
     CREATE TABLE IF NOT EXISTS arena_responses (
@@ -464,6 +465,13 @@ function initializeArenaTables(database: Database.Database): void {
     );
     CREATE INDEX IF NOT EXISTS idx_arena_responses_run ON arena_responses(run_id);
   `);
+
+  // Migration: scope a run to a project folder (group working dir) so
+  // contestant CLIs answer with that codebase as context. NULL = unscoped.
+  const runColumns = database.prepare('PRAGMA table_info(arena_runs)').all() as { name: string }[];
+  if (!runColumns.some((col) => col.name === 'working_dir')) {
+    database.exec('ALTER TABLE arena_runs ADD COLUMN working_dir TEXT DEFAULT NULL');
+  }
 }
 
 export function closeDatabase(): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, ipcMain, dialog, shell, crashReporter } from 'electron';
+import * as fs from 'fs';
 import * as path from 'path';
 import { ptyManager } from './pty-manager';
 import { resolveLaunchProviderId } from './providers';
@@ -1217,11 +1218,20 @@ safeHandle('vault:testKey', async (providerId: unknown) => {
 
 // Arena mode (#100). Two-phase: 'start' only creates the run so the renderer
 // can subscribe with the run id; 'launch' then spawns the contestants.
-safeHandle('arena:start', async (prompt: string, contestants: string[]) => {
+safeHandle('arena:start', async (prompt: string, contestants: string[], workingDir?: string | null) => {
   if (!prompt?.trim() || !Array.isArray(contestants) || contestants.length === 0) {
     throw new Error('Arena run needs a prompt and at least one contestant');
   }
-  return arenaEngine.prepare(prompt, Array.from(new Set(contestants)));
+  // Optional project scoping: contestants spawn inside this folder. Checked
+  // up front so a stale group dir fails the run before any rows are created.
+  let dir: string | null = null;
+  if (typeof workingDir === 'string' && workingDir.trim()) {
+    dir = workingDir.trim();
+    if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+      throw new Error(`Arena working directory does not exist: ${dir}`);
+    }
+  }
+  return arenaEngine.prepare(prompt, Array.from(new Set(contestants)), dir);
 });
 safeHandle('arena:launch', async (runId: string) => {
   arenaEngine.launch(runId);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -198,8 +198,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('vault:testKey', providerId),
 
   // Arena mode (#100)
-  arenaStart: (prompt: string, contestants: string[]): Promise<ArenaRun> =>
-    ipcRenderer.invoke('arena:start', prompt, contestants),
+  arenaStart: (prompt: string, contestants: string[], workingDir?: string | null): Promise<ArenaRun> =>
+    ipcRenderer.invoke('arena:start', prompt, contestants, workingDir ?? null),
   arenaLaunch: (runId: string): Promise<void> =>
     ipcRenderer.invoke('arena:launch', runId),
   arenaCancel: (runId: string): Promise<void> =>

--- a/src/main/repositories/arena.ts
+++ b/src/main/repositories/arena.ts
@@ -31,10 +31,10 @@ function rowToResponse(row: ResponseRow): ArenaResponse {
   };
 }
 
-export function createRun(id: string, prompt: string): void {
+export function createRun(id: string, prompt: string, workingDir: string | null = null): void {
   getDatabase()
-    .prepare('INSERT INTO arena_runs (id, prompt) VALUES (?, ?)')
-    .run(id, prompt);
+    .prepare('INSERT INTO arena_runs (id, prompt, working_dir) VALUES (?, ?, ?)')
+    .run(id, prompt, workingDir);
 }
 
 export function createResponse(id: string, runId: string, provider: string): void {
@@ -80,11 +80,18 @@ export function finalizeResponse(id: string, final: FinalizeResponseInput): void
     );
 }
 
+interface RunRow {
+  id: string;
+  prompt: string;
+  working_dir: string | null;
+  created_at: string;
+}
+
 export function getRun(id: string): ArenaRun | null {
   const db = getDatabase();
-  const run = db.prepare('SELECT id, prompt, created_at FROM arena_runs WHERE id = ?').get(id) as
-    | { id: string; prompt: string; created_at: string }
-    | undefined;
+  const run = db
+    .prepare('SELECT id, prompt, working_dir, created_at FROM arena_runs WHERE id = ?')
+    .get(id) as RunRow | undefined;
   if (!run) return null;
   const rows = db
     .prepare('SELECT * FROM arena_responses WHERE run_id = ? ORDER BY provider')
@@ -92,6 +99,7 @@ export function getRun(id: string): ArenaRun | null {
   return {
     id: run.id,
     prompt: run.prompt,
+    workingDir: run.working_dir,
     createdAt: new Date(run.created_at),
     responses: rows.map(rowToResponse),
   };
@@ -101,12 +109,13 @@ export function getRun(id: string): ArenaRun | null {
 export function listRuns(limit: number = 50): ArenaRun[] {
   const db = getDatabase();
   const runs = db
-    .prepare('SELECT id, prompt, created_at FROM arena_runs ORDER BY created_at DESC LIMIT ?')
-    .all(limit) as { id: string; prompt: string; created_at: string }[];
+    .prepare('SELECT id, prompt, working_dir, created_at FROM arena_runs ORDER BY created_at DESC LIMIT ?')
+    .all(limit) as RunRow[];
   const responsesStmt = db.prepare('SELECT * FROM arena_responses WHERE run_id = ? ORDER BY provider');
   return runs.map((run) => ({
     id: run.id,
     prompt: run.prompt,
+    workingDir: run.working_dir,
     createdAt: new Date(run.created_at),
     responses: (responsesStmt.all(run.id) as ResponseRow[]).map(rowToResponse),
   }));

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -86,6 +86,8 @@ const App: React.FC = () => {
   // Analytics view state (BDHLNDR-18)
   const [analyticsViewOpen, setAnalyticsViewOpen] = useState(false);
   const [arenaViewOpen, setArenaViewOpen] = useState(false);
+  // Group whose working dir the arena panel should scope to ("Ask Arena" menu).
+  const [arenaGroupId, setArenaGroupId] = useState<string | null>(null);
 
   // Code search modal state
   const [codeSearchOpen, setCodeSearchOpen] = useState(false);
@@ -358,6 +360,15 @@ const App: React.FC = () => {
       { label: 'Rename', onClick: () => handleStartEditGroup(groupId, groupName) },
       { label: 'Set Working Directory', onClick: () => handleSetGroupDirectory(groupId) },
       { label: 'New Sub-Group', onClick: () => handleCreateSubGroup(groupId), disabled: !!groups.find(g => g.id === groupId)?.parentId },
+      {
+        label: 'Ask Arena About This Folder',
+        onClick: () => {
+          setArenaGroupId(groupId);
+          setArenaViewOpen(true);
+        },
+        // Arena scoping runs the CLIs inside the group's working dir.
+        disabled: !group?.workingDir,
+      },
     ];
 
     // Account-assignment items (BDHLNDR-31) — only shown when accounts are registered.
@@ -1334,7 +1345,13 @@ const App: React.FC = () => {
             activeSessionId={activeSessionId}
           />
         )}
-        {arenaViewOpen && <ArenaPanel onClose={() => setArenaViewOpen(false)} />}
+        {arenaViewOpen && (
+          <ArenaPanel
+            onClose={() => setArenaViewOpen(false)}
+            groups={groups}
+            initialGroupId={arenaGroupId}
+          />
+        )}
         <div className="terminal-area" style={{ display: analyticsViewOpen || arenaViewOpen ? 'none' : undefined }}>
           {sessions.map(session => (
             <div

--- a/src/renderer/components/ArenaPanel.tsx
+++ b/src/renderer/components/ArenaPanel.tsx
@@ -1,9 +1,14 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { ArenaRun, ArenaUpdate, ProviderStatus } from '../../shared/types';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { ArenaRun, ArenaUpdate, Group, ProviderStatus } from '../../shared/types';
 import { applyArenaUpdate, isRunSettled } from './arenaUpdates';
+import { buildFolderOptions } from './arenaFolderOptions';
 
 interface ArenaPanelProps {
   onClose: () => void;
+  /** Sidebar groups — the ones with a working directory become folder scopes. */
+  groups: Group[];
+  /** Group to pre-select as the folder scope (e.g. "Ask Arena" from its menu). */
+  initialGroupId?: string | null;
 }
 
 const OLLAMA_ID = 'ollama';
@@ -42,14 +47,24 @@ function formatCost(costUsd: number | null): string {
  * streamed side-by-side with latency/token/cost metrics. Runs persist and
  * can be reloaded from the history dropdown.
  */
-export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose }) => {
+export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose, groups, initialGroupId }) => {
   const [prompt, setPrompt] = useState('');
   const [contestants, setContestants] = useState<{ id: string; name: string; available: boolean }[]>([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [run, setRun] = useState<ArenaRun | null>(null);
   const [running, setRunning] = useState(false);
   const [history, setHistory] = useState<ArenaRun[]>([]);
+  // '' = no folder scope; otherwise a group id from folderOptions.
+  const [folderGroupId, setFolderGroupId] = useState<string>(initialGroupId ?? '');
   const runIdRef = useRef<string | null>(null);
+
+  const folderOptions = useMemo(() => buildFolderOptions(groups), [groups]);
+  const scopedDir = folderOptions.find(o => o.groupId === folderGroupId)?.dir ?? null;
+
+  // "Ask Arena" from a group's context menu retargets an already-open panel.
+  useEffect(() => {
+    if (initialGroupId) setFolderGroupId(initialGroupId);
+  }, [initialGroupId]);
 
   // Contestant list: detected provider CLIs plus the local Ollama daemon.
   useEffect(() => {
@@ -91,7 +106,7 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose }) => {
     try {
       // Two-phase: subscribe with the run id BEFORE contestants launch, so
       // even an instantly-failing CLI's updates are never dropped.
-      const newRun = await window.electronAPI.arenaStart(trimmed, Array.from(selected));
+      const newRun = await window.electronAPI.arenaStart(trimmed, Array.from(selected), scopedDir);
       runIdRef.current = newRun.id;
       setRun(newRun);
       await window.electronAPI.arenaLaunch(newRun.id);
@@ -99,7 +114,7 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose }) => {
       console.error('Arena start failed:', error);
       setRunning(false);
     }
-  }, [prompt, selected, running]);
+  }, [prompt, selected, running, scopedDir]);
 
   const cancelRun = useCallback(() => {
     if (runIdRef.current) {
@@ -162,6 +177,18 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose }) => {
           rows={3}
         />
         <div className="arena-contestants">
+          <select
+            className="arena-folder-select"
+            value={folderGroupId}
+            onChange={e => setFolderGroupId(e.target.value)}
+            title="Run inside a project folder so agents answer about that codebase"
+            aria-label="Project folder scope"
+          >
+            <option value="">No folder (generic)</option>
+            {folderOptions.map(o => (
+              <option key={o.groupId} value={o.groupId}>{o.label}</option>
+            ))}
+          </select>
           {contestants.map(c => (
             <label key={c.id} className={`arena-contestant ${c.available ? '' : 'unavailable'}`}>
               <input
@@ -182,6 +209,12 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose }) => {
           </button>
         </div>
       </div>
+
+      {run?.workingDir && (
+        <div className="arena-run-scope" title={run.workingDir}>
+          📁 {run.workingDir}
+        </div>
+      )}
 
       <div className="arena-results">
         {run?.responses.map(r => (

--- a/src/renderer/components/__tests__/arenaFolderOptions.test.ts
+++ b/src/renderer/components/__tests__/arenaFolderOptions.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Arena folder-scope option tests.
+ *
+ * Run with: bun test src/renderer/components/__tests__
+ */
+import { describe, expect, test } from 'bun:test';
+import { buildFolderOptions } from '../arenaFolderOptions';
+
+describe('buildFolderOptions', () => {
+  test('one option per group with a working directory, in given order', () => {
+    const options = buildFolderOptions([
+      { id: 'g1', name: 'API', workingDir: '/work/api' },
+      { id: 'g2', name: 'Scratch', workingDir: '' },
+      { id: 'g3', name: 'App', workingDir: '/work/app' },
+    ]);
+    expect(options).toEqual([
+      { groupId: 'g1', label: 'API — /work/api', dir: '/work/api' },
+      { groupId: 'g3', label: 'App — /work/app', dir: '/work/app' },
+    ]);
+  });
+
+  test('whitespace-only directories are treated as unset', () => {
+    expect(buildFolderOptions([{ id: 'g', name: 'X', workingDir: '   ' }])).toEqual([]);
+  });
+
+  test('duplicate directories are kept — group names disambiguate', () => {
+    const options = buildFolderOptions([
+      { id: 'a', name: 'One', workingDir: '/same' },
+      { id: 'b', name: 'Two', workingDir: '/same' },
+    ]);
+    expect(options.length).toBe(2);
+  });
+
+  test('empty group list produces no options', () => {
+    expect(buildFolderOptions([])).toEqual([]);
+  });
+});

--- a/src/renderer/components/__tests__/arenaUpdates.test.ts
+++ b/src/renderer/components/__tests__/arenaUpdates.test.ts
@@ -11,6 +11,7 @@ function makeRun(): ArenaRun {
   return {
     id: 'run1',
     prompt: 'p',
+    workingDir: null,
     createdAt: new Date(0),
     responses: [
       {

--- a/src/renderer/components/arenaFolderOptions.ts
+++ b/src/renderer/components/arenaFolderOptions.ts
@@ -1,0 +1,24 @@
+import { Group } from '../../shared/types';
+
+export interface ArenaFolderOption {
+  groupId: string;
+  /** Group name plus its directory, for the folder select. */
+  label: string;
+  dir: string;
+}
+
+/**
+ * Build the arena folder-scope options from the sidebar groups: one option
+ * per group that has a working directory set, in sidebar order. Groups
+ * without a directory can't scope a run, so they don't appear. Duplicate
+ * directories are kept — the group name is what the user recognizes.
+ *
+ * Pure — extracted from ArenaPanel for direct unit testing.
+ */
+export function buildFolderOptions(
+  groups: Pick<Group, 'id' | 'name' | 'workingDir'>[]
+): ArenaFolderOption[] {
+  return groups
+    .filter((g) => g.workingDir && g.workingDir.trim() !== '')
+    .map((g) => ({ groupId: g.id, label: `${g.name} — ${g.workingDir}`, dir: g.workingDir }));
+}

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -89,7 +89,7 @@ interface ElectronAPI {
   vaultDeleteKey: (providerId: string) => Promise<void>;
   vaultSetUseKey: (providerId: string, use: boolean) => Promise<void>;
   vaultTestKey: (providerId: string) => Promise<{ ok: boolean; status: number | null; error: string | null }>;
-  arenaStart: (prompt: string, contestants: string[]) => Promise<ArenaRun>;
+  arenaStart: (prompt: string, contestants: string[], workingDir?: string | null) => Promise<ArenaRun>;
   arenaLaunch: (runId: string) => Promise<void>;
   arenaCancel: (runId: string) => Promise<void>;
   arenaListRuns: () => Promise<ArenaRun[]>;

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1540,6 +1540,24 @@ body {
   box-sizing: border-box;
 }
 
+.arena-folder-select {
+  max-width: 320px;
+  background: #2a2a2a;
+  color: #ddd;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+  padding: 4px 8px;
+  text-overflow: ellipsis;
+}
+
+.arena-run-scope {
+  color: #999;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .arena-contestants {
   display: flex;
   align-items: center;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -66,6 +66,8 @@ export interface ArenaResponse {
 export interface ArenaRun {
   id: string;
   prompt: string;
+  /** Project folder the contestants ran in (null = no project context). */
+  workingDir: string | null;
   createdAt: Date;
   responses: ArenaResponse[];
 }


### PR DESCRIPTION
## Why

Arena contestants spawned with no `cwd` — the Electron process cwd, effectively `/` when launched from the Dock — so arena could only answer context-free prompts. Since contestants are the real CLIs (`claude -p`, `codex exec`, `grok -p`), simply spawning them inside a project folder gives them that codebase as context, the same way they behave in a terminal.

## What

- **Engine/IPC**: `arena:start` accepts an optional working directory (validated up front — must exist and be a directory, checked before any rows are created). `ArenaEngine.prepare()` threads it onto each contestant and `runCli` passes it as the spawn `cwd`. Ollama (bare HTTP chat, no filesystem) ignores it.
- **Persistence**: `arena_runs.working_dir` column (additive `PRAGMA table_info` migration, matching the existing pattern); `ArenaRun.workingDir` exposed to the renderer and shown (`📁 <dir>`) when viewing a live or history run.
- **UX — reuses groups instead of a folder picker**: the arena panel gets a "folder scope" select built from sidebar groups that already have a working directory (`buildFolderOptions`, pure + unit-tested like `providerPickerOptions`). Each group's context menu gains **"Ask Arena About This Folder"** (disabled until the group has a working dir), which opens/retargets the arena panel pre-scoped to that group.
- **Test-infra fix**: `shell-launch.test.ts` mocked `'fs'` with only `{existsSync}`; bun's `mock.module` is process-global, so every test file running after it saw a gutted `fs` (the standing chat-parser `fs.readFileSync is not a function` failures in combined runs). The mock now spreads the real module (grabbed via `node:fs`, which stays unmocked).

## Testing

- New engine tests: a scoped run's contestant observes the scoped directory as its cwd (real spawn through the shell wrapper, `pwd` fake provider), and unscoped runs behave as before.
- New `buildFolderOptions` unit tests (dir-less groups excluded, whitespace dirs treated as unset, duplicates kept).
- `bun test src/main src/renderer`: 120 pass; the single remaining failure is the pre-existing `06-response` chat-parser snapshot diff, which fails identically on `development`.
- `tsc` for main + full project: clean (the two `mdns-advertiser` errors pre-exist on `development`). Webpack production build reports the same 3 pre-existing errors as `development`, none in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)