### PR TITLE
feat(relay): dynamic terminal sizing + clean mobile viewer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@huggingface/transformers": "^3.4.1",
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@tanstack/react-query": "^5.62.7",
+        "@xterm/addon-serialize": "^0.14.0",
         "@xterm/headless": "^6.0.0",
         "better-sqlite3": "^12.5.0",
         "bonjour-service": "^1.3.0",
@@ -686,6 +687,8 @@
     "@webpack-cli/serve": ["@webpack-cli/serve@3.0.1", "", { "peerDependencies": { "webpack": "^5.82.0", "webpack-cli": "6.x.x" } }, "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.12", "", {}, "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg=="],
+
+    "@xterm/addon-serialize": ["@xterm/addon-serialize@0.14.0", "", {}, "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA=="],
 
     "@xterm/headless": ["@xterm/headless@6.0.0", "", {}, "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw=="],
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@huggingface/transformers": "^3.4.1",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "@tanstack/react-query": "^5.62.7",
+    "@xterm/addon-serialize": "^0.14.0",
     "@xterm/headless": "^6.0.0",
     "better-sqlite3": "^12.5.0",
     "bonjour-service": "^1.3.0",

--- a/relay/bun.lock
+++ b/relay/bun.lock
@@ -6,6 +6,7 @@
       "name": "bodhilander-relay",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-webgl": "0.19.0",
         "@xterm/xterm": "^6.0.0",
       },
       "devDependencies": {
@@ -20,6 +21,8 @@
     "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/addon-webgl": ["@xterm/addon-webgl@0.19.0", "", {}, "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A=="],
 
     "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
 

--- a/relay/package.json
+++ b/relay/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-webgl": "0.19.0",
     "@xterm/xterm": "^6.0.0"
   }
 }

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -250,7 +250,6 @@ function renderSessions() {
 // ---------------------------------------------------------------------------
 let term: Terminal | null = null;
 let fitAddon: FitAddon | null = null;
-let webglOk = false;
 let termScale = 1;
 const isMobileView = () => matchMedia('(max-width:859px)').matches;
 
@@ -325,7 +324,6 @@ function ensureTerm() {
     const webgl = new WebglAddon();
     webgl.onContextLoss(() => webgl.dispose());
     term.loadAddon(webgl);
-    webglOk = true;
   } catch { /* no WebGL — keep the DOM renderer */ }
   term.onData((d) => app.conn?.command({ type: 'terminal:input', sessionId: app.activeId, data: d }));
   // Mobile touch scroll: xterm's own viewport doesn't reliably scroll from touch,
@@ -679,34 +677,4 @@ function linkErrorText(error?: string): string {
   }
 }
 
-// TEMP diagnostic: open the site with #debug to see live terminal-scroll metrics.
-function startScrollDebug() {
-  if (!location.hash.includes('debug')) return;
-  const box = document.createElement('div');
-  box.style.cssText = 'position:fixed;bottom:120px;left:6px;z-index:9999;background:rgba(0,0,0,.85);color:#4ade80;font:10px/1.3 ui-monospace,monospace;padding:5px 7px;border-radius:6px;white-space:pre;pointer-events:none;max-width:80vw';
-  document.body.appendChild(box);
-  const num = (n: number | undefined) => Math.round(n || 0);
-  setInterval(() => {
-    const sc = $<HTMLElement>('#screen');
-    const xt = $<HTMLElement>('.xterm');
-    const vp = $<HTMLElement>('.xterm-viewport');
-    const xs = $<HTMLElement>('.xterm-screen');
-    const buf = term?.buffer.active;
-    // Dump the buffer line the viewport top is showing, plus its wrap flag — this
-    // shows what xterm's BUFFER holds (vs what's painted), isolating write/wrap
-    // bugs from render bugs.
-    const topY = buf ? buf.viewportY : 0;
-    const l0 = buf?.getLine(topY);
-    const l1 = buf?.getLine(topY + 1);
-    const s0 = (l0?.translateToString(false) ?? '').slice(0, 30);
-    box.textContent =
-      `cols${term?.cols ?? '-'} rows${term?.rows ?? '-'} wgl${webglOk ? 1 : 0}\n` +
-      `xt oH${num(xt?.offsetHeight)} vp cH${num(vp?.clientHeight)} sH${num(vp?.scrollHeight)}\n` +
-      `xs oH${num(xs?.offsetHeight)} sc cH${num(sc?.clientHeight)}\n` +
-      `buf len${buf?.length ?? '-'} base${buf?.baseY ?? '-'} vY${buf?.viewportY ?? '-'}\n` +
-      `L0[w${l1?.isWrapped ? 1 : 0}]|${s0}|`;
-  }, 400);
-}
-
 boot();
-startScrollDebug();

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -1,6 +1,8 @@
 import './styles.css';
 import '@xterm/xterm/css/xterm.css';
 import { Terminal } from '@xterm/xterm';
+import { WebglAddon } from '@xterm/addon-webgl';
+import { FitAddon } from '@xterm/addon-fit';
 import { RelayConnection, type ConnState, type Inner } from './connection';
 
 // ---------------------------------------------------------------------------
@@ -186,15 +188,19 @@ function onAgentMessage(m: Inner) {
     updateTermHeader(); // keep the open terminal's state chip / attention banner live
     return;
   }
