### PR TITLE
feat(providers): add opencode, kimi, cursor, and antigravity CLIs

### DIFF
--- a/src/main/arena/__tests__/parsers.test.ts
+++ b/src/main/arena/__tests__/parsers.test.ts
@@ -6,7 +6,15 @@
  * Run with: bun test src/main/arena
  */
 import { describe, expect, test } from 'bun:test';
-import { claudeParser, codexParser, textParser, ollamaParser } from '../parsers';
+import {
+  claudeParser,
+  codexParser,
+  opencodeParser,
+  kimiParser,
+  cursorParser,
+  textParser,
+  ollamaParser,
+} from '../parsers';
 
 describe('claudeParser', () => {
   test('extracts assistant text and result metrics from stream-json', () => {
@@ -78,6 +86,102 @@ describe('codexParser', () => {
     expect(
       p.onLine(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'alt' } }))
     ).toBe('alt');
+  });
+});
+
+describe('opencodeParser', () => {
+  // Fixtures are shapes captured from a live `opencode run --auto --format json`.
+  test('extracts only text parts, captures sessionID, sums step tokens/cost', () => {
+    const p = opencodeParser();
+    expect(p.onLine(JSON.stringify({
+      type: 'step_start', sessionID: 'ses_08e7', part: { type: 'step-start' },
+    }))).toBe('');
+    // A tool call must not leak into the answer.
+    expect(p.onLine(JSON.stringify({
+      type: 'tool_use', sessionID: 'ses_08e7', part: { type: 'tool', tool: 'read' },
+    }))).toBe('');
+    expect(p.onLine(JSON.stringify({
+      type: 'step_finish', sessionID: 'ses_08e7',
+      part: { type: 'step-finish', tokens: { input: 100, output: 5 }, cost: 0.01 },
+    }))).toBe('');
+    expect(p.onLine(JSON.stringify({
+      type: 'text', sessionID: 'ses_08e7', part: { type: 'text', text: 'bodhilander' },
+    }))).toBe('bodhilander');
+    expect(p.onLine(JSON.stringify({
+      type: 'step_finish', sessionID: 'ses_08e7',
+      part: { type: 'step-finish', tokens: { input: 40, output: 7 }, cost: 0.02 },
+    }))).toBe('');
+
+    const final = p.finalize();
+    expect(final.sessionRef).toBe('ses_08e7');
+    expect(final.inputTokens).toBe(140); // summed across both step_finish events
+    expect(final.outputTokens).toBe(12);
+    expect(final.costUsd).toBeCloseTo(0.03, 5);
+  });
+
+  test('leaves metrics null when no step reports them', () => {
+    const p = opencodeParser();
+    p.onLine(JSON.stringify({ type: 'text', sessionID: 'ses_x', part: { type: 'text', text: 'hi' } }));
+    const final = p.finalize();
+    expect(final.inputTokens).toBeNull();
+    expect(final.outputTokens).toBeNull();
+    expect(final.sessionRef).toBe('ses_x');
+  });
+});
+
+describe('kimiParser', () => {
+  // Fixtures captured from a live `kimi -p --output-format stream-json`.
+  test('emits assistant content, skips tool lines, captures resume-hint session id', () => {
+    const p = kimiParser();
+    // Assistant tool-call line (no string content) → skipped.
+    expect(p.onLine(JSON.stringify({
+      role: 'assistant',
+      tool_calls: [{ type: 'function', id: 'tool_1', function: { name: 'Read', arguments: '{}' } }],
+    }))).toBe('');
+    // Tool result line → skipped.
+    expect(p.onLine(JSON.stringify({ role: 'tool', tool_call_id: 'tool_1', content: 'file contents' }))).toBe('');
+    // Assistant text → shown.
+    expect(p.onLine(JSON.stringify({ role: 'assistant', content: 'zebra42' }))).toBe('zebra42');
+    // Meta resume hint → captured, not shown.
+    expect(p.onLine(JSON.stringify({
+      role: 'meta', type: 'session.resume_hint',
+      session_id: 'session_8539b109-5d48-4f7e-ad9e-25218201c205',
+      command: 'kimi -r session_8539b109-5d48-4f7e-ad9e-25218201c205',
+    }))).toBe('');
+
+    const final = p.finalize();
+    expect(final.sessionRef).toBe('session_8539b109-5d48-4f7e-ad9e-25218201c205');
+    expect(final.inputTokens).toBeNull(); // stream-json reports no usage
+  });
+});
+
+describe('cursorParser', () => {
+  // Fixtures captured from a live `cursor-agent -p --output-format stream-json`.
+  test('extracts assistant text, skips thinking, captures session id and camelCase usage', () => {
+    const p = cursorParser();
+    expect(p.onLine(JSON.stringify({
+      type: 'system', subtype: 'init', apiKeySource: 'login',
+      session_id: 'c701e211-bcaa-4e6c-8c5e-4334364b0b89',
+    }))).toBe('');
+    expect(p.onLine(JSON.stringify({
+      type: 'thinking', subtype: 'delta', text: 'I will remember ',
+      session_id: 'c701e211-bcaa-4e6c-8c5e-4334364b0b89',
+    }))).toBe('');
+    expect(p.onLine(JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'OK' }] },
+      session_id: 'c701e211-bcaa-4e6c-8c5e-4334364b0b89',
+    }))).toBe('OK');
+    expect(p.onLine(JSON.stringify({
+      type: 'result', subtype: 'success', result: 'OK',
+      session_id: 'c701e211-bcaa-4e6c-8c5e-4334364b0b89',
+      usage: { inputTokens: 14811, outputTokens: 37, cacheReadTokens: 128, cacheWriteTokens: 0 },
+    }))).toBe('');
+
+    const final = p.finalize();
+    expect(final.sessionRef).toBe('c701e211-bcaa-4e6c-8c5e-4334364b0b89');
+    expect(final.inputTokens).toBe(14811);
+    expect(final.outputTokens).toBe(37);
   });
 });
 

