### PR TITLE
fix(relay): restore link-code entry + machine switcher in web client

### DIFF
--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -261,19 +261,23 @@ function ensureTerm() {
   // the on-screen keyboard doesn't hide it (and can't be over-scrolled past).
   const vv = window.visualViewport;
   if (vv) {
-    // Pin the terminal pane to the visual viewport. On iOS the on-screen
-    // keyboard both shrinks (vv.height) AND vertically offsets (vv.offsetTop)
-    // the visual viewport; without matching the offset the fixed pane's top
-    // stays at 0 and the bottom (compose bar) gets pushed under the keyboard.
-    const syncViewport = () => {
-      const tp = $('.term-pane');
-      if (!tp || !matchMedia('(max-width:859px)').matches) return;
-      tp.style.height = vv.height + 'px';
-      tp.style.top = vv.offsetTop + 'px';
-    };
-    vv.addEventListener('resize', syncViewport);
-    vv.addEventListener('scroll', syncViewport);
+    vv.addEventListener('resize', syncTermPane);
+    vv.addEventListener('scroll', syncTermPane);
   }
+}
+
+// Pin the terminal pane to the *visual* viewport. The layout viewport (what a
+// `position: fixed; inset: 0` pane fills) is taller than the visible area on
+// mobile — browser chrome and the on-screen keyboard live outside it — so the
+// compose bar and the terminal's bottom rows end up below the fold with no way
+// to reach them. Matching vv.height keeps everything visible; matching
+// vv.offsetTop corrects the iOS keyboard, which offsets the viewport too.
+function syncTermPane() {
+  const vv = window.visualViewport;
+  const tp = $('.term-pane');
+  if (!vv || !tp || !matchMedia('(max-width:859px)').matches) return;
+  tp.style.height = vv.height + 'px';
+  tp.style.top = vv.offsetTop + 'px';
 }
 
 function updateTermHeader() {
@@ -295,6 +299,8 @@ function openTerminal(s: RSession) {
   $('#tMeta')!.innerHTML = `<span class="${s.state === 'waiting' ? '' : ''}">${s.state === 'waiting' ? '● waiting for you' : s.state}</span> · ${esc(gp.label)}`;
   $('#attnBanner')!.classList.toggle('hidden', s.state !== 'waiting');
   document.body.setAttribute('data-view', 'term');
+  syncTermPane();
+  requestAnimationFrame(syncTermPane);
   pushLayer(() => { document.body.removeAttribute('data-view'); if (app.activeId) app.conn?.command({ type: 'terminal:unsubscribe', sessionId: app.activeId }); app.activeId = null; });
   requestAnimationFrame(() => { term!.focus(); });
   app.conn?.command({ type: 'terminal:subscribe', sessionId: s.id });

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -36,7 +36,7 @@ function toggleTheme() { const d = !isDark(); root.setAttribute('data-theme', d 
 // ---------------------------------------------------------------------------
 // App state
 // ---------------------------------------------------------------------------
-const app = { conn: null as RelayConnection | null, machine: null as Machine | null, sessions: [] as RSession[], groups: [] as RGroup[], activeId: null as string | null, fp: '', fpVerified: false, devLogin: false };
+const app = { conn: null as RelayConnection | null, machine: null as Machine | null, machines: [] as Machine[], sessions: [] as RSession[], groups: [] as RGroup[], activeId: null as string | null, fp: '', fpVerified: false, devLogin: false };
 const rootEl = document.getElementById('root')!;
 
 // history-layer nav so Back works within the app
@@ -77,15 +77,21 @@ function renderSignIn() {
 // Main app shell
 // ---------------------------------------------------------------------------
 function renderApp(machines: Machine[]) {
+  app.machines = machines;
   if (!machines.length) {
     rootEl.innerHTML = `<div class="screen-center"><div class="card-center">
       <div class="logo">🖥️</div><h1>No machines linked</h1>
-      <p>In the desktop app, open <b>Settings → Remote Hosting → Generate link code</b>, then link it here.</p>
-      <button class="btn ghost" onclick="location.reload()">Refresh</button>
+      <p>In the desktop app, open <b>Settings → Remote Hosting → Generate link code</b>, then enter the code here to link it.</p>
+      <button class="btn" id="linkBtn">Link a machine</button>
+      <button class="btn ghost" style="margin-top:10px" onclick="location.reload()">Refresh</button>
     </div></div>`;
+    $('#linkBtn')!.onclick = openLinkMachine;
     return;
   }
-  app.machine = machines[0]!; // TODO: machine switcher when >1
+  // Pick the last machine the user chose here, else the first. A machine
+  // switcher (the pill) lets them change it or link another.
+  const preferredId = localStorage.getItem('bodhi.machineId');
+  app.machine = machines.find((m) => m.id === preferredId) ?? machines[0]!;
 
   rootEl.innerHTML = `
   <div class="app">
@@ -124,6 +130,7 @@ function renderApp(machines: Machine[]) {
   $('#theme')!.onclick = toggleTheme;
   $('#fab')!.onclick = openCreate;
   $('#fpBtn')!.onclick = openFp; $('#fpBtn2')!.onclick = openFp;
+  $('#machineBtn')!.onclick = openMachineMenu;
   $('#back')!.onclick = () => history.back();
   buildKeys();
   setupCompose();
@@ -452,6 +459,92 @@ function renderDirs(d: { path: string; entries: string[] }) {
   list.innerHTML = '';
   if (!d.entries.length) list.appendChild(h('li', {}, '<div class="dir empty">No subfolders — use this folder</div>'));
   for (const name of d.entries) { const b = h('button', { class: 'dir' }, `<span class="f-ico">📁</span><span class="f-name">${esc(name)}</span><span class="f-chev">›</span>`); b.onclick = () => browseDir(d.path.replace(/\/$/, '') + '/' + name); const li = document.createElement('li'); li.appendChild(b); list.appendChild(li); }
+}
+
+// ---------------------------------------------------------------------------
+// Machine switching + linking
+// ---------------------------------------------------------------------------
+function openMachineMenu() {
+  const scrim = document.createElement('div');
+  scrim.className = 'sheet-scrim open';
+  scrim.innerHTML = `<div class="sheet" role="dialog" aria-modal="true" aria-labelledby="mmh">
+    <div class="sheet-head"><h3 id="mmh">Machines</h3><button class="iconbtn" id="mmx" aria-label="Close">✕</button></div>
+    <ul class="grouptree" id="mmList" role="listbox" aria-label="Choose a machine"></ul>
+    <button class="newgroup" id="mmLink">＋ Link another machine</button>
+  </div>`;
+  document.body.appendChild(scrim);
+  pushLayer(() => scrim.remove());
+  scrim.onclick = (e) => { if (e.target === scrim) history.back(); };
+  $('#mmx')!.onclick = () => history.back();
+  const list = $('#mmList')!;
+  for (const m of app.machines) {
+    const sel = m.id === app.machine?.id;
+    const b = h('button', { class: 'gitem', role: 'option', 'aria-selected': String(sel) },
+      `<span class="g-dot" style="background:${sel ? 'var(--idle)' : 'var(--stop)'}"></span><span class="g-name">${esc(m.name)}</span><span class="g-check">✓</span>`);
+    b.onclick = () => {
+      if (sel) { history.back(); return; }
+      localStorage.setItem('bodhi.machineId', m.id);
+      location.reload();
+    };
+    const li = document.createElement('li'); li.appendChild(b); list.appendChild(li);
+  }
+  $('#mmLink')!.onclick = () => { history.back(); openLinkMachine(); };
+}
+
+function openLinkMachine() {
+  const scrim = document.createElement('div');
+  scrim.className = 'sheet-scrim open';
+  scrim.innerHTML = `<div class="sheet" role="dialog" aria-modal="true" aria-labelledby="lkh">
+    <div class="sheet-head"><h3 id="lkh">Link a machine</h3><button class="iconbtn" id="lkx" aria-label="Close">✕</button></div>
+    <p>In the desktop app open <b>Settings → Remote Hosting → Generate link code</b>, then enter the code here.</p>
+    <div class="fld-label">Link code</div>
+    <input class="txt" id="lkCode" placeholder="XXXX-XXXX" autocapitalize="characters" autocomplete="off" spellcheck="false" />
+    <div class="banner err hidden" id="lkErr" role="alert"></div>
+    <button class="btn" id="lkGo" style="margin-top:16px">Link machine</button>
+  </div>`;
+  document.body.appendChild(scrim);
+  pushLayer(() => scrim.remove());
+  scrim.onclick = (e) => { if (e.target === scrim) history.back(); };
+  $('#lkx')!.onclick = () => history.back();
+  const codeInput = $<HTMLInputElement>('#lkCode')!;
+  const err = $('#lkErr')!;
+  const go = $<HTMLButtonElement>('#lkGo')!;
+  setTimeout(() => codeInput.focus(), 50);
+  codeInput.addEventListener('input', () => { codeInput.value = codeInput.value.toUpperCase(); });
+  const submit = async () => {
+    const code = codeInput.value.trim();
+    if (!code) return;
+    go.disabled = true; err.classList.add('hidden');
+    try {
+      const res = await api('/link/claim', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ code }) });
+      if (res.ok) {
+        const { machine } = (await res.json()) as { machine: Machine };
+        localStorage.setItem('bodhi.machineId', machine.id);
+        location.reload();
+        return;
+      }
+      const data = (await res.json().catch(() => ({ error: 'link_failed' }))) as { error?: string };
+      err.textContent = linkErrorText(data.error);
+      err.classList.remove('hidden');
+      go.disabled = false;
+    } catch {
+      err.textContent = "Couldn't reach the relay. Check your connection and try again.";
+      err.classList.remove('hidden');
+      go.disabled = false;
+    }
+  };
+  go.onclick = submit;
+  codeInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); submit(); } });
+}
+
+function linkErrorText(error?: string): string {
+  switch (error) {
+    case 'link_not_found': return "That code wasn't found — double-check it and try again.";
+    case 'link_expired': return 'That code expired. Generate a fresh one in the desktop app.';
+    case 'link_already_used': return 'That code was already used. Generate a new one.';
+    case 'invalid_request': return 'Enter a valid link code.';
+    default: return "Couldn't link that code. Please try again.";
+  }
 }
 
 boot();

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -187,7 +187,16 @@ function onAgentMessage(m: Inner) {
     return;
   }
   if (m.type === 'terminal:size') { if (m.sessionId === app.activeId && term) term.resize(Math.max(2, Number(m.cols) || 80), Math.max(2, Number(m.rows) || 24)); return; }
-  if (m.type === 'terminal:output') { if (m.sessionId === app.activeId && term) term.write(String(m.data)); return; }
+  if (m.type === 'terminal:output') {
+    if (m.sessionId === app.activeId && term) {
+      // .screen owns the scroll now, so keep it pinned to the latest output
+      // (tail) unless the user has scrolled up to read history.
+      const screen = $('#screen');
+      const atBottom = !screen || screen.scrollHeight - screen.scrollTop - screen.clientHeight < 40;
+      term.write(String(m.data), () => { if (atBottom && screen) screen.scrollTop = screen.scrollHeight; });
+    }
+    return;
+  }
   if (m.type === 'terminal:exit') { if (m.sessionId === app.activeId && term) term.write('\r\n\x1b[90m[session exited]\x1b[0m\r\n'); return; }
   if (m.type === 'error') { /* surface transient errors */ console.warn('agent error:', m.message); }
 }

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -260,7 +260,20 @@ function ensureTerm() {
   // fit/resize the PTY. We only keep the pane sized to the visible viewport so
   // the on-screen keyboard doesn't hide it (and can't be over-scrolled past).
   const vv = window.visualViewport;
-  if (vv) vv.addEventListener('resize', () => { const tp = $('.term-pane'); if (tp && matchMedia('(max-width:859px)').matches) tp.style.height = vv.height + 'px'; });
+  if (vv) {
+    // Pin the terminal pane to the visual viewport. On iOS the on-screen
+    // keyboard both shrinks (vv.height) AND vertically offsets (vv.offsetTop)
+    // the visual viewport; without matching the offset the fixed pane's top
+    // stays at 0 and the bottom (compose bar) gets pushed under the keyboard.
+    const syncViewport = () => {
+      const tp = $('.term-pane');
+      if (!tp || !matchMedia('(max-width:859px)').matches) return;
+      tp.style.height = vv.height + 'px';
+      tp.style.top = vv.offsetTop + 'px';
+    };
+    vv.addEventListener('resize', syncViewport);
+    vv.addEventListener('scroll', syncViewport);
+  }
 }
 
 function updateTermHeader() {

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -488,7 +488,10 @@ function openMachineMenu() {
     };
     const li = document.createElement('li'); li.appendChild(b); list.appendChild(li);
   }
-  $('#mmLink')!.onclick = () => { history.back(); openLinkMachine(); };
+  // Stack the link sheet on top of the menu (like the create → new-group
+  // flow). Do NOT history.back() first: popstate is async and would fire
+  // after openLinkMachine() pushed its layer, tearing the link sheet down.
+  $('#mmLink')!.onclick = () => openLinkMachine();
 }
 
 function openLinkMachine() {

--- a/relay/web/src/styles.css
+++ b/relay/web/src/styles.css
@@ -117,7 +117,7 @@ input, textarea { font-family: inherit; }
 .term-title .t-meta { font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .screen { flex: 1; min-height: 0; overflow-x: auto; overflow-y: hidden; overscroll-behavior: contain; padding: 8px 6px 4px; background: var(--bg); }
 .screen .xterm { height: 100%; padding: 0 6px; }
-.xterm-viewport { overscroll-behavior: contain; }
+.xterm-viewport { overscroll-behavior: contain; -webkit-overflow-scrolling: touch; touch-action: pan-y; }
 .xterm-viewport::-webkit-scrollbar { width: 8px; }
 .compose { border-top: 1px solid var(--hair); background: var(--surface); }
 .keys { display: flex; gap: 6px; padding: 8px 10px; overflow-x: auto; scrollbar-width: none; }

--- a/relay/web/src/styles.css
+++ b/relay/web/src/styles.css
@@ -57,7 +57,7 @@ input, textarea { font-family: inherit; }
 .pane { min-height: 0; min-width: 0; display: flex; flex-direction: column; background: var(--bg); }
 .list-pane { border-right: 1px solid var(--hair); position: relative; }
 @media (max-width: 859px) {
-  .term-pane { position: fixed; inset: 0; transform: translateX(100%); transition: transform .28s cubic-bezier(.4,0,.2,1); z-index: 20; }
+  .term-pane { position: fixed; top: 0; left: 0; right: 0; height: 100dvh; transform: translateX(100%); transition: transform .28s cubic-bezier(.4,0,.2,1); z-index: 20; }
   body[data-view="term"] .term-pane { transform: translateX(0); }
 }
 @media (prefers-reduced-motion: reduce) { .term-pane { transition: none !important; } }

--- a/relay/web/src/styles.css
+++ b/relay/web/src/styles.css
@@ -150,7 +150,7 @@ input, textarea { font-family: inherit; }
 .attn-banner { display: flex; align-items: center; gap: 10px; margin: 8px 10px 0; padding: 10px 12px; border-radius: 10px; background: var(--wait-dim); border: 1px solid color-mix(in srgb, var(--wait) 40%, transparent); color: var(--wait); font-size: 12.5px; }
 
 /* sheets */
-.sheet-scrim { position: fixed; inset: 0; background: rgba(0,0,0,.5); display: none; z-index: 40; align-items: flex-end; justify-content: center; }
+.sheet-scrim { position: fixed; inset: 0; background: rgba(0,0,0,.5); display: none; z-index: 60; align-items: flex-end; justify-content: center; }
 .sheet-scrim.open { display: flex; }
 .sheet { width: 100%; max-width: 480px; background: var(--surface); border: 1px solid var(--hair); border-radius: 20px 20px 0 0; padding: 18px 20px calc(22px + var(--safe-b)); box-shadow: var(--shadow); max-height: 88dvh; overflow-y: auto; }
 @media (min-width: 520px) { .sheet-scrim { align-items: center; } .sheet { border-radius: 20px; margin: 20px; } }

--- a/relay/web/src/styles.css
+++ b/relay/web/src/styles.css
@@ -115,9 +115,15 @@ input, textarea { font-family: inherit; }
 .term-title { min-width: 0; }
 .term-title .t-name { font-family: var(--mono); font-weight: 600; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .term-title .t-meta { font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.screen { flex: 1; min-height: 0; overflow-x: auto; overflow-y: hidden; overscroll-behavior: contain; padding: 8px 6px 4px; background: var(--bg); }
-.screen .xterm { height: 100%; padding: 0 6px; }
-.xterm-viewport { overscroll-behavior: contain; -webkit-overflow-scrolling: touch; touch-action: pan-y; }
+/* The viewer matches the desktop's terminal size, which is often bigger than
+   the phone. Rather than clamp xterm to the container (clipping the bottom
+   rows) and rely on xterm's internal viewport for vertical scroll (which
+   doesn't respond to touch), let .screen scroll BOTH axes over the terminal
+   at its natural height — the same mechanism that already made horizontal
+   scroll work. xterm's own viewport is neutralized so it doesn't intercept. */
+.screen { flex: 1; min-height: 0; overflow: auto; -webkit-overflow-scrolling: touch; overscroll-behavior: contain; padding: 8px 6px 4px; background: var(--bg); }
+.screen .xterm { padding: 0 6px; }
+.xterm-viewport { overflow: hidden; overscroll-behavior: contain; }
 .xterm-viewport::-webkit-scrollbar { width: 8px; }
 .compose { border-top: 1px solid var(--hair); background: var(--surface); }
 .keys { display: flex; gap: 6px; padding: 8px 10px; overflow-x: auto; scrollbar-width: none; }


### PR DESCRIPTION
## Problem
Reported after the 3.4.1 release: signing in at the relay web app shows the existing (offline) machine with **no way to enter a new link code**. The M3.4 SPA rewrite dropped the link-claim UI, leaving the server's `/link/claim` endpoint orphaned.

## Fix (relay/web only)
- **Link a machine** flow that POSTs the code to `/link/claim`, reachable from the empty state and from a new machine menu.
- The machine pill now opens a **switcher** listing all linked machines; the selection is remembered in `localStorage` so you return to it, and a new machine auto-selects after linking.
- Friendly errors for `not_found` / `expired` / `already_used`.

## Deploy
Already deployed to the relay VM (`bodhilander.sytanek.tech`) to unblock live testing — container healthy, bundle verified to contain the claim flow. This PR is the source-of-truth catch-up. `sonar.sources=src`, so no gate impact from a `relay/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)