### PR TITLE
fix(relay): auto-recover web client when agent comes online

### DIFF
--- a/relay/web/src/connection.ts
+++ b/relay/web/src/connection.ts
@@ -106,8 +106,14 @@ export class RelayConnection {
   }
 
   close(): void {
-    this.ws?.close();
+    const ws = this.ws;
     this.ws = null;
     this.key = null;
+    if (ws) {
+      // Detach handlers first so this deliberate close doesn't surface as a
+      // 'closed' state event (which the caller uses to schedule a reconnect).
+      ws.onopen = ws.onmessage = ws.onclose = ws.onerror = null;
+      ws.close();
+    }
   }
 }

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -2,6 +2,7 @@ import './styles.css';
 import '@xterm/xterm/css/xterm.css';
 import { Terminal } from '@xterm/xterm';
 import { RelayConnection, type ConnState, type Inner } from './connection';
+import { createReconnectScheduler } from './reconnect';
 
 // ---------------------------------------------------------------------------
 // Types (mirror the agent's sealed payloads)
@@ -154,25 +155,20 @@ let lastSessionsJson = '';
 function startPolling() { stopPolling(); pollTimer = setInterval(() => app.conn?.command({ type: 'sessions:list' }), 2500); }
 function stopPolling() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
 
-let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 // Re-open the channel after a delay. Used both when the socket drops (`closed`)
 // and when the agent is `offline` — in the offline case the relay keeps our
 // socket open but won't route until the desktop connects, so without this the
 // view stays stuck on "offline" until a manual refresh even after the machine
 // comes online. Retrying makes it recover on its own within a few seconds.
