### PR TITLE
feat(arena): resumable runs with follow-up rounds

### DIFF
--- a/src/main/arena/__tests__/engine-ollama.test.ts
+++ b/src/main/arena/__tests__/engine-ollama.test.ts
@@ -85,6 +85,21 @@ function ndjsonStream(lines: object[]): ReadableStream<Uint8Array> {
   });
 }
 
+/** Resolve when the engine's next settle (non-running update) arrives. */
+function settleOnce(engine: InstanceType<typeof ArenaEngine>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error('never settled')), 10_000);
+    const listener = (u: ArenaUpdate) => {
+      if (u.status !== 'running') {
+        clearTimeout(t);
+        engine.off('update', listener);
+        resolve();
+      }
+    };
+    engine.on('update', listener);
+  });
+}
+
 function runOllamaAndSettle(engine: InstanceType<typeof ArenaEngine>): Promise<ArenaUpdate[]> {
   const updates: ArenaUpdate[] = [];
   return new Promise((resolve, reject) => {
@@ -176,25 +191,13 @@ describe('ArenaEngine — Ollama contestant', () => {
     }) as typeof fetch;
 
     const engine = new ArenaEngine();
-    const settle = () =>
-      new Promise<void>((resolve, reject) => {
-        const t = setTimeout(() => reject(new Error('never settled')), 10_000);
-        const listener = (u: ArenaUpdate) => {
-          if (u.status !== 'running') {
-            clearTimeout(t);
-            engine.off('update', listener);
-            resolve();
-          }
-        };
-        engine.on('update', listener);
-      });
 
-    let settled = settle();
+    let settled = settleOnce(engine);
     const run = engine.prepare('ollama-prompt', ['ollama']);
     engine.launch(run.id);
     await settled;
 
-    settled = settle();
+    settled = settleOnce(engine);
     engine.prepareFollowUp(run.id, 'and again?');
     engine.launch(run.id);
     await settled;

--- a/src/main/arena/__tests__/engine-ollama.test.ts
+++ b/src/main/arena/__tests__/engine-ollama.test.ts
@@ -16,12 +16,36 @@ mock.module('../../repositories/preferences', () => ({
   getPreference: () => '',
 }));
 
+// In-memory stand-in mirroring the repo's semantics so prepareFollowUp's
+// history replay can be exercised (it reads prior rounds via getRun).
 const finalized: any[] = [];
+const store = { runs: new Map<string, any>(), responses: [] as any[] };
 mock.module('../../repositories/arena', () => ({
-  createRun: () => undefined,
-  createResponse: () => undefined,
-  finalizeResponse: (id: string, final: any) => finalized.push({ id, ...final }),
-  getRun: (id: string) => ({ id, prompt: 'p', createdAt: new Date(0), responses: [] }),
+  createRun: (id: string, prompt: string, workingDir: string | null = null) => {
+    store.runs.set(id, { id, prompt, workingDir, createdAt: new Date(0) });
+  },
+  createResponse: (id: string, runId: string, provider: string, round = 0, prompt: string | null = null) => {
+    store.responses.push({
+      id, runId, provider, round, prompt,
+      sessionRef: null, status: 'running', text: '',
+      ttftMs: null, totalMs: null, inputTokens: null, outputTokens: null, costUsd: null, error: null,
+    });
+  },
+  finalizeResponse: (id: string, final: any) => {
+    finalized.push({ id, ...final });
+    const row = store.responses.find((r) => r.id === id);
+    if (row) {
+      Object.assign(row, { status: final.status, text: final.text, sessionRef: final.sessionRef, error: final.error });
+    }
+  },
+  getRun: (id: string) => {
+    const run = store.runs.get(id);
+    if (!run) return null;
+    const responses = store.responses
+      .filter((r) => r.runId === id)
+      .sort((a, b) => a.round - b.round);
+    return { ...run, responses };
+  },
   listRuns: () => [],
 }));
 mock.module('../../providers', () => ({
@@ -137,6 +161,52 @@ describe('ArenaEngine — Ollama contestant', () => {
     expect(final.status).toBe('error');
     expect(final.error).toContain('not reachable');
   });
+
+  test('follow-up replays prior rounds as explicit chat history', async () => {
+    const chatBodies: any[] = [];
+    globalThis.fetch = (async (url: any, init?: RequestInit) => {
+      if (String(url).endsWith('/api/tags')) {
+        return new Response(JSON.stringify({ models: [{ name: 'llama3' }] }), { status: 200 });
+      }
+      chatBodies.push(JSON.parse(String(init?.body)));
+      return new Response(
+        ndjsonStream([{ message: { content: chatBodies.length === 1 ? 'hello' : 'again' }, done: true }]),
+        { status: 200 }
+      );
+    }) as typeof fetch;
+
+    const engine = new ArenaEngine();
+    const settle = () =>
+      new Promise<void>((resolve, reject) => {
+        const t = setTimeout(() => reject(new Error('never settled')), 10_000);
+        const listener = (u: ArenaUpdate) => {
+          if (u.status !== 'running') {
+            clearTimeout(t);
+            engine.off('update', listener);
+            resolve();
+          }
+        };
+        engine.on('update', listener);
+      });
+
+    let settled = settle();
+    const run = engine.prepare('ollama-prompt', ['ollama']);
+    engine.launch(run.id);
+    await settled;
+
+    settled = settle();
+    engine.prepareFollowUp(run.id, 'and again?');
+    engine.launch(run.id);
+    await settled;
+
+    // Ollama has no server-side session: the second call must carry the
+    // whole conversation, ending with the follow-up prompt.
+    expect(chatBodies[1].messages).toEqual([
+      { role: 'user', content: 'ollama-prompt' },
+      { role: 'assistant', content: 'hello' },
+      { role: 'user', content: 'and again?' },
+    ]);
+  }, 15_000);
 
   test('aborts a hung stream at the contestant timeout', async () => {
     globalThis.fetch = (async (url: any, init?: RequestInit) => {

--- a/src/main/arena/__tests__/engine.test.ts
+++ b/src/main/arena/__tests__/engine.test.ts
@@ -18,12 +18,44 @@ mock.module('../../repositories/preferences', () => ({
   getPreference: () => '',
 }));
 
+// In-memory stand-in mirroring the repo's semantics (round ordering,
+// session_ref persistence) so prepareFollowUp can be exercised for real.
 const finalized: any[] = [];
+const store = {
+  runs: new Map<string, any>(),
+  responses: [] as any[],
+};
 mock.module('../../repositories/arena', () => ({
-  createRun: () => undefined,
-  createResponse: () => undefined,
-  finalizeResponse: (id: string, final: any) => finalized.push({ id, ...final }),
-  getRun: (id: string) => ({ id, prompt: 'p', createdAt: new Date(0), responses: [] }),
+  createRun: (id: string, prompt: string, workingDir: string | null = null) => {
+    store.runs.set(id, { id, prompt, workingDir, createdAt: new Date(0) });
+  },
+  createResponse: (id: string, runId: string, provider: string, round = 0, prompt: string | null = null) => {
+    store.responses.push({
+      id, runId, provider, round, prompt,
+      sessionRef: null, status: 'running', text: '',
+      ttftMs: null, totalMs: null, inputTokens: null, outputTokens: null, costUsd: null, error: null,
+    });
+  },
+  finalizeResponse: (id: string, final: any) => {
+    finalized.push({ id, ...final });
+    const row = store.responses.find((r) => r.id === id);
+    if (row) {
+      Object.assign(row, {
+        status: final.status,
+        text: final.text,
+        sessionRef: final.sessionRef,
+        error: final.error,
+      });
+    }
+  },
+  getRun: (id: string) => {
+    const run = store.runs.get(id);
+    if (!run) return null;
+    const responses = store.responses
+      .filter((r) => r.runId === id)
+      .sort((a, b) => a.round - b.round || a.provider.localeCompare(b.provider));
+    return { ...run, responses };
+  },
   listRuns: () => [],
 }));
 
@@ -78,6 +110,14 @@ const FAKE_PROVIDERS: Record<string, any> = {
       // `cat` reads stdin to EOF — exactly what codex exec does headlessly.
       // If the engine leaves the stdin pipe open this never exits.
       buildCommand: () => 'cat; echo after-stdin-eof',
+      createParser: textParser,
+    },
+  },
+  resumer: {
+    id: 'resumer',
+    arena: {
+      buildCommand: (ref: string, sid: string) => `echo start:${sid}; echo ${ref}`,
+      buildResumeCommand: (ref: string, sid: string) => `echo resumed:${sid}; echo ${ref}`,
       createParser: textParser,
     },
   },
@@ -270,6 +310,57 @@ describe('ArenaEngine', () => {
     expect(final.status).toBe('done');
     expect(updates.map((u) => u.chunk).join('')).toContain('after-stdin-eof');
   }, 15_000);
+
+  test('follow-up round resumes the persisted session ref and records the new prompt', async () => {
+    finalized.length = 0;
+    const engine = new ArenaEngine();
+
+    const settled1 = collectUntilSettled(engine, 1);
+    const run = engine.prepare('first question', ['resumer']);
+    engine.launch(run.id);
+    await settled1;
+    const sessionRef = finalized[0].sessionRef;
+    expect(sessionRef).toBeTruthy();
+
+    // Registered after round 0 settled, so it only observes round 1.
+    const settled2 = collectUntilSettled(engine, 1);
+    const updated = engine.prepareFollowUp(run.id, 'follow-up question');
+    expect(updated.responses.length).toBe(2);
+    expect(updated.responses[1].round).toBe(1);
+    expect(updated.responses[1].prompt).toBe('follow-up question');
+
+    engine.launch(run.id);
+    await settled2;
+
+    expect(finalized.length).toBe(2);
+    expect(finalized[1].status).toBe('done');
+    // The resume command line ran, against the round-0 session ref, and the
+    // follow-up prompt travelled through the environment.
+    expect(finalized[1].text).toContain(`resumed:${sessionRef}`);
+    expect(finalized[1].text).toContain('follow-up question');
+    // Session ref carries forward so a third round can resume again.
+    expect(finalized[1].sessionRef).toBe(sessionRef);
+  }, 25_000);
+
+  test('follow-up refuses a run whose only contestant errored', async () => {
+    finalized.length = 0;
+    const engine = new ArenaEngine();
+    const settled = collectUntilSettled(engine, 1);
+    const run = engine.prepare('p', ['failer']);
+    engine.launch(run.id);
+    await settled;
+    expect(() => engine.prepareFollowUp(run.id, 'follow')).toThrow(/resumed/);
+  }, 25_000);
+
+  test('follow-up skips providers without a resume command', async () => {
+    finalized.length = 0;
+    const engine = new ArenaEngine();
+    const settled = collectUntilSettled(engine, 1);
+    const run = engine.prepare('p', ['echoer']); // echoer has no buildResumeCommand
+    engine.launch(run.id);
+    await settled;
+    expect(() => engine.prepareFollowUp(run.id, 'follow')).toThrow(/resumed/);
+  }, 25_000);
 
   test('unknown contestant fails fast without spawning', async () => {
     finalized.length = 0;

--- a/src/main/arena/__tests__/parsers.test.ts
+++ b/src/main/arena/__tests__/parsers.test.ts
@@ -25,6 +25,7 @@ describe('claudeParser', () => {
         duration_ms: 5973,
         ttft_ms: 5423,
         result: 'pong',
+        session_id: '7f3e9a10-1111-4222-8333-944445555666',
         total_cost_usd: 0.194027,
         usage: { input_tokens: 2, output_tokens: 21 },
       }))
@@ -35,6 +36,7 @@ describe('claudeParser', () => {
       costUsd: 0.194027,
       reportedTtftMs: 5423,
       trailingText: '',
+      sessionRef: '7f3e9a10-1111-4222-8333-944445555666',
     });
   });
 
@@ -49,6 +51,9 @@ describe('claudeParser', () => {
 describe('codexParser', () => {
   test('extracts agent messages and turn usage from exec --json', () => {
     const p = codexParser();
+    // Codex mints its own thread id — the parser must surface it so
+    // follow-up rounds can `codex exec resume` it.
+    expect(p.onLine(JSON.stringify({ type: 'thread.started', thread_id: '019f6af3-ba0e-76d0-88c4-01952d138a85' }))).toBe('');
     expect(p.onLine(JSON.stringify({ type: 'turn.started' }))).toBe('');
     expect(
       p.onLine(JSON.stringify({
@@ -65,6 +70,7 @@ describe('codexParser', () => {
     const final = p.finalize();
     expect(final.inputTokens).toBe(120);
     expect(final.outputTokens).toBe(45);
+    expect(final.sessionRef).toBe('019f6af3-ba0e-76d0-88c4-01952d138a85');
   });
 
   test('accepts item.type as an alternative to item_type', () => {

--- a/src/main/arena/engine.ts
+++ b/src/main/arena/engine.ts
@@ -31,7 +31,7 @@ import * as arenaRepo from '../repositories/arena';
 import { vaultEnvFor } from '../key-vault';
 import { redactEnv } from '../redact-env';
 import { ArenaStreamParser, ollamaParser } from './parsers';
-import { ArenaRun, ArenaUpdate, ArenaResponseStatus } from '../../shared/types';
+import { ArenaResponse, ArenaRun, ArenaUpdate, ArenaResponseStatus } from '../../shared/types';
 
 export const OLLAMA_CONTESTANT_ID = 'ollama';
 const OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
@@ -114,6 +114,44 @@ interface LiveResponse {
  */
 const SESSION_REF_SAFE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
+/**
+ * Continuation seed for one provider's next round, or null when the column
+ * can't continue (latest round didn't finish cleanly, nothing to resume, or
+ * the CLI has no headless resume). `rounds` is that provider's responses in
+ * round order.
+ */
+function followUpSeed(
+  provider: string,
+  rounds: ArenaResponse[],
+  runPrompt: string,
+  prompt: string,
+): Pick<LiveResponse, 'sessionRef' | 'ollamaMessages'> | null {
+  const latest = rounds[rounds.length - 1];
+  if (latest.status !== 'done') return null;
+
+  if (provider === OLLAMA_CONTESTANT_ID) {
+    if (!latest.text) return null;
+    // Ollama has no server-side session — replay every prior round as
+    // explicit chat history.
+    const messages: OllamaMessage[] = rounds.flatMap((r) => [
+      { role: 'user' as const, content: r.prompt ?? runPrompt },
+      { role: 'assistant' as const, content: r.text },
+    ]);
+    messages.push({ role: 'user', content: prompt });
+    return { sessionRef: null, ollamaMessages: messages };
+  }
+
+  if (!latest.sessionRef || !SESSION_REF_SAFE.test(latest.sessionRef)) return null;
+  let providerDef: ReturnType<typeof getProvider>;
+  try {
+    providerDef = getProvider(provider);
+  } catch {
+    return null; // provider removed from the registry since the run
+  }
+  if (!providerDef.arena.buildResumeCommand) return null;
+  return { sessionRef: latest.sessionRef, ollamaMessages: null };
+}
+
 export class ArenaEngine extends EventEmitter {
   private readonly live: Map<string, LiveResponse> = new Map();
   private readonly timeoutMs: number;
@@ -178,30 +216,8 @@ export class ArenaEngine extends EventEmitter {
 
     for (const provider of new Set(run.responses.map((r) => r.provider))) {
       const rounds = run.responses.filter((r) => r.provider === provider);
-      const latest = rounds[rounds.length - 1]; // responses are round-ordered
-      if (latest.status !== 'done') continue;
-
-      let entrySeed: Pick<LiveResponse, 'sessionRef' | 'ollamaMessages'>;
-      if (provider === OLLAMA_CONTESTANT_ID) {
-        if (!latest.text) continue;
-        // Replay every prior round as explicit chat history.
-        const messages: OllamaMessage[] = rounds.flatMap((r) => [
-          { role: 'user' as const, content: r.prompt ?? run.prompt },
-          { role: 'assistant' as const, content: r.text },
-        ]);
-        messages.push({ role: 'user', content: prompt });
-        entrySeed = { sessionRef: null, ollamaMessages: messages };
-      } else {
-        if (!latest.sessionRef || !SESSION_REF_SAFE.test(latest.sessionRef)) continue;
-        let providerDef: ReturnType<typeof getProvider>;
-        try {
-          providerDef = getProvider(provider);
-        } catch {
-          continue; // provider removed from the registry since the run
-        }
-        if (!providerDef.arena.buildResumeCommand) continue;
-        entrySeed = { sessionRef: latest.sessionRef, ollamaMessages: null };
-      }
+      const entrySeed = followUpSeed(provider, rounds, run.prompt, prompt);
+      if (!entrySeed) continue;
 
       const responseId = randomUUID();
       arenaRepo.createResponse(responseId, runId, provider, nextRound, prompt);

--- a/src/main/arena/engine.ts
+++ b/src/main/arena/engine.ts
@@ -78,18 +78,41 @@ function killTree(child: ChildProcess): void {
   child.once('close', () => clearTimeout(escalation));
 }
 
+interface OllamaMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
 interface LiveResponse {
   runId: string;
   provider: string;
   prompt: string;
   /** Project folder CLI contestants spawn in (null = engine process cwd). */
   workingDir: string | null;
+  /** Conversation round: 0 = initial prompt, 1+ = follow-ups. */
+  round: number;
+  /** CLI session id: engine-assigned on round 0, resumed on later rounds. */
+  sessionRef: string | null;
+  /** True when this entry resumes an earlier round's session. */
+  resume: boolean;
+  /**
+   * Ollama has no CLI session to resume — follow-ups replay the prior
+   * conversation as an explicit message history (null for CLI contestants).
+   */
+  ollamaMessages: OllamaMessage[] | null;
   text: string;
   startedAt: number;
   ttftMs: number | null;
   launched: boolean;
   kill: (() => void) | null;
 }
+
+/**
+ * Session refs are inlined into shell command strings (--resume <ref>), so
+ * only pass ones that cannot break out of the command: UUIDs and codex
+ * thread ids match this; anything else is rejected rather than spawned.
+ */
+const SESSION_REF_SAFE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 export class ArenaEngine extends EventEmitter {
   private readonly live: Map<string, LiveResponse> = new Map();
@@ -116,6 +139,13 @@ export class ArenaEngine extends EventEmitter {
         provider,
         prompt,
         workingDir,
+        round: 0,
+        // Name the CLI session upfront so the run can be resumed later.
+        // CLIs that mint their own id (codex) ignore this; their parser
+        // reports the real one, which wins at finalize.
+        sessionRef: provider === OLLAMA_CONTESTANT_ID ? null : randomUUID(),
+        resume: false,
+        ollamaMessages: null,
         text: '',
         startedAt: Date.now(),
         ttftMs: null,
@@ -128,15 +158,87 @@ export class ArenaEngine extends EventEmitter {
     return run;
   }
 
+  /**
+   * Phase 1 of a follow-up round: create response rows for every contestant
+   * of the run that can continue — CLI contestants resume their session
+   * (session_ref + a resume command), Ollama replays the conversation as
+   * message history. Columns whose latest round errored (or whose CLI has no
+   * headless resume) simply don't get a new round. Same two-phase contract
+   * as prepare(): nothing spawns until launch().
+   */
+  prepareFollowUp(runId: string, prompt: string): ArenaRun {
+    const run = arenaRepo.getRun(runId);
+    if (!run) throw new Error(`Arena run not found: ${runId}`);
+    if (run.responses.some((r) => r.status === 'running')) {
+      throw new Error('Arena run still has contestants running');
+    }
+
+    const nextRound = Math.max(...run.responses.map((r) => r.round)) + 1;
+    let continued = 0;
+
+    for (const provider of new Set(run.responses.map((r) => r.provider))) {
+      const rounds = run.responses.filter((r) => r.provider === provider);
+      const latest = rounds[rounds.length - 1]; // responses are round-ordered
+      if (latest.status !== 'done') continue;
+
+      let entrySeed: Pick<LiveResponse, 'sessionRef' | 'ollamaMessages'>;
+      if (provider === OLLAMA_CONTESTANT_ID) {
+        if (!latest.text) continue;
+        // Replay every prior round as explicit chat history.
+        const messages: OllamaMessage[] = rounds.flatMap((r) => [
+          { role: 'user' as const, content: r.prompt ?? run.prompt },
+          { role: 'assistant' as const, content: r.text },
+        ]);
+        messages.push({ role: 'user', content: prompt });
+        entrySeed = { sessionRef: null, ollamaMessages: messages };
+      } else {
+        if (!latest.sessionRef || !SESSION_REF_SAFE.test(latest.sessionRef)) continue;
+        let providerDef: ReturnType<typeof getProvider>;
+        try {
+          providerDef = getProvider(provider);
+        } catch {
+          continue; // provider removed from the registry since the run
+        }
+        if (!providerDef.arena.buildResumeCommand) continue;
+        entrySeed = { sessionRef: latest.sessionRef, ollamaMessages: null };
+      }
+
+      const responseId = randomUUID();
+      arenaRepo.createResponse(responseId, runId, provider, nextRound, prompt);
+      this.live.set(responseId, {
+        runId,
+        provider,
+        prompt,
+        workingDir: run.workingDir,
+        round: nextRound,
+        resume: true,
+        text: '',
+        startedAt: Date.now(),
+        ttftMs: null,
+        launched: false,
+        kill: null,
+        ...entrySeed,
+      });
+      continued += 1;
+    }
+
+    if (continued === 0) {
+      throw new Error('No contestant in this run can be resumed');
+    }
+    const updated = arenaRepo.getRun(runId);
+    if (!updated) throw new Error('Arena run vanished during follow-up');
+    return updated;
+  }
+
   /** Phase 2: spawn every contestant of a prepared run. */
   launch(runId: string): void {
     for (const [responseId, entry] of this.live) {
       if (entry.runId !== runId || entry.launched) continue;
       entry.launched = true;
       if (entry.provider === OLLAMA_CONTESTANT_ID) {
-        void this.runOllama(responseId, entry.prompt);
+        void this.runOllama(responseId, entry);
       } else {
-        this.runCli(responseId, entry.provider, entry.prompt);
+        this.runCli(responseId, entry);
       }
     }
   }
@@ -150,9 +252,8 @@ export class ArenaEngine extends EventEmitter {
     }
   }
 
-  private runCli(responseId: string, providerId: string, prompt: string): void {
-    const entry = this.live.get(responseId);
-    if (!entry) return;
+  private runCli(responseId: string, entry: LiveResponse): void {
+    const providerId = entry.provider;
     let provider: ReturnType<typeof getProvider>;
     try {
       provider = getProvider(providerId);
@@ -161,9 +262,24 @@ export class ArenaEngine extends EventEmitter {
       return;
     }
 
+    if (!entry.sessionRef || !SESSION_REF_SAFE.test(entry.sessionRef)) {
+      // prepare()/prepareFollowUp() always set a validated ref for CLI
+      // contestants; reaching here means a bug upstream, not user input.
+      this.finish(responseId, 'error', null, 'Invalid session reference');
+      return;
+    }
+
+    // prepareFollowUp only continues providers that declare a resume
+    // command, so this is belt-and-braces rather than a reachable path.
+    const build = entry.resume ? provider.arena.buildResumeCommand : provider.arena.buildCommand;
+    if (!build) {
+      this.finish(responseId, 'error', null, `${providerId} cannot resume a session`);
+      return;
+    }
+
     const shellInfo = detectShell(getPreference('customShellPath') ?? '');
     const shellLaunch = getShellLaunch(shellInfo, { needsEnvRef: true });
-    const cmd = provider.arena.buildCommand(shellLaunch.envRef('ARENA_PROMPT'));
+    const cmd = build(shellLaunch.envRef('ARENA_PROMPT'), entry.sessionRef);
     const parser = provider.arena.createParser();
 
     // vaultEnvFor is empty unless the user opted this provider into
@@ -174,7 +290,7 @@ export class ArenaEngine extends EventEmitter {
       log.info(`[Arena] API-key auth enabled for '${providerId}':`, redactEnv(vaultEnv));
     }
     const child = spawn(shellLaunch.shell, shellLaunch.wrap(cmd), {
-      env: { ...process.env, ARENA_PROMPT: prompt, ...vaultEnv },
+      env: { ...process.env, ARENA_PROMPT: entry.prompt, ...vaultEnv },
       // Scoped runs put the CLI inside the project folder, exactly like a
       // terminal session there. A vanished dir surfaces via the 'error'
       // handler below (spawn ENOENT), settling the column as an error.
@@ -230,9 +346,11 @@ export class ArenaEngine extends EventEmitter {
     });
   }
 
-  private async runOllama(responseId: string, prompt: string): Promise<void> {
-    const entry = this.live.get(responseId);
-    if (!entry) return;
+  private async runOllama(responseId: string, entry: LiveResponse): Promise<void> {
+    // Follow-ups replay the prior rounds as message history (Ollama has no
+    // server-side session); round 0 is just the single prompt.
+    const messages: OllamaMessage[] =
+      entry.ollamaMessages ?? [{ role: 'user', content: entry.prompt }];
     const parser = ollamaParser();
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
@@ -257,7 +375,7 @@ export class ArenaEngine extends EventEmitter {
         method: 'POST',
         signal: controller.signal,
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ model, messages: [{ role: 'user', content: prompt }], stream: true }),
+        body: JSON.stringify({ model, messages, stream: true }),
       });
       if (!res.ok || !res.body) {
         this.finish(responseId, 'error', null, `Ollama returned HTTP ${res.status}`);
@@ -313,6 +431,10 @@ export class ArenaEngine extends EventEmitter {
     // it excludes process startup, ours includes it — theirs is the honest
     // model-latency number, ours still shows in total.
     const ttftMs = final?.reportedTtftMs ?? entry.ttftMs;
+    // Same preference for the session ref: CLIs that mint their own id
+    // report it in-stream (codex thread.started); otherwise the engine's
+    // assigned id stands. Persisted so follow-up rounds can resume.
+    const sessionRef = final?.sessionRef ?? entry.sessionRef;
 
     try {
       arenaRepo.finalizeResponse(responseId, {
@@ -324,6 +446,7 @@ export class ArenaEngine extends EventEmitter {
         outputTokens: final?.outputTokens ?? null,
         costUsd: final?.costUsd ?? null,
         error,
+        sessionRef,
       });
     } catch (e) {
       log.error(`[Arena] Failed to persist response ${responseId}:`, e);

--- a/src/main/arena/parsers.ts
+++ b/src/main/arena/parsers.ts
@@ -20,6 +20,12 @@ export interface ArenaFinal {
   reportedTtftMs: number | null;
   /** Text only available at finalize time (single-doc output styles). */
   trailingText: string;
+  /**
+   * CLI-reported session/thread id for resuming (claude result.session_id,
+   * codex thread.started.thread_id). Null for CLIs that don't report one —
+   * the engine falls back to the session id it assigned upfront.
+   */
+  sessionRef: string | null;
 }
 
 export interface ArenaStreamParser {
@@ -35,7 +41,12 @@ const EMPTY_FINAL: ArenaFinal = {
   costUsd: null,
   reportedTtftMs: null,
   trailingText: '',
+  sessionRef: null,
 };
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
 
 function tryParseJson(line: string): any {
   const trimmed = line.trim();
@@ -71,6 +82,7 @@ export function claudeParser(): ArenaStreamParser {
           costUsd: asFiniteNumber(event.total_cost_usd),
           reportedTtftMs: asFiniteNumber(event.ttft_ms),
           trailingText: '',
+          sessionRef: asNonEmptyString(event.session_id),
         };
       }
       return '';
@@ -86,6 +98,10 @@ export function codexParser(): ArenaStreamParser {
     onLine(line) {
       const event = tryParseJson(line);
       if (!event) return '';
+      if (event.type === 'thread.started') {
+        final = { ...final, sessionRef: asNonEmptyString(event.thread_id) };
+        return '';
+      }
       const item = event.item;
       const itemType = item?.item_type ?? item?.type;
       if (event.type === 'item.completed' && itemType === 'agent_message' && typeof item?.text === 'string') {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -472,6 +472,16 @@ function initializeArenaTables(database: Database.Database): void {
   if (!runColumns.some((col) => col.name === 'working_dir')) {
     database.exec('ALTER TABLE arena_runs ADD COLUMN working_dir TEXT DEFAULT NULL');
   }
+
+  // Migration: follow-up rounds. round 0 = the run's initial prompt; later
+  // rounds carry their own prompt. session_ref stores the CLI session/thread
+  // id the response can be resumed from (NULL = column can't continue).
+  const responseColumns = database.prepare('PRAGMA table_info(arena_responses)').all() as { name: string }[];
+  if (!responseColumns.some((col) => col.name === 'round')) {
+    database.exec('ALTER TABLE arena_responses ADD COLUMN round INTEGER NOT NULL DEFAULT 0');
+    database.exec('ALTER TABLE arena_responses ADD COLUMN prompt TEXT DEFAULT NULL');
+    database.exec('ALTER TABLE arena_responses ADD COLUMN session_ref TEXT DEFAULT NULL');
+  }
 }
 
 export function closeDatabase(): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1247,6 +1247,14 @@ safeHandle('arena:start', async (prompt: string, contestants: string[], workingD
 safeHandle('arena:launch', async (runId: string) => {
   arenaEngine.launch(runId);
 });
+// Follow-up round: same two-phase contract — 'followUp' creates the new
+// round's rows (resuming each contestant's CLI session), 'launch' spawns.
+safeHandle('arena:followUp', async (runId: string, prompt: string) => {
+  if (!runId || !prompt?.trim()) {
+    throw new Error('Arena follow-up needs a run id and a prompt');
+  }
+  return arenaEngine.prepareFollowUp(runId, prompt);
+});
 safeHandle('arena:cancel', async (runId: string) => {
   arenaEngine.cancelRun(runId);
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1250,10 +1250,11 @@ safeHandle('arena:launch', async (runId: string) => {
 // Follow-up round: same two-phase contract — 'followUp' creates the new
 // round's rows (resuming each contestant's CLI session), 'launch' spawns.
 safeHandle('arena:followUp', async (runId: string, prompt: string) => {
-  if (!runId || !prompt?.trim()) {
+  const trimmed = prompt?.trim();
+  if (!runId || !trimmed) {
     throw new Error('Arena follow-up needs a run id and a prompt');
   }
-  return arenaEngine.prepareFollowUp(runId, prompt);
+  return arenaEngine.prepareFollowUp(runId, trimmed);
 });
 safeHandle('arena:cancel', async (runId: string) => {
   arenaEngine.cancelRun(runId);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -202,6 +202,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('arena:start', prompt, contestants, workingDir ?? null),
   arenaLaunch: (runId: string): Promise<void> =>
     ipcRenderer.invoke('arena:launch', runId),
+  arenaFollowUp: (runId: string, prompt: string): Promise<ArenaRun> =>
+    ipcRenderer.invoke('arena:followUp', runId, prompt),
   arenaCancel: (runId: string): Promise<void> =>
     ipcRenderer.invoke('arena:cancel', runId),
   arenaListRuns: (): Promise<ArenaRun[]> =>

--- a/src/main/providers/claude.ts
+++ b/src/main/providers/claude.ts
@@ -48,9 +48,13 @@ export const claudeProvider: ProviderDefinition = {
     // result subtype error_max_turns even after streaming a full answer.
     // Runaway runs are already bounded by the engine's contestant timeout.
     // stream-json requires --verbose. Verified live: the result event
-    // reports usage, total_cost_usd, ttft_ms.
-    buildCommand: (promptRef) =>
-      `claude -p ${promptRef} --output-format stream-json --verbose`,
+    // reports usage, total_cost_usd, ttft_ms. --session-id names the
+    // session upfront so follow-up rounds can --resume it (headless resume
+    // keeps the same id — verified live).
+    buildCommand: (promptRef, sessionRef) =>
+      `claude -p ${promptRef} --output-format stream-json --verbose --session-id ${sessionRef}`,
+    buildResumeCommand: (promptRef, sessionRef) =>
+      `claude -p ${promptRef} --output-format stream-json --verbose --resume ${sessionRef}`,
     createParser: claudeArenaParser,
   },
   setup: {

--- a/src/main/providers/codex.ts
+++ b/src/main/providers/codex.ts
@@ -19,8 +19,15 @@ export const codexProvider = passthroughProvider({
     },
   },
   arena: {
-    // JSONL events; turn.completed carries token usage (OpenAI headless docs).
-    buildCommand: (promptRef) => `codex exec --json ${promptRef}`,
+    // JSONL events; turn.completed carries token usage (OpenAI headless
+    // docs). --skip-git-repo-check: codex refuses to run outside a trusted
+    // git directory otherwise, which breaks unscoped arena runs (cwd = the
+    // app dir). Codex mints its own thread id — the engine's assigned
+    // sessionRef is ignored and the parser captures thread.started instead;
+    // follow-up rounds resume that thread (verified live).
+    buildCommand: (promptRef) => `codex exec --json --skip-git-repo-check ${promptRef}`,
+    buildResumeCommand: (promptRef, sessionRef) =>
+      `codex exec resume ${sessionRef} --json --skip-git-repo-check ${promptRef}`,
     createParser: codexParser,
   },
   setup: {

--- a/src/main/providers/grok.ts
+++ b/src/main/providers/grok.ts
@@ -24,7 +24,12 @@ export const grokProvider = passthroughProvider({
     // an "I'll explore..." preamble with the tools never run. --no-plan +
     // auto permissions let the model finish its exploration and answer
     // within that single turn (verified live; --max-turns does not help).
-    buildCommand: (promptRef) => `grok --no-plan --permission-mode auto -p ${promptRef}`,
+    // --session-id names the session upfront; follow-up rounds --resume it
+    // (same id is kept — grok only rotates with --fork-session).
+    buildCommand: (promptRef, sessionRef) =>
+      `grok --session-id ${sessionRef} --no-plan --permission-mode auto -p ${promptRef}`,
+    buildResumeCommand: (promptRef, sessionRef) =>
+      `grok --resume ${sessionRef} --no-plan --permission-mode auto -p ${promptRef}`,
     createParser: textParser,
   },
   setup: {

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -99,9 +99,20 @@ export interface ProviderDefinition {
    * `"$ARENA_PROMPT"`), so the prompt text itself never touches the command
    * string — it travels via the environment, immune to shell injection.
    * Runs under the user's existing CLI login (subscription), never an API key.
+   *
+   * sessionRef is an engine-generated UUID naming the CLI session so the run
+   * can be resumed later for follow-up rounds. CLIs that accept an upfront
+   * session id embed it (claude/grok --session-id); CLIs that mint their own
+   * ignore it and report theirs through the parser instead (codex thread_id).
+   * UUIDs are alphanumeric + hyphens, safe to inline in command strings.
    */
   arena: {
-    buildCommand(promptRef: string): string;
+    buildCommand(promptRef: string, sessionRef: string): string;
+    /**
+     * Resume sessionRef with a follow-up prompt (arena reply rounds). Omit
+     * when the CLI has no headless resume — the column simply can't continue.
+     */
+    buildResumeCommand?(promptRef: string, sessionRef: string): string;
     createParser(): ArenaStreamParser;
   };
   /** Setup guidance surfaced in Settings → Providers when the CLI is missing (#97). */

--- a/src/main/repositories/__tests__/arena.test.ts
+++ b/src/main/repositories/__tests__/arena.test.ts
@@ -31,6 +31,9 @@ function freshDb(): Database {
       id TEXT PRIMARY KEY,
       run_id TEXT NOT NULL REFERENCES arena_runs(id) ON DELETE CASCADE,
       provider TEXT NOT NULL,
+      round INTEGER NOT NULL DEFAULT 0,
+      prompt TEXT DEFAULT NULL,
+      session_ref TEXT DEFAULT NULL,
       status TEXT NOT NULL DEFAULT 'running',
       response_text TEXT NOT NULL DEFAULT '',
       ttft_ms INTEGER DEFAULT NULL,
@@ -76,6 +79,7 @@ describe('settleInterruptedResponses', () => {
       outputTokens: 2,
       costUsd: 0.01,
       error: null,
+      sessionRef: null,
     });
 
     expect(arenaRepo.settleInterruptedResponses()).toBe(1);
@@ -90,5 +94,33 @@ describe('settleInterruptedResponses', () => {
 
   test('no-op on an empty table', () => {
     expect(arenaRepo.settleInterruptedResponses()).toBe(0);
+  });
+});
+
+describe('follow-up rounds', () => {
+  test('round, prompt, and session_ref round-trip; responses come back round-ordered', () => {
+    arenaRepo.createRun('r1', 'initial prompt');
+    arenaRepo.createResponse('a0', 'r1', 'claude');
+    arenaRepo.finalizeResponse('a0', {
+      status: 'done', text: 'first answer', ttftMs: 5, totalMs: 10,
+      inputTokens: null, outputTokens: null, costUsd: null, error: null,
+      sessionRef: '7f3e9a10-1111-4222-8333-944445555666',
+    });
+    arenaRepo.createResponse('a1', 'r1', 'claude', 1, 'follow-up prompt');
+
+    const run = arenaRepo.getRun('r1')!;
+    expect(run.responses.map((r) => r.id)).toEqual(['a0', 'a1']);
+    expect(run.responses[0]).toMatchObject({
+      round: 0,
+      prompt: null,
+      sessionRef: '7f3e9a10-1111-4222-8333-944445555666',
+      status: 'done',
+    });
+    expect(run.responses[1]).toMatchObject({
+      round: 1,
+      prompt: 'follow-up prompt',
+      sessionRef: null,
+      status: 'running',
+    });
   });
 });

--- a/src/main/repositories/arena.ts
+++ b/src/main/repositories/arena.ts
@@ -5,6 +5,9 @@ interface ResponseRow {
   id: string;
   run_id: string;
   provider: string;
+  round: number;
+  prompt: string | null;
+  session_ref: string | null;
   status: string;
   response_text: string;
   ttft_ms: number | null;
@@ -20,6 +23,9 @@ function rowToResponse(row: ResponseRow): ArenaResponse {
     id: row.id,
     runId: row.run_id,
     provider: row.provider,
+    round: row.round,
+    prompt: row.prompt,
+    sessionRef: row.session_ref,
     status: row.status as ArenaResponseStatus,
     text: row.response_text,
     ttftMs: row.ttft_ms,
@@ -37,10 +43,16 @@ export function createRun(id: string, prompt: string, workingDir: string | null 
     .run(id, prompt, workingDir);
 }
 
-export function createResponse(id: string, runId: string, provider: string): void {
+export function createResponse(
+  id: string,
+  runId: string,
+  provider: string,
+  round: number = 0,
+  prompt: string | null = null,
+): void {
   getDatabase()
-    .prepare("INSERT INTO arena_responses (id, run_id, provider, status) VALUES (?, ?, ?, 'running')")
-    .run(id, runId, provider);
+    .prepare("INSERT INTO arena_responses (id, run_id, provider, round, prompt, status) VALUES (?, ?, ?, ?, ?, 'running')")
+    .run(id, runId, provider, round, prompt);
 }
 
 export interface FinalizeResponseInput {
@@ -52,6 +64,8 @@ export interface FinalizeResponseInput {
   outputTokens: number | null;
   costUsd: number | null;
   error: string | null;
+  /** CLI session/thread id for follow-up rounds (null = not resumable). */
+  sessionRef: string | null;
 }
 
 /**
@@ -64,7 +78,8 @@ export function finalizeResponse(id: string, final: FinalizeResponseInput): void
     .prepare(`
       UPDATE arena_responses
       SET status = ?, response_text = ?, ttft_ms = ?, total_ms = ?,
-          input_tokens = ?, output_tokens = ?, cost_usd = ?, error = ?
+          input_tokens = ?, output_tokens = ?, cost_usd = ?, error = ?,
+          session_ref = ?
       WHERE id = ?
     `)
     .run(
@@ -76,6 +91,7 @@ export function finalizeResponse(id: string, final: FinalizeResponseInput): void
       final.outputTokens,
       final.costUsd,
       final.error,
+      final.sessionRef,
       id
     );
 }
@@ -107,7 +123,7 @@ export function getRun(id: string): ArenaRun | null {
     .get(id) as RunRow | undefined;
   if (!run) return null;
   const rows = db
-    .prepare('SELECT * FROM arena_responses WHERE run_id = ? ORDER BY provider')
+    .prepare('SELECT * FROM arena_responses WHERE run_id = ? ORDER BY round, provider')
     .all(id) as ResponseRow[];
   return {
     id: run.id,
@@ -124,7 +140,7 @@ export function listRuns(limit: number = 50): ArenaRun[] {
   const runs = db
     .prepare('SELECT id, prompt, working_dir, created_at FROM arena_runs ORDER BY created_at DESC LIMIT ?')
     .all(limit) as RunRow[];
-  const responsesStmt = db.prepare('SELECT * FROM arena_responses WHERE run_id = ? ORDER BY provider');
+  const responsesStmt = db.prepare('SELECT * FROM arena_responses WHERE run_id = ? ORDER BY round, provider');
   return runs.map((run) => ({
     id: run.id,
     prompt: run.prompt,

--- a/src/renderer/components/ArenaPanel.tsx
+++ b/src/renderer/components/ArenaPanel.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { ArenaRun, ArenaUpdate, Group, ProviderStatus } from '../../shared/types';
 import { applyArenaUpdate, isRunSettled } from './arenaUpdates';
 import { buildFolderOptions } from './arenaFolderOptions';
-import { buildColumns, canFollowUp } from './arenaRounds';
+import { buildColumns, canFollowUp, followUpErrorMessage } from './arenaRounds';
 
 interface ArenaPanelProps {
   onClose: () => void;
@@ -55,6 +55,7 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose, groups, initial
   const [run, setRun] = useState<ArenaRun | null>(null);
   const [running, setRunning] = useState(false);
   const [reply, setReply] = useState('');
+  const [followUpError, setFollowUpError] = useState<string | null>(null);
   const [history, setHistory] = useState<ArenaRun[]>([]);
   // '' = no folder scope; otherwise a group id from folderOptions.
   const [folderGroupId, setFolderGroupId] = useState<string>(initialGroupId ?? '');
@@ -105,6 +106,7 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose, groups, initial
     const trimmed = prompt.trim();
     if (!trimmed || selected.size === 0 || running) return;
     setRunning(true);
+    setFollowUpError(null);
     try {
       // Two-phase: subscribe with the run id BEFORE contestants launch, so
       // even an instantly-failing CLI's updates are never dropped.
@@ -131,6 +133,7 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose, groups, initial
     const trimmed = reply.trim();
     if (!run || !trimmed || running) return;
     setRunning(true);
+    setFollowUpError(null);
     try {
       const updated = await window.electronAPI.arenaFollowUp(run.id, trimmed);
       runIdRef.current = updated.id;
@@ -138,7 +141,11 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose, groups, initial
       setReply('');
       await window.electronAPI.arenaLaunch(updated.id);
     } catch (error) {
+      // canFollowUp is a UI-side heuristic; the engine's resumability check
+      // is authoritative and can reject — surface that instead of silently
+      // doing nothing. The typed reply is kept so the user can retry.
       console.error('Arena follow-up failed:', error);
+      setFollowUpError(followUpErrorMessage(error));
       setRunning(false);
     }
   }, [run, reply, running]);
@@ -151,6 +158,7 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose, groups, initial
       setRun(loaded);
       setPrompt(loaded.prompt);
       setReply('');
+      setFollowUpError(null);
       setRunning(false);
     }
   }, []);
@@ -280,20 +288,23 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose, groups, initial
 
       {run && !running && isRunSettled(run) && canFollowUp(run) && (
         <div className="arena-reply">
-          <textarea
-            className="arena-reply-input"
-            value={reply}
-            onChange={e => setReply(e.target.value)}
-            placeholder="Reply to all agents — each continues its own conversation…"
-            rows={2}
-          />
-          <button
-            className="confirm-btn"
-            onClick={sendFollowUp}
-            disabled={!reply.trim()}
-          >
-            Reply
-          </button>
+          {followUpError && <div className="arena-reply-error">{followUpError}</div>}
+          <div className="arena-reply-bar">
+            <textarea
+              className="arena-reply-input"
+              value={reply}
+              onChange={e => setReply(e.target.value)}
+              placeholder="Reply to all agents — each continues its own conversation…"
+              rows={2}
+            />
+            <button
+              className="confirm-btn"
+              onClick={sendFollowUp}
+              disabled={!reply.trim()}
+            >
+              Reply
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/src/renderer/components/ArenaPanel.tsx
+++ b/src/renderer/components/ArenaPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { ArenaRun, ArenaUpdate, Group, ProviderStatus } from '../../shared/types';
 import { applyArenaUpdate, isRunSettled } from './arenaUpdates';
 import { buildFolderOptions } from './arenaFolderOptions';
+import { buildColumns, canFollowUp } from './arenaRounds';
 
 interface ArenaPanelProps {
   onClose: () => void;
@@ -53,6 +54,7 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose, groups, initial
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [run, setRun] = useState<ArenaRun | null>(null);
   const [running, setRunning] = useState(false);
+  const [reply, setReply] = useState('');
   const [history, setHistory] = useState<ArenaRun[]>([]);
   // '' = no folder scope; otherwise a group id from folderOptions.
   const [folderGroupId, setFolderGroupId] = useState<string>(initialGroupId ?? '');
@@ -122,6 +124,25 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose, groups, initial
     }
   }, []);
 
+  // Follow-up round: each contestant resumes its own CLI session (Ollama
+  // replays history), so answering an agent's question keeps full context.
+  // Works on history-loaded runs too — sessions persist on disk.
+  const sendFollowUp = useCallback(async () => {
+    const trimmed = reply.trim();
+    if (!run || !trimmed || running) return;
+    setRunning(true);
+    try {
+      const updated = await window.electronAPI.arenaFollowUp(run.id, trimmed);
+      runIdRef.current = updated.id;
+      setRun(updated);
+      setReply('');
+      await window.electronAPI.arenaLaunch(updated.id);
+    } catch (error) {
+      console.error('Arena follow-up failed:', error);
+      setRunning(false);
+    }
+  }, [run, reply, running]);
+
   const loadHistoryRun = useCallback(async (id: string) => {
     if (!id) return;
     const loaded = await window.electronAPI.arenaGetRun(id);
@@ -129,6 +150,7 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose, groups, initial
       runIdRef.current = null; // viewing history — ignore live updates
       setRun(loaded);
       setPrompt(loaded.prompt);
+      setReply('');
       setRunning(false);
     }
   }, []);
@@ -217,24 +239,35 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose, groups, initial
       )}
 
       <div className="arena-results">
-        {run?.responses.map(r => (
-          <div key={r.id} className={`arena-column ${r.status}`}>
+        {run && buildColumns(run).map(col => (
+          <div key={col.provider} className={`arena-column ${col.latest.status}`}>
             <div className="arena-column-header">
-              <span className="arena-column-name">{r.provider}</span>
-              <span className={`status-pill ${STATUS_PILL_CLASS[r.status]}`}>
-                {r.status}
+              <span className="arena-column-name">{col.provider}</span>
+              <span className={`status-pill ${STATUS_PILL_CLASS[col.latest.status]}`}>
+                {col.latest.status}
               </span>
             </div>
-            <div className="arena-column-metrics">
-              <span title="Time to first token">TTFT {formatMs(r.ttftMs)}</span>
-              <span title="Total duration">total {formatMs(r.totalMs)}</span>
-              <span title="Token usage">{formatTokens(r.inputTokens, r.outputTokens)}</span>
-              <span title="Runs bill against the CLI's own subscription — no direct cost. When the CLI reports a figure, it's what the same call would cost on the provider's API.">
-                {formatCost(r.costUsd)}
-              </span>
+            <div className="arena-column-rounds">
+              {col.responses.map(r => (
+                <div key={r.id} className="arena-round">
+                  {r.round > 0 && (
+                    <div className="arena-round-prompt" title={r.prompt ?? ''}>
+                      ↳ {r.prompt}
+                    </div>
+                  )}
+                  <div className="arena-column-metrics">
+                    <span title="Time to first token">TTFT {formatMs(r.ttftMs)}</span>
+                    <span title="Total duration">total {formatMs(r.totalMs)}</span>
+                    <span title="Token usage">{formatTokens(r.inputTokens, r.outputTokens)}</span>
+                    <span title="Runs bill against the CLI's own subscription — no direct cost. When the CLI reports a figure, it's what the same call would cost on the provider's API.">
+                      {formatCost(r.costUsd)}
+                    </span>
+                  </div>
+                  {r.error && <div className="arena-column-error">{r.error}</div>}
+                  <pre className="arena-column-text">{columnText(r.text, r.status)}</pre>
+                </div>
+              ))}
             </div>
-            {r.error && <div className="arena-column-error">{r.error}</div>}
-            <pre className="arena-column-text">{columnText(r.text, r.status)}</pre>
           </div>
         ))}
         {!run && (
@@ -244,6 +277,25 @@ export const ArenaPanel: React.FC<ArenaPanelProps> = ({ onClose, groups, initial
           </div>
         )}
       </div>
+
+      {run && !running && isRunSettled(run) && canFollowUp(run) && (
+        <div className="arena-reply">
+          <textarea
+            className="arena-reply-input"
+            value={reply}
+            onChange={e => setReply(e.target.value)}
+            placeholder="Reply to all agents — each continues its own conversation…"
+            rows={2}
+          />
+          <button
+            className="confirm-btn"
+            onClick={sendFollowUp}
+            disabled={!reply.trim()}
+          >
+            Reply
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/renderer/components/__tests__/arenaRounds.test.ts
+++ b/src/renderer/components/__tests__/arenaRounds.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Arena round-grouping tests (follow-up rounds).
+ *
+ * Run with: bun test src/renderer/components/__tests__
+ */
+import { describe, expect, test } from 'bun:test';
+import { buildColumns, canFollowUp } from '../arenaRounds';
+import { ArenaResponse, ArenaRun } from '../../../shared/types';
+
+function response(overrides: Partial<ArenaResponse>): ArenaResponse {
+  return {
+    id: 'x', runId: 'run1', provider: 'claude', round: 0, prompt: null,
+    sessionRef: null, status: 'done', text: 'answer',
+    ttftMs: null, totalMs: null, inputTokens: null, outputTokens: null,
+    costUsd: null, error: null,
+    ...overrides,
+  };
+}
+
+function run(responses: ArenaResponse[]): ArenaRun {
+  return { id: 'run1', prompt: 'p', workingDir: null, createdAt: new Date(0), responses };
+}
+
+describe('buildColumns', () => {
+  test('groups responses per provider with rounds in order and latest exposed', () => {
+    const columns = buildColumns(run([
+      response({ id: 'c0', provider: 'claude', round: 0, sessionRef: 's1' }),
+      response({ id: 'g0', provider: 'grok', round: 0 }),
+      response({ id: 'c1', provider: 'claude', round: 1, prompt: 'more?', status: 'running' }),
+    ]));
+    expect(columns.map(c => c.provider)).toEqual(['claude', 'grok']);
+    expect(columns[0].responses.map(r => r.id)).toEqual(['c0', 'c1']);
+    expect(columns[0].latest.id).toBe('c1');
+    expect(columns[1].latest.id).toBe('g0');
+  });
+});
+
+describe('canFollowUp', () => {
+  test('true when a settled column left a session ref', () => {
+    expect(canFollowUp(run([response({ sessionRef: 's1' })]))).toBe(true);
+  });
+
+  test('true for Ollama-style columns with text but no session ref', () => {
+    expect(canFollowUp(run([response({ provider: 'ollama', text: 'hi' })]))).toBe(true);
+  });
+
+  test('false while anything is still running', () => {
+    expect(canFollowUp(run([
+      response({ sessionRef: 's1' }),
+      response({ id: 'y', provider: 'grok', status: 'running' }),
+    ]))).toBe(false);
+  });
+
+  test('false when every latest round errored', () => {
+    expect(canFollowUp(run([response({ status: 'error', error: 'boom', text: '', sessionRef: null })]))).toBe(false);
+  });
+
+  test('judges the latest round, not earlier ones', () => {
+    expect(canFollowUp(run([
+      response({ id: 'c0', round: 0, sessionRef: 's1' }),
+      response({ id: 'c1', round: 1, status: 'error', error: 'boom', text: '', sessionRef: null }),
+    ]))).toBe(false);
+  });
+});

--- a/src/renderer/components/__tests__/arenaRounds.test.ts
+++ b/src/renderer/components/__tests__/arenaRounds.test.ts
@@ -4,7 +4,7 @@
  * Run with: bun test src/renderer/components/__tests__
  */
 import { describe, expect, test } from 'bun:test';
-import { buildColumns, canFollowUp } from '../arenaRounds';
+import { buildColumns, canFollowUp, followUpErrorMessage } from '../arenaRounds';
 import { ArenaResponse, ArenaRun } from '../../../shared/types';
 
 function response(overrides: Partial<ArenaResponse>): ArenaResponse {
@@ -60,5 +60,23 @@ describe('canFollowUp', () => {
       response({ id: 'c0', round: 0, sessionRef: 's1' }),
       response({ id: 'c1', round: 1, status: 'error', error: 'boom', text: '', sessionRef: null }),
     ]))).toBe(false);
+  });
+});
+
+describe('followUpErrorMessage', () => {
+  test('strips the IPC remote-method wrapper down to the engine detail', () => {
+    expect(followUpErrorMessage(new Error(
+      "Error invoking remote method 'arena:followUp': Error: No contestant in this run can be resumed"
+    ))).toBe('No contestant in this run can be resumed');
+  });
+
+  test('passes plain errors and non-Errors through', () => {
+    expect(followUpErrorMessage(new Error('Arena run still has contestants running')))
+      .toBe('Arena run still has contestants running');
+    expect(followUpErrorMessage('boom')).toBe('boom');
+  });
+
+  test('never returns an empty message', () => {
+    expect(followUpErrorMessage(new Error(''))).toBe('Follow-up failed');
   });
 });

--- a/src/renderer/components/__tests__/arenaUpdates.test.ts
+++ b/src/renderer/components/__tests__/arenaUpdates.test.ts
@@ -15,11 +15,13 @@ function makeRun(): ArenaRun {
     createdAt: new Date(0),
     responses: [
       {
-        id: 'a', runId: 'run1', provider: 'claude', status: 'running', text: 'he',
+        id: 'a', runId: 'run1', provider: 'claude', round: 0, prompt: null, sessionRef: null,
+        status: 'running', text: 'he',
         ttftMs: 100, totalMs: null, inputTokens: null, outputTokens: null, costUsd: null, error: null,
       },
       {
-        id: 'b', runId: 'run1', provider: 'grok', status: 'running', text: '',
+        id: 'b', runId: 'run1', provider: 'grok', round: 0, prompt: null, sessionRef: null,
+        status: 'running', text: '',
         ttftMs: null, totalMs: null, inputTokens: null, outputTokens: null, costUsd: null, error: null,
       },
     ],

--- a/src/renderer/components/arenaRounds.ts
+++ b/src/renderer/components/arenaRounds.ts
@@ -1,0 +1,47 @@
+import { ArenaResponse, ArenaRun } from '../../shared/types';
+
+/**
+ * Round-aware view of an arena run: one column per provider holding its
+ * responses in round order. Pure — extracted from ArenaPanel for direct
+ * unit testing.
+ */
+export interface ArenaColumn {
+  provider: string;
+  /** This provider's responses, round-ascending. */
+  responses: ArenaResponse[];
+  /** The response driving the column's header pill (latest round). */
+  latest: ArenaResponse;
+}
+
+export function buildColumns(run: ArenaRun): ArenaColumn[] {
+  const byProvider = new Map<string, ArenaResponse[]>();
+  // run.responses arrive round-then-provider ordered from the repo; live
+  // follow-up rows are appended in round order too, so per-provider lists
+  // stay round-ascending either way.
+  for (const response of run.responses) {
+    const list = byProvider.get(response.provider);
+    if (list) {
+      list.push(response);
+    } else {
+      byProvider.set(response.provider, [response]);
+    }
+  }
+  return Array.from(byProvider, ([provider, responses]) => ({
+    provider,
+    responses,
+    latest: responses[responses.length - 1],
+  }));
+}
+
+/**
+ * True when a settled run has at least one column that can continue: the
+ * provider's latest round finished cleanly and left something to resume —
+ * a CLI session ref, or (Ollama) prior text to replay as chat history.
+ * The engine re-checks this authoritatively; here it only gates the reply UI.
+ */
+export function canFollowUp(run: ArenaRun): boolean {
+  if (run.responses.some((r) => r.status === 'running')) return false;
+  return buildColumns(run).some(
+    ({ latest }) => latest.status === 'done' && (latest.sessionRef !== null || latest.text.length > 0)
+  );
+}

--- a/src/renderer/components/arenaRounds.ts
+++ b/src/renderer/components/arenaRounds.ts
@@ -39,6 +39,16 @@ export function buildColumns(run: ArenaRun): ArenaColumn[] {
  * a CLI session ref, or (Ollama) prior text to replay as chat history.
  * The engine re-checks this authoritatively; here it only gates the reply UI.
  */
+/**
+ * Human-readable message for a failed follow-up. IPC rejections arrive
+ * wrapped as "Error invoking remote method 'arena:followUp': Error: <detail>"
+ * — strip the plumbing so the user sees the detail.
+ */
+export function followUpErrorMessage(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  return raw.replace(/^Error invoking remote method '[^']+':\s*(Error:\s*)?/, '') || 'Follow-up failed';
+}
+
 export function canFollowUp(run: ArenaRun): boolean {
   if (run.responses.some((r) => r.status === 'running')) return false;
   return buildColumns(run).some(

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -91,6 +91,7 @@ interface ElectronAPI {
   vaultTestKey: (providerId: string) => Promise<{ ok: boolean; status: number | null; error: string | null }>;
   arenaStart: (prompt: string, contestants: string[], workingDir?: string | null) => Promise<ArenaRun>;
   arenaLaunch: (runId: string) => Promise<void>;
+  arenaFollowUp: (runId: string, prompt: string) => Promise<ArenaRun>;
   arenaCancel: (runId: string) => Promise<void>;
   arenaListRuns: () => Promise<ArenaRun[]>;
   arenaGetRun: (id: string) => Promise<ArenaRun | null>;

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1629,14 +1629,61 @@ body {
   white-space: pre-wrap;
 }
 
-.arena-column-text {
+/* Rounds wrapper scrolls the whole conversation; individual round texts
+   flow at natural height so earlier rounds stay readable. */
+.arena-column-rounds {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.arena-round {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.arena-round + .arena-round {
+  border-top: 1px solid #333;
+  padding-top: 8px;
+}
+
+.arena-round-prompt {
+  font-size: 12px;
+  color: #c5a4e8;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.arena-column-text {
   white-space: pre-wrap;
   word-break: break-word;
   font-size: 12.5px;
   margin: 0;
   color: #ddd;
+}
+
+/* Follow-up reply bar (arena rounds) */
+.arena-reply {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  margin-top: 8px;
+}
+
+.arena-reply-input {
+  flex: 1;
+  background: #1e1e1e;
+  border: 1px solid #333;
+  border-radius: 6px;
+  color: #ddd;
+  padding: 8px;
+  font-family: inherit;
+  font-size: 13px;
+  resize: vertical;
 }
 
 .arena-empty {

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1669,9 +1669,21 @@ body {
 /* Follow-up reply bar (arena rounds) */
 .arena-reply {
   display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.arena-reply-bar {
+  display: flex;
   gap: 8px;
   align-items: flex-end;
-  margin-top: 8px;
+}
+
+.arena-reply-error {
+  color: #f28b82;
+  font-size: 12px;
+  white-space: pre-wrap;
 }
 
 .arena-reply-input {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -44,6 +44,15 @@ export interface ArenaResponse {
   runId: string;
   /** Arena contestant id: a provider registry id or 'ollama'. */
   provider: string;
+  /** Conversation round: 0 = the run's initial prompt, 1+ = follow-ups. */
+  round: number;
+  /** The follow-up prompt this response answers (null on round 0 — see ArenaRun.prompt). */
+  prompt: string | null;
+  /**
+   * CLI session/thread id this response can be resumed from (null when the
+   * contestant has no resumable session, e.g. Ollama or an errored run).
+   */
+  sessionRef: string | null;
   status: ArenaResponseStatus;
   /** Accumulated response text (streamed). */
   text: string;


### PR DESCRIPTION
## What

Arena runs become side-by-side **conversations**. After a run settles, a reply box appears; sending a follow-up resumes every contestant's own CLI session with full context and streams a new round into each column. This directly answers "what if a bot needs input / asks a question" — you answer it, and every agent continues where it left off. Follow-ups also work on history-loaded runs, since CLI sessions persist on disk.

## Per-CLI resume mechanics — each verified live (codeword recall test)

| contestant | round 0 | follow-up |
|---|---|---|
| claude | `--session-id <uuid>` names the session upfront | `--resume <uuid>` (headless resume keeps the same id — verified) |
| codex | mints its own thread id; parser captures `thread.started` | `codex exec resume <thread_id>` |
| grok | `--session-id <uuid>` | `--resume <uuid>` |
| ollama | plain chat call | no server-side session — prior rounds replayed as explicit message history |

Bonus fix discovered while verifying: codex refuses to start outside a trusted/git directory ("Not inside a trusted directory") — so **unscoped** arena runs (cwd = app dir) would have kept failing even after #118. `--skip-git-repo-check` is now on both codex commands.

## How

- **Schema** (additive migration): `arena_responses` gains `round`, `prompt`, `session_ref`. Round 0 answers the run's prompt; later rounds carry their own. `session_ref` is persisted at finalize, so resumability survives app restarts; the #118 startup sweep marks interrupted rows errored, and errored columns simply don't continue.
- **Engine**: `prepareFollowUp(runId, prompt)` mirrors `prepare()`'s two-phase contract (rows created first so the renderer can subscribe, `launch()` spawns). It picks, per provider, the latest round; only `done` rounds with something to resume continue. Session refs are validated against a safe-charset pattern before being inlined into resume commands (prompt text itself still travels via `ARENA_PROMPT`, never the command string).
- **Providers**: arena contract becomes `buildCommand(promptRef, sessionRef)` + optional `buildResumeCommand(promptRef, sessionRef)`; parsers can report the CLI's own session ref (`ArenaFinal.sessionRef`), which wins over the engine-assigned one (codex).
- **Renderer**: columns are now per-provider with round-stacked blocks (`arenaRounds.ts`, pure + unit-tested); follow-up prompts render as `↳ prompt` separators with per-round metrics; reply bar shows only when the run is settled and at least one column can continue.

## Tests

- Engine: full follow-up flow over a fake resumable CLI (resume command runs against the persisted ref, new prompt travels via env, ref carries forward); refusal when the only contestant errored or has no resume command; Ollama history-replay body assertion.
- Parsers: claude `session_id` and codex `thread_id` capture.
- Repo: round/prompt/session_ref round-trip + round ordering.
- Renderer: `buildColumns` grouping, `canFollowUp` gating (latest-round semantics).
- Full suite: 141 pass / 1 pre-existing failure (chat-parser `06-response` snapshot, fails identically on `development`); `tsc` clean apart from the two known pre-existing `mdns-advertiser` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)