### PR TITLE
Promote development → production: macOS auto-update install fix (#133)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, ipcMain, dialog, shell, crashReporter } from 'elect
 import * as fs from 'fs';
 import * as path from 'path';
 import { ptyManager } from './pty-manager';
+import { runGuardedShutdown } from './shutdown';
 import { resolveLaunchProviderId } from './providers';
 import { startProviderInstall, cancelProviderInstall } from './provider-install';
 import { detectProviders } from './provider-detector';
@@ -1470,30 +1471,45 @@ app.on('activate', () => {
 
 let cleanupComplete = false;
 
+// Squirrel.Mac's ShipIt cancels an in-progress update with "App Still Running
+// Error" (Code=-9) if this process is still alive shortly after quitAndInstall,
+// so macOS auto-updates downloaded but never installed (issue #133). The
+// teardown below can hang on a wedged native worker, so it MUST NOT gate the
+// process exit — runGuardedShutdown force-exits within the budget regardless.
+// Comfortably inside ShipIt's tolerance; better-sqlite3 WAL is crash-safe.
+const QUIT_CLEANUP_BUDGET_MS = 2000;
+
 app.on('before-quit', (event) => {
   if (cleanupComplete) return;
 
   event.preventDefault();
   isQuitting = true;
 
-  (async () => {
-    try {
-      await ptyManager.killAll();
-    } catch (e) {
-      log.error('Error killing PTYs on quit:', e);
-    }
+  runGuardedShutdown({
+    budgetMs: QUIT_CLEANUP_BUDGET_MS,
+    log: (msg) => log.info(msg),
+    forceExit: () => {
+      cleanupComplete = true;
+      // Hard exit guarantees the PID is gone for ShipIt; ShipIt handles the
+      // post-install relaunch itself, so app.quit() vs app.exit() is moot here.
+      app.exit(0);
+    },
+    cleanup: async () => {
+      try {
+        await ptyManager.killAll();
+      } catch (e) {
+        log.error('Error killing PTYs on quit:', e);
+      }
 
-    disposeVectorSearchManager();
-    trayManager.destroy();
-    stateMonitor?.stop();
-    try {
-      getRelayClient().stop();
-    } catch (e) {
-      log.error('Error stopping relay client on quit:', e);
-    }
-    closeDatabase();
-
-    cleanupComplete = true;
-    app.quit();
-  })();
+      disposeVectorSearchManager();
+      trayManager.destroy();
+      stateMonitor?.stop();
+      try {
+        getRelayClient().stop();
+      } catch (e) {
+        log.error('Error stopping relay client on quit:', e);
+      }
+      closeDatabase();
+    },
+  });
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1469,7 +1469,11 @@ app.on('activate', () => {
   }
 });
 
-let cleanupComplete = false;
+// Set synchronously at the top of the handler (not inside forceExit, which may
+// not fire for up to QUIT_CLEANUP_BUDGET_MS) so a second before-quit within that
+// window — e.g. a tray-quit racing quitAndInstall — can't start a second
+// concurrent teardown and double-run killAll/closeDatabase/etc.
+let shuttingDown = false;
 
 // Squirrel.Mac's ShipIt cancels an in-progress update with "App Still Running
 // Error" (Code=-9) if this process is still alive shortly after quitAndInstall,
@@ -1480,7 +1484,8 @@ let cleanupComplete = false;
 const QUIT_CLEANUP_BUDGET_MS = 2000;
 
 app.on('before-quit', (event) => {
-  if (cleanupComplete) return;
+  if (shuttingDown) return;
+  shuttingDown = true;
 
   event.preventDefault();
   isQuitting = true;
@@ -1488,12 +1493,13 @@ app.on('before-quit', (event) => {
   runGuardedShutdown({
     budgetMs: QUIT_CLEANUP_BUDGET_MS,
     log: (msg) => log.info(msg),
-    forceExit: () => {
-      cleanupComplete = true;
-      // Hard exit guarantees the PID is gone for ShipIt; ShipIt handles the
-      // post-install relaunch itself, so app.quit() vs app.exit() is moot here.
-      app.exit(0);
-    },
+    // Hard exit guarantees the PID is gone for ShipIt; ShipIt handles the
+    // post-install relaunch itself, so app.quit() vs app.exit() is moot here.
+    // On the timeout path this also cuts off any teardown still in flight —
+    // notably ptyManager.killAll(), so child terminals may be orphaned to the
+    // OS. That's an accepted tradeoff: a stuck teardown blocking the update
+    // forever is worse, and the OS reaps orphaned PTYs on session end.
+    forceExit: () => app.exit(0),
     cleanup: async () => {
       try {
         await ptyManager.killAll();

--- a/src/main/shutdown.test.ts
+++ b/src/main/shutdown.test.ts
@@ -1,0 +1,72 @@
+import { test, expect } from 'bun:test';
+import { runGuardedShutdown } from './shutdown';
+
+const tick = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+test('forces exit once after cleanup completes normally', async () => {
+  let exits = 0;
+  runGuardedShutdown({
+    cleanup: async () => {
+      await tick(5);
+    },
+    forceExit: () => {
+      exits++;
+    },
+    budgetMs: 1000,
+  });
+
+  await tick(40);
+  expect(exits).toBe(1);
+});
+
+test('forces exit within budget even when cleanup hangs forever', async () => {
+  let exits = 0;
+  const start = Date.now();
+  let exitedAt = 0;
+
+  runGuardedShutdown({
+    cleanup: () => new Promise<void>(() => { /* never resolves */ }),
+    forceExit: () => {
+      exits++;
+      exitedAt = Date.now();
+    },
+    budgetMs: 20,
+  });
+
+  await tick(80);
+  expect(exits).toBe(1);
+  // Exit was driven by the watchdog, not the (hung) cleanup.
+  expect(exitedAt - start).toBeGreaterThanOrEqual(15);
+});
+
+test('still exits exactly once when cleanup rejects', async () => {
+  let exits = 0;
+  runGuardedShutdown({
+    cleanup: async () => {
+      throw new Error('teardown blew up');
+    },
+    forceExit: () => {
+      exits++;
+    },
+    budgetMs: 1000,
+  });
+
+  await tick(40);
+  expect(exits).toBe(1);
+});
+
+test('does not double-fire when cleanup resolves just after the deadline', async () => {
+  let exits = 0;
+  runGuardedShutdown({
+    cleanup: async () => {
+      await tick(60); // resolves AFTER the 20ms budget
+    },
+    forceExit: () => {
+      exits++;
+    },
+    budgetMs: 20,
+  });
+
+  await tick(120);
+  expect(exits).toBe(1);
+});

--- a/src/main/shutdown.ts
+++ b/src/main/shutdown.ts
@@ -1,0 +1,60 @@
+// Guaranteed-prompt shutdown (issue #133).
+//
+// On macOS, `autoUpdater.quitAndInstall()` hands off to Squirrel.Mac's ShipIt,
+// which waits for THIS process to terminate and then swaps the app bundle. If
+// the process is still alive shortly after the handoff, ShipIt cancels the
+// install with `SQRLInstallerErrorDomain Code=-9 "App Still Running Error"` —
+// the update downloads but never installs, and the app relaunches on the old
+// version. Our `before-quit` handler runs async teardown (killing PTYs,
+// disposing the vector-search worker, closing the DB) which can outlast ShipIt's
+// tolerance, or hang outright on a wedged native worker.
+//
+// `runGuardedShutdown` runs that teardown but GUARANTEES the process is
+// signalled to exit within `budgetMs` regardless of whether cleanup finishes,
+// so ShipIt always sees the process gone in time. Kept free of any `electron`
+// import so it is unit-testable under `bun test`.
+
+export interface GuardedShutdownOptions {
+  /** Async teardown. Must never throw synchronously; rejections are swallowed. */
+  cleanup: () => Promise<void>;
+  /** Terminates the process. Invoked exactly once. Typically `() => app.exit(0)`. */
+  forceExit: () => void;
+  /** Hard deadline: exit is forced this many ms after start even if cleanup hangs. */
+  budgetMs: number;
+  /** Optional diagnostic sink. */
+  log?: (message: string) => void;
+}
+
+/**
+ * Run shutdown cleanup with a hard exit deadline. `forceExit` fires exactly
+ * once — either when cleanup settles (resolve OR reject) or when `budgetMs`
+ * elapses, whichever comes first.
+ */
+export function runGuardedShutdown(opts: GuardedShutdownOptions): void {
+  let exited = false;
+  const fire = (reason: string): void => {
+    if (exited) return;
+    exited = true;
+    opts.log?.(reason);
+    opts.forceExit();
+  };
+
+  const watchdog = setTimeout(
+    () => fire('[shutdown] cleanup exceeded budget; forcing exit so the updater can install'),
+    opts.budgetMs
+  );
+  // Don't let the watchdog itself keep the event loop alive.
+  (watchdog as { unref?: () => void }).unref?.();
+
+  // Start cleanup, but the watchdog above is the real guarantee.
+  Promise.resolve()
+    .then(opts.cleanup)
+    .catch(() => {
+      // Individual steps log their own errors; a rejected cleanup must still
+      // let the process exit.
+    })
+    .finally(() => {
+      clearTimeout(watchdog);
+      fire('[shutdown] cleanup complete; exiting');
+    });
+}

--- a/src/main/vector-search/embedding-provider.ts
+++ b/src/main/vector-search/embedding-provider.ts
@@ -5,7 +5,7 @@ import os from 'os';
 // Import types for TypeScript, runtime value loaded dynamically
 import type { FeatureExtractionPipeline as FeatureExtractionPipelineType } from '@huggingface/transformers';
 
-import { applyModelCacheDir, TransformersEnvLike } from './model-cache';
+import { applyModelCacheDir, type TransformersEnvLike } from './model-cache';
 
 let pipeline: typeof import('@huggingface/transformers').pipeline;
 

--- a/src/main/vector-search/embedding-provider.ts
+++ b/src/main/vector-search/embedding-provider.ts
@@ -5,7 +5,13 @@ import os from 'os';
 // Import types for TypeScript, runtime value loaded dynamically
 import type { FeatureExtractionPipeline as FeatureExtractionPipelineType } from '@huggingface/transformers';
 
+import { applyModelCacheDir, TransformersEnvLike } from './model-cache';
+
 let pipeline: typeof import('@huggingface/transformers').pipeline;
+
+// The live transformers.js `env` object, captured at module load so we can
+// point its model cache at a writable, out-of-bundle directory (issue #133).
+let transformersEnv: TransformersEnvLike | null = null;
 
 // Cap ONNX threads so indexing doesn't saturate every CPU core.
 // Default onnxruntime behavior is intraOpNumThreads = physical cores, which
@@ -29,6 +35,7 @@ const MAX_EMBED_CHARS = 2048;
 try {
   const transformers = require('@huggingface/transformers');
   pipeline = transformers.pipeline;
+  transformersEnv = transformers.env ?? null;
   // WASM numThreads matters when transformers falls back to the WASM backend;
   // harmless when onnxruntime-node is in use.
   if (transformers.env?.backends?.onnx?.wasm) {
@@ -40,6 +47,18 @@ try {
 } catch (e) {
   console.error('[EmbeddingProvider] Failed to load @huggingface/transformers:', e);
   throw e;
+}
+
+/**
+ * Point transformers.js at a writable, out-of-bundle model cache (issue #133).
+ * MUST be called before the first pipeline() load. Callers pass a directory
+ * under app.getPath('userData'); transformers.js downloads to <dir>/<model_id>.
+ * Replaces the old HF_HOME / TRANSFORMERS_CACHE env vars, which transformers.js
+ * ignores — leaving them unset made the model download into the signed .app
+ * bundle and break its code-signature seal.
+ */
+export function setModelCacheDir(cacheDir: string): void {
+  applyModelCacheDir(transformersEnv, cacheDir);
 }
 
 // Alias for use in class

--- a/src/main/vector-search/embedding-worker.ts
+++ b/src/main/vector-search/embedding-worker.ts
@@ -13,18 +13,19 @@ console.log('[EmbeddingWorker] NODE_PATH:', process.env.NODE_PATH);
 console.log('[EmbeddingWorker] __dirname:', __dirname);
 
 import { parentPort } from 'worker_threads';
-import * as path from 'path';
 
 import type { HuggingFaceEmbeddingProvider as HuggingFaceEmbeddingProviderType } from './embedding-provider';
 
 // Native-dependent module loaded via require so a load failure is logged with
 // context (mirrors indexing-worker.ts, which is proven in production).
 let HuggingFaceEmbeddingProviderClass: typeof import('./embedding-provider').HuggingFaceEmbeddingProvider;
+let setModelCacheDir: typeof import('./embedding-provider').setModelCacheDir;
 
 try {
   console.log('[EmbeddingWorker] Loading embedding-provider module...');
   const embeddingModule = require('./embedding-provider');
   HuggingFaceEmbeddingProviderClass = embeddingModule.HuggingFaceEmbeddingProvider;
+  setModelCacheDir = embeddingModule.setModelCacheDir;
   console.log('[EmbeddingWorker] embedding-provider loaded successfully');
 } catch (e) {
   console.error('[EmbeddingWorker] Failed to load embedding-provider:', e);
@@ -73,9 +74,11 @@ parentPort?.on('message', (message: IncomingMessage) => {
   if (message.type === 'init') {
     if (message.cacheDir) {
       try {
-        // @huggingface/transformers reads these to locate the model cache.
-        process.env.HF_HOME = message.cacheDir;
-        process.env.TRANSFORMERS_CACHE = path.join(message.cacheDir, 'models');
+        // transformers.js caches to env.cacheDir (NOT HF_HOME /
+        // TRANSFORMERS_CACHE — those are Python-only and are ignored, which
+        // let the model download into the signed .app bundle, issue #133).
+        // Runs before the first embed → before the pipeline loads.
+        setModelCacheDir(message.cacheDir);
       } catch (e) {
         console.warn('[EmbeddingWorker] Failed to set cache dir:', e);
       }

--- a/src/main/vector-search/indexing-worker.ts
+++ b/src/main/vector-search/indexing-worker.ts
@@ -149,16 +149,11 @@ parentPort?.on('message', async (message: WorkerMessage) => {
     cancelled = false;
     currentIndexId = message.indexId!;
 
-    // Configure HuggingFace cache directory if provided
-    if (message.cacheDir) {
-      try {
-        // Set environment variable for @huggingface/transformers cache
-        process.env.HF_HOME = message.cacheDir;
-        process.env.TRANSFORMERS_CACHE = path.join(message.cacheDir, 'models');
-      } catch (e) {
-        console.warn('[IndexingWorker] Failed to set cache dir:', e);
-      }
-    }
+    // No model cache setup here (issue #133): per BDHLNDR-126 this worker never
+    // loads the embedding model — it parses files and RPCs embed requests to the
+    // single embedding worker, which owns the one InferenceSession and configures
+    // the model cache dir. The old HF_HOME / TRANSFORMERS_CACHE writes here were
+    // both dead and ignored by transformers.js.
 
     await runIndexing(message.indexId!, message.directoryPath!);
     currentIndexId = null;

--- a/src/main/vector-search/model-cache.test.ts
+++ b/src/main/vector-search/model-cache.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from 'bun:test';
+import { applyModelCacheDir } from './model-cache';
+
+test('sets env.cacheDir so transformers.js caches outside the app bundle', () => {
+  const env: { cacheDir?: string; allowRemoteModels?: boolean } = {};
+  applyModelCacheDir(env, '/Users/x/Library/Application Support/bodhilander/huggingface');
+  expect(env.cacheDir).toBe('/Users/x/Library/Application Support/bodhilander/huggingface');
+});
+
+test('keeps remote models allowed so the first-run download still works', () => {
+  const env: { cacheDir?: string; allowRemoteModels?: boolean } = { allowRemoteModels: false };
+  applyModelCacheDir(env, '/tmp/cache');
+  expect(env.allowRemoteModels).toBe(true);
+});
+
+test('does not touch HF_HOME / TRANSFORMERS_CACHE (transformers.js ignores them)', () => {
+  // Regression guard for the original bug: the fix must configure env.cacheDir,
+  // not the Python-only environment variables.
+  const before = { HF_HOME: process.env.HF_HOME, TRANSFORMERS_CACHE: process.env.TRANSFORMERS_CACHE };
+  applyModelCacheDir({}, '/tmp/cache');
+  expect(process.env.HF_HOME).toBe(before.HF_HOME);
+  expect(process.env.TRANSFORMERS_CACHE).toBe(before.TRANSFORMERS_CACHE);
+});
+
+test('is a no-op when the transformers env is unavailable', () => {
+  expect(() => applyModelCacheDir(null, '/tmp/cache')).not.toThrow();
+  expect(() => applyModelCacheDir(undefined, '/tmp/cache')).not.toThrow();
+});

--- a/src/main/vector-search/model-cache.test.ts
+++ b/src/main/vector-search/model-cache.test.ts
@@ -1,15 +1,20 @@
 import { test, expect } from 'bun:test';
 import { applyModelCacheDir } from './model-cache';
 
+// A userData-style destination (what the real caller passes). Deliberately NOT
+// a world-writable OS temp dir like /tmp — using one here would be flagged by
+// SonarQube S5443 and misrepresents where the model actually caches.
+const CACHE_DIR = '/Users/x/Library/Application Support/bodhilander/huggingface';
+
 test('sets env.cacheDir so transformers.js caches outside the app bundle', () => {
   const env: { cacheDir?: string; allowRemoteModels?: boolean } = {};
-  applyModelCacheDir(env, '/Users/x/Library/Application Support/bodhilander/huggingface');
-  expect(env.cacheDir).toBe('/Users/x/Library/Application Support/bodhilander/huggingface');
+  applyModelCacheDir(env, CACHE_DIR);
+  expect(env.cacheDir).toBe(CACHE_DIR);
 });
 
 test('keeps remote models allowed so the first-run download still works', () => {
   const env: { cacheDir?: string; allowRemoteModels?: boolean } = { allowRemoteModels: false };
-  applyModelCacheDir(env, '/tmp/cache');
+  applyModelCacheDir(env, CACHE_DIR);
   expect(env.allowRemoteModels).toBe(true);
 });
 
@@ -17,12 +22,12 @@ test('does not touch HF_HOME / TRANSFORMERS_CACHE (transformers.js ignores them)
   // Regression guard for the original bug: the fix must configure env.cacheDir,
   // not the Python-only environment variables.
   const before = { HF_HOME: process.env.HF_HOME, TRANSFORMERS_CACHE: process.env.TRANSFORMERS_CACHE };
-  applyModelCacheDir({}, '/tmp/cache');
+  applyModelCacheDir({}, CACHE_DIR);
   expect(process.env.HF_HOME).toBe(before.HF_HOME);
   expect(process.env.TRANSFORMERS_CACHE).toBe(before.TRANSFORMERS_CACHE);
 });
 
 test('is a no-op when the transformers env is unavailable', () => {
-  expect(() => applyModelCacheDir(null, '/tmp/cache')).not.toThrow();
-  expect(() => applyModelCacheDir(undefined, '/tmp/cache')).not.toThrow();
+  expect(() => applyModelCacheDir(null, CACHE_DIR)).not.toThrow();
+  expect(() => applyModelCacheDir(undefined, CACHE_DIR)).not.toThrow();
 });

--- a/src/main/vector-search/model-cache.ts
+++ b/src/main/vector-search/model-cache.ts
@@ -1,0 +1,33 @@
+// Model cache location for @huggingface/transformers (issue #133).
+//
+// transformers.js does NOT honor `HF_HOME` / `TRANSFORMERS_CACHE` — those are
+// the Python `huggingface_hub` env vars. In JS the only knob is `env.cacheDir`,
+// which otherwise defaults to a `.cache` folder next to the module. In a
+// packaged macOS build that resolves to INSIDE the signed `.app` bundle
+// (`Contents/Resources/app.asar.unpacked/dist/main/.cache/…`). Writing there
+// breaks the notarized code-signature seal ("a sealed resource is missing or
+// invalid"), which corrupts the install and breaks Gatekeeper + auto-update
+// validation.
+//
+// Kept free of the `@huggingface/transformers` import so it is unit-testable
+// under `bun test` without pulling in native onnxruntime.
+
+/** The subset of the transformers.js `env` object we mutate. */
+export interface TransformersEnvLike {
+  cacheDir?: string;
+  allowRemoteModels?: boolean;
+}
+
+/**
+ * Point transformers.js at a writable, out-of-bundle model cache. Downloads
+ * land under `<cacheDir>/<model_id>/…`. No-op when `env` is unavailable.
+ */
+export function applyModelCacheDir(
+  env: TransformersEnvLike | null | undefined,
+  cacheDir: string
+): void {
+  if (!env) return;
+  env.cacheDir = cacheDir;
+  // First run still needs to fetch the model from the Hub.
+  env.allowRemoteModels = true;
+}


### PR DESCRIPTION
## Release promotion: `development` → `production`

Promotes the accumulated `development` work to the stable release branch.

### What's included
- **fix(updater): make macOS auto-updates actually install (#133, #134)** — resolves the macOS auto-update not installing on quit, including the quit-race fix and graceful-shutdown handling.
- Supporting `shutdown.ts` graceful-shutdown module + tests.
- Vector-search embedding/indexing worker + model-cache adjustments (tie-in with shutdown handling).

### Commits
- `2ddcbf8` Merge PR #134 (fix/133-macos-autoupdate-install)
- `1891051` fix(updater): address PR #134 review — quit race, import type, S5443
- `9eee925` fix(updater): make macOS auto-updates actually install (#133)

### ⚠️ Version note (action required after merge)
This PR carries `package.json` version `3.4.0-beta.13`, which is a beta version and lower than production's current `3.4.2`. Per the release workflow, production accepts **stable versions only** — after merging, bump on `production` to drop the pre-release suffix and set the final stable version:

```bash
# on production, after merge
npm version minor   # or patch/major → e.g. 3.5.0
git push            # DO NOT use --tags
```

The three production-only commits ahead of development (`3.4.0`, `3.4.1`, `3.4.2`) are `npm version` bumps only — no code is lost by this merge.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)