### PR TITLE
feat(providers): friendly CLI launch-failure hints + one-click install

### DIFF
--- a/src/main/__tests__/account-auth.test.ts
+++ b/src/main/__tests__/account-auth.test.ts
@@ -42,6 +42,10 @@ mock.module('../repositories/accounts', () => ({
     if (i >= 0) accounts.splice(i, 1);
   },
   getAccount: (id: string) => accounts.find((a) => a.id === id) ?? null,
+  // Unused here, but pty-manager imports these names from the same module —
+  // bun's mock.module patches globally, so keep the surface a superset.
+  resolveAccountForSession: () => null,
+  touchAccount: () => undefined,
 }));
 
 mock.module('../mcp-config', () => ({

--- a/src/main/__tests__/provider-detector.test.ts
+++ b/src/main/__tests__/provider-detector.test.ts
@@ -58,6 +58,11 @@ describe('detectProviders', () => {
       expect(s.name.length).toBeGreaterThan(0);
       expect(s.command.length).toBeGreaterThan(0);
       expect(s.installHint.length).toBeGreaterThan(0);
+      // Runnable install command is optional (null for GUI-install providers)
+      // but must be a non-empty string when present.
+      if (s.installCommand !== null) {
+        expect(s.installCommand.length).toBeGreaterThan(0);
+      }
       expect(s.docsUrl.startsWith('https://')).toBe(true);
       expect(s.loginHint.length).toBeGreaterThan(0);
       if (!s.installed) {

--- a/src/main/__tests__/provider-install.test.ts
+++ b/src/main/__tests__/provider-install.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Provider install-command orchestration tests.
+ *
+ * The IPC argument validation here is a trust boundary: the renderer only
+ * supplies ids, commands come from the static registry, and the cancel
+ * channel must not be able to kill non-install ptys.
+ *
+ * Run with: bun test src/main/__tests__
+ */
+import { describe, expect, mock, test } from 'bun:test';
+import type { PtyManager } from '../pty-manager';
+
+// The real provider registry pulls in electron (socket-path helpers) — stub
+// it, then load the modules under test dynamically (static imports would be
+// hoisted above the mock).
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
+}));
+
+const { startProviderInstall, cancelProviderInstall, INSTALL_PTY_PREFIX } =
+  await import('../provider-install');
+const { listProviders } = await import('../providers');
+
+interface StubCalls {
+  killed: string[];
+  created: Array<{ id: string; command: string }>;
+}
+
+function stubPtyManager(): { manager: PtyManager; calls: StubCalls } {
+  const calls: StubCalls = { killed: [], created: [] };
+  const manager = {
+    kill: async (id: string) => {
+      calls.killed.push(id);
+    },
+    createInstallSession: (id: string, command: string) => {
+      calls.created.push({ id, command });
+    },
+  } as unknown as PtyManager;
+  return { manager, calls };
+}
+
+describe('startProviderInstall', () => {
+  test('spawns the registry install command under the install namespace', async () => {
+    const { manager, calls } = stubPtyManager();
+    const result = await startProviderInstall(manager, 'codex');
+
+    expect(result.ptyId).toBe(`${INSTALL_PTY_PREFIX}codex`);
+    expect(result.command).toBe(
+      listProviders().find((p) => p.id === 'codex')!.setup.installCommand!
+    );
+    // Stale pty from a previous run is killed before the new spawn.
+    expect(calls.killed).toEqual([result.ptyId]);
+    expect(calls.created).toEqual([{ id: result.ptyId, command: result.command }]);
+  });
+
+  test('rejects unknown providers', async () => {
+    const { manager, calls } = stubPtyManager();
+    await expect(startProviderInstall(manager, 'not-a-provider')).rejects.toThrow(
+      /no runnable install command/
+    );
+    expect(calls.created).toEqual([]);
+  });
+
+  test('rejects providers without a runnable install command', async () => {
+    const guiOnly = listProviders().filter((p) => !p.setup.installCommand);
+    // The registry currently has at least one GUI-install provider (antigravity).
+    expect(guiOnly.length).toBeGreaterThan(0);
+
+    for (const provider of guiOnly) {
+      const { manager, calls } = stubPtyManager();
+      await expect(startProviderInstall(manager, provider.id)).rejects.toThrow(
+        /no runnable install command/
+      );
+      expect(calls.created).toEqual([]);
+    }
+  });
+
+  test('rejects non-string and empty provider ids', async () => {
+    const { manager, calls } = stubPtyManager();
+    for (const bad of [undefined, null, 42, {}, '']) {
+      await expect(startProviderInstall(manager, bad)).rejects.toThrow('Invalid providerId');
+    }
+    expect(calls.created).toEqual([]);
+  });
+});
+
+describe('cancelProviderInstall', () => {
+  test('kills ptys inside the install namespace', async () => {
+    const { manager, calls } = stubPtyManager();
+    await cancelProviderInstall(manager, `${INSTALL_PTY_PREFIX}codex`);
+    expect(calls.killed).toEqual([`${INSTALL_PTY_PREFIX}codex`]);
+  });
+
+  test('rejects ids outside the install namespace — cannot kill session ptys', async () => {
+    const { manager, calls } = stubPtyManager();
+    for (const bad of [
+      'some-session-uuid',
+      '__login-abc',            // account-login pty
+      ` ${INSTALL_PTY_PREFIX}x`, // prefix not at position 0
+      undefined,
+      null,
+      42,
+    ]) {
+      await expect(cancelProviderInstall(manager, bad)).rejects.toThrow('Not an install pty');
+    }
+    expect(calls.killed).toEqual([]);
+  });
+});

--- a/src/main/__tests__/pty-manager.test.ts
+++ b/src/main/__tests__/pty-manager.test.ts
@@ -1,0 +1,238 @@
+/**
+ * PtyManager launch-failure detection + install-pty lifecycle tests.
+ *
+ * node-pty and every DB-backed dependency are mocked; the pty is a hand-fed
+ * fake whose onData/onExit callbacks the tests drive directly. Covers:
+ * - the one-shot providerHint gate and its 15s window cutoff,
+ * - failure signatures surviving a chatty startup (dedicated launch buffer)
+ *   and pty chunk splits,
+ * - createInstallSession's deferred emission, prime flush, and
+ *   exit-before-prime flush.
+ *
+ * Run with: bun test src/main/__tests__
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as os from 'os';
+import { ProviderInstallHint } from '../../shared/types';
+
+interface FakePty {
+  pid: number;
+  spawnFile: string;
+  spawnArgs: string[];
+  dataCb: ((data: string) => void) | null;
+  exitCb: ((event: { exitCode: number }) => void) | null;
+  onData(cb: (data: string) => void): void;
+  onExit(cb: (event: { exitCode: number }) => void): void;
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(): void;
+}
+
+const spawned: FakePty[] = [];
+
+function fakeSpawn(file: string, args: string[]): FakePty {
+  const p: FakePty = {
+    pid: 1000 + spawned.length,
+    spawnFile: file,
+    spawnArgs: args,
+    dataCb: null,
+    exitCb: null,
+    onData(cb) { p.dataCb = cb; },
+    onExit(cb) { p.exitCb = cb; },
+    write() {},
+    resize() {},
+    kill() { p.exitCb?.({ exitCode: 0 }); },
+  };
+  spawned.push(p);
+  return p;
+}
+
+// Mock discipline: bun's mock.module patches a specifier for the whole test
+// process, so ONLY mock modules that no other test file exercises for real
+// (node-pty, electron-log, memory/injector) or that are mocked with a
+// compatible shape elsewhere (electron, preferences, accounts,
+// shell-detector). The provider registry, sessions repository, and key-vault
+// are used REAL — resolve.test/sessions.test/key-vault.test cover them —
+// which works because these tests run codex, a passthrough provider whose
+// capabilities are all false, so no DB-backed function is ever called.
+mock.module('node-pty', () => ({ spawn: fakeSpawn }));
+mock.module('electron-log', () => ({
+  default: { info() {}, warn() {}, error() {} },
+}));
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
+  safeStorage: { isEncryptionAvailable: () => false },
+}));
+// null (not '') so the real key-vault sees "no key stored / opt-in off".
+mock.module('../repositories/preferences', () => ({
+  getPreference: () => null,
+  setPreference: () => {},
+  deletePreference: () => {},
+}));
+// Superset of the accounts-repo surface so account-auth.ts stays satisfied
+// no matter which file's mock a given evaluation order leaves in place.
+mock.module('../repositories/accounts', () => ({
+  resolveAccountForSession: () => null,
+  touchAccount: () => {},
+  getAllAccounts: () => [],
+  createAccount: (a: unknown) => a,
+  updateAccount: () => undefined,
+  deleteAccount: () => undefined,
+  getAccount: () => null,
+}));
+mock.module('../memory/injector', () => ({
+  writeMemoryFile: () => {},
+  getMemoryInjectionContent: () => null,
+}));
+// Any real, existing executable path works — the pty spawn is mocked.
+mock.module('../shell-detector', () => ({
+  detectShell: () => ({ shell: process.execPath, args: ['-l', '-i'], isWSL: false }),
+}));
+
+const { PtyManager } = await import('../pty-manager');
+const { getProvider } = await import('../providers');
+const codexProvider = getProvider('codex');
+
+const realDateNow = Date.now;
+const cwd = os.homedir();
+
+beforeEach(() => {
+  spawned.length = 0;
+});
+
+afterEach(() => {
+  Date.now = realDateNow;
+});
+
+function createAgentSession(manager: InstanceType<typeof PtyManager>, id = 'session-1') {
+  const hints: ProviderInstallHint[] = [];
+  manager.on('providerHint', (hint: ProviderInstallHint) => hints.push(hint));
+  manager.createSession(id, cwd, true, null, 'codex');
+  const ptyProc = spawned[spawned.length - 1];
+  return { hints, ptyProc };
+}
+
+describe('checkSpawnFailure (via session data flow)', () => {
+  test('emits providerHint once for a broken-install signature, then never again', () => {
+    const manager = new PtyManager();
+    const { hints, ptyProc } = createAgentSession(manager);
+
+    ptyProc.dataCb!('Error: spawn /opt/homebrew/lib/node_modules/@openai/codex/vendor/codex ENOENT\n');
+    expect(hints.length).toBe(1);
+    expect(hints[0]).toMatchObject({
+      sessionId: 'session-1',
+      providerId: 'codex',
+      command: 'codex',
+      kind: 'broken',
+      installCommand: codexProvider.setup.installCommand!,
+    });
+
+    // Same signature again — the one-shot gate holds.
+    ptyProc.dataCb!('Error: spawn /x/y ENOENT\n');
+    ptyProc.dataCb!('zsh: command not found: codex\n');
+    expect(hints.length).toBe(1);
+  });
+
+  test("classifies 'missing' from shell command-not-found output", () => {
+    const manager = new PtyManager();
+    const { hints, ptyProc } = createAgentSession(manager);
+
+    ptyProc.dataCb!('zsh: command not found: codex\n');
+    expect(hints.length).toBe(1);
+    expect(hints[0].kind).toBe('missing');
+  });
+
+  test('matches a signature split across pty data chunks', () => {
+    const manager = new PtyManager();
+    const { hints, ptyProc } = createAgentSession(manager);
+
+    ptyProc.dataCb!('zsh: command not fo');
+    expect(hints.length).toBe(0);
+    ptyProc.dataCb!('und: codex\n');
+    expect(hints.length).toBe(1);
+  });
+
+  test('still fires when a chatty startup precedes the failure line (larger than the 100KB scrollback trim)', () => {
+    const manager = new PtyManager();
+    const { hints, ptyProc } = createAgentSession(manager);
+
+    // 150KB of benign output — enough that scrollbackBuffer's tail trim has
+    // discarded the head. The dedicated launch buffer must still catch the
+    // failure line that follows.
+    const chunk = 'installing dependencies .'.repeat(41); // ~1KB
+    for (let i = 0; i < 150; i++) {
+      ptyProc.dataCb!(chunk);
+    }
+    expect(hints.length).toBe(0);
+
+    ptyProc.dataCb!('\nError: spawn /opt/homebrew/lib/node_modules/@openai/codex/vendor/codex ENOENT\n');
+    expect(hints.length).toBe(1);
+    expect(hints[0].kind).toBe('broken');
+  });
+
+  test('ignores failure signatures after the 15s window (agent output, not a launch failure)', () => {
+    const manager = new PtyManager();
+    const { hints, ptyProc } = createAgentSession(manager);
+
+    Date.now = () => realDateNow() + 20_000;
+    ptyProc.dataCb!('Error: spawn /some/tool ENOENT\n');
+    expect(hints.length).toBe(0);
+  });
+
+  test('normal startup output emits nothing', () => {
+    const manager = new PtyManager();
+    const { hints, ptyProc } = createAgentSession(manager);
+
+    ptyProc.dataCb!('OpenAI Codex v0.48.2\nHow can I help?\n');
+    expect(hints.length).toBe(0);
+  });
+});
+
+describe('createInstallSession', () => {
+  test('wraps the install command in the user shell', () => {
+    const manager = new PtyManager();
+    manager.createInstallSession('__install-codex', 'npm install -g --force @openai/codex');
+
+    const ptyProc = spawned[0];
+    expect(ptyProc.spawnFile).toBe(process.execPath);
+    expect(ptyProc.spawnArgs[ptyProc.spawnArgs.length - 1]).toBe('npm install -g --force @openai/codex');
+  });
+
+  test('defers output until primed, then streams live', () => {
+    const manager = new PtyManager();
+    const events: Array<{ id: string; data: string }> = [];
+    manager.on('data', (e: { id: string; data: string }) => events.push(e));
+
+    manager.createInstallSession('__install-codex', 'npm install -g x');
+    const ptyProc = spawned[0];
+
+    ptyProc.dataCb!('resolving packages...\n');
+    expect(events.length).toBe(0); // held until prime
+
+    manager.primePty('__install-codex');
+    expect(events).toEqual([{ id: '__install-codex', data: 'resolving packages...\n' }]);
+
+    ptyProc.dataCb!('added 1 package\n');
+    expect(events.length).toBe(2);
+    expect(events[1].data).toBe('added 1 package\n');
+  });
+
+  test('flushes buffered output when the pty exits before being primed', () => {
+    const manager = new PtyManager();
+    const events: Array<{ id: string; data: string }> = [];
+    const exits: Array<{ id: string; exitCode: number }> = [];
+    manager.on('data', (e: { id: string; data: string }) => events.push(e));
+    manager.on('exit', (e: { id: string; exitCode: number }) => exits.push(e));
+
+    manager.createInstallSession('__install-codex', 'npm install -g x');
+    const ptyProc = spawned[0];
+
+    ptyProc.dataCb!('npm ERR! network unreachable\n');
+    ptyProc.exitCb!({ exitCode: 1 });
+
+    // The fast failure is not a blank box: buffered output flushes first.
+    expect(events).toEqual([{ id: '__install-codex', data: 'npm ERR! network unreachable\n' }]);
+    expect(exits).toEqual([{ id: '__install-codex', exitCode: 1 }]);
+    expect(manager.getSession('__install-codex')).toBeUndefined();
+  });
+});

--- a/src/main/__tests__/spawn-failure.test.ts
+++ b/src/main/__tests__/spawn-failure.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Provider CLI launch-failure classification tests.
+ *
+ * Run with: bun test src/main/__tests__
+ */
+import { describe, expect, test } from 'bun:test';
+import { classifySpawnFailure } from '../spawn-failure';
+
+describe('classifySpawnFailure', () => {
+  describe("'missing' — shell can't find the CLI", () => {
+    test('zsh', () => {
+      expect(classifySpawnFailure('codex', 'zsh: command not found: codex')).toBe('missing');
+    });
+
+    test('bash', () => {
+      expect(classifySpawnFailure('codex', 'bash: line 1: codex: command not found')).toBe('missing');
+    });
+
+    test('POSIX exec', () => {
+      expect(classifySpawnFailure('grok', 'grok: No such file or directory')).toBe('missing');
+    });
+
+    test('cmd.exe', () => {
+      expect(classifySpawnFailure(
+        'codex',
+        "'codex' is not recognized as an internal or external command,\noperable program or batch file."
+      )).toBe('missing');
+    });
+
+    test('PowerShell', () => {
+      expect(classifySpawnFailure(
+        'codex',
+        "The term 'codex' is not recognized as the name of a cmdlet, function, script file, or operable program."
+      )).toBe('missing');
+    });
+
+    test('requires the provider command name — another missing command does not match', () => {
+      expect(classifySpawnFailure('codex', 'zsh: command not found: fooBar')).toBeNull();
+      expect(classifySpawnFailure('codex', 'bash: rg: command not found')).toBeNull();
+    });
+
+    test('matches through ANSI coloring', () => {
+      expect(classifySpawnFailure('codex', '\x1b[31mzsh: command not found: codex\x1b[0m')).toBe('missing');
+    });
+  });
+
+  describe("'broken' — CLI launched but its startup failed", () => {
+    // Verbatim from the user report that motivated this: codex's npm wrapper
+    // spawning a native platform binary npm never installed.
+    const codexEnoent = `Error: spawn /opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex ENOENT
+    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
+    at onErrorNT (node:internal/child_process:484:16)
+    at process.processTicksAndRejections (node:internal/process/task_queues:89:21) {
+  errno: -2,
+  code: 'ENOENT',
+  syscall: 'spawn /opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex',
+  path: '/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex',
+  spawnargs: []
+}`;
+
+    test('npm wrapper spawn ENOENT (codex user report)', () => {
+      expect(classifySpawnFailure('codex', codexEnoent)).toBe('broken');
+    });
+
+    test('Rosetta / architecture mismatch (zsh lowercase and loader capitalized)', () => {
+      expect(classifySpawnFailure('codex', 'zsh: bad CPU type in executable: codex')).toBe('broken');
+      expect(classifySpawnFailure('codex', '/usr/bin/arch: Bad CPU type in executable')).toBe('broken');
+    });
+
+    test('macOS dynamic-link failure', () => {
+      expect(classifySpawnFailure(
+        'claude',
+        "dyld[4242]: Library not loaded: @rpath/libnode.dylib"
+      )).toBe('broken');
+    });
+
+    test("'missing' wins when both shapes appear", () => {
+      const both = `zsh: command not found: codex\nError: spawn /x/y ENOENT`;
+      expect(classifySpawnFailure('codex', both)).toBe('missing');
+    });
+  });
+
+  describe('normal startup output', () => {
+    test('banner and prompt output is not a failure', () => {
+      expect(classifySpawnFailure('claude', 'Welcome to Claude Code!\n\n> Try "fix the build"')).toBeNull();
+      expect(classifySpawnFailure('codex', 'OpenAI Codex v0.48.2\nThinking...')).toBeNull();
+    });
+
+    test('empty output is not a failure', () => {
+      expect(classifySpawnFailure('codex', '')).toBeNull();
+    });
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,8 @@ import { app, BrowserWindow, ipcMain, dialog, shell, crashReporter } from 'elect
 import * as fs from 'fs';
 import * as path from 'path';
 import { ptyManager } from './pty-manager';
-import { resolveLaunchProviderId, listProviders } from './providers';
+import { resolveLaunchProviderId } from './providers';
+import { startProviderInstall, cancelProviderInstall } from './provider-install';
 import { detectProviders } from './provider-detector';
 import * as keyVault from './key-vault';
 import { getDatabase, closeDatabase } from './database';
@@ -1266,29 +1267,12 @@ safeHandle('providers:detect', async () => {
 
 // Run a provider's install command in a visible pty the renderer attaches a
 // Terminal to (Settings → Providers "Install" button / launch-failure
-// banner). Commands come from the static provider registry only — the
-// renderer sends just the provider id.
-safeHandle('providers:run-install', async (providerId: unknown) => {
-  const id = requireIpcString(providerId, 'providerId');
-  const provider = listProviders().find((p) => p.id === id);
-  const command = provider?.setup.installCommand;
-  if (!provider || !command) {
-    throw new Error(`Provider '${id}' has no runnable install command`);
-  }
-  const ptyId = `__install-${id}`;
-  // A previous run's pty may still be around (user reopened the modal).
-  await ptyManager.kill(ptyId);
-  ptyManager.createInstallSession(ptyId, command);
-  return { ptyId, command };
-});
+// banner). Validation + orchestration live in provider-install.ts.
+safeHandle('providers:run-install', (providerId: unknown) =>
+  startProviderInstall(ptyManager, providerId));
 
-safeHandle('providers:cancel-install', async (ptyId: unknown) => {
-  const id = requireIpcString(ptyId, 'ptyId');
-  if (!id.startsWith('__install-')) {
-    throw new Error('Not an install pty');
-  }
-  await ptyManager.kill(id);
-});
+safeHandle('providers:cancel-install', (ptyId: unknown) =>
+  cancelProviderInstall(ptyManager, ptyId));
 
 // Provider API-key vault (#99). Keys go in and are tested; they are never
 // returned to the renderer. IPC is a trust boundary — validate argument

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, ipcMain, dialog, shell, crashReporter } from 'elect
 import * as fs from 'fs';
 import * as path from 'path';
 import { ptyManager } from './pty-manager';
-import { resolveLaunchProviderId } from './providers';
+import { resolveLaunchProviderId, listProviders } from './providers';
 import { detectProviders } from './provider-detector';
 import * as keyVault from './key-vault';
 import { getDatabase, closeDatabase } from './database';
@@ -639,6 +639,11 @@ function createWindow(): void {
     getApiServer().broadcastSessionState(event.sessionId, event.state, event.event);
   });
 
+  // Provider CLI launch-failure hints (missing/broken install banner)
+  ptyManager.on('providerHint', (hint) => {
+    mainWindow?.webContents.send('provider:install-hint', hint);
+  });
+
   // Save window bounds on resize/move
   const saveWindowBounds = () => {
     if (!mainWindow) return;
@@ -1257,6 +1262,32 @@ safeHandle('editor:detectAvailable', async () => {
 
 safeHandle('providers:detect', async () => {
   return detectProviders();
+});
+
+// Run a provider's install command in a visible pty the renderer attaches a
+// Terminal to (Settings → Providers "Install" button / launch-failure
+// banner). Commands come from the static provider registry only — the
+// renderer sends just the provider id.
+safeHandle('providers:run-install', async (providerId: unknown) => {
+  const id = requireIpcString(providerId, 'providerId');
+  const provider = listProviders().find((p) => p.id === id);
+  const command = provider?.setup.installCommand;
+  if (!provider || !command) {
+    throw new Error(`Provider '${id}' has no runnable install command`);
+  }
+  const ptyId = `__install-${id}`;
+  // A previous run's pty may still be around (user reopened the modal).
+  await ptyManager.kill(ptyId);
+  ptyManager.createInstallSession(ptyId, command);
+  return { ptyId, command };
+});
+
+safeHandle('providers:cancel-install', async (ptyId: unknown) => {
+  const id = requireIpcString(ptyId, 'ptyId');
+  if (!id.startsWith('__install-')) {
+    throw new Error('Not an install pty');
+  }
+  await ptyManager.kill(id);
 });
 
 // Provider API-key vault (#99). Keys go in and are tested; they are never

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -195,6 +195,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Shell
   openExternal: (url: string) => ipcRenderer.invoke('shell:openExternal', url),
   detectProviders: (): Promise<ProviderStatus[]> => ipcRenderer.invoke('providers:detect'),
+  runProviderInstall: (providerId: string): Promise<{ ptyId: string; command: string }> =>
+    ipcRenderer.invoke('providers:run-install', providerId),
+  cancelProviderInstall: (ptyId: string): Promise<void> =>
+    ipcRenderer.invoke('providers:cancel-install', ptyId),
+  onProviderInstallHint: (callback: (hint: ProviderInstallHint) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, hint: ProviderInstallHint) => callback(hint);
+    ipcRenderer.on('provider:install-hint', listener);
+    return () => {
+      ipcRenderer.removeListener('provider:install-hint', listener);
+    };
+  },
 
   // Provider API-key vault (#99) — keys go in, never come back out.
   vaultList: (): Promise<KeyVaultStatus[]> => ipcRenderer.invoke('vault:list'),

--- a/src/main/provider-detector.ts
+++ b/src/main/provider-detector.ts
@@ -102,6 +102,7 @@ export function detectProviders(): Promise<ProviderStatus[]> {
         installed,
         version,
         installHint: p.setup.installHint,
+        installCommand: p.setup.installCommand ?? null,
         docsUrl: p.setup.docsUrl,
         loginHint: p.setup.loginHint,
       };

--- a/src/main/provider-install.ts
+++ b/src/main/provider-install.ts
@@ -1,0 +1,60 @@
+/**
+ * Provider install-command orchestration (follow-up to #97's install hints).
+ *
+ * Runs a provider's registry-defined install command in a visible pty the
+ * renderer attaches a Terminal to. Kept out of index.ts so the IPC argument
+ * validation — a trust boundary; the renderer only ever supplies ids — is
+ * unit-testable without loading the whole main process.
+ */
+
+// Type-only: erased at compile time, so importing this module in tests does
+// not drag in node-pty.
+import type { PtyManager } from './pty-manager';
+import { listProviders } from './providers';
+
+/**
+ * Namespace prefix for install ptys. cancelProviderInstall only kills ids
+ * under it, so a malicious/buggy renderer call can't tear down a real
+ * session's pty through the install-cancel channel.
+ */
+export const INSTALL_PTY_PREFIX = '__install-';
+
+export interface ProviderInstallStart {
+  ptyId: string;
+  command: string;
+}
+
+/**
+ * Spawn the install pty for a provider. Commands come only from the static
+ * provider registry — never from the renderer. Throws for unknown providers
+ * and for providers without a runnable install command (e.g. GUI installs).
+ */
+export async function startProviderInstall(
+  ptyManager: PtyManager,
+  providerId: unknown,
+): Promise<ProviderInstallStart> {
+  if (typeof providerId !== 'string' || providerId.length === 0) {
+    throw new Error('Invalid providerId');
+  }
+  const provider = listProviders().find((p) => p.id === providerId);
+  const command = provider?.setup.installCommand;
+  if (!provider || !command) {
+    throw new Error(`Provider '${providerId}' has no runnable install command`);
+  }
+  const ptyId = `${INSTALL_PTY_PREFIX}${providerId}`;
+  // A previous run's pty may still be around (user reopened the modal).
+  await ptyManager.kill(ptyId);
+  ptyManager.createInstallSession(ptyId, command);
+  return { ptyId, command };
+}
+
+/** Kill an install pty. Rejects ids outside the install namespace. */
+export async function cancelProviderInstall(
+  ptyManager: PtyManager,
+  ptyId: unknown,
+): Promise<void> {
+  if (typeof ptyId !== 'string' || !ptyId.startsWith(INSTALL_PTY_PREFIX)) {
+    throw new Error('Not an install pty');
+  }
+  await ptyManager.kill(ptyId);
+}

--- a/src/main/providers/claude.ts
+++ b/src/main/providers/claude.ts
@@ -59,6 +59,9 @@ export const claudeProvider: ProviderDefinition = {
   },
   setup: {
     installHint: 'npm install -g @anthropic-ai/claude-code',
+    // --force so re-running repairs broken installs (missing platform
+    // optionalDependencies after an interrupted install or Rosetta npm).
+    installCommand: 'npm install -g --force @anthropic-ai/claude-code',
     docsUrl: 'https://docs.anthropic.com/en/docs/claude-code/setup',
     loginHint: 'Run `claude` and complete /login in the browser',
   },

--- a/src/main/providers/codex.ts
+++ b/src/main/providers/codex.ts
@@ -32,6 +32,10 @@ export const codexProvider = passthroughProvider({
   },
   setup: {
     installHint: 'npm install -g @openai/codex',
+    // --force so re-running repairs broken installs — the classic failure is
+    // npm dropping @openai/codex-<platform>'s vendored native binary, which
+    // then dies with `spawn ... ENOENT` (user report, 2026-07).
+    installCommand: 'npm install -g --force @openai/codex',
     docsUrl: 'https://developers.openai.com/codex/cli',
     loginHint: 'Run `codex login` (ChatGPT account) or set OPENAI_API_KEY',
   },

--- a/src/main/providers/cursor.ts
+++ b/src/main/providers/cursor.ts
@@ -27,6 +27,7 @@ export const cursorProvider = passthroughProvider({
   },
   setup: {
     installHint: 'curl https://cursor.com/install -fsS | bash',
+    installCommand: 'curl https://cursor.com/install -fsS | bash',
     docsUrl: 'https://cursor.com/docs/cli/overview',
     loginHint: 'Run `cursor-agent login` (or set CURSOR_API_KEY)',
   },

--- a/src/main/providers/grok.ts
+++ b/src/main/providers/grok.ts
@@ -34,6 +34,7 @@ export const grokProvider = passthroughProvider({
   },
   setup: {
     installHint: 'curl -fsSL https://x.ai/cli/install.sh | bash',
+    installCommand: 'curl -fsSL https://x.ai/cli/install.sh | bash',
     docsUrl: 'https://docs.x.ai/build/overview',
     loginHint: 'Run `grok` — the first launch prompts sign-in with your X/xAI account (requires SuperGrok or X Premium+)',
   },

--- a/src/main/providers/kimi.ts
+++ b/src/main/providers/kimi.ts
@@ -25,6 +25,7 @@ export const kimiProvider = passthroughProvider({
   },
   setup: {
     installHint: 'curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash',
+    installCommand: 'curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash',
     docsUrl: 'https://moonshotai.github.io/kimi-code/',
     loginHint: 'Works out of the box; run `kimi login` to use your own Moonshot account',
   },

--- a/src/main/providers/opencode.ts
+++ b/src/main/providers/opencode.ts
@@ -25,6 +25,7 @@ export const opencodeProvider = passthroughProvider({
   },
   setup: {
     installHint: 'curl -fsSL https://opencode.ai/install | bash',
+    installCommand: 'curl -fsSL https://opencode.ai/install | bash',
     docsUrl: 'https://opencode.ai/docs',
     loginHint: 'Run `opencode auth login` and add a provider (or set that provider’s API key)',
   },

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -119,6 +119,14 @@ export interface ProviderDefinition {
   setup: {
     /** Install command or instruction, shown as copyable text. */
     installHint: string;
+    /**
+     * Directly runnable install command Bodhilander can execute for the user
+     * in a visible pty (Settings → Providers "Install" button and the
+     * launch-failure banner). Must be non-interactive and safe to re-run over
+     * an existing install — it doubles as the repair path for broken installs.
+     * Omit when installation needs manual steps (e.g. a GUI download).
+     */
+    installCommand?: string;
     /** Official installation/authentication documentation URL. */
     docsUrl: string;
     /** How to authenticate after installing. */

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1,5 +1,6 @@
 import * as pty from 'node-pty';
 import * as fs from 'fs';
+import * as os from 'os';
 import { execFile } from 'child_process';
 import { EventEmitter } from 'events';
 import {
@@ -58,6 +59,14 @@ interface PtySession {
    */
   spawnFailureNotified: boolean;
   /**
+   * Output retained for launch-failure classification. Separate from
+   * scrollbackBuffer, whose tail-keeping 100KB trim could evict an early
+   * failure line behind a chatty startup. This buffer keeps output from the
+   * HEAD (capped at LAUNCH_OUTPUT_CAP) and is emptied once the failure
+   * window passes or a hint fires, so it never outlives spawn diagnosis.
+   */
+  launchOutput: string;
+  /**
    * When true, incoming pty output is accumulated in scrollbackBuffer but NOT
    * emitted as 'data' events (BDHLNDR-33). Used by the interactive-login pty
    * to avoid losing startup output in the window between pty spawn and the
@@ -85,6 +94,14 @@ const MAX_SCROLLBACK_SIZE = 100 * 1024;
  * code must not retrigger the banner.
  */
 const SPAWN_FAILURE_WINDOW_MS = 15_000;
+
+/**
+ * Cap on the per-session launch-output buffer. A genuinely failing launch
+ * produces far less than this inside the failure window, so the signature is
+ * always retained; the cap only bounds memory if a healthy chatty session
+ * floods the first seconds.
+ */
+const LAUNCH_OUTPUT_CAP = 256 * 1024;
 
 /**
  * Provider-agnostic "waiting for user input" patterns — generic prompt shapes
@@ -253,6 +270,7 @@ export class PtyManager extends EventEmitter {
       this.emit('data', { id, data: filteredData });
 
       if (provider) {
+        this.recordLaunchOutput(session, filteredData);
         this.checkSpawnFailure(id);
         this.detectAgentState(id, data);
       }
@@ -322,6 +340,7 @@ export class PtyManager extends EventEmitter {
       lastRows: 24,
       killing: false,
       spawnFailureNotified: false,
+      launchOutput: '',
       // Regular sessions spawn only after the renderer explicitly called
       // pty:create, so listeners are already attached — no deferral needed.
       deferEmission: false,
@@ -423,21 +442,38 @@ export class PtyManager extends EventEmitter {
   }
 
   /**
+   * Accumulate output into the launch-failure buffer while it can still
+   * matter; free it the moment it can't (hint already fired, or the failure
+   * window has passed).
+   */
+  private recordLaunchOutput(session: PtySession, data: string): void {
+    if (session.spawnFailureNotified) return;
+    if (Date.now() - session.spawnedAt > SPAWN_FAILURE_WINDOW_MS) {
+      session.launchOutput = '';
+      return;
+    }
+    if (session.launchOutput.length < LAUNCH_OUTPUT_CAP) {
+      session.launchOutput = (session.launchOutput + data).slice(0, LAUNCH_OUTPUT_CAP);
+    }
+  }
+
+  /**
    * Classify early session output as a CLI launch failure (missing from
    * PATH, or installed-but-broken like codex's `spawn ... ENOENT`) and emit
    * a one-shot 'providerHint' event so the renderer can show a friendly
-   * install banner. Checks the accumulated scrollback rather than the chunk,
-   * so an error split across pty reads still matches.
+   * install banner. Checks the accumulated launch buffer rather than the
+   * chunk, so an error split across pty reads still matches.
    */
   private checkSpawnFailure(id: string): void {
     const session = this.sessions.get(id);
     if (!session?.provider || session.spawnFailureNotified) return;
     if (Date.now() - session.spawnedAt > SPAWN_FAILURE_WINDOW_MS) return;
 
-    const kind = classifySpawnFailure(session.provider.command, session.scrollbackBuffer);
+    const kind = classifySpawnFailure(session.provider.command, session.launchOutput);
     if (!kind) return;
 
     session.spawnFailureNotified = true;
+    session.launchOutput = '';
     const { setup } = session.provider;
     log.warn(`[PTY] ${session.provider.name} launch failure (${kind}) detected for session ${id}`);
     const hint: ProviderInstallHint = {
@@ -466,7 +502,7 @@ export class PtyManager extends EventEmitter {
       throw new Error(`Shell not found: ${shellInfo.shell || '(empty)'}`);
     }
 
-    const cwd = require('os').homedir();
+    const cwd = os.homedir();
     // Static registry string (never user input) with no env interpolation.
     const shellLaunch = getShellLaunch(shellInfo, { needsEnvRef: false });
 
@@ -536,6 +572,7 @@ export class PtyManager extends EventEmitter {
       lastRows: 24,
       killing: false,
       spawnFailureNotified: false,
+      launchOutput: '',
       // Spawned before the renderer's Terminal mounts — same race as the
       // login pty (BDHLNDR-33).
       deferEmission: true,
@@ -558,7 +595,7 @@ export class PtyManager extends EventEmitter {
       throw new Error(`Shell not found: ${shellInfo.shell || '(empty)'}`);
     }
 
-    const cwd = require('os').homedir();
+    const cwd = os.homedir();
     const processEnv: { [key: string]: string } = {
       ...(process.env as { [key: string]: string }),
       [CLAUDE_CONFIG_DIR_ENV]: configDir,
@@ -639,6 +676,7 @@ export class PtyManager extends EventEmitter {
       lastRows: 24,
       killing: false,
       spawnFailureNotified: false,
+      launchOutput: '',
       // Login ptys defer event emission until the renderer attaches its
       // listener and calls primePty — avoids losing claude's startup banner
       // in the IPC-round-trip + React-render gap (BDHLNDR-33).

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -13,6 +13,8 @@ import {
   ProviderDefinition,
 } from './providers';
 import { detectShell, ShellInfo } from './shell-detector';
+import { classifySpawnFailure } from './spawn-failure';
+import { ProviderInstallHint } from '../shared/types';
 import { getShellLaunch } from './shell-launch';
 import { getPreference } from './repositories/preferences';
 import {
@@ -51,6 +53,11 @@ interface PtySession {
   /** Set to true when kill() is in progress — guards against use-after-free on native PTY handle. */
   killing: boolean;
   /**
+   * Set once a launch-failure hint has been emitted for this session, so the
+   * renderer sees at most one banner per spawn.
+   */
+  spawnFailureNotified: boolean;
+  /**
    * When true, incoming pty output is accumulated in scrollbackBuffer but NOT
    * emitted as 'data' events (BDHLNDR-33). Used by the interactive-login pty
    * to avoid losing startup output in the window between pty spawn and the
@@ -70,6 +77,14 @@ const RESUME_FAILURE_WINDOW_MS = 5000;
 
 // Max scrollback buffer size (100KB should be plenty for recent terminal history)
 const MAX_SCROLLBACK_SIZE = 100 * 1024;
+
+/**
+ * Only classify launch failures in this window after spawn. The 'broken'
+ * patterns (`spawn ... ENOENT`) aren't tied to the provider's command name,
+ * so a running agent that later prints such an error from executing user
+ * code must not retrigger the banner.
+ */
+const SPAWN_FAILURE_WINDOW_MS = 15_000;
 
 /**
  * Provider-agnostic "waiting for user input" patterns — generic prompt shapes
@@ -238,6 +253,7 @@ export class PtyManager extends EventEmitter {
       this.emit('data', { id, data: filteredData });
 
       if (provider) {
+        this.checkSpawnFailure(id);
         this.detectAgentState(id, data);
       }
     });
@@ -305,6 +321,7 @@ export class PtyManager extends EventEmitter {
       lastCols: 80,
       lastRows: 24,
       killing: false,
+      spawnFailureNotified: false,
       // Regular sessions spawn only after the renderer explicitly called
       // pty:create, so listeners are already attached — no deferral needed.
       deferEmission: false,
@@ -406,6 +423,126 @@ export class PtyManager extends EventEmitter {
   }
 
   /**
+   * Classify early session output as a CLI launch failure (missing from
+   * PATH, or installed-but-broken like codex's `spawn ... ENOENT`) and emit
+   * a one-shot 'providerHint' event so the renderer can show a friendly
+   * install banner. Checks the accumulated scrollback rather than the chunk,
+   * so an error split across pty reads still matches.
+   */
+  private checkSpawnFailure(id: string): void {
+    const session = this.sessions.get(id);
+    if (!session?.provider || session.spawnFailureNotified) return;
+    if (Date.now() - session.spawnedAt > SPAWN_FAILURE_WINDOW_MS) return;
+
+    const kind = classifySpawnFailure(session.provider.command, session.scrollbackBuffer);
+    if (!kind) return;
+
+    session.spawnFailureNotified = true;
+    const { setup } = session.provider;
+    log.warn(`[PTY] ${session.provider.name} launch failure (${kind}) detected for session ${id}`);
+    const hint: ProviderInstallHint = {
+      sessionId: id,
+      providerId: session.provider.id,
+      providerName: session.provider.name,
+      command: session.provider.command,
+      kind,
+      installHint: setup.installHint,
+      installCommand: setup.installCommand ?? null,
+      docsUrl: setup.docsUrl,
+    };
+    this.emit('providerHint', hint);
+  }
+
+  /**
+   * Spawn a pty running a provider's install command so the user can watch it
+   * instead of copy-pasting into their own terminal (follow-up to #97's
+   * install hints). Runs through the user's shell like sessions do, defers
+   * emission until the renderer primes it (BDHLNDR-33), and exits when the
+   * install command does — the pty's exit code is the install's.
+   */
+  createInstallSession(id: string, installCommand: string): void {
+    const shellInfo = this.getShellInfo();
+    if (!shellInfo.shell || !fs.existsSync(shellInfo.shell)) {
+      throw new Error(`Shell not found: ${shellInfo.shell || '(empty)'}`);
+    }
+
+    const cwd = require('os').homedir();
+    // Static registry string (never user input) with no env interpolation.
+    const shellLaunch = getShellLaunch(shellInfo, { needsEnvRef: false });
+
+    log.info(`[PTY] Starting install pty ${id}: ${installCommand}`);
+
+    const ptyProcess = pty.spawn(shellLaunch.shell, shellLaunch.wrap(installCommand), {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+      cwd: shellInfo.isWSL ? undefined : cwd,
+      env: process.env as { [key: string]: string },
+      ...(process.platform === 'win32' ? {
+        useConptyDll: true,
+        conptyInheritCursor: false,
+      } : {}),
+    });
+
+    ptyProcess.onData((data) => {
+      const session = this.sessions.get(id);
+      if (!session || session.killing) return;
+
+      let filteredData = data;
+      if (process.platform === 'win32') {
+        filteredData = filteredData.replace(/windows pid \d+, Win32 error \d+/gi, '');
+        if (filteredData.trim() === '') return;
+      }
+
+      session.scrollbackBuffer += filteredData;
+      if (session.scrollbackBuffer.length > MAX_SCROLLBACK_SIZE) {
+        session.scrollbackBuffer = session.scrollbackBuffer.slice(-MAX_SCROLLBACK_SIZE);
+      }
+
+      if (session.deferEmission) return;
+
+      this.emit('data', { id, data: filteredData });
+    });
+
+    ptyProcess.onExit(({ exitCode }) => {
+      // Flush pre-prime output so a fast failure isn't a blank box.
+      const session = this.sessions.get(id);
+      if (session?.deferEmission && session.scrollbackBuffer) {
+        this.emit('data', { id, data: session.scrollbackBuffer });
+        session.deferEmission = false;
+      }
+      this.emit('exit', { id, exitCode });
+      this.sessions.delete(id);
+    });
+
+    this.sessions.set(id, {
+      id,
+      pty: ptyProcess,
+      cwd,
+      groupId: null,
+      // No provider: install ptys need no agent state detection or hints.
+      provider: null,
+      shellInfo,
+      lastState: 'idle',
+      outputBuffer: '',
+      scrollbackBuffer: '',
+      idleTimeout: null,
+      workingDebounce: null,
+      recentOutputBytes: 0,
+      lastOutputTime: 0,
+      resumeAttempted: false,
+      spawnedAt: Date.now(),
+      lastCols: 80,
+      lastRows: 24,
+      killing: false,
+      spawnFailureNotified: false,
+      // Spawned before the renderer's Terminal mounts — same race as the
+      // login pty (BDHLNDR-33).
+      deferEmission: true,
+    });
+  }
+
+  /**
    * Spawn a pty running `claude` under an isolated CLAUDE_CONFIG_DIR for the
    * interactive add-account login flow (BDHLNDR-31). Keyed by an arbitrary pty
    * id that's not tied to a DB session — reuses the standard pty events so the
@@ -501,6 +638,7 @@ export class PtyManager extends EventEmitter {
       lastCols: 80,
       lastRows: 24,
       killing: false,
+      spawnFailureNotified: false,
       // Login ptys defer event emission until the renderer attaches its
       // listener and calls primePty — avoids losing claude's startup banner
       // in the IPC-round-trip + React-render gap (BDHLNDR-33).

--- a/src/main/spawn-failure.ts
+++ b/src/main/spawn-failure.ts
@@ -1,0 +1,80 @@
+/**
+ * Provider CLI launch-failure classification.
+ *
+ * When an agent session's CLI fails to start, the user is left staring at a
+ * raw shell or Node error in the terminal. Session output from the first few
+ * seconds is classified here so the renderer can show a friendly banner with
+ * the provider's install command instead.
+ *
+ * Two failure shapes:
+ * - 'missing' — the shell couldn't find the CLI on PATH at all.
+ * - 'broken'  — the CLI launched but its own startup failed. Canonical case:
+ *   an npm wrapper (e.g. @openai/codex) spawning its native platform binary
+ *   that isn't on disk — npm dropped the platform optionalDependency, the
+ *   install ran under a Rosetta x64 Node, or security software stripped the
+ *   unsigned binary. Surfaces as `Error: spawn <path> ENOENT`.
+ *
+ * (Pure module — no node-pty import — so tests don't drag the native module in.)
+ */
+
+export type SpawnFailureKind = 'missing' | 'broken';
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Shell "command not found" shapes, parameterized by CLI name so unrelated
+ * output (an agent compiling code, say) can't trigger the hint:
+ * - zsh:        `zsh: command not found: codex`
+ * - bash/dash:  `bash: line 1: codex: command not found`
+ * - POSIX exec: `codex: No such file or directory`
+ * - cmd.exe:    `'codex' is not recognized as an internal or external command`
+ * - PowerShell: `The term 'codex' is not recognized as the name of a cmdlet`
+ */
+function missingPatterns(command: string): RegExp[] {
+  const cmd = escapeRegExp(command);
+  return [
+    new RegExp(`command not found:\\s*${cmd}\\b`),
+    new RegExp(`\\b${cmd}: command not found`),
+    new RegExp(`\\b${cmd}: No such file or directory`),
+    new RegExp(`'${cmd}' is not recognized as an internal or external command`),
+    new RegExp(`The term '${cmd}' is not recognized`),
+  ];
+}
+
+/**
+ * Startup failures of an installed-but-broken CLI. Not parameterized by
+ * command name — the failing path is internal to the CLI's own package (e.g.
+ * .../@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex) —
+ * so callers must only run this against EARLY session output, before the
+ * agent itself could plausibly print such an error from running user code.
+ */
+const BROKEN_PATTERNS: readonly RegExp[] = [
+  /spawn [^\n]{1,500}ENOENT/,          // Node launcher can't find its native binary
+  /bad CPU type in executable/i,       // arch mismatch (Rosetta-installed x64 pkg)
+  /cannot execute binary file/,
+  /dyld(\[\d+\])?: Library not loaded/, // macOS dynamic-link failure
+];
+
+/** ANSI CSI/OSC stripper (same grammar as pty-manager's state detector). */
+function stripAnsi(text: string): string {
+  return text
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '') // NOSONAR(S6324) ESC required to strip CSI sequences
+    .replace(/\x1b\][^\x07]*\x07/g, '');
+}
+
+/**
+ * Classify early session output as a CLI launch failure, or null if it looks
+ * like a normal startup. `command` is the provider's CLI binary name.
+ */
+export function classifySpawnFailure(command: string, output: string): SpawnFailureKind | null {
+  const text = stripAnsi(output);
+  if (missingPatterns(command).some((p) => p.test(text))) {
+    return 'missing';
+  }
+  if (BROKEN_PATTERNS.some((p) => p.test(text))) {
+    return 'broken';
+  }
+  return null;
+}

--- a/src/main/spawn-failure.ts
+++ b/src/main/spawn-failure.ts
@@ -61,7 +61,7 @@ const BROKEN_PATTERNS: readonly RegExp[] = [
 function stripAnsi(text: string): string {
   return text
     .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '') // NOSONAR(S6324) ESC required to strip CSI sequences
-    .replace(/\x1b\][^\x07]*\x07/g, '');
+    .replace(/\x1b\][^\x07]*\x07/g, ''); // NOSONAR(S6324) ESC/BEL delimit OSC sequences
 }
 
 /**

--- a/src/renderer/components/ProviderInstallModal.css
+++ b/src/renderer/components/ProviderInstallModal.css
@@ -1,6 +1,10 @@
 /* Provider install modal — reuses the global .modal-overlay */
 
 .provider-install-modal {
+  /* Native <dialog> UA-style resets so it behaves as a plain flex child of
+     the centered .modal-overlay. */
+  position: static;
+  margin: 0;
   background: #252526;
   border: 1px solid #3c3c3c;
   border-radius: 8px;

--- a/src/renderer/components/ProviderInstallModal.css
+++ b/src/renderer/components/ProviderInstallModal.css
@@ -1,0 +1,91 @@
+/* Provider install modal — reuses the global .modal-overlay */
+
+.provider-install-modal {
+  background: #252526;
+  border: 1px solid #3c3c3c;
+  border-radius: 8px;
+  padding: 20px 24px;
+  width: 760px;
+  max-width: 92vw;
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  color: #d4d4d4;
+}
+
+.provider-install-modal h3 {
+  margin: 0 0 4px 0;
+  font-size: 15px;
+  color: #e0e0e0;
+}
+
+.provider-install-modal .hint {
+  font-size: 12px;
+  color: #888;
+  margin: 0 0 14px 0;
+  line-height: 1.5;
+}
+
+.provider-install-modal .hint code {
+  color: #b8d0f0;
+}
+
+.provider-install-modal .terminal-host {
+  flex: 1;
+  min-height: 360px;
+  background: #000;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+
+.provider-install-modal .result-banner {
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+
+.provider-install-modal .result-banner.success {
+  background: #1e3a1e;
+  border: 1px solid #2e5a2e;
+  color: #b8f0b8;
+}
+
+.provider-install-modal .result-banner.failure {
+  background: #3a1e1e;
+  border: 1px solid #5a2e2e;
+  color: #f0b8b8;
+}
+
+.provider-install-modal .footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.provider-install-modal button {
+  padding: 8px 14px;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  border: none;
+  background: #3c3c3c;
+  color: #d4d4d4;
+}
+
+.provider-install-modal button:hover {
+  background: #4c4c4c;
+}
+
+.provider-install-modal .primary {
+  background: linear-gradient(135deg, #5a7aff 0%, #69ADFF 100%);
+  color: #fff;
+  font-weight: 500;
+}
+
+.provider-install-modal .primary:hover {
+  opacity: 0.9;
+}

--- a/src/renderer/components/ProviderInstallModal.tsx
+++ b/src/renderer/components/ProviderInstallModal.tsx
@@ -47,11 +47,10 @@ export const ProviderInstallModal: React.FC<ProviderInstallModalProps> = ({
   }, [exitCode, onClose, providerName, ptyId]);
 
   return (
-    <div className="modal-overlay" onClick={(e) => e.stopPropagation()}>
-      <div
+    <div className="modal-overlay">
+      <dialog
+        open
         className="provider-install-modal"
-        role="dialog"
-        aria-modal="true"
         aria-labelledby="provider-install-title"
       >
         <h3 id="provider-install-title">Installing {providerName}</h3>
@@ -86,7 +85,7 @@ export const ProviderInstallModal: React.FC<ProviderInstallModalProps> = ({
             {exitCode === null ? 'Cancel install' : 'Close'}
           </button>
         </div>
-      </div>
+      </dialog>
     </div>
   );
 };

--- a/src/renderer/components/ProviderInstallModal.tsx
+++ b/src/renderer/components/ProviderInstallModal.tsx
@@ -1,0 +1,92 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import Terminal from './Terminal';
+import './ProviderInstallModal.css';
+
+/**
+ * Runs a provider CLI's install command in a visible embedded terminal so the
+ * user can watch it instead of copy-pasting into their own shell. The pty is
+ * spawned by main (providers:run-install) before this mounts; the Terminal
+ * attaches with externalPty and the pty's exit code is the install's.
+ *
+ * Used from Settings → Providers ("Install" on a missing CLI) and from the
+ * session launch-failure banner ("Reinstall" on a broken CLI).
+ */
+
+interface ProviderInstallModalProps {
+  providerName: string;
+  command: string;
+  ptyId: string;
+  /** Called when the modal closes; succeeded is true iff the command exited 0. */
+  onClose: (succeeded: boolean) => void;
+}
+
+export const ProviderInstallModal: React.FC<ProviderInstallModalProps> = ({
+  providerName,
+  command,
+  ptyId,
+  onClose,
+}) => {
+  const [exitCode, setExitCode] = useState<number | null>(null);
+
+  useEffect(() => {
+    return window.electronAPI.onPtyExit((id, code) => {
+      if (id === ptyId) {
+        setExitCode(code);
+      }
+    });
+  }, [ptyId]);
+
+  const handleClose = useCallback(() => {
+    if (exitCode === null) {
+      const confirmed = window.confirm(`Cancel the running install for ${providerName}?`);
+      if (!confirmed) return;
+    }
+    // Kills the pty if it is still running; a no-op after exit.
+    window.electronAPI.cancelProviderInstall(ptyId).catch(() => {});
+    onClose(exitCode === 0);
+  }, [exitCode, onClose, providerName, ptyId]);
+
+  return (
+    <div className="modal-overlay" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="provider-install-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="provider-install-title"
+      >
+        <h3 id="provider-install-title">Installing {providerName}</h3>
+        <p className="hint">
+          Running <code>{command}</code> in your shell. If the installer asks
+          questions, answer them in the terminal below.
+        </p>
+
+        {exitCode === 0 && (
+          <div className="result-banner success">
+            Install finished. Close this window, then start (or restart) the session.
+          </div>
+        )}
+        {exitCode !== null && exitCode !== 0 && (
+          <div className="result-banner failure">
+            The installer exited with code {exitCode}. Check its output above, then close and retry.
+          </div>
+        )}
+
+        <div className="terminal-host">
+          <Terminal
+            sessionId={ptyId}
+            cwd={window.electronAPI.homedir}
+            launchClaude={false}
+            externalPty={true}
+            isActive={true}
+          />
+        </div>
+
+        <div className="footer">
+          <button className={exitCode === 0 ? 'primary' : ''} onClick={handleClose}>
+            {exitCode === null ? 'Cancel install' : 'Close'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/components/ProviderSettings.tsx
+++ b/src/renderer/components/ProviderSettings.tsx
@@ -30,6 +30,9 @@ export const ProviderSettings: React.FC = () => {
   }, [refresh]);
 
   const handleInstall = useCallback(async (p: ProviderStatus) => {
+    // Install commands run remote scripts / global npm installs — show the
+    // exact command before executing anything.
+    if (!window.confirm(`This will run in your shell:\n\n${p.installCommand}\n\nContinue?`)) return;
     try {
       const { ptyId, command } = await window.electronAPI.runProviderInstall(p.id);
       setInstallFlow({ name: p.name, ptyId, command });

--- a/src/renderer/components/ProviderSettings.tsx
+++ b/src/renderer/components/ProviderSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { ProviderStatus } from '../../shared/types';
 import { ProviderKeyVault } from './ProviderKeyVault';
+import { ProviderInstallModal } from './ProviderInstallModal';
 
 /**
  * Settings → Providers panel: provider CLI detection status + setup guidance
@@ -10,6 +11,7 @@ import { ProviderKeyVault } from './ProviderKeyVault';
 export const ProviderSettings: React.FC = () => {
   const [statuses, setStatuses] = useState<ProviderStatus[] | null>(null);
   const [loading, setLoading] = useState(false);
+  const [installFlow, setInstallFlow] = useState<{ name: string; ptyId: string; command: string } | null>(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -24,6 +26,20 @@ export const ProviderSettings: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleInstall = useCallback(async (p: ProviderStatus) => {
+    try {
+      const { ptyId, command } = await window.electronAPI.runProviderInstall(p.id);
+      setInstallFlow({ name: p.name, ptyId, command });
+    } catch (error) {
+      console.error('Failed to start provider install:', error);
+    }
+  }, []);
+
+  const handleInstallClose = useCallback(() => {
+    setInstallFlow(null);
     refresh();
   }, [refresh]);
 
@@ -63,6 +79,15 @@ export const ProviderSettings: React.FC = () => {
               <div className="provider-status-setup">
                 <div>Install: <code>{p.installHint}</code></div>
                 <div>Sign in: {p.loginHint}</div>
+                {p.installCommand && (
+                  <button
+                    className="settings-button"
+                    disabled={!!installFlow}
+                    onClick={() => handleInstall(p)}
+                  >
+                    Install for me
+                  </button>
+                )}
                 <button
                   className="settings-link-button"
                   onClick={() => window.electronAPI.openExternal(p.docsUrl)}
@@ -76,6 +101,15 @@ export const ProviderSettings: React.FC = () => {
       </div>
 
       <ProviderKeyVault />
+
+      {installFlow && (
+        <ProviderInstallModal
+          providerName={installFlow.name}
+          command={installFlow.command}
+          ptyId={installFlow.ptyId}
+          onClose={handleInstallClose}
+        />
+      )}
     </div>
   );
 };

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -121,6 +121,9 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
 
   const handleRunInstall = useCallback(async () => {
     if (!installHint?.installCommand) return;
+    // Install commands run remote scripts / global npm installs — show the
+    // exact command before executing anything.
+    if (!window.confirm(`This will run in your shell:\n\n${installHint.installCommand}\n\nContinue?`)) return;
     try {
       const flow = await window.electronAPI.runProviderInstall(installHint.providerId);
       setInstallFlow(flow);

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { Terminal as XTerm } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import { WebglAddon } from 'xterm-addon-webgl';
+import { ProviderInstallHint } from '../../shared/types';
+import { ProviderInstallModal } from './ProviderInstallModal';
 import 'xterm/css/xterm.css';
 import '../styles/terminal.css';
 
@@ -59,6 +61,11 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   const [isRunning, setIsRunning] = useState(!isStopped);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({ visible: false, x: 0, y: 0, hasSelection: false });
   const [error, setError] = useState<string | null>(null);
+  // Launch-failure hint from main (provider CLI missing or broken): shown as
+  // a dismissible banner over the terminal, with a one-click (re)install.
+  const [installHint, setInstallHint] = useState<ProviderInstallHint | null>(null);
+  const [installFlow, setInstallFlow] = useState<{ ptyId: string; command: string } | null>(null);
+  const [installSucceeded, setInstallSucceeded] = useState(false);
 
   // Track isActive in a ref so handleResize (set up in the main effect which
   // does NOT depend on isActive) can skip hidden terminals. Without this,
@@ -99,6 +106,28 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       console.warn('[Terminal] resize during teardown (non-fatal):', e);
     }
   }, [sessionId]);
+
+  // Surface provider launch failures (spawn ENOENT / command not found)
+  // detected by main for this session's pty.
+  useEffect(() => {
+    if (externalPty) return; // login/install ptys never produce hints
+    return window.electronAPI.onProviderInstallHint((hint) => {
+      if (hint.sessionId === sessionId) {
+        setInstallHint(hint);
+        setInstallSucceeded(false);
+      }
+    });
+  }, [sessionId, externalPty]);
+
+  const handleRunInstall = useCallback(async () => {
+    if (!installHint?.installCommand) return;
+    try {
+      const flow = await window.electronAPI.runProviderInstall(installHint.providerId);
+      setInstallFlow(flow);
+    } catch (err) {
+      console.error('Failed to start provider install:', err);
+    }
+  }, [installHint]);
 
   // Sync isStopped prop changes to isRunning state (fixes stop button)
   useEffect(() => {
@@ -542,12 +571,16 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
 
   const handleStart = () => {
     setError(null);
+    setInstallHint(null);
+    setInstallSucceeded(false);
     setIsRunning(true);
     onStart?.();
   };
 
   const handleRetry = () => {
     setError(null);
+    setInstallHint(null);
+    setInstallSucceeded(false);
     setIsRunning(false);
     // Small delay then restart
     setTimeout(() => {
@@ -555,6 +588,55 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       onStart?.();
     }, 100);
   };
+
+  // Launch-failure banner + install modal, shared by the running and stopped
+  // views (a 'missing' CLI usually exits the shell, flipping this component
+  // into its stopped state — the hint must survive that).
+  const installHintUi = installHint && (
+    <>
+      <div className="provider-install-banner">
+        <div className="provider-install-banner-text">
+          {installSucceeded ? (
+            <>Install finished — restart the session to try again.</>
+          ) : installHint.kind === 'missing' ? (
+            <>
+              The {installHint.providerName} CLI (<code>{installHint.command}</code>) wasn't
+              found on your PATH. Install it with <code>{installHint.installHint}</code>, or
+              let Bodhilander do it.
+            </>
+          ) : (
+            <>
+              The <code>{installHint.command}</code> CLI is installed but failed to start —
+              its install looks broken (often a missing native binary after an interrupted
+              or wrong-architecture install). Reinstalling usually fixes it.
+            </>
+          )}
+        </div>
+        <div className="provider-install-banner-actions">
+          {installSucceeded ? (
+            <button className="primary" onClick={handleRetry}>Restart session</button>
+          ) : installHint.installCommand ? (
+            <button className="primary" disabled={!!installFlow} onClick={handleRunInstall}>
+              {installHint.kind === 'missing' ? 'Install for me' : 'Reinstall for me'}
+            </button>
+          ) : null}
+          <button onClick={() => window.electronAPI.openExternal(installHint.docsUrl)}>Docs ↗</button>
+          <button onClick={() => setInstallHint(null)}>Dismiss</button>
+        </div>
+      </div>
+      {installFlow && (
+        <ProviderInstallModal
+          providerName={installHint.providerName}
+          command={installFlow.command}
+          ptyId={installFlow.ptyId}
+          onClose={(succeeded) => {
+            setInstallFlow(null);
+            if (succeeded) setInstallSucceeded(true);
+          }}
+        />
+      )}
+    </>
+  );
 
   if (error) {
     return (
@@ -572,6 +654,7 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   if (!isRunning) {
     return (
       <div className="terminal-stopped">
+        {installHintUi}
         <p>Session stopped</p>
         <button onClick={handleStart}>Start Session</button>
       </div>
@@ -585,6 +668,7 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
         className="terminal-container"
         onContextMenu={handleContextMenu}
       />
+      {installHintUi}
       {contextMenu.visible && (
         <div
           className="terminal-context-menu"

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -592,34 +592,47 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   // Launch-failure banner + install modal, shared by the running and stopped
   // views (a 'missing' CLI usually exits the shell, flipping this component
   // into its stopped state — the hint must survive that).
+  const renderBannerText = (hint: ProviderInstallHint): React.ReactNode => {
+    if (installSucceeded) {
+      return <>Install finished — restart the session to try again.</>;
+    }
+    if (hint.kind === 'missing') {
+      return (
+        <>
+          The {hint.providerName} CLI (<code>{hint.command}</code>) wasn't found on your
+          PATH. Install it with <code>{hint.installHint}</code>, or let Bodhilander do it.
+        </>
+      );
+    }
+    return (
+      <>
+        The <code>{hint.command}</code> CLI is installed but failed to start — its install
+        looks broken (often a missing native binary after an interrupted or
+        wrong-architecture install). Reinstalling usually fixes it.
+      </>
+    );
+  };
+
+  const renderBannerAction = (hint: ProviderInstallHint): React.ReactNode => {
+    if (installSucceeded) {
+      return <button className="primary" onClick={handleRetry}>Restart session</button>;
+    }
+    if (hint.installCommand) {
+      return (
+        <button className="primary" disabled={!!installFlow} onClick={handleRunInstall}>
+          {hint.kind === 'missing' ? 'Install for me' : 'Reinstall for me'}
+        </button>
+      );
+    }
+    return null;
+  };
+
   const installHintUi = installHint && (
     <>
       <div className="provider-install-banner">
-        <div className="provider-install-banner-text">
-          {installSucceeded ? (
-            <>Install finished — restart the session to try again.</>
-          ) : installHint.kind === 'missing' ? (
-            <>
-              The {installHint.providerName} CLI (<code>{installHint.command}</code>) wasn't
-              found on your PATH. Install it with <code>{installHint.installHint}</code>, or
-              let Bodhilander do it.
-            </>
-          ) : (
-            <>
-              The <code>{installHint.command}</code> CLI is installed but failed to start —
-              its install looks broken (often a missing native binary after an interrupted
-              or wrong-architecture install). Reinstalling usually fixes it.
-            </>
-          )}
-        </div>
+        <div className="provider-install-banner-text">{renderBannerText(installHint)}</div>
         <div className="provider-install-banner-actions">
-          {installSucceeded ? (
-            <button className="primary" onClick={handleRetry}>Restart session</button>
-          ) : installHint.installCommand ? (
-            <button className="primary" disabled={!!installFlow} onClick={handleRunInstall}>
-              {installHint.kind === 'missing' ? 'Install for me' : 'Reinstall for me'}
-            </button>
-          ) : null}
+          {renderBannerAction(installHint)}
           <button onClick={() => window.electronAPI.openExternal(installHint.docsUrl)}>Docs ↗</button>
           <button onClick={() => setInstallHint(null)}>Dismiss</button>
         </div>

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus } from '../shared/types';
+import { Group, Session, Memory, MemoryCreateInput, MemoryUpdateInput, CodeIndex, CodeSearchResult, SymbolSearchResult, IndexProgress, SymbolType, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -86,6 +86,9 @@ interface ElectronAPI {
   // Shell
   openExternal: (url: string) => Promise<void>;
   detectProviders: () => Promise<ProviderStatus[]>;
+  runProviderInstall: (providerId: string) => Promise<{ ptyId: string; command: string }>;
+  cancelProviderInstall: (ptyId: string) => Promise<void>;
+  onProviderInstallHint: (callback: (hint: ProviderInstallHint) => void) => () => void;
   vaultList: () => Promise<KeyVaultStatus[]>;
   vaultSetKey: (providerId: string, key: string) => Promise<void>;
   vaultDeleteKey: (providerId: string) => Promise<void>;

--- a/src/renderer/styles/terminal.css
+++ b/src/renderer/styles/terminal.css
@@ -177,3 +177,78 @@
   color: #888;
   margin-left: 24px;
 }
+
+/* Provider launch-failure banner — overlays the top of the terminal inside
+   the .terminal-wrapper positioning context; static flow in the stopped view. */
+.provider-install-banner {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 10px 14px;
+  background: #3a2e1e;
+  border: 1px solid #6a542e;
+  border-radius: 6px;
+  color: #f0e0b8;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.terminal-stopped .provider-install-banner {
+  position: static;
+  margin-bottom: 12px;
+  max-width: 560px;
+}
+
+.provider-install-banner code {
+  color: #ffd890;
+  background: rgba(0, 0, 0, 0.25);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.provider-install-banner-text {
+  flex: 1;
+  min-width: 240px;
+}
+
+.provider-install-banner-actions {
+  display: flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.provider-install-banner-actions button {
+  padding: 5px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+  border: none;
+  background: #4a3c26;
+  color: #f0e0b8;
+}
+
+.provider-install-banner-actions button:hover {
+  background: #5a4a30;
+}
+
+.provider-install-banner-actions button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.provider-install-banner-actions .primary {
+  background: linear-gradient(135deg, #5a7aff 0%, #69ADFF 100%);
+  color: #fff;
+  font-weight: 500;
+}
+
+.provider-install-banner-actions .primary:hover {
+  opacity: 0.9;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -141,8 +141,28 @@ export interface ProviderStatus {
   /** First version-looking line of `<command> --version`, when available. */
   version: string | null;
   installHint: string;
+  /** Runnable install command Bodhilander can execute for the user, when one exists. */
+  installCommand: string | null;
   docsUrl: string;
   loginHint: string;
+}
+
+/**
+ * Emitted when a provider session's CLI failed to launch (missing from PATH,
+ * or installed-but-broken — e.g. codex's native binary absent). The renderer
+ * shows a friendly banner with the install guidance instead of leaving the
+ * user to decode a raw `spawn ... ENOENT`.
+ */
+export interface ProviderInstallHint {
+  sessionId: string;
+  providerId: string;
+  providerName: string;
+  /** CLI binary name (e.g. 'codex'). */
+  command: string;
+  kind: 'missing' | 'broken';
+  installHint: string;
+  installCommand: string | null;
+  docsUrl: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-ups to #97's provider setup guidance, motivated by a user report of Codex dying with a raw `spawn .../@openai/codex-darwin-arm64/.../codex ENOENT` (npm dropped the vendored platform binary from a global `@openai/codex` install — works fine on other machines).

**1. Friendly launch-failure banner.** New `spawn-failure.ts` classifies early session output as:
- `missing` — shell command-not-found shapes (zsh/bash/POSIX exec/cmd.exe/PowerShell), parameterized by the provider's CLI name so unrelated output can't trigger it, or
- `broken` — the CLI launched but its startup failed (`spawn ... ENOENT`, `bad CPU type in executable` from Rosetta-mismatched installs, `dyld: Library not loaded`).

`PtyManager` checks the scrollback within 15s of spawn (once per session — a running agent later printing such an error from user code can't retrigger it) and emits a hint event. The Terminal renders a dismissible banner explaining the failure in plain language, with install guidance, a docs link, and a one-click fix. The banner survives into the "Session stopped" view, since a missing CLI exits the shell immediately.

**2. "Install for me".** `ProviderDefinition.setup` gains an optional `installCommand` — directly runnable and re-run-safe (npm providers use `npm install -g --force` so the same command *repairs* broken installs; a plain reinstall over an existing package won't restore a dropped platform optionalDependency). `providers:run-install` spawns it in a visible pty (reusing the login-pty pattern incl. BDHLNDR-33 deferred emission; commands come only from the static registry — the renderer sends just a provider id). The new `ProviderInstallModal` attaches a Terminal to it and reports the exit code. Wired into both the failure banner ("Install/Reinstall for me" → then "Restart session") and Settings → Providers ("Install for me" on missing CLIs, with re-detection on close). Antigravity has no `installCommand` (GUI install) and keeps the text-only hint.

## Test plan

- `bun test` — 201 pass; the single `chat-parser` snapshot failure (`06-response`) reproduces on a clean tree and is unrelated.
- New unit tests in `spawn-failure.test.ts` cover all five command-not-found shell shapes, the verbatim codex ENOENT report, arch-mismatch/dyld variants, ANSI-wrapped output, missing-vs-broken precedence, and normal-startup non-matches.
- `tsc` clean for main + renderer configs; production webpack build compiles.
- Manual: break a codex install (`rm` the vendored binary), launch a codex session → banner appears; "Reinstall for me" runs the npm command in the modal, exits 0, "Restart session" launches successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)