### PR TITLE
fix: reclaim orphaned code-index tables + deterministic session ordering

### DIFF
--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -240,7 +240,13 @@ function groupPath(groupId: string): { label: string; color: string } {
 
 function renderSessions() {
   const ul = $('#sessions')!;
-  const sorted = [...app.sessions].sort((a, b) => STATE_RANK[a.state] - STATE_RANK[b.state] || a.name.localeCompare(b.name));
+  // Sort by attention state, then name, then id. The id tiebreak matters: two
+  // sessions can share a name (same name in different folders), and without a
+  // total order the comparator returns 0, leaving them in whatever order the
+  // agent happened to send — which used to shuffle and make them swap places.
+  const sorted = [...app.sessions].sort(
+    (a, b) => STATE_RANK[a.state] - STATE_RANK[b.state] || a.name.localeCompare(b.name) || a.id.localeCompare(b.id),
+  );
   const waiting = sorted.filter((s) => s.state === 'waiting').length;
   const attn = $('#attn')!;
   if (waiting) { attn.textContent = `${waiting} needs you`; attn.classList.remove('hidden'); } else attn.classList.add('hidden');

--- a/src/main/__tests__/database-cleanup.test.ts
+++ b/src/main/__tests__/database-cleanup.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for dropLegacyCodeSearchTables — the one-time reclaim of the removed
+ * code-indexing feature's tables. These can be very large (chunk source text +
+ * 768-dim embeddings), and this runs against the database holding the user's
+ * real data, so the contract is: drop the legacy tables, never touch anything
+ * else, and never throw.
+ *
+ * Run with: bun test src/main/__tests__/database-cleanup.test.ts
+ */
+import { describe, expect, mock, test } from 'bun:test';
+// better-sqlite3 is a native module bun:test can't load. bun:sqlite exposes the
+// same prepare()/exec()/close() surface this function uses, so we drive it with
+// that and cast — the behavior under test is pure SQL.
+import { Database } from 'bun:sqlite';
+import type BetterSqlite3 from 'better-sqlite3';
+
+type Db = BetterSqlite3.Database;
+const asDb = (d: Database) => d as unknown as Db;
+
+// Superset of the electron surface database.ts touches at import time.
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
+  safeStorage: { isEncryptionAvailable: () => false },
+}));
+mock.module('electron-log', () => ({
+  default: { info() {}, warn() {}, error() {} },
+}));
+
+const { dropLegacyCodeSearchTables } = await import('../database');
+
+/** A db with the legacy code-search tables plus a couple of "real" user tables. */
+function makeLegacyDb(): Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE code_indexes (id TEXT PRIMARY KEY, directory_path TEXT);
+    CREATE TABLE indexed_files (id TEXT PRIMARY KEY, index_id TEXT REFERENCES code_indexes(id));
+    CREATE TABLE code_chunks (id TEXT PRIMARY KEY, index_id TEXT REFERENCES code_indexes(id), content TEXT);
+    CREATE TABLE symbols (id TEXT PRIMARY KEY, index_id TEXT REFERENCES code_indexes(id), name TEXT);
+    CREATE INDEX idx_chunks_index_id ON code_chunks(index_id);
+    CREATE INDEX idx_symbols_name ON symbols(name);
+
+    -- real user data that must survive untouched
+    CREATE TABLE sessions (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE memories (id TEXT PRIMARY KEY, content TEXT);
+  `);
+  db.prepare("INSERT INTO code_indexes (id, directory_path) VALUES ('i1', '/tmp/x')").run();
+  db.prepare("INSERT INTO code_chunks (id, index_id, content) VALUES ('c1','i1','some source')").run();
+  db.prepare("INSERT INTO sessions (id, name) VALUES ('s1','My Session')").run();
+  db.prepare("INSERT INTO memories (id, content) VALUES ('m1','remember this')").run();
+  return db;
+}
+
+const tableNames = (db: Database): string[] =>
+  (db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[]).map((r) => r.name);
+
+describe('dropLegacyCodeSearchTables', () => {
+  test('drops every legacy code-search table and reports it did work', () => {
+    const db = makeLegacyDb();
+    expect(dropLegacyCodeSearchTables(asDb(db))).toBe(true);
+    const names = tableNames(db);
+    for (const t of ['code_indexes', 'indexed_files', 'code_chunks', 'symbols']) {
+      expect(names).not.toContain(t);
+    }
+    db.close();
+  });
+
+  test('leaves real user data completely intact', () => {
+    const db = makeLegacyDb();
+    dropLegacyCodeSearchTables(asDb(db));
+    expect(tableNames(db)).toContain('sessions');
+    expect(tableNames(db)).toContain('memories');
+    expect(db.prepare('SELECT name FROM sessions WHERE id = ?').get('s1')).toEqual({ name: 'My Session' });
+    expect(db.prepare('SELECT content FROM memories WHERE id = ?').get('m1')).toEqual({ content: 'remember this' });
+    db.close();
+  });
+
+  test('drops the legacy indexes along with their tables', () => {
+    const db = makeLegacyDb();
+    dropLegacyCodeSearchTables(asDb(db));
+    const indexes = (db.prepare("SELECT name FROM sqlite_master WHERE type='index'").all() as { name: string }[])
+      .map((r) => r.name);
+    expect(indexes).not.toContain('idx_chunks_index_id');
+    expect(indexes).not.toContain('idx_symbols_name');
+    db.close();
+  });
+
+  test('is a no-op (returns false) on a database with nothing to clean', () => {
+    const db = new Database(':memory:');
+    db.exec("CREATE TABLE sessions (id TEXT PRIMARY KEY, name TEXT)");
+    expect(dropLegacyCodeSearchTables(asDb(db))).toBe(false);
+    expect(tableNames(db)).toEqual(['sessions']);
+    db.close();
+  });
+
+  test('is idempotent — a second run finds nothing and returns false', () => {
+    const db = makeLegacyDb();
+    expect(dropLegacyCodeSearchTables(asDb(db))).toBe(true);
+    expect(dropLegacyCodeSearchTables(asDb(db))).toBe(false);
+    db.close();
+  });
+
+  test('never throws, even on a closed/unusable database', () => {
+    const db = new Database(':memory:');
+    db.close();
+    expect(() => dropLegacyCodeSearchTables(asDb(db))).not.toThrow();
+  });
+});

--- a/src/main/__tests__/database-cleanup.test.ts
+++ b/src/main/__tests__/database-cleanup.test.ts
@@ -39,6 +39,9 @@ function makeLegacyDb(): Database {
     CREATE INDEX idx_chunks_index_id ON code_chunks(index_id);
     CREATE INDEX idx_symbols_name ON symbols(name);
 
+    -- the completion marker lives here (same as production)
+    CREATE TABLE preferences (key TEXT PRIMARY KEY, value TEXT);
+
     -- real user data that must survive untouched
     CREATE TABLE sessions (id TEXT PRIMARY KEY, name TEXT);
     CREATE TABLE memories (id TEXT PRIMARY KEY, content TEXT);
@@ -86,9 +89,9 @@ describe('dropLegacyCodeSearchTables', () => {
 
   test('is a no-op (returns false) on a database with nothing to clean', () => {
     const db = new Database(':memory:');
-    db.exec("CREATE TABLE sessions (id TEXT PRIMARY KEY, name TEXT)");
+    db.exec("CREATE TABLE preferences (key TEXT PRIMARY KEY, value TEXT); CREATE TABLE sessions (id TEXT PRIMARY KEY, name TEXT)");
     expect(dropLegacyCodeSearchTables(asDb(db))).toBe(false);
-    expect(tableNames(db)).toEqual(['sessions']);
+    expect(tableNames(db)).toContain('sessions');
     db.close();
   });
 
@@ -103,5 +106,84 @@ describe('dropLegacyCodeSearchTables', () => {
     const db = new Database(':memory:');
     db.close();
     expect(() => dropLegacyCodeSearchTables(asDb(db))).not.toThrow();
+  });
+});
+
+/**
+ * A db that also has the vec0 virtual table and its shadow tables (where the
+ * embeddings actually live).
+ */
+function makeVecDb(): Database {
+  const db = makeLegacyDb();
+  db.exec(`
+    CREATE TABLE code_chunks_vec (chunk_id TEXT);            -- stands in for the vec0 vtab
+    CREATE TABLE code_chunks_vec_chunks (id INTEGER);        -- shadow: the embedding data
+    CREATE TABLE code_chunks_vec_rowids (rowid_ INTEGER);    -- shadow
+  `);
+  return db;
+}
+
+/**
+ * Mimic the real world: sqlite-vec is no longer bundled, so DROPping the vec0
+ * virtual table ALWAYS raises "no such module: vec0". Shadow tables are ordinary
+ * tables and still drop fine.
+ */
+function withMissingVecModule(db: Database): Database {
+  return new Proxy(db, {
+    get(target, prop) {
+      if (prop === 'exec') {
+        return (sql: string) => {
+          if (sql.trim() === 'DROP TABLE IF EXISTS code_chunks_vec') {
+            throw new Error('no such module: vec0');
+          }
+          return (target as unknown as Record<string, (s: string) => unknown>).exec.call(target, sql);
+        };
+      }
+      const value = (target as unknown as Record<string | symbol, unknown>)[prop];
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  }) as Database;
+}
+
+describe('dropLegacyCodeSearchTables — vec0 virtual table fallback', () => {
+  test('drops the shadow tables (where the embeddings live) when the module is gone', () => {
+    const db = makeVecDb();
+    expect(dropLegacyCodeSearchTables(asDb(withMissingVecModule(db)))).toBe(true);
+    const names = tableNames(db);
+    // The actual reclaim: shadow tables holding the embedding data are gone.
+    expect(names).not.toContain('code_chunks_vec_chunks');
+    expect(names).not.toContain('code_chunks_vec_rowids');
+    // Documented limitation: the vtab's own schema row survives (no vec0 module
+    // to drop it, and we deliberately don't hand-edit sqlite_master).
+    expect(names).toContain('code_chunks_vec');
+    db.close();
+  });
+
+  test('converges — does NOT re-run (and re-VACUUM) on every later launch', () => {
+    const db = makeVecDb();
+    const proxied = withMissingVecModule(db);
+    expect(dropLegacyCodeSearchTables(asDb(proxied))).toBe(true);
+    // Regression guard: code_chunks_vec is STILL in sqlite_master and always
+    // will be. Deriving "work remaining" from the schema made this return true
+    // forever, re-VACUUMing the whole database on every single app start.
+    expect(dropLegacyCodeSearchTables(asDb(proxied))).toBe(false);
+    expect(dropLegacyCodeSearchTables(asDb(proxied))).toBe(false);
+    db.close();
+  });
+
+  test('still preserves real user data on the fallback path', () => {
+    const db = makeVecDb();
+    dropLegacyCodeSearchTables(asDb(withMissingVecModule(db)));
+    expect(db.prepare('SELECT name FROM sessions WHERE id = ?').get('s1')).toEqual({ name: 'My Session' });
+    expect(db.prepare('SELECT content FROM memories WHERE id = ?').get('m1')).toEqual({ content: 'remember this' });
+    db.close();
+  });
+
+  test('records the completion marker so the work is genuinely one-time', () => {
+    const db = makeVecDb();
+    dropLegacyCodeSearchTables(asDb(withMissingVecModule(db)));
+    const row = db.prepare('SELECT value FROM preferences WHERE key = ?').get('legacyCodeSearchCleanupDone');
+    expect(row).toEqual({ value: 'true' });
+    db.close();
   });
 });

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -17,7 +17,10 @@ export function getDatabase(): Database.Database {
   initializeTables(db);
   initializeArenaTables(db);
 
-  // One-time reclaim for the removed code-indexing feature (see below).
+  // Reclaim for the removed code-indexing feature. dropLegacyCodeSearchTables
+  // records a completion marker, so this branch — including the synchronous
+  // VACUUM — runs at most ONCE per database (on the first launch after
+  // upgrading), never on subsequent startups.
   if (dropLegacyCodeSearchTables(db)) {
     try {
       db.exec('VACUUM');
@@ -35,18 +38,56 @@ export function getDatabase(): Database.Database {
 const LEGACY_CODE_SEARCH_TABLES = ['code_chunks', 'symbols', 'indexed_files', 'code_indexes'] as const;
 
 /**
+ * Marker recording that the one-time cleanup has run.
+ *
+ * This must NOT be re-derived from the schema. `code_chunks_vec` is a vec0
+ * VIRTUAL table whose module is no longer bundled, so its sqlite_master row can
+ * never be dropped — deriving "is there work left?" from the schema would report
+ * work forever and re-run a full VACUUM on every single launch.
+ */
+const CODE_SEARCH_CLEANUP_PREF = 'legacyCodeSearchCleanupDone';
+
+function codeSearchCleanupAlreadyRan(database: Database.Database): boolean {
+  try {
+    const row = database
+      .prepare('SELECT value FROM preferences WHERE key = ?')
+      .get(CODE_SEARCH_CLEANUP_PREF) as { value?: string } | undefined;
+    return row?.value === 'true';
+  } catch {
+    return false; // preferences unavailable — treat as not-yet-run
+  }
+}
+
+function markCodeSearchCleanupRan(database: Database.Database): void {
+  try {
+    database
+      .prepare('INSERT OR REPLACE INTO preferences (key, value) VALUES (?, ?)')
+      .run(CODE_SEARCH_CLEANUP_PREF, 'true');
+  } catch (e) {
+    log.warn('[DB] could not record code-search cleanup marker:', (e as Error).message);
+  }
+}
+
+/**
  * Drop the leftover tables from the removed code-indexing / semantic-search
  * feature. Nothing reads them anymore and they can be very large (chunk source
  * text plus 768-dimension embeddings), so we reclaim the space on first launch
  * after upgrading.
  *
+ * Runs at most ONCE per database (guarded by CODE_SEARCH_CLEANUP_PREF), so the
+ * caller's VACUUM is a one-time startup cost rather than something that repeats
+ * on every launch.
+ *
  * Deliberately best-effort and non-fatal: this runs against the database holding
  * the user's real data (sessions, groups, memories), so every step is guarded and
  * a failure only logs rather than aborting startup or leaving things half-done.
  *
- * @returns true if anything was found to clean up (so the caller can VACUUM).
+ * @returns true if it actually dropped something (so the caller can VACUUM).
  */
 export function dropLegacyCodeSearchTables(database: Database.Database): boolean {
+  // Converge: once we've run, never do this work (or the VACUUM) again.
+  if (codeSearchCleanupAlreadyRan(database)) return false;
+
   let present: string[];
   try {
     present = (
@@ -63,7 +104,10 @@ export function dropLegacyCodeSearchTables(database: Database.Database): boolean
     log.warn('[DB] could not check for legacy code-search tables:', (e as Error).message);
     return false;
   }
-  if (present.length === 0) return false;
+  if (present.length === 0) {
+    markCodeSearchCleanupRan(database); // fresh install — nothing to do, ever
+    return false;
+  }
 
   log.info('[DB] Removing legacy code-search tables:', present.join(', '));
 
@@ -93,9 +137,13 @@ export function dropLegacyCodeSearchTables(database: Database.Database): boolean
           log.warn(`[DB] could not drop shadow table ${shadow}:`, (e as Error).message);
         }
       }
+      // The code_chunks_vec sqlite_master row itself stays (no vec0 module to
+      // drop it, and editing sqlite_master isn't worth the risk to real user
+      // data). It's inert — the marker below is what stops us retrying forever.
     }
   }
 
+  markCodeSearchCleanupRan(database);
   return true;
 }
 

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -17,7 +17,86 @@ export function getDatabase(): Database.Database {
   initializeTables(db);
   initializeArenaTables(db);
 
+  // One-time reclaim for the removed code-indexing feature (see below).
+  if (dropLegacyCodeSearchTables(db)) {
+    try {
+      db.exec('VACUUM');
+      log.info('[DB] VACUUM complete — reclaimed code-index disk space');
+    } catch (e) {
+      // Space stays allocated until a later VACUUM; the data is already gone.
+      log.warn('[DB] VACUUM after code-index cleanup failed:', (e as Error).message);
+    }
+  }
+
   return db;
+}
+
+/** Tables created by the removed code-indexing feature. */
+const LEGACY_CODE_SEARCH_TABLES = ['code_chunks', 'symbols', 'indexed_files', 'code_indexes'] as const;
+
+/**
+ * Drop the leftover tables from the removed code-indexing / semantic-search
+ * feature. Nothing reads them anymore and they can be very large (chunk source
+ * text plus 768-dimension embeddings), so we reclaim the space on first launch
+ * after upgrading.
+ *
+ * Deliberately best-effort and non-fatal: this runs against the database holding
+ * the user's real data (sessions, groups, memories), so every step is guarded and
+ * a failure only logs rather than aborting startup or leaving things half-done.
+ *
+ * @returns true if anything was found to clean up (so the caller can VACUUM).
+ */
+export function dropLegacyCodeSearchTables(database: Database.Database): boolean {
+  let present: string[];
+  try {
+    present = (
+      database
+        .prepare(
+          `SELECT name FROM sqlite_master
+            WHERE type = 'table'
+              AND (name IN ('code_chunks','symbols','indexed_files','code_indexes')
+                   OR name LIKE 'code_chunks_vec%')`,
+        )
+        .all() as { name: string }[]
+    ).map((r) => r.name);
+  } catch (e) {
+    log.warn('[DB] could not check for legacy code-search tables:', (e as Error).message);
+    return false;
+  }
+  if (present.length === 0) return false;
+
+  log.info('[DB] Removing legacy code-search tables:', present.join(', '));
+
+  // Plain tables first — dropping them also drops their indexes. Child tables
+  // before code_indexes so the FK references go away cleanly.
+  for (const table of LEGACY_CODE_SEARCH_TABLES) {
+    try {
+      database.exec(`DROP TABLE IF EXISTS ${table}`);
+    } catch (e) {
+      log.warn(`[DB] could not drop ${table}:`, (e as Error).message);
+    }
+  }
+
+  // code_chunks_vec is a vec0 VIRTUAL table. sqlite-vec is no longer bundled, so
+  // a normal DROP raises "no such module: vec0". Fall back to dropping its shadow
+  // tables directly — that's where the embedding data actually lives, so this is
+  // what reclaims the space. Any leftover schema entry is inert (nothing queries
+  // it), and we do NOT edit sqlite_master: not worth risking real user data.
+  if (present.includes('code_chunks_vec')) {
+    try {
+      database.exec('DROP TABLE IF EXISTS code_chunks_vec');
+    } catch {
+      for (const shadow of present.filter((n) => n.startsWith('code_chunks_vec_'))) {
+        try {
+          database.exec(`DROP TABLE IF EXISTS "${shadow}"`);
+        } catch (e) {
+          log.warn(`[DB] could not drop shadow table ${shadow}:`, (e as Error).message);
+        }
+      }
+    }
+  }
+
+  return true;
 }
 
 function initializeTables(database: Database.Database): void {

--- a/src/main/repositories/groups.ts
+++ b/src/main/repositories/groups.ts
@@ -3,7 +3,7 @@ import { Group } from '../../shared/types';
 
 export function getAllGroups(): Group[] {
   const db = getDatabase();
-  const rows = db.prepare('SELECT * FROM groups ORDER BY "order"').all() as any[];
+  const rows = db.prepare('SELECT * FROM groups ORDER BY "order", created_at, id').all() as any[];
 
   return rows.map(row => ({
     id: row.id,

--- a/src/main/repositories/groups.ts
+++ b/src/main/repositories/groups.ts
@@ -3,7 +3,7 @@ import { Group } from '../../shared/types';
 
 export function getAllGroups(): Group[] {
   const db = getDatabase();
-  const rows = db.prepare('SELECT * FROM groups ORDER BY "order", created_at, id').all() as any[];
+  const rows = db.prepare('SELECT * FROM groups ORDER BY "order", created_at IS NULL, created_at, id').all() as any[];
 
   return rows.map(row => ({
     id: row.id,

--- a/src/main/repositories/sessions.ts
+++ b/src/main/repositories/sessions.ts
@@ -9,7 +9,7 @@ export function sessionExists(id: string): boolean {
 
 export function getAllSessions(): Session[] {
   const db = getDatabase();
-  const rows = db.prepare('SELECT * FROM sessions ORDER BY "order"').all() as any[];
+  const rows = db.prepare('SELECT * FROM sessions ORDER BY "order", created_at, id').all() as any[];
 
   return rows.map(row => ({
     id: row.id,

--- a/src/main/repositories/sessions.ts
+++ b/src/main/repositories/sessions.ts
@@ -9,7 +9,7 @@ export function sessionExists(id: string): boolean {
 
 export function getAllSessions(): Session[] {
   const db = getDatabase();
-  const rows = db.prepare('SELECT * FROM sessions ORDER BY "order", created_at, id').all() as any[];
+  const rows = db.prepare('SELECT * FROM sessions ORDER BY "order", created_at IS NULL, created_at, id').all() as any[];
 
   return rows.map(row => ({
     id: row.id,


### PR DESCRIPTION
Two follow-ups for the next beta.

## 1. Reclaim the orphaned code-index data

Removing the indexing feature (#137) left its tables behind. Nothing reads them, but they can be **very large** — chunk source text plus 768-dimension embeddings. On first launch after upgrading we now drop `code_chunks` / `symbols` / `indexed_files` / `code_indexes` and **`VACUUM`** to actually return the disk space.

Deliberately **best-effort and non-fatal** — this runs against the database holding the user's real data (sessions, groups, memories), so every step is guarded and a failure only logs rather than aborting startup.

⚠️ **One honest caveat:** `code_chunks_vec` is a `vec0` **virtual** table, and sqlite-vec is no longer bundled, so a normal `DROP` raises `no such module: vec0`. We fall back to dropping its **shadow tables** — which is where the embedding data actually lives, so the space is still reclaimed. We deliberately do **not** edit `sqlite_master` to remove the leftover virtual-table schema entry: it's inert (nothing queries it) and not worth risking real user data over.

## 2. Deterministic session ordering

Sessions sharing a name in different folders intermittently **swapped places** in the web view. Two causes compounding:

- `SELECT * FROM sessions ORDER BY "order"` leaves ties in an **unspecified** order, and sessions are `UPDATE`d constantly (state changes), which reshuffles physical row order between queries.
- The web sort returned **0** for same-state + same-name, and `Array.sort` is stable — so it faithfully preserved that just-shuffled input order.

Fixed at both layers:
- Order by `("order", created_at, id)` for a **total order** at the source. Bonus: this also stops needless full re-renders every 2.5s poll, since the session JSON no longer churns.
- An `id` tiebreak in the web sort, so the display is deterministic regardless of what order the agent sends.

Same ordering fix applied to `groups`.

## Tests
6 new cases for the cleanup: drops the legacy tables *and* their indexes, leaves real user data completely intact, is a no-op / idempotent when there's nothing to clean, and never throws (even on an unusable database).

Typechecks clean (main / renderer / relay web). Test suite: the single `ChatParser > 06-response` snapshot failure **pre-exists on `development`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)