-function scheduleReconnect(delayMs: number) {
-  if (reconnectTimer) return; // one attempt already in flight
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null;
-    app.conn?.close();
-    connect();
-  }, delayMs);
-}
+const reconnector = createReconnectScheduler({
+  isAlive: () => app.conn != null, // false ⇒ deliberate teardown, don't resurrect
+  reconnect: () => { app.conn?.close(); connect(); },
+});
 
 function onConnState(s: ConnState, detail?: string) {
   const dot = $('#mdot'); const list = $('#sessions');
   if (s === 'ready') {
-    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+    reconnector.cancel();
     dot?.classList.remove('off');
     app.conn!.command({ type: 'groups:list' });
     app.conn!.command({ type: 'sessions:list' });
@@ -180,13 +176,16 @@ function onConnState(s: ConnState, detail?: string) {
   } else if (s === 'offline') {
     stopPolling(); dot?.classList.add('off');
     if (list) list.innerHTML = `<li class="empty-note"><div style="font-size:28px">🌙</div><p>This machine is offline. It'll appear here when it reconnects.</p></li>`;
-    scheduleReconnect(3000); // agent not connected yet — keep polling until it appears
+    reconnector.schedule(3000); // agent not connected yet — keep polling until it appears
   } else if (s === 'error') {
+    // A hard error (e.g. identity-verification failure) should surface, not retry.
+    // Cancel any reconnect queued by a prior offline/closed so it can't fire on top.
+    reconnector.cancel();
     stopPolling(); dot?.classList.add('off');
     if (list) list.innerHTML = `<li class="empty-note"><div style="font-size:28px">⚠️</div><p>${esc(detail || 'Connection problem.')}</p></li>`;
   } else if (s === 'closed') {
     stopPolling(); dot?.classList.add('off');
-    scheduleReconnect(3000); // socket dropped — reconnect
+    reconnector.schedule(3000); // socket dropped — reconnect
   }
 }
 

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -154,9 +154,25 @@ let lastSessionsJson = '';
 function startPolling() { stopPolling(); pollTimer = setInterval(() => app.conn?.command({ type: 'sessions:list' }), 2500); }
 function stopPolling() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
 
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+// Re-open the channel after a delay. Used both when the socket drops (`closed`)
+// and when the agent is `offline` — in the offline case the relay keeps our
+// socket open but won't route until the desktop connects, so without this the
+// view stays stuck on "offline" until a manual refresh even after the machine
+// comes online. Retrying makes it recover on its own within a few seconds.
+function scheduleReconnect(delayMs: number) {
+  if (reconnectTimer) return; // one attempt already in flight
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    app.conn?.close();
+    connect();
+  }, delayMs);
+}
+
 function onConnState(s: ConnState, detail?: string) {
   const dot = $('#mdot'); const list = $('#sessions');
   if (s === 'ready') {
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
     dot?.classList.remove('off');
     app.conn!.command({ type: 'groups:list' });
     app.conn!.command({ type: 'sessions:list' });
@@ -164,12 +180,13 @@ function onConnState(s: ConnState, detail?: string) {
   } else if (s === 'offline') {
     stopPolling(); dot?.classList.add('off');
     if (list) list.innerHTML = `<li class="empty-note"><div style="font-size:28px">🌙</div><p>This machine is offline. It'll appear here when it reconnects.</p></li>`;
+    scheduleReconnect(3000); // agent not connected yet — keep polling until it appears
   } else if (s === 'error') {
     stopPolling(); dot?.classList.add('off');
     if (list) list.innerHTML = `<li class="empty-note"><div style="font-size:28px">⚠️</div><p>${esc(detail || 'Connection problem.')}</p></li>`;
   } else if (s === 'closed') {
     stopPolling(); dot?.classList.add('off');
-    setTimeout(() => { if (app.conn) connect(); }, 3000); // simple reconnect
+    scheduleReconnect(3000); // socket dropped — reconnect
   }
 }
 

--- a/relay/web/src/reconnect.test.ts
+++ b/relay/web/src/reconnect.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for the reconnect scheduler (the offline/closed → auto-recover
+ * timer logic). Uses short real delays so it stays DOM-free and deterministic.
+ *
+ * Run with: bun test relay/web/src/reconnect.test.ts
+ */
+import { describe, expect, test } from 'bun:test';
+import { createReconnectScheduler } from './reconnect';
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('createReconnectScheduler', () => {
+  test('fires reconnect once after the delay when still alive', async () => {
+    let count = 0;
+    const s = createReconnectScheduler({ isAlive: () => true, reconnect: () => { count++; } });
+    s.schedule(10);
+    expect(s.pending).toBe(true);
+    await wait(25);
+    expect(count).toBe(1);
+    expect(s.pending).toBe(false);
+  });
+
+  test('schedules at most one reconnect while a timer is in flight', async () => {
+    let count = 0;
+    const s = createReconnectScheduler({ isAlive: () => true, reconnect: () => { count++; } });
+    s.schedule(10);
+    s.schedule(10); // ignored — one already pending
+    s.schedule(10); // ignored
+    await wait(25);
+    expect(count).toBe(1);
+  });
+
+  test('does NOT resurrect the connection when torn down (isAlive false)', async () => {
+    let count = 0;
+    let alive = true;
+    const s = createReconnectScheduler({ isAlive: () => alive, reconnect: () => { count++; } });
+    s.schedule(10);
+    alive = false; // e.g. logout / machine-switch nulled the connection
+    await wait(25);
+    expect(count).toBe(0);
+    expect(s.pending).toBe(false);
+  });
+
+  test('cancel() prevents a pending reconnect from firing', async () => {
+    let count = 0;
+    const s = createReconnectScheduler({ isAlive: () => true, reconnect: () => { count++; } });
+    s.schedule(10);
+    s.cancel();
+    expect(s.pending).toBe(false);
+    await wait(25);
+    expect(count).toBe(0);
+  });
+
+  test('can schedule again after firing', async () => {
+    let count = 0;
+    const s = createReconnectScheduler({ isAlive: () => true, reconnect: () => { count++; } });
+    s.schedule(10);
+    await wait(25);
+    s.schedule(10);
+    await wait(25);
+    expect(count).toBe(2);
+  });
+});

--- a/relay/web/src/reconnect.ts
+++ b/relay/web/src/reconnect.ts
@@ -1,0 +1,38 @@
+/**
+ * Reconnect scheduler for the relay connection. Kept DOM-free so the timer logic
+ * (schedule-at-most-one, bail-if-torn-down, cancel) is unit-testable without a
+ * browser harness.
+ *
+ * Behavior:
+ *  - schedule(delay) is a no-op if a reconnect is already pending (at most one
+ *    in flight), so repeated offline/closed events don't stack timers.
+ *  - when the timer fires it checks `isAlive()` first: if the app deliberately
+ *    tore the connection down (nulled its connection), it must NOT resurrect it.
+ *  - cancel() clears any pending timer (used on `ready` and on a hard `error`).
+ */
+export interface ReconnectScheduler {
+  schedule(delayMs: number): void;
+  cancel(): void;
+  readonly pending: boolean;
+}
+
+export function createReconnectScheduler(opts: {
+  isAlive: () => boolean;
+  reconnect: () => void;
+}): ReconnectScheduler {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  return {
+    schedule(delayMs: number) {
+      if (timer) return; // one attempt already in flight
+      timer = setTimeout(() => {
+        timer = null;
+        if (!opts.isAlive()) return; // deliberate teardown — don't resurrect
+        opts.reconnect();
+      }, delayMs);
+    },
+    cancel() {
+      if (timer) { clearTimeout(timer); timer = null; }
+    },
+    get pending() { return timer != null; },
+  };
+}

--- a/relay/web/tsconfig.json
+++ b/relay/web/tsconfig.json
@@ -12,5 +12,6 @@
     "verbatimModuleSyntax": true,
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Problem

After linking a machine, the desktop app showed **online** but the web client stayed **offline** until a hard refresh.

When a web client opens its channel and the desktop agent isn't connected to the relay yet, the relay replies `agent:offline` **but keeps the socket open** (`ws.ts`). The web client only scheduled a reconnect on the `closed` state — never on `offline` — so it sat on the "🌙 offline" card indefinitely, even after the agent came online seconds later. Only a manual reload (by which point the agent is connected) recovered it.

## Fix

- Retry the channel-open on `offline` too (every 3s) so the view recovers on its own once the agent appears; cancel the pending retry on `ready`.
- Harden `RelayConnection.close()` to detach its socket handlers before closing, so a deliberate close during a retry can't surface a phantom `closed` event and stack duplicate reconnect timers.

## Testing

- `bun run typecheck` + `bun run typecheck:web` clean.
- Deployed to the `bodhi-dev` relay (`https://bodhilander.bodhilabs.dev`) and verified: with the web page open, toggling the desktop's remote hosting off→on flips the web view from the offline card back to the live session list within a few seconds, no refresh.

Scope is entirely `relay/web/` (the browser client) — no desktop-app or relay-server protocol changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)