--- a/src/main/arena/parsers.ts
+++ b/src/main/arena/parsers.ts
@@ -121,6 +121,103 @@ export function codexParser(): ArenaStreamParser {
   };
 }
 
+/**
+ * opencode run --format json — newline-delimited events (verified live):
+ * `{type:"text",part:{type:"text",text}}` carries assistant text; tool calls
+ * (`type:"tool_use"`) and reasoning stay out; `sessionID` is on every event
+ * (ses_...); `type:"step_finish"` parts report tokens.{input,output} and cost.
+ * Tokens/cost sum across steps so tool-using runs report a true total.
+ */
+export function opencodeParser(): ArenaStreamParser {
+  let final: ArenaFinal = { ...EMPTY_FINAL };
+  const add = (a: number | null, b: number | null): number | null =>
+    b === null ? a : (a ?? 0) + b; // null stays null until a real value appears
+  return {
+    onLine(line) {
+      const event = tryParseJson(line);
+      if (!event) return '';
+      const sessionRef = asNonEmptyString(event.sessionID);
+      if (sessionRef) final = { ...final, sessionRef };
+      const part = event.part;
+      if (event.type === 'step_finish' && part) {
+        final = {
+          ...final,
+          inputTokens: add(final.inputTokens, asFiniteNumber(part.tokens?.input)),
+          outputTokens: add(final.outputTokens, asFiniteNumber(part.tokens?.output)),
+          costUsd: add(final.costUsd, asFiniteNumber(part.cost)),
+        };
+      }
+      if (event.type === 'text' && part?.type === 'text' && typeof part.text === 'string') {
+        return part.text;
+      }
+      return '';
+    },
+    finalize: () => final,
+  };
+}
+
+/**
+ * kimi -p --output-format stream-json — JSON lines (verified live). Only
+ * `{role:"assistant",content:<string>}` is display text; assistant tool-call
+ * lines carry no string content and role:"tool" results are skipped. The
+ * session id (session_...) arrives on a
+ * `{role:"meta",type:"session.resume_hint",session_id}` line. No token/cost
+ * reporting in stream-json.
+ */
+export function kimiParser(): ArenaStreamParser {
+  let final: ArenaFinal = { ...EMPTY_FINAL };
+  return {
+    onLine(line) {
+      const event = tryParseJson(line);
+      if (!event) return '';
+      if (event.role === 'meta' && event.type === 'session.resume_hint') {
+        const sessionRef = asNonEmptyString(event.session_id);
+        if (sessionRef) final = { ...final, sessionRef };
+        return '';
+      }
+      if (event.role === 'assistant' && typeof event.content === 'string') {
+        return event.content;
+      }
+      return '';
+    },
+    finalize: () => final,
+  };
+}
+
+/**
+ * cursor-agent -p --output-format stream-json — Claude-shaped events (verified
+ * live). `{type:"assistant",message:{content:[{type:"text",text}]}}` carries
+ * text; `type:"thinking"` deltas and `type:"user"` echoes stay out; every
+ * event carries `session_id` (a UUID); the final `type:"result"` reports
+ * `usage.inputTokens/outputTokens` (camelCase). No cost/ttft reported.
+ */
+export function cursorParser(): ArenaStreamParser {
+  let final: ArenaFinal = { ...EMPTY_FINAL };
+  return {
+    onLine(line) {
+      const event = tryParseJson(line);
+      if (!event) return '';
+      const sessionRef = asNonEmptyString(event.session_id);
+      if (sessionRef) final = { ...final, sessionRef };
+      if (event.type === 'result') {
+        final = {
+          ...final,
+          inputTokens: asFiniteNumber(event.usage?.inputTokens),
+          outputTokens: asFiniteNumber(event.usage?.outputTokens),
+        };
+      }
+      if (event.type === 'assistant') {
+        const parts: unknown[] = event.message?.content ?? [];
+        return parts
+          .map((p: any) => (p?.type === 'text' && typeof p.text === 'string' ? p.text : ''))
+          .join('');
+      }
+      return '';
+    },
+    finalize: () => final,
+  };
+}
+
 /** Plain-text CLIs (grok -p). */
 export function textParser(): ArenaStreamParser {
   return {

--- a/src/main/providers/__tests__/resolve.test.ts
+++ b/src/main/providers/__tests__/resolve.test.ts
@@ -15,17 +15,36 @@ mock.module('electron', () => ({
 const providers = await import('../index');
 
 describe('provider registry resolution', () => {
+  const ALL_IDS = ['claude', 'codex', 'grok', 'opencode', 'kimi', 'cursor', 'antigravity'];
+
   test('isKnownProvider reflects the registry', () => {
-    expect(providers.isKnownProvider('claude')).toBe(true);
-    expect(providers.isKnownProvider('codex')).toBe(true);
-    expect(providers.isKnownProvider('grok')).toBe(true);
+    for (const id of ALL_IDS) {
+      expect(providers.isKnownProvider(id)).toBe(true);
+    }
     expect(providers.isKnownProvider('nope')).toBe(false);
     expect(providers.isKnownProvider('')).toBe(false);
   });
 
   test('resolveProvider returns the matching definition for known ids', () => {
-    for (const id of ['claude', 'codex', 'grok']) {
+    for (const id of ALL_IDS) {
       expect(providers.resolveProvider(id).id).toBe(id);
+    }
+  });
+
+  test('every registered provider exposes an arena command + parser', () => {
+    for (const p of providers.listProviders()) {
+      expect(typeof p.arena.buildCommand).toBe('function');
+      expect(typeof p.arena.createParser).toBe('function');
+    }
+  });
+
+  test('follow-up resume is supported by every provider except antigravity', () => {
+    // antigravity has no machine-readable conversation id to resume, so it
+    // deliberately omits buildResumeCommand (the engine skips it in follow-up
+    // rounds). Every other provider supports resumable arena conversations.
+    for (const p of providers.listProviders()) {
+      const hasResume = typeof p.arena.buildResumeCommand === 'function';
+      expect(hasResume).toBe(p.id !== 'antigravity');
     }
   });
 

--- a/src/main/providers/antigravity.ts
+++ b/src/main/providers/antigravity.ts
@@ -1,0 +1,39 @@
+import { passthroughProvider } from './passthrough';
+import { textParser } from '../arena/parsers';
+
+/**
+ * Google Antigravity CLI (`agy`). Auth is the Antigravity app's Google
+ * sign-in; sessions launch the interactive TUI bare, like the other
+ * passthrough CLIs.
+ *
+ * Headless output is plain text with no machine-readable conversation id, and
+ * a fresh id cannot be assigned up front (verified live: --conversation only
+ * resumes agy's own on-disk ids, which never appear in stdout). Its only
+ * resume path is --continue, which targets the globally most-recent
+ * conversation and so can't reliably re-enter a specific arena column under
+ * concurrent use. Rather than resume the wrong conversation, arena follow-up
+ * is deliberately not supported: buildResumeCommand is omitted, so the engine
+ * skips this column in later rounds (it still answers the initial prompt and
+ * works as a normal session provider).
+ */
+export const antigravityProvider = passthroughProvider({
+  id: 'antigravity',
+  name: 'Antigravity',
+  command: 'agy',
+  arena: {
+    // -p runs one prompt non-interactively and prints plain text.
+    // --dangerously-skip-permissions is antigravity's headless auto-approve
+    // (its own error message prescribes it): without it, tool-using questions
+    // — e.g. a folder-scoped "analyze this codebase" — are auto-denied and
+    // produce no output. Same auto-approve tradeoff arena already makes for
+    // the other CLIs (grok --permission-mode auto, cursor --force, opencode
+    // --auto).
+    buildCommand: (promptRef) => `agy --dangerously-skip-permissions -p ${promptRef}`,
+    createParser: textParser,
+  },
+  setup: {
+    installHint: 'Install Antigravity from https://antigravity.google, then run `agy install`',
+    docsUrl: 'https://antigravity.google',
+    loginHint: 'Sign in through the Antigravity app (Google account)',
+  },
+});

--- a/src/main/providers/cursor.ts
+++ b/src/main/providers/cursor.ts
@@ -1,0 +1,33 @@
+import { passthroughProvider } from './passthrough';
+import { cursorParser } from '../arena/parsers';
+
+/**
+ * Cursor Agent (`cursor-agent`). Auth is handled by the CLI itself
+ * (`cursor-agent login`, or the CURSOR_API_KEY env var). The bare command is
+ * deliberately `cursor-agent`, not the `agent` alias its installer also
+ * drops on PATH — `agent` collides with grok's own `agent` alias, whereas
+ * `cursor-agent` is unambiguous. Sessions launch the interactive TUI bare.
+ */
+export const cursorProvider = passthroughProvider({
+  id: 'cursor',
+  name: 'Cursor Agent',
+  command: 'cursor-agent',
+  arena: {
+    // -p/--print is the headless entry; stream-json is Claude-shaped. --force
+    // auto-allows tool calls and --trust trusts the workspace so folder-scoped
+    // questions can read files headlessly (both verified live; without --trust
+    // a git workspace blocks tool use). cursor mints its own session id (a
+    // UUID), captured by the parser from session_id; follow-up rounds resume
+    // via --resume <id>.
+    buildCommand: (promptRef) =>
+      `cursor-agent -p --output-format stream-json --force --trust ${promptRef}`,
+    buildResumeCommand: (promptRef, sessionRef) =>
+      `cursor-agent -p --output-format stream-json --force --trust --resume ${sessionRef} ${promptRef}`,
+    createParser: cursorParser,
+  },
+  setup: {
+    installHint: 'curl https://cursor.com/install -fsS | bash',
+    docsUrl: 'https://cursor.com/docs/cli/overview',
+    loginHint: 'Run `cursor-agent login` (or set CURSOR_API_KEY)',
+  },
+});

--- a/src/main/providers/index.ts
+++ b/src/main/providers/index.ts
@@ -7,6 +7,10 @@ import { ProviderDefinition } from './types';
 import { claudeProvider } from './claude';
 import { codexProvider } from './codex';
 import { grokProvider } from './grok';
+import { opencodeProvider } from './opencode';
+import { kimiProvider } from './kimi';
+import { cursorProvider } from './cursor';
+import { antigravityProvider } from './antigravity';
 
 export * from './types';
 export { claudeProvider, CLAUDE_CONFIG_DIR_ENV } from './claude';
@@ -18,7 +22,15 @@ export const DEFAULT_PROVIDER_ID = DEFAULT_SESSION_PROVIDER;
 // (June 2026), so out of the box it dead-ends at "client is no longer
 // supported". Persisted 'gemini' sessions degrade via resolveProvider().
 const REGISTRY: ReadonlyMap<string, ProviderDefinition> = new Map(
-  [claudeProvider, codexProvider, grokProvider].map((p) => [p.id, p])
+  [
+    claudeProvider,
+    codexProvider,
+    grokProvider,
+    opencodeProvider,
+    kimiProvider,
+    cursorProvider,
+    antigravityProvider,
+  ].map((p) => [p.id, p])
 );
 
 if (!REGISTRY.has(DEFAULT_PROVIDER_ID)) {

--- a/src/main/providers/kimi.ts
+++ b/src/main/providers/kimi.ts
@@ -1,0 +1,31 @@
+import { passthroughProvider } from './passthrough';
+import { kimiParser } from '../arena/parsers';
+
+/**
+ * Kimi Code (Moonshot AI, `kimi`). Auth is handled by the CLI itself
+ * (`kimi login` device-code flow) and works out of the box on the free tier,
+ * so no single API-key env var is wired into the key vault. Sessions launch
+ * the interactive TUI bare, like the other passthrough CLIs.
+ */
+export const kimiProvider = passthroughProvider({
+  id: 'kimi',
+  name: 'Kimi Code',
+  command: 'kimi',
+  arena: {
+    // -p runs one prompt non-interactively; stream-json emits assistant
+    // content lines plus a meta resume_hint carrying the session id. Headless
+    // -p already auto-approves tool reads, so folder-scoped questions work
+    // without a permission flag (--auto/--yolo are in fact rejected alongside
+    // --prompt). kimi mints its own session id (session_...), captured by the
+    // parser; follow-up rounds resume via -r <id>.
+    buildCommand: (promptRef) => `kimi -p ${promptRef} --output-format stream-json`,
+    buildResumeCommand: (promptRef, sessionRef) =>
+      `kimi -r ${sessionRef} -p ${promptRef} --output-format stream-json`,
+    createParser: kimiParser,
+  },
+  setup: {
+    installHint: 'curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash',
+    docsUrl: 'https://moonshotai.github.io/kimi-code/',
+    loginHint: 'Works out of the box; run `kimi login` to use your own Moonshot account',
+  },
+});

--- a/src/main/providers/opencode.ts
+++ b/src/main/providers/opencode.ts
@@ -1,0 +1,31 @@
+import { passthroughProvider } from './passthrough';
+import { opencodeParser } from '../arena/parsers';
+
+/**
+ * opencode (sst/opencode). A multi-provider agent CLI: auth is per-model
+ * provider, managed by the CLI itself (`opencode auth login`), so there is no
+ * single API-key env var and Bodhilander's key vault is not wired up here.
+ * Sessions launch the interactive TUI bare, like the other passthrough CLIs.
+ */
+export const opencodeProvider = passthroughProvider({
+  id: 'opencode',
+  name: 'opencode',
+  command: 'opencode',
+  arena: {
+    // `run` is the headless entry; --format json emits newline-delimited
+    // events. --auto approves tool use so folder-scoped questions can read
+    // files (verified live; without it a read prompt would stall). opencode
+    // mints its own session id (ses_...), captured by the parser from the
+    // sessionID field, so the engine's pre-assigned ref is ignored. Follow-up
+    // rounds resume via -s <id>.
+    buildCommand: (promptRef) => `opencode run --auto --format json ${promptRef}`,
+    buildResumeCommand: (promptRef, sessionRef) =>
+      `opencode run --auto -s ${sessionRef} --format json ${promptRef}`,
+    createParser: opencodeParser,
+  },
+  setup: {
+    installHint: 'curl -fsSL https://opencode.ai/install | bash',
+    docsUrl: 'https://opencode.ai/docs',
+    loginHint: 'Run `opencode auth login` and add a provider (or set that provider’s API key)',
+  },
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -139,6 +139,10 @@ export const PROVIDER_LABELS: Record<string, string> = {
   claude: 'Claude',
   codex: 'Codex',
   grok: 'Grok',
+  opencode: 'opencode',
+  kimi: 'Kimi',
+  cursor: 'Cursor',
+  antigravity: 'Antigravity',
 };
 
 export interface Group {


### PR DESCRIPTION
## What

Adds four agent CLIs as first-class providers — selectable when starting a session **and** as arena contestants (with folder scoping and, where the CLI allows, follow-up rounds):

| provider | command | headless | resume | metrics |
|---|---|---|---|---|
| opencode | `opencode` | `run --auto --format json` | `-s <id>` | tokens + cost |
| Kimi Code | `kimi` | `-p --output-format stream-json` | `-r <id>` | — |
| Cursor Agent | `cursor-agent` | `-p --output-format stream-json --force --trust` | `--resume <id>` | tokens |
| Antigravity | `agy` | `--dangerously-skip-permissions -p` | — (see below) | — |

Registry membership is all that's needed: the new-session picker, Settings → Providers detection, and arena are all registry/detection-driven, so no per-surface wiring.

## Verified live (not from docs)

Every contract was mapped by running the installed, logged-in CLIs, then **re-verified end-to-end through the real `ArenaEngine`** (shell-launch → CLI with its real permission flags → parser → session-ref capture → follow-up resume), folder-scoped to this repo:

- **Round 0**: all four read `package.json` and returned `bodhilander`.
- **Follow-up**: opencode / kimi / cursor resumed their own session and answered the `version` field (`3.4.0-beta.13`); antigravity was correctly skipped.

Each parser is unit-tested against JSON shapes captured from those live runs.

## Notes / decisions

- **Cursor command is `cursor-agent`, not `agent`.** Both cursor and grok's installers drop a bare `agent` onto PATH (they collide; grok wins by PATH order). Keying off the unambiguous `cursor-agent` symlink avoids the collision and survives Cursor's per-version install dir.
- **Antigravity has no follow-up rounds, on purpose.** Its headless output is plain text with no machine-readable conversation id, a fresh id can't be assigned up front (verified: `--conversation <new-uuid>` starts a fresh conversation instead of adopting the id), and `--continue` only targets the *globally* most-recent conversation — which can't reliably re-enter a specific arena column under concurrent use. Rather than resume the wrong conversation, `buildResumeCommand` is omitted; the engine already skips such providers in later rounds. It still answers the initial arena prompt and works as a normal session provider.
- **Auth:** all four use their own CLI login (opencode's multi-provider auth, kimi/cursor sign-in, antigravity's Google account), so none wire an `apiKey` into the key vault. `ProviderDefinition.apiKey` is already optional.
- **Permission flags** mirror arena's existing auto-approve tradeoff (grok `--permission-mode auto`, cursor `--force`, opencode `--auto`) so folder-scoped questions can actually read files. Antigravity's `--dangerously-skip-permissions` is its own prescribed headless auto-approve (plain `agy -p` auto-denies tool perms and produces no output).

## Tests

- New parser unit tests (opencode/kimi/cursor) with real captured fixtures; antigravity reuses `textParser`.
- resolve.test.ts: the four new ids are known/resolvable, and follow-up resume is asserted present for every provider **except** antigravity.
- Full suite: 150 pass / 1 pre-existing failure (`ChatParser 06-response` snapshot, fails identically on `development`); `tsc` clean apart from the two known pre-existing `mdns-advertiser` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
