### PR TITLE
fix(updater): flag quit before quitAndInstall so macOS updates restart

### DIFF
--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -2,6 +2,7 @@ import { autoUpdater, UpdateInfo } from 'electron-updater';
 import { BrowserWindow, dialog, Notification } from 'electron';
 import * as log from 'electron-log';
 import { getPreference, setPreference } from './repositories/preferences';
+import { markAppQuitting } from './quit-state';
 
 // Configure logging
 autoUpdater.logger = log;
@@ -240,7 +241,10 @@ autoUpdater.on('update-downloaded', (info: UpdateInfo) => {
   }).then((result) => {
     isDialogOpen = false;
     if (result.response === 0) {
-      // User clicked Restart Now
+      // User clicked Restart Now. Flag the quit BEFORE quitAndInstall so the
+      // main window's close-to-tray handler doesn't swallow the window close
+      // and strand the app running — which blocks ShipIt from installing (#139).
+      markAppQuitting();
       autoUpdater.quitAndInstall(false, true);
     }
   });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { ptyManager } from './pty-manager';
 import { runGuardedShutdown } from './shutdown';
+import { isAppQuitting, markAppQuitting, shouldHideToTrayOnClose } from './quit-state';
 import { resolveLaunchProviderId } from './providers';
 import { startProviderInstall, cancelProviderInstall } from './provider-install';
 import { detectProviders } from './provider-detector';
