### PR TITLE
fix(vector-search): address #128 review findings on the shared embedding worker

### DIFF
--- a/src/main/vector-search/__tests__/concurrency.test.ts
+++ b/src/main/vector-search/__tests__/concurrency.test.ts
@@ -20,7 +20,8 @@ import { EventEmitter } from 'events';
 mock.module('electron', () => ({
   app: {
     isPackaged: false,
-    getPath: () => '/tmp/bodhilander-test-userdata',
+    // A fake, never-written path — the fs layer is fully mocked in these tests.
+    getPath: () => '/bodhilander-test-fixtures/userdata',
   },
 }));
 
@@ -49,7 +50,7 @@ mock.module('../embedding-provider', () => ({ EMBEDDING_VERSION: 2 }));
  * cannot preempt — it never settles and never exits.
  */
 class FakeWorker extends EventEmitter {
-  static instances: FakeWorker[] = [];
+  static readonly instances: FakeWorker[] = [];
   posted: any[] = [];
   terminated = false;
   hung = false;
@@ -183,11 +184,19 @@ mock.module('../embedding-service', () => ({
 const { VectorSearchManager } = await import('../index');
 
 const tick = () => new Promise<void>((r) => setImmediate(r));
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 const lastWorker = () => FakeWorker.instances[FakeWorker.instances.length - 1];
 const DEFAULT_TIMEOUT_MS = (RealEmbeddingService as any).REQUEST_TIMEOUT_MS;
 
 afterEach(() => {
-  FakeWorker.instances = [];
+  FakeWorker.instances.length = 0;
   indexes.clear();
   indexSeq = 0;
   vectorSearchCalls.length = 0;
@@ -429,15 +438,12 @@ describe('VectorSearchManager indexing gate', () => {
     const idxA = repo.getIndexByDirectory('/proj/a');
     const w = lastWorker();
 
-    let release!: () => void;
-    embedImpl = () =>
-      new Promise((resolve) => {
-        release = () => resolve([[0.5]]);
-      });
+    const pending = deferred<number[][]>();
+    embedImpl = () => pending.promise;
     w.msg({ type: 'embed-request', requestId: 'r1', texts: ['chunk'] });
     await m.cancelIndexing(idxA.id);
     const postedBefore = w.posted.length;
-    release();
+    pending.resolve([[0.5]]);
     await tick();
     expect(w.posted.length).toBe(postedBefore); // no reply to a dead worker
     m.dispose();

--- a/src/main/vector-search/__tests__/concurrency.test.ts
+++ b/src/main/vector-search/__tests__/concurrency.test.ts
@@ -1,0 +1,483 @@
+/**
+ * BDHLNDR-126 concurrency-machinery tests (#128 review): the single shared
+ * embedding worker (EmbeddingService) and the global indexing serialization
+ * gate/queue in VectorSearchManager. These paths exist to prevent two
+ * concurrent onnxruntime InferenceSessions from crashing the process, so the
+ * races they guard (cancel + same-index restart, superseded-worker exits,
+ * queue draining, hung-worker timeout) are what is exercised here.
+ *
+ * Run with: bun test src/main/vector-search
+ */
+import { describe, expect, test, afterEach, mock } from 'bun:test';
+import { EventEmitter } from 'events';
+
+// ---------------------------------------------------------------------------
+// Module mocks. mock.module is process-global in bun, so every stub is
+// registered before the modules under test are imported (same pattern as
+// src/main/__tests__/*).
+// ---------------------------------------------------------------------------
+
+mock.module('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => '/tmp/bodhilander-test-userdata',
+  },
+}));
+
+const logStub = { info: () => {}, warn: () => {}, error: () => {} };
+mock.module('electron-log', () => ({ default: logStub, ...logStub }));
+
+mock.module('chokidar', () => ({
+  watch: () => {
+    const w = { on: () => w, close: () => {} };
+    return w;
+  },
+}));
+
+mock.module('../worker-path', () => ({
+  resolveVectorSearchWorker: (name: string) => `/fake/${name}`,
+}));
+
+// embedding-provider has top-level side effects (loads @huggingface/transformers)
+mock.module('../embedding-provider', () => ({ EMBEDDING_VERSION: 2 }));
+
+/**
+ * Stand-in for worker_threads.Worker. Records posted messages; `exit(code)` /
+ * `msg(m)` simulate the real events. terminate() resolves after emitting
+ * 'exit' asynchronously (like the real thing) unless `hung` is set, which
+ * models a worker wedged in a synchronous native call that terminate()
+ * cannot preempt — it never settles and never exits.
+ */
+class FakeWorker extends EventEmitter {
+  static instances: FakeWorker[] = [];
+  posted: any[] = [];
+  terminated = false;
+  hung = false;
+  stdout = null;
+  stderr = null;
+
+  constructor(
+    public scriptPath: string,
+    public options: any
+  ) {
+    super();
+    FakeWorker.instances.push(this);
+  }
+
+  postMessage(m: any): void {
+    this.posted.push(m);
+  }
+
+  terminate(): Promise<number> {
+    if (this.hung) return new Promise(() => {});
+    this.terminated = true;
+    return new Promise((resolve) => {
+      setImmediate(() => {
+        this.emit('exit', 1);
+        resolve(1);
+      });
+    });
+  }
+
+  exit(code: number): void {
+    this.emit('exit', code);
+  }
+
+  msg(m: any): void {
+    this.emit('message', m);
+  }
+}
+
+mock.module('worker_threads', () => ({ Worker: FakeWorker }));
+
+// In-memory stand-in for the code-search repository.
+let indexSeq = 0;
+const indexes = new Map<string, any>();
+const vectorSearchCalls: any[] = [];
+const repo = {
+  getIndexByDirectory: (d: string) =>
+    [...indexes.values()].find((i) => i.directoryPath === d) ?? null,
+  createIndex: (d: string) => {
+    const idx = {
+      id: `idx-${++indexSeq}`,
+      directoryPath: d,
+      status: 'pending',
+      error: null,
+      fileCount: 0,
+      chunkCount: 0,
+      consecutiveFailures: 0,
+      embeddingVersion: 2,
+    };
+    indexes.set(idx.id, idx);
+    return idx;
+  },
+  getIndexById: (id: string) => indexes.get(id) ?? null,
+  updateIndexStatus: (id: string, status: string, error: string | null = null) => {
+    const i = indexes.get(id);
+    if (i) {
+      i.status = status;
+      i.error = error;
+    }
+  },
+  incrementConsecutiveFailures: (id: string) => {
+    const i = indexes.get(id);
+    i.consecutiveFailures = (i.consecutiveFailures ?? 0) + 1;
+    return i.consecutiveFailures;
+  },
+  resetConsecutiveFailures: (id: string) => {
+    const i = indexes.get(id);
+    if (i) i.consecutiveFailures = 0;
+  },
+  getEmbeddingVersion: (id: string) => indexes.get(id)?.embeddingVersion ?? null,
+  setEmbeddingVersion: (id: string, v: number) => {
+    const i = indexes.get(id);
+    if (i) i.embeddingVersion = v;
+  },
+  clearIndexData: (id: string, v: number) => {
+    const i = indexes.get(id);
+    if (i) {
+      i.status = 'pending';
+      i.embeddingVersion = v;
+      i.chunkCount = 0;
+    }
+  },
+  getIndexedFiles: () => [],
+  updateIndexCounts: () => {},
+  deleteChunksByFile: () => {},
+  deleteSymbolsByFile: () => {},
+  deleteIndexedFile: () => {},
+  upsertIndexedFile: () => {},
+  updateFileChunkCount: () => {},
+  createChunk: () => {},
+  createSymbol: () => ({ id: 'sym-1' }),
+  searchChunksByVector: (...args: any[]) => {
+    vectorSearchCalls.push(args);
+    return [{ chunkId: 'c1' }];
+  },
+  searchSymbols: () => [],
+  deleteIndex: (id: string) => {
+    indexes.delete(id);
+  },
+};
+mock.module('../../repositories/code-search', () => repo);
+
+// Import the real EmbeddingService (against the mocked deps above), capture it
+// into plain consts, THEN re-mock the module so VectorSearchManager gets a
+// controllable singleton. Capturing before mock.module registers is load-
+// bearing: bun retargets bindings on the module namespace once the mock is in.
+const realEmbeddingModule = await import('../embedding-service');
+const RealEmbeddingService = realEmbeddingModule.EmbeddingService;
+
+let embedImpl: (texts: string[]) => Promise<number[][]> = async (t) => t.map(() => [0.1]);
+let embedQueryImpl: (q: string) => Promise<number[]> = async () => [0.1];
+const embedStub = {
+  embed: (texts: string[]) => embedImpl(texts),
+  embedQuery: (q: string) => embedQueryImpl(q),
+};
+mock.module('../embedding-service', () => ({
+  EmbeddingService: RealEmbeddingService,
+  getEmbeddingService: () => embedStub,
+  disposeEmbeddingService: () => {},
+}));
+
+const { VectorSearchManager } = await import('../index');
+
+const tick = () => new Promise<void>((r) => setImmediate(r));
+const lastWorker = () => FakeWorker.instances[FakeWorker.instances.length - 1];
+const DEFAULT_TIMEOUT_MS = (RealEmbeddingService as any).REQUEST_TIMEOUT_MS;
+
+afterEach(() => {
+  FakeWorker.instances = [];
+  indexes.clear();
+  indexSeq = 0;
+  vectorSearchCalls.length = 0;
+  embedImpl = async (t) => t.map(() => [0.1]);
+  embedQueryImpl = async () => [0.1];
+  (RealEmbeddingService as any).REQUEST_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
+});
+
+// ---------------------------------------------------------------------------
+// EmbeddingService — the single shared embedding worker
+// ---------------------------------------------------------------------------
+
+describe('EmbeddingService', () => {
+  const embedRequest = (w: FakeWorker, i = 0) =>
+    w.posted.filter((m) => m.type === 'embed')[i];
+
+  test('resolves a request when the worker replies with embed-result', async () => {
+    const svc = new RealEmbeddingService();
+    const p = svc.embed(['a', 'b']);
+    const w = lastWorker();
+    expect(w.posted[0]).toMatchObject({ type: 'init' });
+    const req = embedRequest(w);
+    expect(req.texts).toEqual(['a', 'b']);
+    w.msg({ type: 'embed-result', requestId: req.requestId, embeddings: [[1], [2]] });
+    expect(await p).toEqual([[1], [2]]);
+    svc.dispose();
+  });
+
+  test('embed-error rejects only the matching request', async () => {
+    const svc = new RealEmbeddingService();
+    const p1 = svc.embed(['a']);
+    const p2 = svc.embed(['b']);
+    const w = lastWorker();
+    const [r1, r2] = [embedRequest(w, 0), embedRequest(w, 1)];
+    w.msg({ type: 'embed-error', requestId: r1.requestId, error: 'boom' });
+    await expect(p1).rejects.toThrow('boom');
+    w.msg({ type: 'embed-result', requestId: r2.requestId, embeddings: [[9]] });
+    expect(await p2).toEqual([[9]]);
+    svc.dispose();
+  });
+
+  test('worker exit rejects all pending; next request respawns a fresh worker', async () => {
+    const svc = new RealEmbeddingService();
+    // Settle both to their error values up front — handlers must be attached
+    // before the exit fires or the second rejection is flagged as unhandled
+    // while the first is awaited.
+    const p1 = svc.embed(['a']).catch((e: Error) => e);
+    const p2 = svc.embed(['b']).catch((e: Error) => e);
+    const w1 = lastWorker();
+    w1.exit(1);
+    expect(((await p1) as Error).message).toContain('exited (code 1)');
+    expect(((await p2) as Error).message).toContain('exited (code 1)');
+
+    const p3 = svc.embed(['c']);
+    const w2 = lastWorker();
+    expect(w2).not.toBe(w1);
+    const req = embedRequest(w2);
+    w2.msg({ type: 'embed-result', requestId: req.requestId, embeddings: [[3]] });
+    expect(await p3).toEqual([[3]]);
+    svc.dispose();
+  });
+
+  test('a late exit from a superseded worker cannot fail the replacement worker', async () => {
+    const svc = new RealEmbeddingService();
+    const p1 = svc.embed(['a']);
+    const w1 = lastWorker();
+    w1.exit(1);
+    await expect(p1).rejects.toThrow();
+
+    const p2 = svc.embed(['b']);
+    const w2 = lastWorker();
+    // 'error' and 'exit' both fire for a dying worker — replay the stale exit
+    // after w2 owns the service state.
+    w1.exit(1);
+    const req = embedRequest(w2);
+    w2.msg({ type: 'embed-result', requestId: req.requestId, embeddings: [[7]] });
+    expect(await p2).toEqual([[7]]);
+    svc.dispose();
+  });
+
+  test('request timeout fails pending immediately and blocks respawn until the hung worker exits', async () => {
+    (RealEmbeddingService as any).REQUEST_TIMEOUT_MS = 20;
+    const svc = new RealEmbeddingService();
+    const p = svc.embed(['a']);
+    const w1 = lastWorker();
+    // Wedged in a synchronous native call: terminate() never completes and
+    // 'exit' never fires on its own.
+    w1.hung = true;
+    await expect(p).rejects.toThrow('unresponsive');
+
+    // The single-ONNX-session invariant: no replacement worker may spawn
+    // while the wedged one is still alive — requests fail fast instead.
+    await expect(svc.embed(['b'])).rejects.toThrow('temporarily unavailable');
+    expect(FakeWorker.instances.length).toBe(1);
+
+    // The wedged native call finally returns and the thread dies — service
+    // recovers on the next request.
+    w1.exit(1);
+    const p3 = svc.embed(['c']);
+    const w2 = lastWorker();
+    expect(w2).not.toBe(w1);
+    const req = w2.posted.find((m: any) => m.type === 'embed');
+    w2.msg({ type: 'embed-result', requestId: req.requestId, embeddings: [[5]] });
+    expect(await p3).toEqual([[5]]);
+    svc.dispose();
+  });
+
+  test('dispose rejects pending requests', async () => {
+    const svc = new RealEmbeddingService();
+    const p = svc.embed(['a']);
+    svc.dispose();
+    await expect(p).rejects.toThrow('disposed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VectorSearchManager — global serialization gate, queue, crash breaker
+// ---------------------------------------------------------------------------
+
+describe('VectorSearchManager indexing gate', () => {
+  const makeManager = () => new VectorSearchManager();
+
+  test('second directory queues behind the gate and starts when the active worker exits', async () => {
+    const m = makeManager();
+    await m.startIndexing('/proj/a');
+    expect(FakeWorker.instances.length).toBe(1);
+    const wA = lastWorker();
+    expect(wA.posted[0]).toMatchObject({ type: 'start', directoryPath: '/proj/a' });
+
+    // B (twice — the queue dedupes) while A holds the gate: no new worker.
+    await m.startIndexing('/proj/b');
+    await m.startIndexing('/proj/b');
+    expect(FakeWorker.instances.length).toBe(1);
+
+    // A's worker ends → gate released → B starts.
+    wA.exit(0);
+    await tick();
+    expect(FakeWorker.instances.length).toBe(2);
+    expect(lastWorker().posted[0]).toMatchObject({ type: 'start', directoryPath: '/proj/b' });
+
+    m.dispose();
+  });
+
+  test('cancelling a queued directory removes it — the gate drain must not resurrect it', async () => {
+    const m = makeManager();
+    await m.startIndexing('/proj/a');
+    const wA = lastWorker();
+    await m.startIndexing('/proj/b');
+    const idxB = repo.getIndexByDirectory('/proj/b');
+
+    await m.cancelIndexing(idxB.id);
+    wA.exit(0);
+    await tick();
+
+    // Only A's worker ever existed; B was dequeued, not started.
+    expect(FakeWorker.instances.length).toBe(1);
+    m.dispose();
+  });
+
+  test('cancel + immediate same-index restart: the superseded worker\'s late exit cannot release the new worker\'s gate or slot', async () => {
+    const m = makeManager();
+    await m.startIndexing('/proj/a');
+    const idxA = repo.getIndexByDirectory('/proj/a');
+    const w1 = lastWorker();
+
+    // Cancel (removes w1 from `workers` synchronously, gate still held) and
+    // restart before w1's exit fires — the same-index gate bypass.
+    w1.hung = true; // hold termination so the restart truly races the exit
+    const cancelPromise = m.cancelIndexing(idxA.id);
+    await m.startIndexing('/proj/a');
+    const w2 = lastWorker();
+    expect(w2).not.toBe(w1);
+    expect((m as any).activeWorker).toBe(w2);
+
+    // The superseded worker finally exits. Identity guards must keep it from
+    // deleting w2's slot, reporting a false error, or releasing w2's gate.
+    w1.exit(1);
+    await tick();
+    expect((m as any).activeWorker).toBe(w2);
+    expect((m as any).activeIndexId).toBe(idxA.id);
+    expect((m as any).workers.get(idxA.id)).toBe(w2);
+    expect(repo.getIndexById(idxA.id).status).toBe('indexing');
+    expect(w2.terminated).toBe(false);
+
+    // A directory queued behind the restart must stay queued (gate not freed).
+    await m.startIndexing('/proj/b');
+    expect(FakeWorker.instances.length).toBe(2);
+
+    m.dispose();
+    await Promise.race([cancelPromise, tick()]);
+  });
+
+  test('crash circuit breaker: repeated crashed attempts stop spawning and release the queue', async () => {
+    const m = makeManager();
+    const idx = repo.createIndex('/proj/crashy');
+    idx.status = 'indexing'; // stale 'indexing' = previous attempt crashed the process
+    idx.consecutiveFailures = 1;
+
+    const errors: any[] = [];
+    m.on('indexing-error', (e) => errors.push(e));
+
+    await m.startIndexing('/proj/crashy');
+    expect(FakeWorker.instances.length).toBe(0); // breaker tripped, no worker
+    expect(repo.getIndexById(idx.id).status).toBe('error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error).toContain('consecutive crashes');
+    m.dispose();
+  });
+
+  test('embed-request from an indexing worker is brokered and answered on the same requestId', async () => {
+    const m = makeManager();
+    await m.startIndexing('/proj/a');
+    const w = lastWorker();
+
+    w.msg({ type: 'embed-request', requestId: 'r1', texts: ['chunk'] });
+    await tick();
+    expect(w.posted).toContainEqual({
+      type: 'embed-response',
+      requestId: 'r1',
+      embeddings: [[0.1]],
+    });
+
+    embedImpl = async () => {
+      throw new Error('model gone');
+    };
+    w.msg({ type: 'embed-request', requestId: 'r2', texts: ['chunk'] });
+    await tick();
+    expect(w.posted).toContainEqual({
+      type: 'embed-error',
+      requestId: 'r2',
+      error: 'model gone',
+    });
+    m.dispose();
+  });
+
+  test('embed-response is not posted to a worker that was cancelled while embedding', async () => {
+    const m = makeManager();
+    await m.startIndexing('/proj/a');
+    const idxA = repo.getIndexByDirectory('/proj/a');
+    const w = lastWorker();
+
+    let release!: () => void;
+    embedImpl = () =>
+      new Promise((resolve) => {
+        release = () => resolve([[0.5]]);
+      });
+    w.msg({ type: 'embed-request', requestId: 'r1', texts: ['chunk'] });
+    await m.cancelIndexing(idxA.id);
+    const postedBefore = w.posted.length;
+    release();
+    await tick();
+    expect(w.posted.length).toBe(postedBefore); // no reply to a dead worker
+    m.dispose();
+  });
+});
+
+describe('VectorSearchManager.searchCode', () => {
+  const readyIndex = (dir: string) => {
+    const idx = repo.createIndex(dir);
+    idx.status = 'ready';
+    return idx;
+  };
+
+  test('surfaces an embedding failure as an error instead of an empty result', async () => {
+    const m = new VectorSearchManager();
+    readyIndex('/proj/s');
+    embedQueryImpl = async () => {
+      throw new Error('worker exploded');
+    };
+    await expect(m.searchCode('/proj/s', 'query')).rejects.toThrow(
+      'Semantic search is unavailable: worker exploded'
+    );
+    expect(vectorSearchCalls).toHaveLength(0);
+    m.dispose();
+  });
+
+  test('returns vector matches when embedding succeeds', async () => {
+    const m = new VectorSearchManager();
+    readyIndex('/proj/s');
+    const results = await m.searchCode('/proj/s', 'query');
+    expect(results).toEqual([{ chunkId: 'c1' }] as any);
+    expect(vectorSearchCalls).toHaveLength(1);
+    m.dispose();
+  });
+
+  test('returns [] without searching when the index is not ready', async () => {
+    const m = new VectorSearchManager();
+    repo.createIndex('/proj/s'); // status 'pending'
+    expect(await m.searchCode('/proj/s', 'query')).toEqual([]);
+    expect(vectorSearchCalls).toHaveLength(0);
+    m.dispose();
+  });
+});

--- a/src/main/vector-search/embedding-service.ts
+++ b/src/main/vector-search/embedding-service.ts
@@ -25,6 +25,16 @@ export class EmbeddingService {
   private readonly pending = new Map<string, PendingRequest>();
   private seq = 0;
 
+  // A worker that timed out and was told to terminate, but whose 'exit' has
+  // not fired yet. terminate() reliably interrupts JS execution and
+  // Atomics.wait, but it CANNOT preempt a synchronous native call — a wedged
+  // InferenceSession::Run only lets the thread die when it returns. Until the
+  // exit is observed we must not spawn a replacement: two live ONNX sessions
+  // is the exact crash this service exists to prevent (BDHLNDR-126). While
+  // set, requests fail fast with a clear error instead of queueing behind a
+  // dead worker.
+  private blocked: Worker | null = null;
+
   // A stalled native inference emits no 'error'/'exit', so bound every request.
   // Generous enough to cover a cold model download on the first call (matches
   // the indexing init timeout); only a genuine hang trips it.
@@ -32,6 +42,15 @@ export class EmbeddingService {
 
   private ensureWorker(): Worker {
     if (this.worker) return this.worker;
+
+    if (this.blocked) {
+      // A hung worker is still shutting down (or wedged in a native call that
+      // terminate() cannot interrupt). Fail fast — callers surface this to the
+      // UI — and recover automatically the moment its 'exit' finally fires.
+      throw new Error(
+        'Embedding worker is unresponsive and still shutting down; embedding is temporarily unavailable'
+      );
+    }
 
     const workerPath = resolveVectorSearchWorker('embedding-worker.js');
     const workerOptions: any = { stdout: true, stderr: true };
@@ -103,6 +122,8 @@ export class EmbeddingService {
       if (code !== 0) {
         log.error(`[EmbeddingService] Worker exited with code ${code}`);
       }
+      // A timed-out worker has finally died — lift the respawn block.
+      if (this.blocked === worker) this.blocked = null;
       failAll(new Error(`Embedding worker exited (code ${code})`));
     });
 
@@ -136,12 +157,7 @@ export class EmbeddingService {
           `[EmbeddingService] Embed request ${requestId} exceeded ` +
             `${EmbeddingService.REQUEST_TIMEOUT_MS}ms; restarting embedding worker`
         );
-        // A hung worker won't recover on its own. Terminating fires 'exit' →
-        // failAll, which rejects every pending request for this worker and
-        // clears this.worker so the next request respawns a fresh one.
-        worker.terminate().catch((err) => {
-          log.warn('[EmbeddingService] Error terminating hung worker:', err);
-        });
+        this.failHungWorker(worker);
       }, EmbeddingService.REQUEST_TIMEOUT_MS);
       this.pending.set(requestId, {
         resolve: (embeddings) => {
@@ -157,6 +173,30 @@ export class EmbeddingService {
     });
   }
 
+  /**
+   * A request timed out — the worker is hung. Reject every pending request
+   * NOW rather than waiting for terminate() → 'exit': if the worker is wedged
+   * inside a synchronous native call (a stuck InferenceSession::Run),
+   * terminate() cannot interrupt it and 'exit' may not fire until the call
+   * returns — possibly never. Callers get an immediate, descriptive error
+   * (surfaced by searchCode / the indexing pipeline) instead of stacking more
+   * timeouts behind a dead worker. The worker is parked in `blocked` until its
+   * exit is actually observed, so we never overlap two ONNX sessions.
+   */
+  private failHungWorker(worker: Worker): void {
+    if (this.worker !== worker) return; // superseded; a newer worker owns state
+    const err = new Error(
+      `Embedding request timed out after ${EmbeddingService.REQUEST_TIMEOUT_MS}ms (embedding worker unresponsive)`
+    );
+    for (const [, p] of this.pending) p.reject(err);
+    this.pending.clear();
+    this.worker = null;
+    this.blocked = worker;
+    worker.terminate().catch((terminateErr) => {
+      log.warn('[EmbeddingService] Error terminating hung worker:', terminateErr);
+    });
+  }
+
   dispose(): void {
     for (const [, p] of this.pending) {
       p.reject(new Error('Embedding service disposed'));
@@ -168,6 +208,7 @@ export class EmbeddingService {
       });
       this.worker = null;
     }
+    this.blocked = null;
   }
 }
 

--- a/src/main/vector-search/index.ts
+++ b/src/main/vector-search/index.ts
@@ -263,6 +263,18 @@ export class VectorSearchManager extends EventEmitter {
     // indexing, queue this directory instead of spawning a second worker —
     // two concurrent onnxruntime InferenceSessions crash the process. The
     // queue is drained (startNextQueued) whenever the active worker ends.
+    //
+    // Same-index bypass invariant: `activeIndexId === index.id` here only
+    // happens during a cancel + immediate restart of the SAME index —
+    // cancelIndexing removes the worker from `workers` synchronously (so the
+    // `workers.has` guard above passes) but the gate stays held until the
+    // dying worker's 'exit' fires. The restart re-enters the gate it already
+    // owns and installs a new worker/activeWorker; the superseded worker's
+    // exit and error handlers are identity-guarded (ownsSlot/ownsGate below)
+    // so the late exit can neither kill the new worker nor release the new
+    // worker's gate. Changing any of these three pieces (sync workers.delete
+    // in cancelIndexing, this bypass, the identity guards) requires
+    // re-checking the other two.
     if (this.activeIndexId !== null && this.activeIndexId !== index.id) {
       if (!this.queuedDirectories.has(directoryPath)) {
         this.queuedDirectories.add(directoryPath);
@@ -822,15 +834,18 @@ export class VectorSearchManager extends EventEmitter {
     }
 
     // Generate query embedding via the single embedding worker (BDHLNDR-126) —
-    // never a main-process ONNX session, which could race an active index. Only
-    // the embedding is guarded here; a DB/search failure (corruption, dimension
-    // mismatch) should surface, not be masked as an empty result.
+    // never a main-process ONNX session, which could race an active index.
     let queryEmbedding: number[];
     try {
       queryEmbedding = await getEmbeddingService().embedQuery(query);
     } catch (err) {
       log.error('[VectorSearch] searchCode embedding failed:', err);
-      return [];
+      // Rethrow rather than returning [] — an empty array here is
+      // indistinguishable from "no matches" in the UI. The IPC handler
+      // propagates the rejection to useCodeSearch (which renders
+      // searchError) and the HTTP route maps it to a 500.
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Semantic search is unavailable: ${msg}`);
     }
     if (queryEmbedding.length === 0) {
       return [];


### PR DESCRIPTION
## Summary

Addresses the blocking findings from @brannon-bowden's review on release PR #128 (the BDHLNDR-126 concurrent-ONNX fix).

### 1. `searchCode` no longer swallows embedding failures
It rethrows `Semantic search is unavailable: <cause>` instead of returning `[]`. The propagation path already existed end-to-end: `safeHandle` re-throws over IPC → `useCodeSearch` catches into `searchError` (rendered in the UI); the HTTP route maps the rejection to a 500. A dead embedding worker is now visibly distinct from "no matches".

### 2. Hung-worker recovery no longer depends on `terminate()` interrupting native code
Verified empirically: `worker.terminate()` interrupts a tight synchronous JS loop and an `Atomics.wait` block in ~2–3 ms, but per Node docs it cannot preempt a synchronous **native** call (a wedged `InferenceSession::Run`) — `exit` may never fire. On request timeout the service now:
- rejects all pending requests **immediately** (callers get a descriptive error, surfaced by item 1),
- parks the wedged worker in a `blocked` slot and terminates best-effort,
- **defers respawn until the worker's `exit` is actually observed** — spawning a second ONNX session while the old one may still be inside `Run` would reintroduce the exact concurrent-inference crash this machinery exists to prevent. Until then, new requests fail fast instead of stacking 5-minute timeouts.

Net: JS-level hangs recover automatically in milliseconds; a true native wedge degrades to loud, immediate errors instead of a silently dead service.

### 3. Tests for the concurrency machinery
New `src/main/vector-search/__tests__/concurrency.test.ts` (15 tests, `bun test src/main/vector-search`) covering: request/response correlation; per-request error isolation; exit fail-all + respawn; superseded-worker late exits (service and manager); the timeout/blocked/recovery path; gate serialization + queue dedupe/drain; cancel-of-queued not resurrected by the drain; **cancel + immediate same-index restart race** (the ownsSlot/ownsGate invariant); the crash circuit breaker; embed-request brokering (success/error/cancelled-worker); and `searchCode` error surfacing.

### 4. Same-index gate-bypass invariant documented
The subtle `activeIndexId === index.id` bypass in `startIndexing` now carries a comment spelling out the three pieces it depends on (sync `workers.delete` in `cancelIndexing`, the bypass, the identity guards) — plus the test above locks the behavior in.

## Verification
- `bun test src/main/vector-search` — 15/15 pass
- `bun test src/main` — 143 pass / 1 pre-existing failure (`chat-parser 06-response` snapshot, fails on `development` too, unrelated)
- `tsc -p tsconfig.main.json --noEmit` — clean

The reviewer's non-blocking suggestion to surface a "queued" indexing state in the UI needs a new `IndexStatus` value through shared types + renderer; proposing to track that as a follow-up ticket rather than grow the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)