-  if (m.type === 'terminal:size') { if (m.sessionId === app.activeId && term) term.resize(Math.max(2, Number(m.cols) || 80), Math.max(2, Number(m.rows) || 24)); return; }
-  if (m.type === 'terminal:output') {
+  if (m.type === 'terminal:size') {
+    // The PTY's authoritative size. Mirror it exactly (rendering a different grid
+    // than the PTY clamps Claude's cursor moves and garbles output). With dynamic
+    // sizing this is usually the size WE just reported, so the terminal fits the
+    // pane 1:1; when the desktop owns a bigger size, scaleTerm shrinks it to fit.
     if (m.sessionId === app.activeId && term) {
-      // .screen owns the scroll now, so keep it pinned to the latest output
-      // (tail) unless the user has scrolled up to read history.
-      const screen = $('#screen');
-      const atBottom = !screen || screen.scrollHeight - screen.scrollTop - screen.clientHeight < 40;
-      term.write(String(m.data), () => { if (atBottom && screen) screen.scrollTop = screen.scrollHeight; });
+      term.resize(Math.max(2, Number(m.cols) || 80), Math.max(2, Number(m.rows) || 24));
+      scaleTerm();
     }
+    return;
+  }
+  if (m.type === 'terminal:output') {
+    if (m.sessionId === app.activeId && term) term.write(String(m.data));
     return;
   }
   if (m.type === 'terminal:exit') { if (m.sessionId === app.activeId && term) term.write('\r\n\x1b[90m[session exited]\x1b[0m\r\n'); return; }
@@ -243,6 +249,47 @@ function renderSessions() {
 // Terminal (xterm)
 // ---------------------------------------------------------------------------
 let term: Terminal | null = null;
+let fitAddon: FitAddon | null = null;
+let webglOk = false;
+let termScale = 1;
+const isMobileView = () => matchMedia('(max-width:859px)').matches;
+
+// Dynamic sizing: on mobile the phone reports its own grid to the agent
+// (terminal:resize), which resizes the shared PTY so Claude REDRAWS to fit the
+// phone — clean, readable, no garble. We compute the grid with FitAddon's
+// proposeDimensions (measures the pane at our font size) without locally resizing
+// (the size comes back authoritatively via terminal:size). Only assert on real
+// changes to avoid reflow churn.
+function assertMobileSize() {
+  if (!term || !fitAddon || !isMobileView() || !app.activeId) return;
+  const dims = fitAddon.proposeDimensions();
+  if (!dims || !dims.cols || !dims.rows || !isFinite(dims.cols) || !isFinite(dims.rows)) return;
+  // No-op if the PTY is already our size (term.cols/rows track the last
+  // terminal:size). If the desktop reclaimed a bigger size, this differs and we
+  // re-assert — that's how the phone takes the size back when it's active again.
+  if (dims.cols === term.cols && dims.rows === term.rows) return;
+  app.conn?.command({ type: 'terminal:resize', sessionId: app.activeId, cols: dims.cols, rows: dims.rows });
+}
+
+// Fallback scaler: normally the PTY matches our reported size so the terminal
+// fits the pane 1:1 (scale ≈ 1). But when another viewer (the desktop) is active
+// and owns a larger size, we render THAT size and scale it down so it stays clean
+// (not garbled/clipped) until we reclaim the size on the next interaction.
+function scaleTerm() {
+  const xtermEl = term?.element as HTMLElement | undefined;
+  const screenEl = $<HTMLElement>('#screen');
+  if (!xtermEl || !screenEl) return;
+  if (!isMobileView()) { xtermEl.style.transform = ''; xtermEl.style.transformOrigin = ''; termScale = 1; return; }
+  xtermEl.style.transformOrigin = 'top left';
+  xtermEl.style.transform = 'none';
+  const natural = xtermEl.querySelector<HTMLElement>('.xterm-screen')?.getBoundingClientRect().width || xtermEl.scrollWidth || 1;
+  const avail = screenEl.clientWidth;
+  let s = avail / natural;
+  if (!isFinite(s) || s <= 0) s = 1;
+  s = Math.min(1, s);
+  termScale = s;
+  xtermEl.style.transform = `scale(${s})`;
+}
 function xtermTheme() {
   const dark = isDark();
   return dark
@@ -252,7 +299,11 @@ function xtermTheme() {
 function applyTermTheme() { if (term) term.options.theme = xtermTheme(); }
 function ensureTerm() {
   if (term) return;
-  term = new Terminal({ fontFamily: 'var(--mono)', fontSize: 13, cursorBlink: true, scrollback: 5000, theme: xtermTheme(), allowProposedApi: true, screenReaderMode: true });
+  // xterm measures the character cell with this font on a canvas, where a CSS
+  // `var(--mono)` does NOT resolve — it would silently fall back to a different
+  // font and mis-measure the cell, so FitAddon then computes the wrong cols/rows
+  // (garbled wrapping). Pass the resolved stack literally.
+  term = new Terminal({ fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace', fontSize: 13, cursorBlink: true, scrollback: 5000, theme: xtermTheme(), allowProposedApi: true, screenReaderMode: true });
   // This is a read-only VIEWER of the desktop's real terminal. Swallow terminal
   // query sequences (Device Attributes, cursor-position / status reports) so we
   // never echo an auto-response back into the shared PTY — the desktop is the
@@ -264,15 +315,60 @@ function ensureTerm() {
   term.parser.registerCsiHandler({ prefix: '?', final: 'c' }, swallow);
   term.parser.registerCsiHandler({ final: 'n' }, swallow); // DSR / cursor-position report
   term.open($('#screen')!);
+  fitAddon = new FitAddon();
+  term.loadAddon(fitAddon); // used only to PROPOSE a size to report; never fit() locally
+  // Use the WebGL renderer: the default DOM renderer accumulates sub-pixel cell
+  // drift on some mobile browsers, overlapping adjacent rows (garbled text). The
+  // WebGL renderer paints every cell at exact pixel coordinates. Fall back to the
+  // DOM renderer if the GL context can't be created / is lost.
+  try {
+    const webgl = new WebglAddon();
+    webgl.onContextLoss(() => webgl.dispose());
+    term.loadAddon(webgl);
+    webglOk = true;
+  } catch { /* no WebGL — keep the DOM renderer */ }
   term.onData((d) => app.conn?.command({ type: 'terminal:input', sessionId: app.activeId, data: d }));
-  // The terminal matches the desktop's size (via terminal:size), so we don't
-  // fit/resize the PTY. We only keep the pane sized to the visible viewport so
-  // the on-screen keyboard doesn't hide it (and can't be over-scrolled past).
+  // Mobile touch scroll: xterm's own viewport doesn't reliably scroll from touch,
+  // but its programmatic scroll (what wheel uses on desktop) does. Translate a
+  // vertical finger drag into term.scrollLines so history is reachable.
+  const screenEl = $('#screen')!;
+  let lastTouchY = 0, scrollAccum = 0;
+  screenEl.addEventListener('touchstart', (e) => {
+    if (e.touches.length === 1) { lastTouchY = e.touches[0]!.clientY; scrollAccum = 0; }
+    // Touching the terminal = the phone is the active viewer → reclaim our size
+    // if the desktop had taken it (no-op when already ours).
+    assertMobileSizeDebounced();
+  }, { passive: true });
+  screenEl.addEventListener('touchmove', (e) => {
+    if (!term || e.touches.length !== 1) return;
+    const y = e.touches[0]!.clientY;
+    scrollAccum += y - lastTouchY;
+    lastTouchY = y;
+    // Cell height on screen = unscaled cell height × the visual scale.
+    const cellUnscaled = Math.max(1, (screenEl.querySelector<HTMLElement>('.xterm-viewport')?.clientHeight || screenEl.clientHeight) / term.rows);
+    const cell = cellUnscaled * termScale;
+    const lines = Math.trunc(scrollAccum / cell);
+    if (lines !== 0) {
+      term.scrollLines(-lines); // drag down → reveal older lines above
+      scrollAccum -= lines * cell;
+      e.preventDefault(); // we handled it; don't let the page rubber-band
+    }
+  }, { passive: false });
+  // Keep the pane pinned to the visible viewport (keyboard show/hide) and, when
+  // the visible size settles, report our new grid to the agent so Claude reflows.
   const vv = window.visualViewport;
   if (vv) {
-    vv.addEventListener('resize', syncTermPane);
+    vv.addEventListener('resize', () => { syncTermPane(); scaleTerm(); assertMobileSizeDebounced(); });
     vv.addEventListener('scroll', syncTermPane);
   }
+}
+
+// Reporting our size reflows Claude on the desktop end, so debounce it — a
+// keyboard animation or orientation change shouldn't fire a dozen resizes.
+let assertTimer: ReturnType<typeof setTimeout> | null = null;
+function assertMobileSizeDebounced() {
+  if (assertTimer) clearTimeout(assertTimer);
+  assertTimer = setTimeout(() => { assertTimer = null; assertMobileSize(); }, 250);
 }
 
 // Pin the terminal pane to the *visual* viewport. The layout viewport (what a
@@ -309,10 +405,15 @@ function openTerminal(s: RSession) {
   $('#attnBanner')!.classList.toggle('hidden', s.state !== 'waiting');
   document.body.setAttribute('data-view', 'term');
   syncTermPane();
-  requestAnimationFrame(syncTermPane);
   pushLayer(() => { document.body.removeAttribute('data-view'); if (app.activeId) app.conn?.command({ type: 'terminal:unsubscribe', sessionId: app.activeId }); app.activeId = null; });
-  requestAnimationFrame(() => { term!.focus(); });
-  app.conn?.command({ type: 'terminal:subscribe', sessionId: s.id });
+  requestAnimationFrame(() => {
+    syncTermPane();
+    term!.focus();
+    app.conn?.command({ type: 'terminal:subscribe', sessionId: s.id });
+    // Report our grid so the agent reflows Claude to fit the phone. The size
+    // comes back via terminal:size and drives the local xterm + scale.
+    assertMobileSize();
+  });
 }
 
 // accessory keys
@@ -578,4 +679,34 @@ function linkErrorText(error?: string): string {
   }
 }
 
+// TEMP diagnostic: open the site with #debug to see live terminal-scroll metrics.
+function startScrollDebug() {
+  if (!location.hash.includes('debug')) return;
+  const box = document.createElement('div');
+  box.style.cssText = 'position:fixed;bottom:120px;left:6px;z-index:9999;background:rgba(0,0,0,.85);color:#4ade80;font:10px/1.3 ui-monospace,monospace;padding:5px 7px;border-radius:6px;white-space:pre;pointer-events:none;max-width:80vw';
+  document.body.appendChild(box);
+  const num = (n: number | undefined) => Math.round(n || 0);
+  setInterval(() => {
+    const sc = $<HTMLElement>('#screen');
+    const xt = $<HTMLElement>('.xterm');
+    const vp = $<HTMLElement>('.xterm-viewport');
+    const xs = $<HTMLElement>('.xterm-screen');
+    const buf = term?.buffer.active;
+    // Dump the buffer line the viewport top is showing, plus its wrap flag — this
+    // shows what xterm's BUFFER holds (vs what's painted), isolating write/wrap
+    // bugs from render bugs.
+    const topY = buf ? buf.viewportY : 0;
+    const l0 = buf?.getLine(topY);
+    const l1 = buf?.getLine(topY + 1);
+    const s0 = (l0?.translateToString(false) ?? '').slice(0, 30);
+    box.textContent =
+      `cols${term?.cols ?? '-'} rows${term?.rows ?? '-'} wgl${webglOk ? 1 : 0}\n` +
+      `xt oH${num(xt?.offsetHeight)} vp cH${num(vp?.clientHeight)} sH${num(vp?.scrollHeight)}\n` +
+      `xs oH${num(xs?.offsetHeight)} sc cH${num(sc?.clientHeight)}\n` +
+      `buf len${buf?.length ?? '-'} base${buf?.baseY ?? '-'} vY${buf?.viewportY ?? '-'}\n` +
+      `L0[w${l1?.isWrapped ? 1 : 0}]|${s0}|`;
+  }, 400);
+}
+
 boot();
+startScrollDebug();

--- a/relay/web/src/styles.css
+++ b/relay/web/src/styles.css
@@ -115,16 +115,13 @@ input, textarea { font-family: inherit; }
 .term-title { min-width: 0; }
 .term-title .t-name { font-family: var(--mono); font-weight: 600; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .term-title .t-meta { font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-/* The viewer matches the desktop's terminal size, which is often wider/taller
-   than the phone. Vertical scrolling — including through scrollback HISTORY —
-   is xterm's OWN viewport: xterm keeps scrollback off-DOM and only reveals it
-   when its viewport scrolls. On desktop that happens via wheel events (works
-   regardless of CSS overflow); on TOUCH devices the viewport must be natively
-   scrollable, so it needs overflow-y:auto + touch-action:pan-y. Neutralizing it
-   (overflow:hidden) is exactly what left mobile unable to reach history.
-   We bound .xterm/.viewport to the pane height so the viewport becomes a real
-   scroll window over the taller content; .screen handles horizontal panning. */
-.screen { flex: 1; min-height: 0; overflow: hidden; padding: 4px 0; background: var(--bg); }
+/* On desktop the viewer mirrors the desktop's terminal size, which can be wider
+   or taller than the browser window — so .screen scrolls (both axes) as the
+   escape hatch. On mobile (<860px) we instead use dynamic sizing (Claude reflows
+   to the phone) + a scale fallback + touch→scrollLines, so .screen is clipped and
+   the scroll is handled by those; see the max-width:859px override below. */
+.screen { flex: 1; min-height: 0; overflow: auto; padding: 4px 0; background: var(--bg); }
+@media (max-width: 859px) { .screen { overflow: hidden; } }
 /* xterm's own viewport is the vertical scroller (scrollback lives here). It must
    stay natively scrollable so TOUCH works — the desktop path uses wheel events,
    but mobile needs a real scroll container. */

--- a/relay/web/src/styles.css
+++ b/relay/web/src/styles.css
@@ -115,15 +115,20 @@ input, textarea { font-family: inherit; }
 .term-title { min-width: 0; }
 .term-title .t-name { font-family: var(--mono); font-weight: 600; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .term-title .t-meta { font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-/* The viewer matches the desktop's terminal size, which is often bigger than
-   the phone. Rather than clamp xterm to the container (clipping the bottom
-   rows) and rely on xterm's internal viewport for vertical scroll (which
-   doesn't respond to touch), let .screen scroll BOTH axes over the terminal
-   at its natural height — the same mechanism that already made horizontal
-   scroll work. xterm's own viewport is neutralized so it doesn't intercept. */
-.screen { flex: 1; min-height: 0; overflow: auto; -webkit-overflow-scrolling: touch; overscroll-behavior: contain; padding: 8px 6px 4px; background: var(--bg); }
-.screen .xterm { padding: 0 6px; }
-.xterm-viewport { overflow: hidden; overscroll-behavior: contain; }
+/* The viewer matches the desktop's terminal size, which is often wider/taller
+   than the phone. Vertical scrolling — including through scrollback HISTORY —
+   is xterm's OWN viewport: xterm keeps scrollback off-DOM and only reveals it
+   when its viewport scrolls. On desktop that happens via wheel events (works
+   regardless of CSS overflow); on TOUCH devices the viewport must be natively
+   scrollable, so it needs overflow-y:auto + touch-action:pan-y. Neutralizing it
+   (overflow:hidden) is exactly what left mobile unable to reach history.
+   We bound .xterm/.viewport to the pane height so the viewport becomes a real
+   scroll window over the taller content; .screen handles horizontal panning. */
+.screen { flex: 1; min-height: 0; overflow: hidden; padding: 4px 0; background: var(--bg); }
+/* xterm's own viewport is the vertical scroller (scrollback lives here). It must
+   stay natively scrollable so TOUCH works — the desktop path uses wheel events,
+   but mobile needs a real scroll container. */
+.xterm-viewport { overflow-y: auto; overflow-x: hidden; -webkit-overflow-scrolling: touch; touch-action: pan-y; overscroll-behavior: contain; }
 .xterm-viewport::-webkit-scrollbar { width: 8px; }
 .compose { border-top: 1px solid var(--hair); background: var(--surface); }
 .keys { display: flex; gap: 6px; padding: 8px 10px; overflow-x: auto; scrollbar-width: none; }

--- a/src/main/__tests__/pty-manager.test.ts
+++ b/src/main/__tests__/pty-manager.test.ts
@@ -236,3 +236,57 @@ describe('createInstallSession', () => {
     expect(manager.getSession('__install-codex')).toBeUndefined();
   });
 });
+
+describe('resize (dynamic sizing)', () => {
+  test('drives the pty and fans out a resize event; skips no-op resizes', () => {
+    const manager = new PtyManager();
+    const { ptyProc } = createAgentSession(manager);
+    const calls: Array<[number, number]> = [];
+    ptyProc.resize = (c: number, r: number) => calls.push([c, r]);
+    const events: Array<{ id: string; cols: number; rows: number }> = [];
+    manager.on('resize', (e: { id: string; cols: number; rows: number }) => events.push(e));
+
+    manager.resize('session-1', 100, 40);
+    expect(calls).toEqual([[100, 40]]);
+    expect(events).toEqual([{ id: 'session-1', cols: 100, rows: 40 }]);
+
+    // A no-op resize (same dimensions) must not churn the pty or re-emit — other
+    // viewers shouldn't get a redundant terminal:size.
+    manager.resize('session-1', 100, 40);
+    expect(calls.length).toBe(1);
+    expect(events.length).toBe(1);
+
+    manager.resize('session-1', 80, 24);
+    expect(events.length).toBe(2);
+    expect(events[1]).toEqual({ id: 'session-1', cols: 80, rows: 24 });
+  });
+
+  test('resizing an unknown session is a no-op (no throw, no event)', () => {
+    const manager = new PtyManager();
+    const events: unknown[] = [];
+    manager.on('resize', (e) => events.push(e));
+    manager.resize('does-not-exist', 100, 40);
+    expect(events).toEqual([]);
+  });
+});
+
+describe('getSerializedBuffer (rendered-text history)', () => {
+  test('returns resolved text of the scrollback, keeping content that scrolled off', async () => {
+    const manager = new PtyManager();
+    const { ptyProc } = createAgentSession(manager);
+    ptyProc.dataCb!('\x1b[32mhello\x1b[0m world\r\n');
+    for (let i = 0; i < 40; i++) ptyProc.dataCb!(`line ${i}\r\n`);
+
+    const text = await manager.getSerializedBuffer('session-1');
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain('hello');
+    // "line 5" scrolled off the 24-row screen — it must survive in the serialized
+    // scrollback (this is the history a phone reads).
+    expect(text).toContain('line 5');
+  });
+
+  test('returns empty string for an unknown session', async () => {
+    const manager = new PtyManager();
+    expect(await manager.getSerializedBuffer('nope')).toBe('');
+  });
+});

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -138,7 +138,7 @@ export class SessionTunnel {
         this.handleSessionCreate(clientId, inner);
         break;
       case 'terminal:subscribe':
-        this.handleSubscribe(clientId, s, inner);
+        void this.handleSubscribe(clientId, s, inner);
         break;
       case 'terminal:unsubscribe':
         if (typeof inner.sessionId === 'string') s.subs.delete(inner.sessionId);
@@ -185,15 +185,19 @@ export class SessionTunnel {
     }
   }
 
-  private handleSubscribe(clientId: string, s: ClientSession, inner: ClientFrame): void {
+  private async handleSubscribe(clientId: string, s: ClientSession, inner: ClientFrame): Promise<void> {
     if (typeof inner.sessionId !== 'string') return;
-    s.subs.add(inner.sessionId);
-    // Tell the viewer the PTY's real size so it matches (renders TUIs correctly)
-    // instead of resizing the shared terminal.
-    const size = ptyManager.getSize(inner.sessionId);
-    this.sealTo(clientId, { type: 'terminal:size', sessionId: inner.sessionId, cols: size.cols, rows: size.rows });
-    // Replay scrollback so the browser shows history, then live output streams.
-    this.sealTo(clientId, { type: 'terminal:output', sessionId: inner.sessionId, data: ptyManager.getBuffer(inner.sessionId) });
+    const sessionId = inner.sessionId;
+    s.subs.add(sessionId);
+    // Tell the viewer the PTY's current size so it renders TUIs correctly.
+    const size = ptyManager.getSize(sessionId);
+    this.sealTo(clientId, { type: 'terminal:size', sessionId, cols: size.cols, rows: size.rows });
+    // Replay history as RENDERED TEXT (reflow-safe) so a phone can resize the
+    // shared terminal without the scrollback garbling. Then live output streams.
+    const history = await ptyManager.getSerializedBuffer(sessionId);
+    if (s.subs.has(sessionId)) {
+      this.sealTo(clientId, { type: 'terminal:output', sessionId, data: history });
+    }
   }
 
   private handleDirsList(clientId: string, inner: ClientFrame): void {

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -39,6 +39,7 @@ interface ClientSession {
   subs: Set<string>;
   onData: (e: { id: string; data: string }) => void;
   onExit: (e: { id: string; exitCode: number }) => void;
+  onResize: (e: { id: string; cols: number; rows: number }) => void;
 }
 
 /** Decrypted command from a web client (union of every message's fields). */
@@ -82,9 +83,16 @@ export class SessionTunnel {
         const s = this.sessions.get(clientId);
         if (s?.subs.has(e.id)) this.sealTo(clientId, { type: 'terminal:exit', sessionId: e.id, exitCode: e.exitCode });
       };
+      // Dynamic sizing: when the PTY is resized (by this or any other viewer),
+      // tell subscribed clients the new size so they re-render at it.
+      const onResize = (e: { id: string; cols: number; rows: number }) => {
+        const s = this.sessions.get(clientId);
+        if (s?.subs.has(e.id)) this.sealTo(clientId, { type: 'terminal:size', sessionId: e.id, cols: e.cols, rows: e.rows });
+      };
       ptyManager.on('data', onData);
       ptyManager.on('exit', onExit);
-      this.sessions.set(clientId, { key, sendCounter: 0, recvCounter: -1, subs: new Set(), onData, onExit });
+      ptyManager.on('resize', onResize);
+      this.sessions.set(clientId, { key, sendCounter: 0, recvCounter: -1, subs: new Set(), onData, onExit, onResize });
 
       // Unsealed handshake reply: client verifies `signature` against the
       // machine's known Ed25519 pubkey, then derives the same session key.
@@ -140,9 +148,13 @@ export class SessionTunnel {
         if (typeof inner.sessionId === 'string' && typeof inner.data === 'string') ptyManager.write(inner.sessionId, inner.data);
         break;
       case 'terminal:resize':
-        // Intentionally ignored — the desktop owns the terminal size, so a
-        // mobile viewer never reflows the shared PTY. Viewers match the size
-        // reported by terminal:size.
+        // Dynamic sizing: the active viewer drives the shared PTY size, so a
+        // phone can reflow Claude to fit its screen. The desktop re-asserts its
+        // own size when it regains focus. The client is authenticated as the
+        // machine owner, so it's allowed to resize.
+        if (typeof inner.sessionId === 'string' && typeof inner.cols === 'number' && typeof inner.rows === 'number') {
+          ptyManager.resize(inner.sessionId, Math.max(2, Math.floor(inner.cols)), Math.max(2, Math.floor(inner.rows)));
+        }
         break;
       case 'sessions:list':
         this.sendSessions(clientId);
@@ -220,6 +232,7 @@ export class SessionTunnel {
     if (!s) return;
     ptyManager.off('data', s.onData);
     ptyManager.off('exit', s.onExit);
+    ptyManager.off('resize', s.onResize);
     this.sessions.delete(clientId);
   }
 

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -23,6 +23,7 @@ import { getAllGroups } from '../../repositories/groups';
 import { createRemoteSession, createRemoteGroup } from './remote-sessions';
 import { deriveSharedSecret, ensureIdentity, signWithIdentity } from './relay-identity';
 import { deriveSessionKey, sealJson, openJson, buildHandshakeProof, type SealedFrame } from './e2e';
+import { sanitizeSize } from './terminal-size';
 
 /** Expand a leading `~` to the user's home directory. */
 function expandHome(p: string): string {
@@ -30,6 +31,7 @@ function expandHome(p: string): string {
   if (p.startsWith('~/')) return path.join(os.homedir(), p.slice(2));
   return p;
 }
+
 
 interface ClientSession {
   key: Buffer;
@@ -144,18 +146,23 @@ export class SessionTunnel {
         if (typeof inner.sessionId === 'string') s.subs.delete(inner.sessionId);
         break;
       case 'terminal:input':
-        // The client is authenticated as the machine owner → full control.
-        if (typeof inner.sessionId === 'string' && typeof inner.data === 'string') ptyManager.write(inner.sessionId, inner.data);
-        break;
-      case 'terminal:resize':
-        // Dynamic sizing: the active viewer drives the shared PTY size, so a
-        // phone can reflow Claude to fit its screen. The desktop re-asserts its
-        // own size when it regains focus. The client is authenticated as the
-        // machine owner, so it's allowed to resize.
-        if (typeof inner.sessionId === 'string' && typeof inner.cols === 'number' && typeof inner.rows === 'number') {
-          ptyManager.resize(inner.sessionId, Math.max(2, Math.floor(inner.cols)), Math.max(2, Math.floor(inner.rows)));
+        // The client is authenticated as the machine owner (E2E handshake), but
+        // scope input to sessions it's actually subscribed to as defense-in-depth.
+        if (typeof inner.sessionId === 'string' && typeof inner.data === 'string' && s.subs.has(inner.sessionId)) {
+          ptyManager.write(inner.sessionId, inner.data);
         }
         break;
+      case 'terminal:resize': {
+        // Dynamic sizing: the active viewer drives the shared PTY size so a phone
+        // can reflow Claude to fit. Now that this is live network-triggered input
+        // into a native PTY resize, clamp/validate the size and scope it to a
+        // subscribed session.
+        const size = sanitizeSize(inner.cols, inner.rows);
+        if (typeof inner.sessionId === 'string' && size && s.subs.has(inner.sessionId)) {
+          ptyManager.resize(inner.sessionId, size.cols, size.rows);
+        }
+        break;
+      }
       case 'sessions:list':
         this.sendSessions(clientId);
         break;

--- a/src/main/api/relay/terminal-size.test.ts
+++ b/src/main/api/relay/terminal-size.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for sanitizeSize — the validation/clamping applied to a remote
+ * (web/phone) client's terminal:resize before it reaches the native PTY resize.
+ *
+ * Run with: bun test src/main/api/relay/terminal-size.test.ts
+ */
+import { describe, expect, test } from 'bun:test';
+import { sanitizeSize, MAX_COLS, MAX_ROWS, MIN_DIM } from './terminal-size';
+
+describe('sanitizeSize', () => {
+  test('passes a normal size through, floored to integers', () => {
+    expect(sanitizeSize(80, 24)).toEqual({ cols: 80, rows: 24 });
+    expect(sanitizeSize(120.9, 40.2)).toEqual({ cols: 120, rows: 40 });
+  });
+
+  test('clamps up to the minimum', () => {
+    expect(sanitizeSize(1, 1)).toEqual({ cols: MIN_DIM, rows: MIN_DIM });
+    expect(sanitizeSize(0, 0)).toEqual({ cols: MIN_DIM, rows: MIN_DIM });
+    expect(sanitizeSize(-50, -3)).toEqual({ cols: MIN_DIM, rows: MIN_DIM });
+  });
+
+  test('clamps down to the maximum (prevents an absurd native resize)', () => {
+    expect(sanitizeSize(100000, 999999)).toEqual({ cols: MAX_COLS, rows: MAX_ROWS });
+    expect(sanitizeSize(MAX_COLS + 1, MAX_ROWS + 1)).toEqual({ cols: MAX_COLS, rows: MAX_ROWS });
+  });
+
+  test('rejects non-finite values (NaN / Infinity)', () => {
+    expect(sanitizeSize(NaN, 24)).toBeNull();
+    expect(sanitizeSize(80, NaN)).toBeNull();
+    expect(sanitizeSize(Infinity, 24)).toBeNull();
+    expect(sanitizeSize(80, -Infinity)).toBeNull();
+  });
+
+  test('rejects non-number shapes (missing/wrong-typed frame fields)', () => {
+    expect(sanitizeSize(undefined, 24)).toBeNull();
+    expect(sanitizeSize(80, undefined)).toBeNull();
+    expect(sanitizeSize('80', '24')).toBeNull();
+    expect(sanitizeSize(null, null)).toBeNull();
+    expect(sanitizeSize({ cols: 80 }, 24)).toBeNull();
+  });
+});

--- a/src/main/api/relay/terminal-size.ts
+++ b/src/main/api/relay/terminal-size.ts
@@ -1,0 +1,24 @@
+/**
+ * Validation for terminal sizes arriving from a remote (web/phone) client before
+ * they reach the native PTY resize. Kept dependency-free so it's trivially
+ * unit-testable in isolation from the E2E tunnel.
+ */
+
+/** Upper bounds for a remote-supplied terminal size — generous but sane. */
+export const MAX_COLS = 1000;
+export const MAX_ROWS = 1000;
+export const MIN_DIM = 2;
+
+/**
+ * Validate & clamp a terminal size from an (untrusted-shaped) client frame.
+ * Rejects non-numbers and non-finite values (NaN/Infinity), floors to integers,
+ * and clamps into [MIN_DIM, MAX_*]. Returns null when the input can't be valid.
+ */
+export function sanitizeSize(cols: unknown, rows: unknown): { cols: number; rows: number } | null {
+  if (typeof cols !== 'number' || typeof rows !== 'number') return null;
+  if (!Number.isFinite(cols) || !Number.isFinite(rows)) return null;
+  return {
+    cols: Math.min(MAX_COLS, Math.max(MIN_DIM, Math.floor(cols))),
+    rows: Math.min(MAX_ROWS, Math.max(MIN_DIM, Math.floor(rows))),
+  };
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -598,6 +598,12 @@ function createWindow(): void {
     }
   });
 
+  // Dynamic sizing: forward PTY resizes to the renderer so a session that was
+  // shrunk by a mobile viewer can show a "resized for mobile" banner + Resume.
+  ptyManager.on('resize', ({ id, cols, rows }) => {
+    mainWindow?.webContents.send('pty:resized', id, cols, rows);
+  });
+
   ptyManager.on('exit', ({ id, exitCode }) => {
     mainWindow?.webContents.send('pty:exit', id, exitCode);
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -35,6 +35,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.removeListener('pty:exit', listener);
     };
   },
+  // Dynamic sizing: the PTY was resized (possibly by a remote/mobile viewer).
+  onPtyResize: (callback: (id: string, cols: number, rows: number) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, id: string, cols: number, rows: number) => callback(id, cols, rows);
+    ipcRenderer.on('pty:resized', listener);
+    return () => {
+      ipcRenderer.removeListener('pty:resized', listener);
+    };
+  },
   onStateChange: (callback: (event: { sessionId: string; state: string; event: string; timestamp: number }) => void) => {
     const listener = (_: Electron.IpcRendererEvent, event: any) => callback(event);
     ipcRenderer.on('state:change', listener);

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -84,8 +84,25 @@ interface PtySession {
  */
 const RESUME_FAILURE_WINDOW_MS = 5000;
 
-// Max scrollback buffer size (100KB should be plenty for recent terminal history)
-const MAX_SCROLLBACK_SIZE = 100 * 1024;
+// Max scrollback buffer replayed to remote viewers (web/phone) on attach. This
+// is the ONLY history a remote viewer can see — it has no live stream from before
+// it connected — so it needs to be generous. 100KB is barely one screen on a
+// wide terminal (e.g. 184 cols), which left the phone with nothing to scroll. 2MB
+// holds thousands of lines even on a wide terminal.
+const MAX_SCROLLBACK_SIZE = 2 * 1024 * 1024;
+
+/**
+ * Append PTY output to a session's replay buffer, trimming to the cap. The trim
+ * is amortized: we only slice once the buffer grows 25% past the cap (then cut
+ * back to the cap), so a chatty PTY doesn't pay an O(cap) string copy on every
+ * single chunk once it's full.
+ */
+function appendScrollback(session: PtySession, data: string): void {
+  session.scrollbackBuffer += data;
+  if (session.scrollbackBuffer.length > MAX_SCROLLBACK_SIZE * 1.25) {
+    session.scrollbackBuffer = session.scrollbackBuffer.slice(-MAX_SCROLLBACK_SIZE);
+  }
+}
 
 /**
  * Only classify launch failures in this window after spawn. The 'broken'
@@ -258,14 +275,8 @@ export class PtyManager extends EventEmitter {
         }
       }
 
-      // Append to scrollback buffer
-      if (session) {
-        session.scrollbackBuffer += filteredData;
-        // Trim if too large (keep last MAX_SCROLLBACK_SIZE bytes)
-        if (session.scrollbackBuffer.length > MAX_SCROLLBACK_SIZE) {
-          session.scrollbackBuffer = session.scrollbackBuffer.slice(-MAX_SCROLLBACK_SIZE);
-        }
-      }
+      // Append to scrollback buffer (replayed to remote viewers on attach).
+      if (session) appendScrollback(session, filteredData);
 
       this.emit('data', { id, data: filteredData });
 
@@ -530,10 +541,7 @@ export class PtyManager extends EventEmitter {
         if (filteredData.trim() === '') return;
       }
 
-      session.scrollbackBuffer += filteredData;
-      if (session.scrollbackBuffer.length > MAX_SCROLLBACK_SIZE) {
-        session.scrollbackBuffer = session.scrollbackBuffer.slice(-MAX_SCROLLBACK_SIZE);
-      }
+      appendScrollback(session, filteredData);
 
       if (session.deferEmission) return;
 
@@ -632,10 +640,7 @@ export class PtyManager extends EventEmitter {
         if (filteredData.trim() === '') return;
       }
 
-      session.scrollbackBuffer += filteredData;
-      if (session.scrollbackBuffer.length > MAX_SCROLLBACK_SIZE) {
-        session.scrollbackBuffer = session.scrollbackBuffer.slice(-MAX_SCROLLBACK_SIZE);
-      }
+      appendScrollback(session, filteredData);
 
       // Hold emission until the renderer primes this pty (BDHLNDR-33). The
       // scrollback is accumulated above regardless, so nothing is lost.
@@ -715,6 +720,11 @@ export class PtyManager extends EventEmitter {
     session.lastCols = cols;
     session.lastRows = rows;
     session.pty.resize(cols, rows);
+    // Notify listeners (e.g. the relay agent, which forwards the new size to
+    // remote viewers so they re-render at the current PTY dimensions). Dynamic
+    // sizing: whichever viewer is active drives the size, and everyone else
+    // follows via this event.
+    this.emit('resize', { id, cols, rows });
   }
 
   kill(id: string): Promise<void> {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { execFile } from 'child_process';
 import { EventEmitter } from 'events';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { SerializeAddon } from '@xterm/addon-serialize';
 import {
   resolveProvider,
   getSocketPath,
@@ -817,6 +819,37 @@ export class PtyManager extends EventEmitter {
   getBuffer(id: string): string {
     const session = this.sessions.get(id);
     return session?.scrollbackBuffer || '';
+  }
+
+  /**
+   * Rendered-text history for remote viewers. Replays the raw scrollback through
+   * a headless terminal at the session's CURRENT width and serializes the result
+   * to resolved text (colors kept, but no cursor-addressing). Unlike the raw
+   * bytes, this can be reflowed to a different width (e.g. a phone) WITHOUT
+   * garbling — Claude's absolute cursor moves have already been applied here.
+   * Falls back to the raw buffer if serialization isn't available.
+   */
+  async getSerializedBuffer(id: string): Promise<string> {
+    const session = this.sessions.get(id);
+    const raw = session?.scrollbackBuffer;
+    if (!session || !raw) return '';
+    try {
+      const term = new HeadlessTerminal({
+        cols: session.lastCols || 80,
+        rows: session.lastRows || 24,
+        scrollback: 20000,
+        allowProposedApi: true,
+      });
+      const serializer = new SerializeAddon();
+      term.loadAddon(serializer);
+      await new Promise<void>((resolve) => term.write(raw, () => resolve()));
+      const text = serializer.serialize({ scrollback: 20000 });
+      term.dispose();
+      return text;
+    } catch (err) {
+      console.warn('[PtyManager] getSerializedBuffer failed, falling back to raw:', err);
+      return raw;
+    }
   }
 
   /**

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -66,6 +66,12 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   const [installHint, setInstallHint] = useState<ProviderInstallHint | null>(null);
   const [installFlow, setInstallFlow] = useState<{ ptyId: string; command: string } | null>(null);
   const [installSucceeded, setInstallSucceeded] = useState(false);
+  // Dynamic sizing: when a remote/mobile viewer shrinks the shared PTY below this
+  // desktop's size, we show a banner + a Resume button. `desktopSizeRef` tracks
+  // the size THIS window last asked for, so we can tell a mobile resize (smaller,
+  // unrequested) from our own.
+  const desktopSizeRef = useRef<{ cols: number; rows: number } | null>(null);
+  const [mobileSize, setMobileSize] = useState<{ cols: number; rows: number } | null>(null);
 
   // Track isActive in a ref so handleResize (set up in the main effect which
   // does NOT depend on isActive) can skip hidden terminals. Without this,
@@ -100,11 +106,39 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       const { cols, rows } = xtermRef.current;
       // Guard: don't propagate bogus dimensions from an unsized container.
       if (cols >= MIN_COLS && rows >= MIN_ROWS) {
+        desktopSizeRef.current = { cols, rows };
+        setMobileSize(null); // we're (re)asserting the desktop's own size
         window.electronAPI.resizeSession(sessionId, cols, rows);
       }
     } catch (e) {
       console.warn('[Terminal] resize during teardown (non-fatal):', e);
     }
+  }, [sessionId]);
+
+  // Resume the desktop's own size (undo a mobile viewer's shrink).
+  const resumeDesktopSize = useCallback(() => {
+    setMobileSize(null);
+    handleResize();
+  }, [handleResize]);
+
+  // Dynamic sizing: react to PTY resizes driven by another viewer. If the shared
+  // terminal was shrunk (by a phone) below this window's size, follow it locally
+  // (so nothing renders stale/garbled) and show the banner. When it matches our
+  // own size again, clear the banner.
+  useEffect(() => {
+    return window.electronAPI.onPtyResize((id, cols, rows) => {
+      if (id !== sessionId) return;
+      const desk = desktopSizeRef.current;
+      if (!desk) return; // haven't fit yet — nothing to compare against
+      if (cols === desk.cols && rows === desk.rows) {
+        setMobileSize(null);
+        return;
+      }
+      if (cols < desk.cols || rows < desk.rows) {
+        setMobileSize({ cols, rows });
+        try { xtermRef.current?.resize(cols, rows); } catch { /* disposed */ }
+      }
+    });
   }, [sessionId]);
 
   // Surface provider launch failures (spawn ENOENT / command not found)
@@ -689,6 +723,16 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
         className="terminal-container"
         onContextMenu={handleContextMenu}
       />
+      {mobileSize && (
+        <div className="mobile-resize-banner">
+          <span className="mobile-resize-banner-text">
+            📱 Resized to fit a mobile viewer ({mobileSize.cols}×{mobileSize.rows}).
+          </span>
+          <button className="mobile-resize-banner-btn" onClick={resumeDesktopSize}>
+            Resume desktop size
+          </button>
+        </div>
+      )}
       {installHintUi}
       {contextMenu.visible && (
         <div

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -526,6 +526,10 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     }
 
     window.addEventListener('resize', handleResize);
+    // Dynamic sizing: a remote viewer (phone) can shrink the shared PTY to fit
+    // its screen while the user is away. When the desktop window regains focus,
+    // re-assert its own fit size so the terminal snaps back to full width.
+    window.addEventListener('focus', handleResize);
 
     // Initial fit after layout settles
     requestAnimationFrame(() => {
@@ -539,6 +543,7 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       // fire handleResize into the disposed terminal after this cleanup.
       if (resizeRafId) cancelAnimationFrame(resizeRafId);
       window.removeEventListener('resize', handleResize);
+      window.removeEventListener('focus', handleResize);
       resizeObserver.disconnect();
       cleanupPtyData();
       window.electronAPI.killSession(sessionId);

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -14,6 +14,7 @@ interface ElectronAPI {
   // PTY events
   onPtyData: (callback: (id: string, data: string) => void) => () => void;
   onPtyExit: (callback: (id: string, exitCode: number) => void) => () => void;
+  onPtyResize: (callback: (id: string, cols: number, rows: number) => void) => () => void;
   onStateChange: (callback: (event: { sessionId: string; state: string; event: string; timestamp: number }) => void) => () => void;
   onSessionsRefresh: (callback: () => void) => () => void;
   onGroupsRefresh: (callback: () => void) => () => void;

--- a/src/renderer/styles/terminal.css
+++ b/src/renderer/styles/terminal.css
@@ -206,6 +206,41 @@
   max-width: 560px;
 }
 
+/* Dynamic sizing: shown when a mobile viewer has shrunk this session's terminal. */
+.mobile-resize-banner {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 8px 14px;
+  background: #1e2f3a;
+  border: 1px solid #2e546a;
+  border-radius: 6px;
+  color: #b8dcf0;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.mobile-resize-banner-btn {
+  flex: none;
+  padding: 4px 12px;
+  background: #35c2d1;
+  color: #06222a;
+  border: none;
+  border-radius: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.mobile-resize-banner-btn:hover {
+  background: #4dd3e1;
+}
+
 .provider-install-banner code {
   color: #ffd890;
   background: rgba(0, 0, 0, 0.25);

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -35,6 +35,7 @@ export interface ElectronAPI {
   killSession: (id: string) => void;
   onPtyData: (callback: (id: string, data: string) => void) => () => void;
   onPtyExit: (callback: (id: string, exitCode: number) => void) => () => void;
+  onPtyResize: (callback: (id: string, cols: number, rows: number) => void) => () => void;
   onStateChange: (callback: (event: StateChangeEvent) => void) => () => void;
 
   // Menu events


### PR DESCRIPTION
## Problem

The mobile web viewer mirrored the desktop's exact terminal grid (often **184 columns**). On a phone that forces a lose-lose: **scale down** → unreadably small, or **reflow to a narrow grid** → Claude's absolute cursor moves get clamped onto the last column and the output garbles (characters piled at the right edge).

## Fix — dynamic sizing ("active viewer drives the size", tmux-style)

- **Web** (`relay/web`): the phone reports its own grid via `terminal:resize`, so **Claude redraws to fit the phone** — clean, readable, no garble. It renders at whatever size the PTY reports (`terminal:size`); a fallback CSS scale keeps it clean when the desktop transiently owns a larger size. Vertical scrolling is a touch-drag → `term.scrollLines` handler (reliable on mobile where the native viewport won't touch-scroll). WebGL renderer + a resolved monospace stack fix sub-pixel cell drift.
- **Agent** (`session-tunnel.ts`): apply `terminal:resize` → `ptyManager.resize`; forward PTY resize events to subscribed viewers as `terminal:size`.
- **pty-manager**: emit a `resize` event; raise the remote replay buffer **100 KB → 2 MB** (100 KB was ~one screen on a wide terminal, leaving the phone nothing to scroll) with amortized trimming.
- **Desktop renderer** (`Terminal.tsx`): re-assert its own fit size on **window focus**, so the desktop snaps back to full width when you return to it.

## Behavior

- On the phone, Claude reflows to the phone's width → readable, no panning, no garble.
- While you're on the phone, the desktop terminal reflows to the phone's width; it snaps back the instant the desktop window regains focus. Standard multiplexer behavior — not a permanent restriction.

## Known follow-up

Pre-existing scrollback was captured at the old width, so scrolling into *old* history can reflow imperfectly. A rendered-text history snapshot (via the already-present `@xterm/headless`) is the planned follow-up. The **live view — the primary interaction — is now clean and readable.**

## Testing

- `tsc -p tsconfig.main.json`, base `tsc`, and relay `typecheck:web` all clean.
- Web deployed to the `bodhi-dev` relay. Full end-to-end needs the app agent, so this rides a beta build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)