@@ -97,7 +98,8 @@ if (process.platform === 'win32') {
 
 let mainWindow: BrowserWindow | null = null;
 let stateMonitor: StateMonitor | null = null;
-let isQuitting = false;
+// "App is quitting" is tracked in the shared, electron-free quit-state module
+// (see ./quit-state) so auto-updater.ts can flag a quitAndInstall the same way.
 
 // Register deep link protocol
 if (process.defaultApp) {
@@ -622,16 +624,16 @@ function createWindow(): void {
   mainWindow.on('resize', saveWindowBounds);
   mainWindow.on('move', saveWindowBounds);
 
-  // Handle close-to-tray behavior
+  // Handle close-to-tray behavior. Crucially, when the app is quitting (e.g.
+  // autoUpdater.quitAndInstall() closes all windows before app.quit()), we must
+  // NOT hide to tray — otherwise the window never closes, app.quit() is never
+  // reached, before-quit never runs, and Squirrel's ShipIt waits forever for a
+  // PID that never dies (issue #139).
   mainWindow.on('close', (event) => {
-    if (!isQuitting) {
-      const closeToTray = prefsRepo.getPreference('closeToTray');
-      // Default is true (close to tray)
-      if (closeToTray !== 'false') {
-        event.preventDefault();
-        mainWindow?.hide();
-        return;
-      }
+    const closeToTray = prefsRepo.getPreference('closeToTray');
+    if (shouldHideToTrayOnClose(isAppQuitting(), closeToTray ?? undefined)) {
+      event.preventDefault();
+      mainWindow?.hide();
     }
   });
 
@@ -954,6 +956,10 @@ safeHandle('app:download-update', () => {
 
 // App restart and update (for About dialog)
 safeHandle('app:restart-and-update', async () => {
+  // Flag the quit BEFORE quitAndInstall so the close-to-tray handler lets the
+  // window actually close (issue #139). Without this the app hides to tray and
+  // never terminates, so the downloaded update never installs.
+  markAppQuitting();
   const { autoUpdater } = await import('electron-updater');
   autoUpdater.quitAndInstall(false, true);
 });
@@ -1386,7 +1392,7 @@ app.on('before-quit', (event) => {
   shuttingDown = true;
 
   event.preventDefault();
-  isQuitting = true;
+  markAppQuitting();
 
   runGuardedShutdown({
     budgetMs: QUIT_CLEANUP_BUDGET_MS,

--- a/src/main/quit-state.test.ts
+++ b/src/main/quit-state.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from 'bun:test';
+import {
+  isAppQuitting,
+  markAppQuitting,
+  shouldHideToTrayOnClose,
+} from './quit-state';
+
+test('shouldHideToTrayOnClose hides to tray when not quitting and pref is default (undefined)', () => {
+  expect(shouldHideToTrayOnClose(false, undefined)).toBe(true);
+});
+
+test('shouldHideToTrayOnClose hides to tray when not quitting and pref is explicitly enabled', () => {
+  expect(shouldHideToTrayOnClose(false, 'true')).toBe(true);
+});
+
+test('shouldHideToTrayOnClose does NOT hide to tray when close-to-tray disabled', () => {
+  expect(shouldHideToTrayOnClose(false, 'false')).toBe(false);
+});
+
+test('shouldHideToTrayOnClose NEVER hides to tray while quitting — even with pref enabled (issue #139)', () => {
+  // The core regression: quitAndInstall() closes windows then calls app.quit().
+  // If close-to-tray swallowed that close, the app would never terminate and
+  // Squirrel/ShipIt would wait forever ("App Still Running").
+  expect(shouldHideToTrayOnClose(true, undefined)).toBe(false);
+  expect(shouldHideToTrayOnClose(true, 'true')).toBe(false);
+  expect(shouldHideToTrayOnClose(true, 'false')).toBe(false);
+});
+
+test('markAppQuitting latches the shared quitting flag', () => {
+  // Default state (before any quit path runs) must allow normal tray behavior.
+  expect(isAppQuitting()).toBe(false);
+  markAppQuitting();
+  expect(isAppQuitting()).toBe(true);
+  // Idempotent — calling again keeps it set.
+  markAppQuitting();
+  expect(isAppQuitting()).toBe(true);
+});

--- a/src/main/quit-state.ts
+++ b/src/main/quit-state.ts
@@ -1,0 +1,53 @@
+// Single source of truth for "the app is genuinely quitting" (issue #139,
+// follow-up to #133).
+//
+// The main window's `close` handler hides to tray instead of closing whenever
+// the app is not quitting. On macOS, `autoUpdater.quitAndInstall()` CLOSES ALL
+// WINDOWS and THEN calls `app.quit()`. That window `close` fires while the app
+// is not yet flagged as quitting, so a naive close-to-tray handler calls
+// `event.preventDefault()` and hides the window — `app.quit()` is never
+// reached, `before-quit` never runs, the process never exits, and Squirrel's
+// ShipIt waits forever ("App Still Running Error", Code=-9). The update then
+// downloads but never installs (#133's symptom, via a different mechanism than
+// #133 fixed).
+//
+// Every path that must bypass close-to-tray — `quitAndInstall`, `before-quit`,
+// the tray "Quit" item — MUST call `markAppQuitting()` BEFORE triggering the
+// quit, so the window can actually close.
+//
+// Kept free of any `electron` import so it is unit-testable under `bun test`.
+
+let quitting = false;
+
+/** True once any real-quit path has started (see `markAppQuitting`). */
+export function isAppQuitting(): boolean {
+  return quitting;
+}
+
+/**
+ * Latch the "app is quitting" flag. Idempotent. Call this BEFORE
+ * `autoUpdater.quitAndInstall()` / `app.quit()` so the main window's `close`
+ * handler does not trap the quit in the system tray.
+ */
+export function markAppQuitting(): void {
+  quitting = true;
+}
+
+/**
+ * Decide whether a main-window `close` should hide to tray instead of actually
+ * closing. Returns `false` (allow the real close) whenever the app is quitting,
+ * so an in-progress `quitAndInstall()` / `app.quit()` is never swallowed by the
+ * close-to-tray behavior.
+ *
+ * @param quitting        Whether the app is quitting (typically `isAppQuitting()`).
+ * @param closeToTrayPref The stored `closeToTray` preference. Anything other
+ *                        than the string `'false'` is treated as enabled
+ *                        (close-to-tray is the default).
+ */
+export function shouldHideToTrayOnClose(
+  quitting: boolean,
+  closeToTrayPref: string | undefined
+): boolean {
+  if (quitting) return false;
+  return closeToTrayPref !== 'false';
+}


### PR DESCRIPTION
## Problem
Follow-up to #133. On macOS, the auto-update **downloads but the app never restarts on its own** — you have to manually quit it, after which ShipIt installs and relaunches fine.

## Root cause (confirmed at every layer)
`autoUpdater.quitAndInstall()` on macOS **closes all windows, then calls `app.quit()`**. The main window's close-to-tray handler (`index.ts:675`) calls `event.preventDefault()` + `hide()` whenever `isQuitting` is false — and `isQuitting` was **only** set inside `before-quit`, which never runs because `app.quit()` is never reached. The window hides to tray, the PID never dies, and Squirrel's ShipIt waits forever (`App Still Running Error`, `Code=-9`).

#133's `runGuardedShutdown` only makes termination *fast once quitting starts* — but nothing was starting the quit.

### Evidence (real 3.4.3 → 3.5.0-beta.2 attempt on a build that already had the #133 fix)
| Time | Event |
|------|-------|
| 13:43:30 | electron-updater hands zip to Squirrel; **ShipIt launches, waits for PID** |
| 13:43:30–13:43:57 | **27s of nothing** — app hidden to tray, still running |
| 13:43:59 | `[shutdown] cleanup exceeded budget; forcing exit` — `before-quit` finally ran (from a *manual* quit) |
| 13:44:00 | ShipIt "Beginning installation" |
| 13:44:07 | ShipIt relaunched app on new version |

## Fix
New electron-free, unit-tested `quit-state` module (matches the `shutdown.ts` pattern):
- `markAppQuitting()` / `isAppQuitting()` — single shared source of truth (so `auto-updater.ts` and `index.ts` agree).
- `shouldHideToTrayOnClose(quitting, pref)` — pure decision: **never** hide to tray while quitting.

Every path that must bypass close-to-tray now calls `markAppQuitting()` **before** triggering the quit:
- `index.ts` About-dialog restart (`app:restart-and-update`)
- `auto-updater.ts` "Restart Now" dialog
- `before-quit` (manual/tray quit) — replaces the old local `isQuitting`

Both `quitAndInstall` call sites are covered.

## Testing
- `bun test src/main/quit-state.test.ts` — 5 pass (covers the quitting-bypasses-tray regression).
- Full suite: 196 pass; the only failures are pre-existing `@xterm/headless` missing-dep errors identical on `development` (unrelated).
- ⚠️ **End-to-end auto-update restart cannot be verified locally** — it requires two signed/released builds and updating between them. Root cause is confirmed from the ShipIt + app logs and the electron-updater 6.8.3 source, and the fix directly removes the deadlock. Real-world confirmation will come from updating a build carrying this fix to a newer release.

Closes #139