### PR TITLE
fix(arena): unblock codex, settle claude/grok headless CLI quirks

### DIFF
--- a/src/main/arena/__tests__/engine.test.ts
+++ b/src/main/arena/__tests__/engine.test.ts
@@ -72,6 +72,15 @@ const FAKE_PROVIDERS: Record<string, any> = {
       createParser: textParser,
     },
   },
+  stdinReader: {
+    id: 'stdinReader',
+    arena: {
+      // `cat` reads stdin to EOF — exactly what codex exec does headlessly.
+      // If the engine leaves the stdin pipe open this never exits.
+      buildCommand: () => 'cat; echo after-stdin-eof',
+      createParser: textParser,
+    },
+  },
 };
 mock.module('../../providers', () => ({
   getProvider: (id: string) => {
@@ -249,6 +258,18 @@ describe('ArenaEngine', () => {
     const updates = await settled;
     expect(updates[updates.length - 1].status).toBe('done');
   }, 25_000);
+
+  test('stdin is closed at spawn so stdin-to-EOF CLIs cannot hang (codex exec)', async () => {
+    finalized.length = 0;
+    const engine = new ArenaEngine();
+    const settled = collectUntilSettled(engine, 1, 10_000);
+    const run = engine.prepare('p', ['stdinReader']);
+    engine.launch(run.id);
+    const updates = await settled;
+    const final = updates[updates.length - 1];
+    expect(final.status).toBe('done');
+    expect(updates.map((u) => u.chunk).join('')).toContain('after-stdin-eof');
+  }, 15_000);
 
   test('unknown contestant fails fast without spawning', async () => {
     finalized.length = 0;

--- a/src/main/arena/engine.ts
+++ b/src/main/arena/engine.ts
@@ -183,6 +183,11 @@ export class ArenaEngine extends EventEmitter {
       // Own process group on POSIX so killTree can signal the whole tree.
       detached: process.platform !== 'win32',
     });
+    // The prompt travels via ARENA_PROMPT, never stdin — close it so CLIs
+    // that read stdin to EOF when it isn't a TTY don't block forever waiting
+    // for input that will never come (codex exec hangs; claude warns). Same
+    // fix as the provider detector's probe (#111).
+    child.stdin?.end();
     entry.startedAt = Date.now();
 
     const timeout = setTimeout(() => {

--- a/src/main/arena/parsers.ts
+++ b/src/main/arena/parsers.ts
@@ -4,8 +4,8 @@
  * electron dependencies — so every parser is directly unit-testable.
  *
  * Verified output contracts:
- * - claude: `-p --output-format stream-json --verbose --max-turns 1` emits
- *   JSONL; `assistant` events carry text content, the final `result` event
+ * - claude: `-p --output-format stream-json --verbose` emits JSONL;
+ *   `assistant` events carry text content, the final `result` event
  *   carries usage, total_cost_usd, ttft_ms and duration_ms (verified live).
  * - codex: `exec --json` emits JSONL; agent_message items carry text,
  *   `turn.completed` carries token usage (per OpenAI headless docs).

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -394,6 +394,17 @@ function createWindow(): void {
   // Mark all sessions as stopped on startup (PTY processes don't survive restarts)
   sessionsRepo.markAllSessionsStopped();
 
+  // Settle arena responses orphaned mid-run by a quit/restart, so history
+  // never shows a column stuck on "running" (#100).
+  try {
+    const settled = arenaRepo.settleInterruptedResponses();
+    if (settled > 0) {
+      log.info(`[Arena] Settled ${settled} response(s) interrupted by a previous app run`);
+    }
+  } catch (error) {
+    log.error('[Arena] Failed to settle interrupted responses:', error);
+  }
+
   // Prune session events older than 90 days (BDHLNDR-17)
   try {
     const pruned = sessionEventsRepo.pruneEvents(new Date(Date.now() - 90 * 24 * 60 * 60 * 1000));

--- a/src/main/providers/claude.ts
+++ b/src/main/providers/claude.ts
@@ -43,11 +43,14 @@ export const claudeProvider: ProviderDefinition = {
     },
   },
   arena: {
-    // --max-turns 1 keeps the arena chat-shaped (no agentic tool loops);
+    // No --max-turns cap: folder-scoped arena questions need the agentic
+    // loop (reading files), and hitting the cap makes the CLI exit 1 with
+    // result subtype error_max_turns even after streaming a full answer.
+    // Runaway runs are already bounded by the engine's contestant timeout.
     // stream-json requires --verbose. Verified live: the result event
     // reports usage, total_cost_usd, ttft_ms.
     buildCommand: (promptRef) =>
-      `claude -p ${promptRef} --output-format stream-json --verbose --max-turns 1`,
+      `claude -p ${promptRef} --output-format stream-json --verbose`,
     createParser: claudeArenaParser,
   },
   setup: {

--- a/src/main/providers/grok.ts
+++ b/src/main/providers/grok.ts
@@ -19,7 +19,12 @@ export const grokProvider = passthroughProvider({
   },
   arena: {
     // Plain-text headless output; no documented JSON/usage reporting yet.
-    buildCommand: (promptRef) => `grok -p ${promptRef}`,
+    // `-p` is hard single-turn: it prints the model's first message and
+    // exits 0, so with default plan mode on, a codebase question ends after
+    // an "I'll explore..." preamble with the tools never run. --no-plan +
+    // auto permissions let the model finish its exploration and answer
+    // within that single turn (verified live; --max-turns does not help).
+    buildCommand: (promptRef) => `grok --no-plan --permission-mode auto -p ${promptRef}`,
     createParser: textParser,
   },
   setup: {

--- a/src/main/repositories/__tests__/arena.test.ts
+++ b/src/main/repositories/__tests__/arena.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Arena repository tests — the startup sweep that settles responses a
+ * quit/restart orphaned mid-run, and that finalized rows are left alone.
+ *
+ * Uses bun:sqlite (API-compatible with better-sqlite3 for the statements the
+ * repo issues) so no native build is required to run the suite.
+ *
+ * Run with: bun test src/main/repositories
+ */
+import { describe, expect, test, beforeEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+
+let db: Database;
+
+mock.module('../../database', () => ({
+  getDatabase: () => db,
+}));
+
+const arenaRepo = await import('../arena');
+
+function freshDb(): Database {
+  const d = new Database(':memory:');
+  d.exec(`
+    CREATE TABLE arena_runs (
+      id TEXT PRIMARY KEY,
+      prompt TEXT NOT NULL,
+      working_dir TEXT DEFAULT NULL,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE arena_responses (
+      id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES arena_runs(id) ON DELETE CASCADE,
+      provider TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'running',
+      response_text TEXT NOT NULL DEFAULT '',
+      ttft_ms INTEGER DEFAULT NULL,
+      total_ms INTEGER DEFAULT NULL,
+      input_tokens INTEGER DEFAULT NULL,
+      output_tokens INTEGER DEFAULT NULL,
+      cost_usd REAL DEFAULT NULL,
+      error TEXT DEFAULT NULL
+    );
+  `);
+  return d;
+}
+
+beforeEach(() => {
+  db = freshDb();
+});
+
+describe('settleInterruptedResponses', () => {
+  test('settles running rows as errored and reports the count', () => {
+    arenaRepo.createRun('r1', 'prompt');
+    arenaRepo.createResponse('a', 'r1', 'claude');
+    arenaRepo.createResponse('b', 'r1', 'codex');
+
+    expect(arenaRepo.settleInterruptedResponses()).toBe(2);
+
+    const run = arenaRepo.getRun('r1')!;
+    for (const response of run.responses) {
+      expect(response.status).toBe('error');
+      expect(response.error).toBe('Interrupted by app restart');
+    }
+  });
+
+  test('leaves finalized rows untouched', () => {
+    arenaRepo.createRun('r1', 'prompt');
+    arenaRepo.createResponse('a', 'r1', 'claude');
+    arenaRepo.createResponse('b', 'r1', 'codex');
+    arenaRepo.finalizeResponse('a', {
+      status: 'done',
+      text: 'answer',
+      ttftMs: 10,
+      totalMs: 20,
+      inputTokens: 1,
+      outputTokens: 2,
+      costUsd: 0.01,
+      error: null,
+    });
+
+    expect(arenaRepo.settleInterruptedResponses()).toBe(1);
+
+    const run = arenaRepo.getRun('r1')!;
+    const done = run.responses.find((r) => r.id === 'a')!;
+    expect(done.status).toBe('done');
+    expect(done.text).toBe('answer');
+    expect(done.error).toBeNull();
+    expect(run.responses.find((r) => r.id === 'b')!.status).toBe('error');
+  });
+
+  test('no-op on an empty table', () => {
+    expect(arenaRepo.settleInterruptedResponses()).toBe(0);
+  });
+});

--- a/src/main/repositories/arena.ts
+++ b/src/main/repositories/arena.ts
@@ -80,6 +80,19 @@ export function finalizeResponse(id: string, final: FinalizeResponseInput): void
     );
 }
 
+/**
+ * Settle responses left 'running' by a previous app run. Contestant
+ * processes don't survive restarts (and finalize never fired for them), so
+ * without this sweep a quit mid-run leaves permanently spinning columns in
+ * history. Mirrors sessions' markAllSessionsStopped() on startup.
+ */
+export function settleInterruptedResponses(): number {
+  const result = getDatabase()
+    .prepare("UPDATE arena_responses SET status = 'error', error = 'Interrupted by app restart' WHERE status = 'running'")
+    .run();
+  return result.changes;
+}
+
 interface RunRow {
   id: string;
   prompt: string;


### PR DESCRIPTION
## Problem

A real folder-scoped arena run ("suggest 3 improvements for this codebase") failed three different ways, one per contestant:

- **claude** streamed a 9.5k-char answer, then the column flagged an **error**
- **codex** never produced a single byte (and it turns out it never has in arena)
- **grok** printed one "I'll look into it…" sentence and exited "successfully"

Each cause was reproduced live outside the app before fixing.

## Root causes & fixes

**1. Engine left the contestant's stdin pipe open** → `codex exec` reads stdin to EOF when it isn't a TTY ("Reading additional input from stdin…") and blocked forever before doing anything; claude emitted a "no stdin data received in 3s" stderr warning that then surfaced as the column's error text. Fix: `child.stdin?.end()` at spawn — the prompt travels via `ARENA_PROMPT`, never stdin. Same fix as the provider-detector probe (#111). Verified: codex answers in ~4s with stdin closed, hangs indefinitely without.

**2. claude arena command used `--max-turns 1`** → any scoped question needs tool calls, so the CLI exits 1 with result `subtype: error_max_turns` even after streaming a complete answer. Fix: drop the cap (the engine's 5-minute contestant timeout still bounds runaways). Verified: same prompt exits 0 / `subtype: success`, and the `result` event still carries the usage/cost/TTFT metrics the parser reads.

**3. grok `-p` is hard single-turn** — it prints the model's *first* message and exits 0. With default plan mode, a codebase question ends after the preamble with tools never run. Fix: `grok --no-plan --permission-mode auto -p …`. Verified live with the exact failing prompt: full multi-section answer. (`--max-turns 15` and a `--rules` append were tried first; neither helps.)

**4. Hardening: startup sweep for orphaned rows.** The failing run's codex row is stuck `running` in the DB forever because the app was restarted before the contestant timeout fired — finalize never runs for processes that don't survive a restart. New `settleInterruptedResponses()` marks leftover `running` rows as errored ("Interrupted by app restart") on startup, mirroring `markAllSessionsStopped()`.

## Tests

- New engine test: a `cat`-based fake contestant (reads stdin to EOF, exactly like codex) must complete instead of hanging.
- New `repositories/__tests__/arena.test.ts`: sweep settles running rows, leaves finalized rows untouched, no-ops when empty.
- Full suite: 130 pass / 1 pre-existing failure (chat-parser `06-response` snapshot, fails identically on `development`). `tsc` clean apart from the two known pre-existing `mdns-advertiser` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)