### PR TITLE
fix(settings): remove redundant single-child fragment (S6749)

### DIFF
--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -784,19 +784,17 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                   </div>
 
                   {!apiStatus.running && (
-                    <>
-                      <div className="settings-row">
-                        <label htmlFor="api-port">Port:</label>
-                        <input
-                          id="api-port"
-                          type="number"
-                          value={port}
-                          onChange={e => setPort(parseInt(e.target.value) || 8443)}
-                          min={1024}
-                          max={65535}
-                        />
-                      </div>
-                    </>
+                    <div className="settings-row">
+                      <label htmlFor="api-port">Port:</label>
+                      <input
+                        id="api-port"
+                        type="number"
+                        value={port}
+                        onChange={e => setPort(parseInt(e.target.value) || 8443)}
+                        min={1024}
+                        max={65535}
+                      />
+                    </div>
                   )}
 
                   <div className="settings-actions">


### PR DESCRIPTION
## Summary

Removes a redundant `<>...</>` fragment wrapping a single `div` in `SettingsModal.tsx` (SonarQube rule `typescript:S6749`).

This is the one new violation failing the quality gate on `development`, which is blocking the release PR #128. Once merged, the branch re-analysis should turn the gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)