### PR TITLE
ci: ignore private org-standards repo in Dependabot actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,10 @@ updates:
       actions:
         patterns:
           - '*'
+    ignore:
+      # Private org repo hosting the reusable workflows (jira-key-prefix,
+      # pr-title). Dependabot has no access to it — without this ignore the
+      # whole github-actions job fails with git_dependencies_not_reachable.
+      # Versioning of those workflows is managed upstream in org-standards.
+      - dependency-name: Software-Development-LLC/org-standards
+


### PR DESCRIPTION
The first Dependabot run after #114 landed ([run 29432672408](https://github.com/Software-Development-LLC/Bodhilander/actions/runs/29432672408)) failed with two `git_dependencies_not_reachable` errors: `jira-key-prefix.yml` and `pr-title.yml` call reusable workflows in the **private** `Software-Development-LLC/org-standards` repo, which Dependabot can't reach.

Adding an `ignore` for that dependency lets the weekly github-actions job proceed for everything it *can* update (the SHA-pinned actions in `release.yml`/`sonarqube.yml`). Versioning of the org-standards reusable workflows is managed upstream in that repo.

Alternative considered: granting Dependabot access to private repos in org settings (Settings → Code security → "Allow Dependabot access to private repositories") — that's an org-admin UI toggle and would also work; the ignore is the narrower fix and doesn't require broadening Dependabot's private-repo access. Happy to switch approaches if you prefer the org-settings route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)