### PR TITLE
fix: seed first account's config dir with legacy ~/.claude transcripts

### DIFF
--- a/src/main/__tests__/account-auth.test.ts
+++ b/src/main/__tests__/account-auth.test.ts
@@ -19,7 +19,8 @@ import type { PtyManager } from '../pty-manager';
 let userDataDir = '';
 mock.module('electron', () => ({
   app: { getPath: () => userDataDir },
-  BrowserWindow: class {},
+  // Only referenced in type positions by account-auth; never constructed.
+  BrowserWindow: Object,
 }));
 
 interface AccountRow {
@@ -61,8 +62,8 @@ mock.module('../legacy-claude-seed', () => ({
 }));
 
 // Keep node-pty out of the test process; the flow only calls methods on the
-// instance we pass in.
-mock.module('../pty-manager', () => ({ PtyManager: class {} }));
+// instance we pass in (PtyManager is only referenced in type positions).
+mock.module('../pty-manager', () => ({ PtyManager: Object }));
 
 const accountAuth = await import('../account-auth');
 

--- a/src/main/__tests__/account-auth.test.ts
+++ b/src/main/__tests__/account-auth.test.ts
@@ -1,0 +1,134 @@
+/**
+ * startLoginFlow integration tests: legacy-transcript seeding fires for the
+ * FIRST account only, and the first-account check stays atomic with account
+ * creation (no await between check and insert), so overlapping calls can't
+ * both become the default.
+ *
+ * electron, the accounts repo (better-sqlite3), mcp-config, pty-manager
+ * (node-pty), and the seed helper are all stubbed; the flow's own fs usage
+ * (mkdir, watch) runs against a temp userData dir.
+ *
+ * Run with: bun test src/main/__tests__
+ */
+import { describe, expect, test, mock, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { PtyManager } from '../pty-manager';
+
+let userDataDir = '';
+mock.module('electron', () => ({
+  app: { getPath: () => userDataDir },
+  BrowserWindow: class {},
+}));
+
+interface AccountRow {
+  id: string;
+  label: string;
+  configDir: string;
+  isDefault: boolean;
+}
+const accounts: AccountRow[] = [];
+mock.module('../repositories/accounts', () => ({
+  getAllAccounts: () => [...accounts],
+  createAccount: (a: AccountRow) => {
+    accounts.push(a);
+    return { ...a, email: null, createdAt: new Date() };
+  },
+  updateAccount: () => undefined,
+  deleteAccount: (id: string) => {
+    const i = accounts.findIndex((a) => a.id === id);
+    if (i >= 0) accounts.splice(i, 1);
+  },
+  getAccount: (id: string) => accounts.find((a) => a.id === id) ?? null,
+}));
+
+mock.module('../mcp-config', () => ({
+  registerMcpServer: () => undefined,
+  registerHooks: () => undefined,
+}));
+
+// Seed spy with a controllable delay — a slow copy is exactly what widened
+// the old check-then-act window across an await boundary.
+const seedCalls: string[] = [];
+let seedDelayMs = 0;
+mock.module('../legacy-claude-seed', () => ({
+  seedLegacyConversations: async (configDir: string) => {
+    seedCalls.push(configDir);
+    if (seedDelayMs > 0) await new Promise((r) => setTimeout(r, seedDelayMs));
+    return true;
+  },
+}));
+
+// Keep node-pty out of the test process; the flow only calls methods on the
+// instance we pass in.
+mock.module('../pty-manager', () => ({ PtyManager: class {} }));
+
+const accountAuth = await import('../account-auth');
+
+function fakePtyManager(): PtyManager & { loginSessions: string[] } {
+  const stub = {
+    loginSessions: [] as string[],
+    createLoginSession(id: string) {
+      stub.loginSessions.push(id);
+    },
+    on() {},
+    off() {},
+    kill() {},
+  };
+  return stub as unknown as PtyManager & { loginSessions: string[] };
+}
+
+beforeEach(() => {
+  userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'account-auth-'));
+  accounts.length = 0;
+  seedCalls.length = 0;
+  seedDelayMs = 0;
+});
+
+afterEach(() => {
+  fs.rmSync(userDataDir, { recursive: true, force: true });
+});
+
+describe('startLoginFlow legacy seeding', () => {
+  test('first account: seeded into its config dir and marked default', async () => {
+    const pty = fakePtyManager();
+    const { account, ptyId } = await accountAuth.startLoginFlow(pty, null, 'Work');
+
+    expect(seedCalls).toEqual([account.configDir]);
+    expect(accounts.length).toBe(1);
+    expect(accounts[0].isDefault).toBe(true);
+    expect(pty.loginSessions).toEqual([ptyId]);
+
+    accountAuth.cancelLoginFlow(pty, ptyId, false);
+  });
+
+  test('subsequent accounts: no seeding, not default', async () => {
+    const pty = fakePtyManager();
+    const first = await accountAuth.startLoginFlow(pty, null, 'Work');
+    const second = await accountAuth.startLoginFlow(pty, null, 'Personal');
+
+    expect(seedCalls).toEqual([first.account.configDir]);
+    expect(accounts.map((a) => a.isDefault)).toEqual([true, false]);
+
+    accountAuth.cancelLoginFlow(pty, first.ptyId, false);
+    accountAuth.cancelLoginFlow(pty, second.ptyId, false);
+  });
+
+  test('overlapping calls produce exactly one default and one seed', async () => {
+    const pty = fakePtyManager();
+    seedDelayMs = 50; // hold the first call inside the seed await
+
+    const [a, b] = await Promise.all([
+      accountAuth.startLoginFlow(pty, null, 'One'),
+      accountAuth.startLoginFlow(pty, null, 'Two'),
+    ]);
+
+    expect(accounts.length).toBe(2);
+    expect(accounts.filter((acc) => acc.isDefault).length).toBe(1);
+    expect(seedCalls.length).toBe(1);
+
+    accountAuth.cancelLoginFlow(pty, a.ptyId, false);
+    accountAuth.cancelLoginFlow(pty, b.ptyId, false);
+  });
+});

--- a/src/main/__tests__/legacy-claude-seed.test.ts
+++ b/src/main/__tests__/legacy-claude-seed.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Legacy-conversation seeding tests: the first registered account's config
+ * dir must inherit ~/.claude/projects transcripts so pre-account sessions'
+ * stored --resume UUIDs keep resolving.
+ *
+ * Run with: bun test src/main/__tests__
+ */
+import { describe, expect, test, beforeEach, afterEach, mock } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
+}));
+
+const { seedLegacyConversations } = await import('../legacy-claude-seed');
+
+let tmp: string;
+let legacyDir: string;
+let configDir: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'legacy-seed-'));
+  legacyDir = path.join(tmp, '.claude');
+  configDir = path.join(tmp, 'account', '.claude');
+  fs.mkdirSync(configDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeLegacyTranscript(project: string, uuid: string): string {
+  const dir = path.join(legacyDir, 'projects', project);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${uuid}.jsonl`);
+  fs.writeFileSync(file, '{"type":"conversation"}\n');
+  return file;
+}
+
+describe('seedLegacyConversations', () => {
+  test('copies the legacy projects tree into the account config dir', async () => {
+    writeLegacyTranscript('-Users-x-repo', 'aaaa-1111');
+    writeLegacyTranscript('-Users-x-other', 'bbbb-2222');
+
+    expect(await seedLegacyConversations(configDir, legacyDir)).toBe(true);
+
+    const copied = path.join(configDir, 'projects', '-Users-x-repo', 'aaaa-1111.jsonl');
+    expect(fs.existsSync(copied)).toBe(true);
+    expect(fs.readFileSync(copied, 'utf-8')).toContain('conversation');
+    expect(fs.existsSync(path.join(configDir, 'projects', '-Users-x-other', 'bbbb-2222.jsonl'))).toBe(true);
+  });
+
+  test('copies only projects/ — credentials and settings stay behind', async () => {
+    writeLegacyTranscript('-Users-x-repo', 'aaaa-1111');
+    fs.writeFileSync(path.join(legacyDir, '.credentials.json'), '{"secret":true}');
+    fs.writeFileSync(path.join(legacyDir, 'settings.json'), '{}');
+
+    await seedLegacyConversations(configDir, legacyDir);
+
+    expect(fs.existsSync(path.join(configDir, '.credentials.json'))).toBe(false);
+    expect(fs.existsSync(path.join(configDir, 'settings.json'))).toBe(false);
+  });
+
+  test('no legacy projects dir → no-op', async () => {
+    fs.mkdirSync(legacyDir, { recursive: true }); // .claude exists but has no projects/
+    expect(await seedLegacyConversations(configDir, legacyDir)).toBe(false);
+    expect(fs.existsSync(path.join(configDir, 'projects'))).toBe(false);
+  });
+
+  test('never clobbers an existing projects dir in the target', async () => {
+    writeLegacyTranscript('-Users-x-repo', 'aaaa-1111');
+    const existing = path.join(configDir, 'projects', '-Users-x-mine');
+    fs.mkdirSync(existing, { recursive: true });
+    fs.writeFileSync(path.join(existing, 'cccc-3333.jsonl'), 'mine\n');
+
+    expect(await seedLegacyConversations(configDir, legacyDir)).toBe(false);
+
+    expect(fs.readFileSync(path.join(existing, 'cccc-3333.jsonl'), 'utf-8')).toBe('mine\n');
+    expect(fs.existsSync(path.join(configDir, 'projects', '-Users-x-repo'))).toBe(false);
+  });
+
+  test('copy failure is swallowed and reported as not seeded', async () => {
+    writeLegacyTranscript('-Users-x-repo', 'aaaa-1111');
+    // A file where the target dir should go makes cp fail without throwing here.
+    fs.rmSync(configDir, { recursive: true, force: true });
+    fs.mkdirSync(path.dirname(configDir), { recursive: true });
+    fs.writeFileSync(configDir, 'not a directory');
+
+    expect(await seedLegacyConversations(configDir, legacyDir)).toBe(false);
+  });
+});

--- a/src/main/__tests__/shell-launch.test.ts
+++ b/src/main/__tests__/shell-launch.test.ts
@@ -10,14 +10,19 @@ import * as realFs from 'node:fs';
 import type { ShellInfo } from '../shell-detector';
 
 // The cmd→PowerShell reroute resolves an absolute powershell.exe on disk;
-// stub fs.existsSync so that path is testable on a POSIX runner. The rest
-// of fs is passed through: mock.module is process-global in bun, so a
-// bare {existsSync} would gut fs for every test file that runs after this
-// one (the real module is grabbed via 'node:fs', which stays unmocked).
+// stub fs.existsSync for that one path so it is testable on a POSIX runner.
+// Everything else delegates to the real module: mock.module is process-global
+// in bun (and covers 'node:fs' too), so a blanket stub would poison fs for
+// every test file that runs after this one. The real existsSync is captured
+// into a plain const BEFORE the mock registers — going through the module
+// namespace inside the stub would resolve to the mock itself once bun
+// retargets the binding, recursing forever.
+const realExistsSync = realFs.existsSync;
 let powershellExists = true;
 mock.module('fs', () => ({
   ...realFs,
-  existsSync: () => powershellExists,
+  existsSync: (p: realFs.PathLike) =>
+    String(p).includes('WindowsPowerShell') ? powershellExists : realExistsSync(p),
 }));
 
 const { getShellLaunch } = await import('../shell-launch');

--- a/src/main/account-auth.ts
+++ b/src/main/account-auth.ts
@@ -23,6 +23,7 @@ import log from 'electron-log';
 import { PtyManager } from './pty-manager';
 import * as accountsRepo from './repositories/accounts';
 import { registerMcpServer, registerHooks } from './mcp-config';
+import { seedLegacyConversations } from './legacy-claude-seed';
 import { ClaudeAccount } from '../shared/types';
 
 interface LoginFlow {
@@ -53,17 +54,24 @@ function configDirFor(accountId: string): string {
  * Begin an interactive login flow for a new account.
  * Returns the new account row + the login pty id the renderer should attach to.
  */
-export function startLoginFlow(
+export async function startLoginFlow(
   ptyManager: PtyManager,
   mainWindow: BrowserWindow | null,
   label: string,
-): StartLoginResult {
+): Promise<StartLoginResult> {
   const accountId = crypto.randomUUID();
   const configDir = configDirFor(accountId);
   fs.mkdirSync(configDir, { recursive: true });
 
-  // First account becomes the default fallback.
+  // First account becomes the default fallback — which re-homes every
+  // unassigned session's CLAUDE_CONFIG_DIR here on its next launch. Seed the
+  // dir with the legacy ~/.claude transcripts first, so those sessions'
+  // stored --resume UUIDs keep resolving instead of coming back "No
+  // conversation found" (the pre-accounts history lives in ~/.claude).
   const isFirst = accountsRepo.getAllAccounts().length === 0;
+  if (isFirst) {
+    await seedLegacyConversations(configDir);
+  }
   const account = accountsRepo.createAccount({
     id: accountId,
     label,

--- a/src/main/account-auth.ts
+++ b/src/main/account-auth.ts
@@ -63,21 +63,29 @@ export async function startLoginFlow(
   const configDir = configDirFor(accountId);
   fs.mkdirSync(configDir, { recursive: true });
 
-  // First account becomes the default fallback — which re-homes every
-  // unassigned session's CLAUDE_CONFIG_DIR here on its next launch. Seed the
-  // dir with the legacy ~/.claude transcripts first, so those sessions'
-  // stored --resume UUIDs keep resolving instead of coming back "No
-  // conversation found" (the pre-accounts history lives in ~/.claude).
+  // First account becomes the default fallback. The check and the insert
+  // stay synchronous — no await between them — so two overlapping
+  // startLoginFlow calls can't both observe "no accounts yet" and both
+  // become the default.
   const isFirst = accountsRepo.getAllAccounts().length === 0;
-  if (isFirst) {
-    await seedLegacyConversations(configDir);
-  }
   const account = accountsRepo.createAccount({
     id: accountId,
     label,
     configDir,
     isDefault: isFirst,
   });
+
+  // Becoming the default re-homes every unassigned session's
+  // CLAUDE_CONFIG_DIR here on its next launch. Seed the dir with the legacy
+  // ~/.claude transcripts so those sessions' stored --resume UUIDs keep
+  // resolving instead of coming back "No conversation found" (pre-accounts
+  // history lives in ~/.claude). Awaited before the login pty spawns: the
+  // account only becomes reachable for session launches once the user logs
+  // in, so finishing the copy first avoids resumes against a half-seeded
+  // dir. Subsequent accounts are separate identities and inherit nothing.
+  if (isFirst) {
+    await seedLegacyConversations(configDir);
+  }
 
   // Register the Bodhilander MCP server + hooks into the new account's
   // isolated config before spawning the login pty, so the session has them

--- a/src/main/legacy-claude-seed.ts
+++ b/src/main/legacy-claude-seed.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import log from 'electron-log';
+
+/**
+ * Seed a brand-new account config dir with the legacy ~/.claude conversation
+ * transcripts.
+ *
+ * Before any account exists, sessions resume against legacy ~/.claude. The
+ * first registered account becomes the default and re-homes every unassigned
+ * session to its config dir — which starts empty, so every stored --resume
+ * UUID stops resolving ("No conversation found with session ID: x") and all
+ * pre-account conversation history is orphaned. Copying projects/ (the
+ * per-cwd transcript store Claude Code reads on --resume) into the first
+ * account's dir preserves that continuity.
+ *
+ * Deliberately NOT copied: credentials (the login flow authenticates the
+ * account fresh) and settings.json (MCP/hook registration writes its own).
+ *
+ * Failures are logged and swallowed — a missed seed degrades to the old
+ * behavior (fresh conversations), never blocks account creation.
+ *
+ * (Lives outside account-auth so it stays importable without node-pty.)
+ *
+ * @returns true when transcripts were copied.
+ */
+export async function seedLegacyConversations(
+  configDir: string,
+  legacyDir: string = path.join(os.homedir(), '.claude'),
+): Promise<boolean> {
+  const source = path.join(legacyDir, 'projects');
+  const target = path.join(configDir, 'projects');
+  try {
+    if (!fs.existsSync(source)) return false;
+    // A populated target means this dir already has history — never clobber.
+    if (fs.existsSync(target)) return false;
+    await fs.promises.cp(source, target, { recursive: true });
+    log.info(`[Accounts] Seeded legacy conversation transcripts: ${source} → ${target}`);
+    return true;
+  } catch (err) {
+    log.warn(
+      '[Accounts] Failed to seed legacy conversations — resume of pre-account sessions may fail:',
+      err,
+    );
+    return false;
+  }
+}


### PR DESCRIPTION
## Why

Registering your **first** Claude account silently breaks every existing session's conversation history. Root-caused from a field incident on 3.4.0-beta.10:

1. Before any account exists, sessions launch against legacy `~/.claude` (where all conversation transcripts live).
2. The first registered account becomes the default, and `resolveAccountForSession`'s fallback chain (`session → group → default`) re-homes every unassigned session's `CLAUDE_CONFIG_DIR` to the new account's dir on next launch.
3. That dir starts **empty**, so every stored `--resume` UUID fails with "No conversation found with session ID: x" — for all sessions at once.

The account-resolution code is long-standing and correct; the landmine is the fresh config dir starting with no history.

## What

- New `seedLegacyConversations(configDir, legacyDir)` (`src/main/legacy-claude-seed.ts`, kept outside `account-auth` so it's importable without node-pty): copies `~/.claude/projects/` — the per-cwd transcript store Claude Code reads on `--resume` — into a first account's config dir. Deliberately not copied: credentials (login authenticates fresh) and `settings.json` (MCP/hook registration writes its own). Never clobbers an existing `projects/` dir; failures log a warning and degrade to the old behavior rather than blocking account creation.
- `startLoginFlow` awaits the seed for the first account only (subsequent accounts are separate identities and shouldn't inherit another account's history). The IPC handler already awaits, so the async signature change is transparent.
- Test-infra fix found while validating: the shell-launch fs stub's delegating `existsSync` must call a **pre-captured** real function. Referencing `realFs.existsSync` inside the stub resolves through the module namespace, which bun retargets to the mock itself — infinite recursion that hung the entire combined suite at 98% CPU.

## Testing

- 5 new unit tests: transcript tree copied; credentials/settings excluded; no-op without a legacy dir; existing target never clobbered; copy failure swallowed and reported.
- Full suite: 123 pass / 1 fail — the failure is the pre-existing `06-response` chat-parser snapshot diff that fails identically on `development`.
- `tsc` main: clean (mdns-advertiser pre-existing errors excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)