### PR TITLE
Add sidebar text filter for groups, sub-groups and sessions

### DIFF
--- a/.scannerwork/report-task.txt
+++ b/.scannerwork/report-task.txt
@@ -1,0 +1,6 @@
+projectKey=Software-Development-LLC_Bodhilander_2d637ced-8612-41e6-a7d6-d6127023db10
+serverUrl=https://sonarqube.bodhilabs.dev
+serverVersion=25.6.0.109173
+dashboardUrl=https://sonarqube.bodhilabs.dev/dashboard?id=Software-Development-LLC_Bodhilander_2d637ced-8612-41e6-a7d6-d6127023db10&pullRequest=143
+ceTaskId=8d858536-ee95-4963-95b5-be022afd4d20
+ceTaskUrl=https://sonarqube.bodhilabs.dev/api/ce/task?id=8d858536-ee95-4963-95b5-be022afd4d20

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,10 @@
       },
       "devDependencies": {
         "@electron/notarize": "^3.1.1",
+        "@happy-dom/global-registrator": "^20.11.1",
         "@tailwindcss/vite": "^4.0.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/better-sqlite3": "^7.6.13",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
@@ -325,6 +328,8 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
 
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.11.1" } }, "sha512-1C0wwHiyMlEdsbrJqff5ORE2PwaXBOam5rMqkZVOReAezd5nt6Tl/WGg28UAo75Ziuwchs0KaF8lvnn2oAtvJA=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
@@ -463,7 +468,13 @@
 
     "@tanstack/react-query": ["@tanstack/react-query@5.100.13", "", { "dependencies": { "@tanstack/query-core": "5.100.13" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-HSBr8CycQEAoXsJR7KNDawBnINJEJ96Eme8oE0hCXjyodE2I97vg3IDzDJBDu18LsbzpVVJcKo80eqLfVCykxw=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
     "@trickfilm400/rollup-plugin-off-main-thread": ["@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1", "", { "dependencies": { "ejs": "^3.1.10", "json5": "^2.2.3", "magic-string": "^0.30.21", "string.prototype.matchall": "^4.0.12" } }, "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -559,6 +570,8 @@
 
     "@types/web-push": ["@types/web-push@3.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
@@ -629,13 +642,15 @@
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "app-builder-bin": ["app-builder-bin@5.0.0-alpha.12", "", {}, "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w=="],
 
     "app-builder-lib": ["app-builder-lib@26.8.1", "", { "dependencies": { "@develar/schema-utils": "~2.6.5", "@electron/asar": "3.4.1", "@electron/fuses": "^1.8.0", "@electron/get": "^3.0.0", "@electron/notarize": "2.5.0", "@electron/osx-sign": "1.3.3", "@electron/rebuild": "^4.0.3", "@electron/universal": "2.0.3", "@malept/flatpak-bundler": "^0.4.0", "@types/fs-extra": "9.0.13", "async-exit-hook": "^2.0.1", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chromium-pickle-js": "^0.2.0", "ci-info": "4.3.1", "debug": "^4.3.4", "dotenv": "^16.4.5", "dotenv-expand": "^11.0.6", "ejs": "^3.1.8", "electron-publish": "26.8.1", "fs-extra": "^10.1.0", "hosted-git-info": "^4.1.0", "isbinaryfile": "^5.0.0", "jiti": "^2.4.2", "js-yaml": "^4.1.0", "json5": "^2.2.3", "lazy-val": "^1.0.5", "minimatch": "^10.0.3", "plist": "3.1.0", "proper-lockfile": "^4.1.2", "resedit": "^1.7.0", "semver": "~7.7.3", "tar": "^7.5.7", "temp-file": "^3.4.0", "tiny-async-pool": "1.3.0", "which": "^5.0.0" }, "peerDependencies": { "dmg-builder": "26.8.1", "electron-builder-squirrel-windows": "26.8.1" } }, "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
 
@@ -700,6 +715,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "builder-util": ["builder-util@26.8.1", "", { "dependencies": { "7zip-bin": "~5.2.0", "@types/debug": "^4.1.6", "app-builder-bin": "5.0.0-alpha.12", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "cross-spawn": "^7.0.6", "debug": "^4.3.4", "fs-extra": "^10.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "js-yaml": "^4.1.0", "sanitize-filename": "^1.6.3", "source-map-support": "^0.5.19", "stat-mode": "^1.0.0", "temp-file": "^3.4.0", "tiny-async-pool": "1.3.0" } }, "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw=="],
 
@@ -857,6 +874,8 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
@@ -870,6 +889,8 @@
     "dmg-license": ["dmg-license@1.0.11", "", { "dependencies": { "@types/plist": "^3.0.1", "@types/verror": "^1.10.3", "ajv": "^6.10.0", "crc": "^3.8.0", "iconv-corefoundation": "^1.1.7", "plist": "^3.0.4", "smart-buffer": "^4.0.2", "verror": "^1.10.0" }, "os": "darwin", "bin": { "dmg-license": "bin/dmg-license.js" } }, "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q=="],
 
     "dns-packet": ["dns-packet@5.6.1", "", { "dependencies": { "@leichtgewicht/ip-codec": "^2.0.1" } }, "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dom-converter": ["dom-converter@0.2.0", "", { "dependencies": { "utila": "~0.4" } }, "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA=="],
 
@@ -923,7 +944,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
-    "entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -1074,6 +1095,8 @@
     "got": ["got@11.8.6", "", { "dependencies": { "@sindresorhus/is": "^4.0.0", "@szmarczak/http-timer": "^4.0.5", "@types/cacheable-request": "^6.0.1", "@types/responselike": "^1.0.0", "cacheable-lookup": "^5.0.3", "cacheable-request": "^7.0.2", "decompress-response": "^6.0.0", "http2-wrapper": "^1.0.0-beta.5.2", "lowercase-keys": "^2.0.0", "p-cancelable": "^2.0.0", "responselike": "^2.0.0" } }, "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1313,6 +1336,8 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "make-fetch-happen": ["make-fetch-happen@14.0.3", "", { "dependencies": { "@npmcli/agent": "^3.0.0", "cacache": "^19.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^4.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^5.0.0", "promise-retry": "^2.0.1", "ssri": "^12.0.0" } }, "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ=="],
@@ -1484,6 +1509,8 @@
     "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
 
     "pretty-error": ["pretty-error@4.0.0", "", { "dependencies": { "lodash": "^4.17.20", "renderkid": "^3.0.0" } }, "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "proc-log": ["proc-log@5.0.0", "", {}, "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ=="],
 
@@ -1837,6 +1864,8 @@
 
     "webpack-sources": ["webpack-sources@3.3.4", "", {}, "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
 
     "which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
@@ -1989,6 +2018,8 @@
 
     "cacache/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "clean-css/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
@@ -1998,6 +2029,8 @@
     "dir-compare/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "dmg-license/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "electron/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
@@ -2011,9 +2044,13 @@
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "happy-dom/ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "html-minifier-terser/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "htmlparser2/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "iconv-corefoundation/node-addon-api": ["node-addon-api@1.7.2", "", {}, "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="],
 
@@ -2035,6 +2072,8 @@
 
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
@@ -2048,6 +2087,8 @@
     "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+
+    "slice-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -2070,6 +2111,10 @@
     "workbox-build/source-map": ["source-map@0.8.0-beta.0", "", { "dependencies": { "whatwg-url": "^7.0.0" } }, "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA=="],
 
     "workbox-expiration/idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@develar/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -2212,6 +2257,8 @@
     "cacache/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "cacache/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "qrcode/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test-setup/happydom.ts"]

--- a/docs/superpowers/plans/2026-07-23-sidebar-group-filter.md
+++ b/docs/superpowers/plans/2026-07-23-sidebar-group-filter.md
@@ -1,0 +1,525 @@
+# Sidebar Group/Session Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a text filter box at the top of the sidebar that instantly narrows the visible groups, sub-groups, and sessions as the user types.
+
+**Architecture:** All matching logic lives in one pure, unit-tested module (`src/renderer/store/groupFilter.ts`) that takes the flat `groups` and `sessions` arrays plus a query string and returns two id sets — which groups render and which sessions render. `App.tsx` calls it inside a `useMemo` and applies the sets as `.filter(...)` guards on the three existing render lists. No IPC, no DB, no new state beyond one ephemeral `useState` string.
+
+**Tech Stack:** TypeScript, React 18, Electron renderer, `bun:test` for unit tests, plain CSS in `src/renderer/styles/global.css`.
+
+## Global Constraints
+
+- Tests are written with `bun:test` (`import { describe, expect, test } from 'bun:test'`) and run with `bun test <path>`. There is no jest config and no `npm test` script.
+- Test files live in a `__tests__/` directory next to the code, named `<module>.test.ts`, and open with a docblock stating the run command (match `src/renderer/components/__tests__/arenaRounds.test.ts`).
+- Types come from `src/shared/types.ts`: `Group` has `id`, `name`, `parentId: string \| null`, `collapsed: boolean`; `Session` has `id`, `name`, `groupId: string`.
+- The sidebar tree is exactly two levels: top-level group → sub-group. Sessions attach to either via `groupId`.
+- Matching is case-insensitive plain substring (`String.includes`). No fuzzy matching, no regex.
+- Filtering must never write to the persisted `collapsed` flag — auto-expand is view-only.
+- CSS is dark-theme, hand-written, appended to `src/renderer/styles/global.css` near the existing `.sidebar-header` rules (line ~166). Palette in use: background `#252526`, borders `#3c3c3c`/`#555`, muted text `#888`, accent `#5a7aff`.
+- Branch: `feature/141-sidebar-group-filter`. Every commit references issue #141.
+
+---
+
+### Task 1: Pure filter module + unit tests
+
+**Files:**
+- Create: `src/renderer/store/groupFilter.ts`
+- Test: `src/renderer/store/__tests__/groupFilter.test.ts`
+
+**Interfaces:**
+- Consumes: `Group` and `Session` from `src/shared/types.ts`.
+- Produces:
+  ```ts
+  export interface GroupFilterResult {
+    active: boolean;
+    visibleGroupIds: Set<string>;
+    visibleSessionIds: Set<string>;
+  }
+  export function computeGroupFilter(
+    groups: Group[],
+    sessions: Session[],
+    rawQuery: string,
+  ): GroupFilterResult;
+  ```
+  Task 2 consumes exactly these three fields.
+
+**Design note — why only two sets:** the design doc floated a third set, `fullyMatchedGroupIds`. It is unnecessary: when a group matches by name, the module already walks its subtree and puts every descendant session id into `visibleSessionIds`. The renderer therefore only ever asks "is this group id visible?" and "is this session id visible?". Dropping the third set (YAGNI) keeps the API at two questions.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/renderer/store/__tests__/groupFilter.test.ts`:
+
+```ts
+/**
+ * Sidebar group/session filter tests (BDHLNDR #141).
+ *
+ * Run with: bun test src/renderer/store/__tests__
+ */
+import { describe, expect, test } from 'bun:test';
+import { computeGroupFilter } from '../groupFilter';
+import { Group, Session } from '../../../shared/types';
+
+function group(id: string, name: string, parentId: string | null = null): Group {
+  return {
+    id,
+    name,
+    color: '#61afef',
+    workingDir: '',
+    order: 0,
+    createdAt: new Date(0),
+    parentId,
+    collapsed: false,
+    claudeAccountId: null,
+  } as Group;
+}
+
+function session(id: string, name: string, groupId: string): Session {
+  return { id, name, groupId } as Session;
+}
+
+// Tree used by most tests:
+//   api        (top)  -> sessions: s-api
+//     api-auth (sub)  -> sessions: s-login
+//     api-bill (sub)  -> sessions: s-invoice
+//   web        (top)  -> sessions: s-home
+const GROUPS = [
+  group('api', 'API'),
+  group('api-auth', 'Auth', 'api'),
+  group('api-bill', 'Billing', 'api'),
+  group('web', 'Web'),
+];
+const SESSIONS = [
+  session('s-api', 'api scratch', 'api'),
+  session('s-login', 'login flow', 'api-auth'),
+  session('s-invoice', 'invoice bug', 'api-bill'),
+  session('s-home', 'homepage', 'web'),
+];
+
+describe('computeGroupFilter', () => {
+  test('empty query is inactive with empty sets', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, '');
+    expect(r.active).toBe(false);
+    expect(r.visibleGroupIds.size).toBe(0);
+    expect(r.visibleSessionIds.size).toBe(0);
+  });
+
+  test('whitespace-only query is inactive', () => {
+    expect(computeGroupFilter(GROUPS, SESSIONS, '   ').active).toBe(false);
+  });
+
+  test('matching a top-level group reveals its whole subtree', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, 'api');
+    expect(r.active).toBe(true);
+    expect([...r.visibleGroupIds].sort()).toEqual(['api', 'api-auth', 'api-bill']);
+    expect([...r.visibleSessionIds].sort()).toEqual(['s-api', 's-invoice', 's-login']);
+  });
+
+  test('match is case-insensitive and trims the query', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, '  WEB  ');
+    expect(r.visibleGroupIds.has('web')).toBe(true);
+    expect(r.visibleSessionIds.has('s-home')).toBe(true);
+  });
+
+  test('matching a sub-group keeps the parent visible but hides siblings', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, 'auth');
+    expect([...r.visibleGroupIds].sort()).toEqual(['api', 'api-auth']);
+    // parent is context only: its own session is not revealed
+    expect([...r.visibleSessionIds]).toEqual(['s-login']);
+  });
+
+  test('matching a session in a top-level group shows only that session', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, 'scratch');
+    expect([...r.visibleGroupIds]).toEqual(['api']);
+    expect([...r.visibleSessionIds]).toEqual(['s-api']);
+  });
+
+  test('matching a session in a sub-group reveals sub-group and parent', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, 'invoice');
+    expect([...r.visibleGroupIds].sort()).toEqual(['api', 'api-bill']);
+    expect([...r.visibleSessionIds]).toEqual(['s-invoice']);
+  });
+
+  test('no matches leaves active true with empty sets', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, 'zzzz');
+    expect(r.active).toBe(true);
+    expect(r.visibleGroupIds.size).toBe(0);
+    expect(r.visibleSessionIds.size).toBe(0);
+  });
+
+  test('a name-matched group reveals descendants whose names do not match', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, 'billing');
+    expect([...r.visibleGroupIds].sort()).toEqual(['api', 'api-bill']);
+    // 'invoice bug' does not contain 'billing' but is revealed by its group
+    expect([...r.visibleSessionIds]).toEqual(['s-invoice']);
+  });
+
+  test('a session whose group is missing does not throw', () => {
+    const r = computeGroupFilter(GROUPS, [session('orphan', 'orphan', 'gone')], 'orphan');
+    expect(r.visibleSessionIds.has('orphan')).toBe(true);
+    expect(r.visibleGroupIds.size).toBe(0);
+  });
+
+  test('returns fresh sets on each call', () => {
+    const a = computeGroupFilter(GROUPS, SESSIONS, '');
+    const b = computeGroupFilter(GROUPS, SESSIONS, '');
+    expect(a.visibleGroupIds).not.toBe(b.visibleGroupIds);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test src/renderer/store/__tests__/groupFilter.test.ts`
+Expected: FAIL — module `../groupFilter` cannot be resolved.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/renderer/store/groupFilter.ts`:
+
+```ts
+import { Group, Session } from '../../shared/types';
+
+/**
+ * Result of applying the sidebar filter (BDHLNDR #141).
+ *
+ * `visibleGroupIds` covers both top-level groups and sub-groups; the renderer
+ * asks only "should this row render?", so one set serves both levels.
+ */
+export interface GroupFilterResult {
+  /** False when the query is empty/whitespace — callers render everything. */
+  active: boolean;
+  visibleGroupIds: Set<string>;
+  visibleSessionIds: Set<string>;
+}
+
+/**
+ * Decide which groups, sub-groups and sessions survive a text filter.
+ *
+ * Rules:
+ *  - A group matched by name reveals its entire subtree (sub-groups + sessions).
+ *  - A matching sub-group or session keeps its ancestors visible as context,
+ *    without revealing that ancestor's other children.
+ *  - Anything with no match in its subtree is omitted.
+ *
+ * Pure and total: no I/O, no mutation of the inputs.
+ */
+export function computeGroupFilter(
+  groups: Group[],
+  sessions: Session[],
+  rawQuery: string,
+): GroupFilterResult {
+  const visibleGroupIds = new Set<string>();
+  const visibleSessionIds = new Set<string>();
+
+  const query = rawQuery.trim().toLowerCase();
+  if (!query) {
+    return { active: false, visibleGroupIds, visibleSessionIds };
+  }
+
+  const byId = new Map(groups.map(g => [g.id, g]));
+
+  const childrenOf = new Map<string, Group[]>();
+  for (const g of groups) {
+    if (!g.parentId) continue;
+    const siblings = childrenOf.get(g.parentId);
+    if (siblings) siblings.push(g);
+    else childrenOf.set(g.parentId, [g]);
+  }
+
+  const sessionsOf = new Map<string, Session[]>();
+  for (const s of sessions) {
+    const existing = sessionsOf.get(s.groupId);
+    if (existing) existing.push(s);
+    else sessionsOf.set(s.groupId, [s]);
+  }
+
+  const matches = (name: string) => name.toLowerCase().includes(query);
+
+  // Guards against re-walking a subtree, and against infinite recursion if a
+  // malformed parentId ever produced a cycle.
+  const revealed = new Set<string>();
+
+  /** Reveal a matched group and everything beneath it. */
+  const revealSubtree = (group: Group) => {
+    if (revealed.has(group.id)) return;
+    revealed.add(group.id);
+    visibleGroupIds.add(group.id);
+    for (const s of sessionsOf.get(group.id) ?? []) visibleSessionIds.add(s.id);
+    for (const child of childrenOf.get(group.id) ?? []) revealSubtree(child);
+  };
+
+  /** Reveal a group and its ancestors as context (children untouched). */
+  const revealAncestry = (groupId: string | null | undefined) => {
+    let current = groupId ? byId.get(groupId) : undefined;
+    while (current) {
+      visibleGroupIds.add(current.id);
+      current = current.parentId ? byId.get(current.parentId) : undefined;
+    }
+  };
+
+  for (const group of groups) {
+    if (!matches(group.name)) continue;
+    revealSubtree(group);
+    revealAncestry(group.parentId);
+  }
+
+  for (const s of sessions) {
+    if (!matches(s.name)) continue;
+    visibleSessionIds.add(s.id);
+    revealAncestry(s.groupId);
+  }
+
+  return { active: true, visibleGroupIds, visibleSessionIds };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test src/renderer/store/__tests__/groupFilter.test.ts`
+Expected: PASS — 11 pass, 0 fail.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bunx tsc --noEmit -p tsconfig.json`
+Expected: no errors introduced by `groupFilter.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/store/groupFilter.ts src/renderer/store/__tests__/groupFilter.test.ts
+git commit -m "feat(sidebar): pure group/session filter module (#141)"
+```
+
+---
+
+### Task 2: Wire the filter into the sidebar
+
+**Files:**
+- Modify: `src/renderer/App.tsx` (imports; new state + memo; filter input JSX under `.sidebar-header` ~line 946; top-level group map ~line 948; direct-session map ~line 1057; sub-group map ~line 1143; sub-group session map; the two `!group.collapsed` / `!subGroup.collapsed` guards)
+- Modify: `src/renderer/styles/global.css` (append filter styles after the `.sidebar-header-actions` block, ~line 176)
+
+**Interfaces:**
+- Consumes: `computeGroupFilter` and `GroupFilterResult` from Task 1 — `{ active, visibleGroupIds, visibleSessionIds }`.
+- Produces: no exported API; UI only.
+
+- [ ] **Step 1: Import the module**
+
+In `src/renderer/App.tsx`, after `import { useGroups } from './store/groups';`, add:
+
+```ts
+import { computeGroupFilter } from './store/groupFilter';
+```
+
+- [ ] **Step 2: Add filter state and the memoized result**
+
+Next to the other sidebar state (near `const [sidebarWidth, setSidebarWidth] = useState(260);`), add:
+
+```ts
+const [filterText, setFilterText] = useState('');
+const filterInputRef = useRef<HTMLInputElement>(null);
+const filter = useMemo(
+  () => computeGroupFilter(groups, sessions, filterText),
+  [groups, sessions, filterText],
+);
+```
+
+- [ ] **Step 3: Render the filter input**
+
+Immediately after the closing `</div>` of `.sidebar-header` (line ~946, before the `{getTopLevelGroups().map(...)}` block), insert:
+
+```tsx
+<div className="sidebar-filter">
+  <input
+    ref={filterInputRef}
+    className="sidebar-filter-input"
+    type="text"
+    value={filterText}
+    placeholder="Filter groups & sessions…"
+    aria-label="Filter groups and sessions"
+    onChange={(e) => setFilterText(e.target.value)}
+    onKeyDown={(e) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setFilterText('');
+      }
+    }}
+  />
+  {filterText && (
+    <button
+      className="sidebar-filter-clear"
+      onClick={() => {
+        setFilterText('');
+        filterInputRef.current?.focus();
+      }}
+      title="Clear filter"
+      aria-label="Clear filter"
+    >
+      ×
+    </button>
+  )}
+</div>
+```
+
+- [ ] **Step 4: Filter the top-level group list**
+
+Change the opening of the group map (line ~948) from:
+
+```tsx
+{getTopLevelGroups().map(group => (
+```
+
+to:
+
+```tsx
+{getTopLevelGroups()
+  .filter(group => !filter.active || filter.visibleGroupIds.has(group.id))
+  .map(group => (
+```
+
+Close the extra paren: the map's closing `))}` becomes `))}` on the same expression — verify the JSX still balances after the edit (the block ends with `))}` after the sub-group map).
+
+- [ ] **Step 5: Filter the sub-group list and auto-expand**
+
+Change (line ~1143):
+
+```tsx
+{!group.collapsed && getSubGroups(group.id).map(subGroup => (
+```
+
+to:
+
+```tsx
+{(filter.active || !group.collapsed) && getSubGroups(group.id)
+  .filter(subGroup => filter.visibleGroupIds.has(subGroup.id) || !filter.active)
+  .map(subGroup => (
+```
+
+And change the direct-sessions guard (line ~1051) from:
+
+```tsx
+{!group.collapsed && (
+```
+
+to:
+
+```tsx
+{(filter.active || !group.collapsed) && (
+```
+
+Apply the same `(filter.active || !subGroup.collapsed)` change to the sub-group's own sessions guard.
+
+- [ ] **Step 6: Filter the session lists**
+
+For the top-level group's sessions (line ~1057), change:
+
+```tsx
+{getSessionsByGroup(group.id).sort((a, b) => a.order - b.order).map(session => (
+```
+
+to:
+
+```tsx
+{getSessionsByGroup(group.id)
+  .filter(session => !filter.active || filter.visibleSessionIds.has(session.id))
+  .sort((a, b) => a.order - b.order).map(session => (
+```
+
+Apply the identical change to the sub-group's session list (`getSessionsByGroup(subGroup.id)`).
+
+- [ ] **Step 7: Add the empty state**
+
+Directly after the top-level group map block closes, add:
+
+```tsx
+{filter.active && filter.visibleGroupIds.size === 0 && (
+  <div className="sidebar-filter-empty">No groups or sessions match</div>
+)}
+```
+
+- [ ] **Step 8: Add the CSS**
+
+Append to `src/renderer/styles/global.css` after the `.sidebar-header-actions` rule:
+
+```css
+.sidebar-filter {
+  position: relative;
+  margin-bottom: 10px;
+}
+
+.sidebar-filter-input {
+  width: 100%;
+  box-sizing: border-box;
+  background: #1e1e1e;
+  border: 1px solid #3c3c3c;
+  border-radius: 3px;
+  color: #ddd;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 5px 22px 5px 8px;
+}
+
+.sidebar-filter-input::placeholder {
+  color: #666;
+}
+
+.sidebar-filter-input:focus {
+  outline: none;
+  border-color: #5a7aff;
+}
+
+.sidebar-filter-clear {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 3px;
+}
+
+.sidebar-filter-clear:hover {
+  color: #ddd;
+}
+
+.sidebar-filter-empty {
+  color: #666;
+  font-size: 12px;
+  font-style: italic;
+  padding: 8px 2px;
+}
+```
+
+- [ ] **Step 9: Typecheck and run the full test suite**
+
+Run: `bunx tsc --noEmit -p tsconfig.json && bun test src/renderer`
+Expected: no type errors; all tests pass.
+
+- [ ] **Step 10: Build the renderer to confirm the JSX compiles**
+
+Run: `bun run build:renderer`
+Expected: webpack completes without errors.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/renderer/App.tsx src/renderer/styles/global.css
+git commit -m "feat(sidebar): filter box for groups, sub-groups and sessions (#141)"
+```
+
+---
+
+## Verification
+
+Manual check with `bun run dev`:
+1. Sidebar shows the filter box under the "Groups" header; the list is unchanged while it's empty.
+2. Typing a top-level group name shows that group with all its sub-groups and sessions.
+3. Typing a sub-group name shows the sub-group plus its parent, with sibling sub-groups hidden.
+4. Typing a session name shows just that session under its group (and sub-group).
+5. A collapsed group auto-expands while filtering; clearing the filter restores it collapsed.
+6. Gibberish shows "No groups or sessions match".
+7. The × button and Escape both clear the filter.

--- a/docs/superpowers/specs/2026-07-23-sidebar-group-filter-design.md
+++ b/docs/superpowers/specs/2026-07-23-sidebar-group-filter-design.md
@@ -1,0 +1,107 @@
+# Sidebar Group/Session Filter — Design
+
+**Issue:** [#141](https://github.com/Software-Development-LLC/Bodhilander/issues/141)
+**Date:** 2026-07-23
+
+## Problem
+
+The sidebar renders top-level **groups**, each with one level of nested **sub-groups**, and **sessions** inside groups and sub-groups. Users with many groups/sub-groups have to scroll and visually hunt for what they want. There is no way to narrow the list.
+
+## Goal
+
+Add a text filter box at the top of the sidebar that instantly narrows the visible groups, sub-groups, and sessions as the user types.
+
+## Scope
+
+**In scope:** filtering which group / sub-group / session rows render in the sidebar; the filter input UI; auto-expanding collapsed groups while filtering; an empty-state message.
+
+**Out of scope (unchanged):** drag-and-drop reordering, keyboard navigation (Ctrl+Q sidebar focus, arrow nav, etc.), and the memory / analytics / arena panels. The filter only affects which rows render.
+
+## UI
+
+A single-line text input placed at the top of the sidebar, directly under the `sidebar-header` (the "Groups" title + action buttons row) and above the group list.
+
+- Placeholder: `Filter groups & sessions…`
+- A clear (`×`) button appears at the right edge of the input only when it contains text; clicking it empties the filter and returns focus to the input.
+- Pressing **Escape** while the input is focused clears it.
+- The filter value is **ephemeral** React state — it starts empty on every launch and is never persisted.
+- An empty filter renders the normal, fully unfiltered sidebar (identical to today's behavior).
+
+## Filtering logic
+
+The matching logic lives in a new pure, unit-tested module so `App.tsx` only consumes a result object.
+
+### Module: `src/renderer/store/groupFilter.ts`
+
+```ts
+export interface FilterResult {
+  active: boolean;                 // true when query is non-empty after trim
+  visibleGroupIds: Set<string>;    // groups + sub-groups that should render
+  visibleSessionIds: Set<string>;  // sessions that should render
+  fullyMatchedGroupIds: Set<string>; // groups matched by name → show all descendants
+}
+
+export function computeGroupFilter(
+  groups: Group[],
+  sessions: Session[],
+  rawQuery: string,
+): FilterResult;
+```
+
+### Definitions
+
+Let `q = rawQuery.trim().toLowerCase()`.
+
+- If `q === ''` → `active: false`; all sets empty. Callers treat `active === false` as "show everything" and skip filtering entirely.
+- `groupMatches(g)  = g.name.toLowerCase().includes(q)`
+- `sessionMatches(s) = s.name.toLowerCase().includes(q)`
+
+Matching is a plain case-insensitive substring test (no fuzzy matching, no regex).
+
+### Rules (when `active`)
+
+The tree is exactly two levels deep: top-level group → sub-group → session (sessions also attach directly to top-level groups). `groups` is a flat list where sub-groups carry `parentId`; sessions carry a `groupId` that may point at either a top-level group or a sub-group.
+
+1. **A group/sub-group matched by name is "fully matched"** — it and its entire subtree render. Its id goes in `fullyMatchedGroupIds`, and every descendant group + session id is added to the visible sets. This covers: a matched top-level group reveals all its sub-groups and all sessions beneath it; a matched sub-group reveals all its sessions.
+
+2. **A matching session makes its ancestry visible** — the session id → `visibleSessionIds`; its owning group and (if that group is a sub-group) the sub-group's parent → `visibleGroupIds`.
+
+3. **A matching sub-group (by name) makes its parent visible** — parent top-level group id → `visibleGroupIds` (rule 1 already added the sub-group and its sessions).
+
+4. **Everything else is hidden** — a group/sub-group whose subtree contains no name match and no session match is absent from `visibleGroupIds`; a session that neither matches nor lives under a fully-matched group is absent from `visibleSessionIds`.
+
+Consequently, within a group that is visible only because a child matched (i.e. it is **not** in `fullyMatchedGroupIds`), only its matching sessions render — exactly the intent that a non-name-matched group shows only its matching sessions.
+
+## App.tsx integration
+
+1. Add `const [filterText, setFilterText] = useState('')`.
+2. `const filter = useMemo(() => computeGroupFilter(groups, sessions, filterText), [groups, sessions, filterText])`.
+3. Render the filter input in the sidebar (below `sidebar-header`).
+4. In the render pipeline:
+   - **Top-level groups:** when `filter.active`, render only groups whose id ∈ `filter.visibleGroupIds`.
+   - **Sub-groups:** when `filter.active`, render only sub-groups whose id ∈ `filter.visibleGroupIds`.
+   - **Sessions:** when `filter.active`, render only sessions whose id ∈ `filter.visibleSessionIds`. (Applies to both the direct-sessions list of a top-level group and the sessions list of a sub-group.)
+   - **Auto-expand:** the two `!group.collapsed` / `!subGroup.collapsed` guards become `(filter.active || !group.collapsed)`. This is view-only — no call to `toggleCollapse` / `updateGroup`, so the persisted `collapsed` flag is never written by filtering. Clearing the filter restores each group's real collapse state.
+5. **Empty state:** when `filter.active` and `filter.visibleGroupIds.size === 0`, render a muted line (e.g. `No groups or sessions match`) in place of the group list.
+
+The existing helpers `getTopLevelGroups()` and `getSubGroups(parentId)` already return correctly ordered lists; filtering is applied as a `.filter(...)` on top of them at render time, preserving order.
+
+## Error handling
+
+Filtering is pure and total over in-memory arrays — there is no I/O and nothing to fail. A malformed/empty query simply yields `active: false`. No new IPC, no DB writes.
+
+## Testing
+
+Unit tests for `computeGroupFilter` in `src/renderer/store/__tests__/groupFilter.test.ts` (Jest, matching the existing `__tests__` convention):
+
+- Empty / whitespace-only query → `active: false`, empty sets.
+- Case-insensitive substring match on a top-level group name → group fully matched, all sub-groups + sessions visible.
+- Match on a sub-group name → sub-group fully matched (its sessions visible) **and** parent top-level group visible, but sibling sub-groups hidden.
+- Match on a session name (in a top-level group) → that session + its group visible; sibling sessions hidden; group not fully matched.
+- Match on a session name inside a sub-group → session + sub-group + parent group all visible; group/sub-group not fully matched.
+- No matches anywhere → `active: true`, all sets empty (drives the empty-state UI).
+- A group matched by name whose sub-group/session names do **not** match → still shows all descendants (fully-matched precedence).
+
+## Rollout
+
+Single PR to `development`, closing #141. No migration, no settings, no channel/version implications.

--- a/docs/superpowers/specs/2026-07-23-sidebar-group-filter-design.md
+++ b/docs/superpowers/specs/2026-07-23-sidebar-group-filter-design.md
@@ -34,19 +34,23 @@ The matching logic lives in a new pure, unit-tested module so `App.tsx` only con
 ### Module: `src/renderer/store/groupFilter.ts`
 
 ```ts
-export interface FilterResult {
+export interface GroupFilterResult {
   active: boolean;                 // true when query is non-empty after trim
   visibleGroupIds: Set<string>;    // groups + sub-groups that should render
   visibleSessionIds: Set<string>;  // sessions that should render
-  fullyMatchedGroupIds: Set<string>; // groups matched by name → show all descendants
 }
 
 export function computeGroupFilter(
   groups: Group[],
   sessions: Session[],
   rawQuery: string,
-): FilterResult;
+): GroupFilterResult;
 ```
+
+Two sets are sufficient. A third "fully matched" set is unnecessary because when a
+group matches by name the module already walks its subtree and adds every
+descendant session id to `visibleSessionIds` — so the renderer only ever asks
+"is this group visible?" and "is this session visible?".
 
 ### Definitions
 
@@ -62,7 +66,7 @@ Matching is a plain case-insensitive substring test (no fuzzy matching, no regex
 
 The tree is exactly two levels deep: top-level group → sub-group → session (sessions also attach directly to top-level groups). `groups` is a flat list where sub-groups carry `parentId`; sessions carry a `groupId` that may point at either a top-level group or a sub-group.
 
-1. **A group/sub-group matched by name is "fully matched"** — it and its entire subtree render. Its id goes in `fullyMatchedGroupIds`, and every descendant group + session id is added to the visible sets. This covers: a matched top-level group reveals all its sub-groups and all sessions beneath it; a matched sub-group reveals all its sessions.
+1. **A group/sub-group matched by name is "fully matched"** — it and its entire subtree render. Every descendant group + session id is added to the visible sets. This covers: a matched top-level group reveals all its sub-groups and all sessions beneath it; a matched sub-group reveals all its sessions.
 
 2. **A matching session makes its ancestry visible** — the session id → `visibleSessionIds`; its owning group and (if that group is a sub-group) the sub-group's parent → `visibleGroupIds`.
 
@@ -70,7 +74,7 @@ The tree is exactly two levels deep: top-level group → sub-group → session (
 
 4. **Everything else is hidden** — a group/sub-group whose subtree contains no name match and no session match is absent from `visibleGroupIds`; a session that neither matches nor lives under a fully-matched group is absent from `visibleSessionIds`.
 
-Consequently, within a group that is visible only because a child matched (i.e. it is **not** in `fullyMatchedGroupIds`), only its matching sessions render — exactly the intent that a non-name-matched group shows only its matching sessions.
+Consequently, within a group that is visible only because a child matched (i.e. it was not itself name-matched), only its matching sessions render — exactly the intent that a non-name-matched group shows only its matching sessions.
 
 ## App.tsx integration
 
@@ -92,7 +96,7 @@ Filtering is pure and total over in-memory arrays — there is no I/O and nothin
 
 ## Testing
 
-Unit tests for `computeGroupFilter` in `src/renderer/store/__tests__/groupFilter.test.ts` (Jest, matching the existing `__tests__` convention):
+Unit tests for `computeGroupFilter` in `src/renderer/store/__tests__/groupFilter.test.ts` (`bun:test`, matching the existing `__tests__` convention; run with `bun test`):
 
 - Empty / whitespace-only query → `active: false`, empty sets.
 - Case-insensitive substring match on a top-level group name → group fully matched, all sub-groups + sessions visible.

--- a/package.json
+++ b/package.json
@@ -73,7 +73,10 @@
   },
   "devDependencies": {
     "@electron/notarize": "^3.1.1",
+    "@happy-dom/global-registrator": "^20.11.1",
     "@tailwindcss/vite": "^4.0.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/better-sqlite3": "^7.6.13",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,6 +5,7 @@ import ContextMenu, { MenuItem } from './components/ContextMenu';
 import { NamePromptModal } from './components/NamePromptModal';
 import { SettingsModal } from './components/SettingsModal';
 import { NewItemChoice } from './components/NewItemChoice';
+import { SidebarFilter } from './components/SidebarFilter';
 import { MemoryPanel } from './components/panels/MemoryPanel';
 import AnalyticsPanel from './components/panels/AnalyticsPanel';
 import { ArenaPanel } from './components/ArenaPanel';
@@ -62,7 +63,6 @@ const App: React.FC = () => {
 
   // Sidebar text filter (#141). Ephemeral — never persisted.
   const [filterText, setFilterText] = useState('');
-  const filterInputRef = useRef<HTMLInputElement>(null);
   const [isResizing, setIsResizing] = useState(false);
 
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -303,9 +303,12 @@ const App: React.FC = () => {
 
   const handleFinishEditGroup = async () => {
     if (editingGroupId && editingGroupName.trim()) {
-      await updateGroup(editingGroupId, { name: editingGroupName.trim() });
-      // The new name may not match the active filter (#141).
-      setFilterText('');
+      const trimmed = editingGroupName.trim();
+      const changed = groups.find(g => g.id === editingGroupId)?.name !== trimmed;
+      await updateGroup(editingGroupId, { name: trimmed });
+      // Only when the name actually changed: a click that merely opens (and
+      // blurs) the rename input must not wipe the user's query (#141).
+      if (changed) setFilterText('');
     }
     setEditingGroupId(null);
     setEditingGroupName('');
@@ -431,9 +434,11 @@ const App: React.FC = () => {
 
   const handleFinishEditSession = async () => {
     if (editingSessionId && editingSessionName.trim()) {
-      await updateSession(editingSessionId, { name: editingSessionName.trim() });
-      // The new name may not match the active filter (#141).
-      setFilterText('');
+      const trimmed = editingSessionName.trim();
+      const changed = sessions.find(s => s.id === editingSessionId)?.name !== trimmed;
+      await updateSession(editingSessionId, { name: trimmed });
+      // Only when the name actually changed (see handleFinishEditGroup).
+      if (changed) setFilterText('');
     }
     setEditingSessionId(null);
     setEditingSessionName('');
@@ -768,7 +773,9 @@ const App: React.FC = () => {
       return [
         { key: '↑↓', label: 'Navigate' },
         { key: 'Enter', label: 'Select' },
-        { key: '←→', label: 'Collapse' },
+        // Collapse/expand is unavailable while filtering — rows are
+        // force-expanded, so advertising it would be a lie (#141).
+        ...(filter.active ? [] : [{ key: '←→', label: 'Collapse' }]),
         { key: 'Ctrl+G', label: 'New Group' },
       ];
     }
@@ -777,7 +784,7 @@ const App: React.FC = () => {
       { key: 'Ctrl+Tab', label: 'Next' },
       { key: 'Ctrl+W', label: 'Close' },
     ];
-  }, [sidebarFocused]);
+  }, [sidebarFocused, filter.active]);
 
   const handleNewSubGroup = useCallback(async () => {
     if (focusedItemType === 'group' && focusedItemId) {
@@ -958,44 +965,7 @@ const App: React.FC = () => {
           </div>
         </div>
 
-        <div className="sidebar-filter">
-          <div className="sidebar-filter-field">
-          <input
-            ref={filterInputRef}
-            className="sidebar-filter-input"
-            type="text"
-            value={filterText}
-            placeholder="Filter groups & sessions…"
-            aria-label="Filter groups and sessions"
-            onChange={(e) => setFilterText(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key !== 'Escape') return;
-              if (filterText) {
-                // Consume the first Escape to clear the query.
-                e.stopPropagation();
-                setFilterText('');
-              } else {
-                // Already empty: step out of the box so keyboard users have a
-                // route back, and let app-level dismiss handlers see the key.
-                filterInputRef.current?.blur();
-              }
-            }}
-          />
-          {filterText && (
-            <button
-              className="sidebar-filter-clear"
-              onClick={() => {
-                setFilterText('');
-                filterInputRef.current?.focus();
-              }}
-              title="Clear filter"
-              aria-label="Clear filter"
-            >
-              ×
-            </button>
-          )}
-          </div>
-        </div>
+        <SidebarFilter value={filterText} onChange={setFilterText} />
 
         {filter.active && visibleTopLevelGroups.length === 0 && (
           <div className="sidebar-filter-empty" role="status">No groups or sessions match</div>
@@ -1420,7 +1390,11 @@ const App: React.FC = () => {
             >
               <TerminalHeader
                 session={session}
-                onRename={(name) => updateSession(session.id, { name })}
+                onRename={(name) => {
+                  updateSession(session.id, { name });
+                  // Keep the renamed session visible in the sidebar (#141).
+                  if (session.name !== name) setFilterText('');
+                }}
                 onRestart={() => setRestartKeys(prev => ({ ...prev, [session.id]: (prev[session.id] || 0) + 1 }))}
                 onStop={() => updateSession(session.id, { state: 'stopped' })}
                 onClose={() => handleRemoveSession(session.id)}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -245,6 +245,16 @@ const App: React.FC = () => {
     setSessionPrompt({ groupId, defaultName: `Session ${count}` });
   }, [getSessionsByGroup]);
 
+  /**
+   * A newly created group/session becomes active straight away, so it has to be
+   * visible. Clear the filter only when the new name would not match it —
+   * an unrelated query is left untouched (#141).
+   */
+  const revealNewItem = useCallback((name: string) => {
+    const query = filterText.trim().toLowerCase();
+    if (query && !name.toLowerCase().includes(query)) setFilterText('');
+  }, [filterText]);
+
   // Actually create the session after name is confirmed
   const handleConfirmSession = useCallback(async (
     name: string,
@@ -256,11 +266,8 @@ const App: React.FC = () => {
     const cwd = getEffectiveWorkingDir(sessionPrompt.groupId) || homedir;
     await createSession(sessionPrompt.groupId, name, cwd, true, provider); // launchClaude = true
     setSessionPrompt(null);
-    // A new/renamed row may not match the active filter; clearing it keeps the
-    // result visible instead of silently vanishing (#141).
-    setFilterText('');
-
-  }, [sessionPrompt, getEffectiveWorkingDir, createSession, homedir]);
+    revealNewItem(name);
+  }, [sessionPrompt, revealNewItem, getEffectiveWorkingDir, createSession, homedir]);
 
   // Show prompt for new group name
   const handleCreateGroup = () => {
@@ -271,9 +278,7 @@ const App: React.FC = () => {
   // Actually create the group after name is confirmed
   const handleConfirmGroup = async (name: string, path?: string, claudeAccountId?: string | null) => {
     setGroupPrompt(null);
-    // A new/renamed row may not match the active filter; clearing it keeps the
-    // result visible instead of silently vanishing (#141).
-    setFilterText('');
+    revealNewItem(name);
 
     // Create the group first
     const newGroup = await createGroup(name);
@@ -308,7 +313,7 @@ const App: React.FC = () => {
       }
     }
     setSubGroupPrompt(null);
-    setFilterText('');
+    revealNewItem(name);
   };
 
   const handleStartEditGroup = (groupId: string, currentName: string) => {
@@ -318,12 +323,7 @@ const App: React.FC = () => {
 
   const handleFinishEditGroup = async () => {
     if (editingGroupId && editingGroupName.trim()) {
-      const trimmed = editingGroupName.trim();
-      const changed = groups.find(g => g.id === editingGroupId)?.name !== trimmed;
-      await updateGroup(editingGroupId, { name: trimmed });
-      // Only when the name actually changed: a click that merely opens (and
-      // blurs) the rename input must not wipe the user's query (#141).
-      if (changed) setFilterText('');
+      await updateGroup(editingGroupId, { name: editingGroupName.trim() });
     }
     setEditingGroupId(null);
     setEditingGroupName('');
@@ -449,11 +449,7 @@ const App: React.FC = () => {
 
   const handleFinishEditSession = async () => {
     if (editingSessionId && editingSessionName.trim()) {
-      const trimmed = editingSessionName.trim();
-      const changed = sessions.find(s => s.id === editingSessionId)?.name !== trimmed;
-      await updateSession(editingSessionId, { name: trimmed });
-      // Only when the name actually changed (see handleFinishEditGroup).
-      if (changed) setFilterText('');
+      await updateSession(editingSessionId, { name: editingSessionName.trim() });
     }
     setEditingSessionId(null);
     setEditingSessionName('');
@@ -776,13 +772,13 @@ const App: React.FC = () => {
   const handleNewGroup = useCallback(async () => {
     const name = `Group ${groups.filter(g => !g.parentId).length + 1}`;
     const newGroup = await createGroup(name);
-    setFilterText('');
+    revealNewItem(name);
 
     const dir = await window.electronAPI.selectDirectory();
     if (dir) {
       await updateGroup(newGroup.id, { workingDir: dir });
     }
-  }, [createGroup, updateGroup, groups]);
+  }, [createGroup, updateGroup, groups, revealNewItem]);
 
   // Wiring for one session row. Hoisted out of the JSX so the per-row callbacks
   // are not nested five closures deep inside the group/sub-group maps.
@@ -812,7 +808,7 @@ const App: React.FC = () => {
   }), [
     activeSessionId, focusedItemType, focusedItemId, draggedItem, dropTarget,
     filter.active, effectiveAccountForSession, editingSessionId, editingSessionName,
-    handleFinishEditSession, handleSessionClick, handleSessionContextMenu,
+    handleStartEditSession, handleFinishEditSession, handleSessionClick, handleSessionContextMenu,
     handleSessionDragStart, handleDragEnd, handleSessionDragOver, handleSessionDrop,
     handleRemoveSession,
   ]);
@@ -1272,8 +1268,6 @@ const App: React.FC = () => {
                 session={session}
                 onRename={(name) => {
                   updateSession(session.id, { name });
-                  // Keep the renamed session visible in the sidebar (#141).
-                  if (session.name !== name) setFilterText('');
                 }}
                 onRestart={() => setRestartKeys(prev => ({ ...prev, [session.id]: (prev[session.id] || 0) + 1 }))}
                 onStop={() => updateSession(session.id, { state: 'stopped' })}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1120,10 +1120,8 @@ const App: React.FC = () => {
                 </button>
               </div>
               {(filter.active || !group.collapsed) && (
-                <div
+                <ul
                   className={`group-sessions ${dropTarget?.id === `group:${group.id}` ? 'drop-target' : ''}`}
-                  role="listbox"
-                  aria-label="Sessions"
                   onDragOver={(e) => handleGroupAreaDragOver(e, group.id)}
                   onDrop={(e) => handleGroupAreaDrop(e, group.id)}
                 >
@@ -1132,7 +1130,7 @@ const App: React.FC = () => {
                   .sort((a, b) => a.order - b.order).map(session => (
                   <SessionRow key={session.id} {...sessionRowProps(session, group.id)} />
                   ))}
-                </div>
+                </ul>
               )}
             </li>
 
@@ -1230,10 +1228,8 @@ const App: React.FC = () => {
                   </button>
                 </div>
                 {(filter.active || !subGroup.collapsed) && (
-                  <div
+                  <ul
                     className={`group-sessions ${dropTarget?.id === `group:${subGroup.id}` ? 'drop-target' : ''}`}
-                  role="listbox"
-                  aria-label="Sessions"
                     onDragOver={(e) => handleGroupAreaDragOver(e, subGroup.id)}
                     onDrop={(e) => handleGroupAreaDrop(e, subGroup.id)}
                   >
@@ -1242,7 +1238,7 @@ const App: React.FC = () => {
                     .sort((a, b) => a.order - b.order).map(session => (
                     <SessionRow key={session.id} {...sessionRowProps(session, subGroup.id)} />
                     ))}
-                  </div>
+                  </ul>
                 )}
               </li>
             ))}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,6 +13,7 @@ import { ClaudeAccountsModal } from './components/ClaudeAccountsModal';
 import { ClaudeAccount, PROVIDER_LABELS } from '../shared/types';
 import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
+import { computeGroupFilter } from './store/groupFilter';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import './styles/global.css';
 import './styles/context-menu.css';
@@ -58,6 +59,10 @@ const App: React.FC = () => {
   const [focusedItemType, setFocusedItemType] = useState<'group' | 'session' | null>(null);
   const sidebarRef = useRef<HTMLDivElement>(null);
   const [sidebarWidth, setSidebarWidth] = useState(260);
+
+  // Sidebar text filter (#141). Ephemeral — never persisted.
+  const [filterText, setFilterText] = useState('');
+  const filterInputRef = useRef<HTMLInputElement>(null);
   const [isResizing, setIsResizing] = useState(false);
 
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -117,6 +122,12 @@ const App: React.FC = () => {
   const homedir = window.electronAPI.homedir;
   const counts = getStateCounts();
   const isLoading = groupsLoading || sessionsLoading;
+
+  // Which sidebar rows survive the text filter (#141).
+  const filter = useMemo(
+    () => computeGroupFilter(groups, sessions, filterText),
+    [groups, sessions, filterText],
+  );
 
   // Get the active session's group ID for memory panel
   const activeSession = sessions.find(s => s.id === activeSessionId);
@@ -945,7 +956,44 @@ const App: React.FC = () => {
           </div>
         </div>
 
-        {getTopLevelGroups().map(group => (
+        <div className="sidebar-filter">
+          <input
+            ref={filterInputRef}
+            className="sidebar-filter-input"
+            type="text"
+            value={filterText}
+            placeholder="Filter groups & sessions…"
+            aria-label="Filter groups and sessions"
+            onChange={(e) => setFilterText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.stopPropagation();
+                setFilterText('');
+              }
+            }}
+          />
+          {filterText && (
+            <button
+              className="sidebar-filter-clear"
+              onClick={() => {
+                setFilterText('');
+                filterInputRef.current?.focus();
+              }}
+              title="Clear filter"
+              aria-label="Clear filter"
+            >
+              ×
+            </button>
+          )}
+        </div>
+
+        {filter.active && filter.visibleGroupIds.size === 0 && (
+          <div className="sidebar-filter-empty">No groups or sessions match</div>
+        )}
+
+        {getTopLevelGroups()
+          .filter(group => !filter.active || filter.visibleGroupIds.has(group.id))
+          .map(group => (
           <div key={group.id} className="group-container">
             {/* Render main group */}
             <div
@@ -970,7 +1018,7 @@ const App: React.FC = () => {
                   title={group.collapsed ? 'Expand' : 'Collapse'}
                   aria-label={group.collapsed ? 'Expand group' : 'Collapse group'}
                 >
-                  {group.collapsed ? '▶' : '▼'}
+                  {group.collapsed && !filter.active ? '▶' : '▼'}
                 </button>
                 <button
                   className="group-color"
@@ -1048,13 +1096,15 @@ const App: React.FC = () => {
                   +
                 </button>
               </div>
-              {!group.collapsed && (
+              {(filter.active || !group.collapsed) && (
                 <div
                   className={`group-sessions ${dropTarget?.id === `group:${group.id}` ? 'drop-target' : ''}`}
                   onDragOver={(e) => handleGroupAreaDragOver(e, group.id)}
                   onDrop={(e) => handleGroupAreaDrop(e, group.id)}
                 >
-                {getSessionsByGroup(group.id).sort((a, b) => a.order - b.order).map(session => (
+                {getSessionsByGroup(group.id)
+                  .filter(session => !filter.active || filter.visibleSessionIds.has(session.id))
+                  .sort((a, b) => a.order - b.order).map(session => (
                   <div
                     key={session.id}
                     className={`session ${session.id === activeSessionId ? 'active' : ''} ${focusedItemType === 'session' && focusedItemId === session.id ? 'item-focused' : ''} ${draggedItem?.type === 'session' && draggedItem.id === session.id ? 'dragging' : ''} ${dropTarget?.type === 'session' && dropTarget.id === session.id ? `drop-${dropTarget.position}` : ''}`}
@@ -1140,7 +1190,9 @@ const App: React.FC = () => {
             </div>
 
             {/* Render sub-groups when parent not collapsed */}
-            {!group.collapsed && getSubGroups(group.id).map(subGroup => (
+            {(filter.active || !group.collapsed) && getSubGroups(group.id)
+              .filter(subGroup => !filter.active || filter.visibleGroupIds.has(subGroup.id))
+              .map(subGroup => (
               <div
                 key={subGroup.id}
                 className={`group sub-group ${draggedItem?.type === 'group' && draggedItem.id === subGroup.id ? 'dragging' : ''} ${dropTarget?.type === 'group' && dropTarget.id === subGroup.id ? `drop-${dropTarget.position}` : ''}`}
@@ -1164,7 +1216,7 @@ const App: React.FC = () => {
                     title={subGroup.collapsed ? 'Expand' : 'Collapse'}
                     aria-label={subGroup.collapsed ? 'Expand sub-group' : 'Collapse sub-group'}
                   >
-                    {subGroup.collapsed ? '▶' : '▼'}
+                    {subGroup.collapsed && !filter.active ? '▶' : '▼'}
                   </button>
                   <button
                     className="group-color sub-group-color"
@@ -1239,13 +1291,15 @@ const App: React.FC = () => {
                     +
                   </button>
                 </div>
-                {!subGroup.collapsed && (
+                {(filter.active || !subGroup.collapsed) && (
                   <div
                     className={`group-sessions ${dropTarget?.id === `group:${subGroup.id}` ? 'drop-target' : ''}`}
                     onDragOver={(e) => handleGroupAreaDragOver(e, subGroup.id)}
                     onDrop={(e) => handleGroupAreaDrop(e, subGroup.id)}
                   >
-                  {getSessionsByGroup(subGroup.id).sort((a, b) => a.order - b.order).map(session => (
+                  {getSessionsByGroup(subGroup.id)
+                    .filter(session => !filter.active || filter.visibleSessionIds.has(session.id))
+                    .sort((a, b) => a.order - b.order).map(session => (
                     <div
                       key={session.id}
                       className={`session ${session.id === activeSessionId ? 'active' : ''} ${focusedItemType === 'session' && focusedItemId === session.id ? 'item-focused' : ''} ${draggedItem?.type === 'session' && draggedItem.id === session.id ? 'dragging' : ''} ${dropTarget?.type === 'session' && dropTarget.id === session.id ? `drop-${dropTarget.position}` : ''}`}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,7 +13,7 @@ import { ClaudeAccountsModal } from './components/ClaudeAccountsModal';
 import { ClaudeAccount, PROVIDER_LABELS } from '../shared/types';
 import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
-import { computeGroupFilter } from './store/groupFilter';
+import { computeGroupFilter, buildNavItems } from './store/groupFilter';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import './styles/global.css';
 import './styles/context-menu.css';
@@ -129,6 +129,13 @@ const App: React.FC = () => {
     [groups, sessions, filterText],
   );
 
+  // The top-level rows actually rendered. Drives both the list and the empty
+  // state, so the two can never disagree.
+  const visibleTopLevelGroups = useMemo(
+    () => getTopLevelGroups().filter(g => !filter.active || filter.visibleGroupIds.has(g.id)),
+    [getTopLevelGroups, filter],
+  );
+
   // Get the active session's group ID for memory panel
   const activeSession = sessions.find(s => s.id === activeSessionId);
   const activeGroupId = activeSession?.groupId || null;
@@ -234,6 +241,10 @@ const App: React.FC = () => {
     const cwd = getEffectiveWorkingDir(sessionPrompt.groupId) || homedir;
     await createSession(sessionPrompt.groupId, name, cwd, true, provider); // launchClaude = true
     setSessionPrompt(null);
+    // A new/renamed row may not match the active filter; clearing it keeps the
+    // result visible instead of silently vanishing (#141).
+    setFilterText('');
+
   }, [sessionPrompt, getEffectiveWorkingDir, createSession, homedir]);
 
   // Show prompt for new group name
@@ -245,6 +256,9 @@ const App: React.FC = () => {
   // Actually create the group after name is confirmed
   const handleConfirmGroup = async (name: string, path?: string, claudeAccountId?: string | null) => {
     setGroupPrompt(null);
+    // A new/renamed row may not match the active filter; clearing it keeps the
+    // result visible instead of silently vanishing (#141).
+    setFilterText('');
 
     // Create the group first
     const newGroup = await createGroup(name);
@@ -279,6 +293,7 @@ const App: React.FC = () => {
       }
     }
     setSubGroupPrompt(null);
+    setFilterText('');
   };
 
   const handleStartEditGroup = (groupId: string, currentName: string) => {
@@ -289,6 +304,8 @@ const App: React.FC = () => {
   const handleFinishEditGroup = async () => {
     if (editingGroupId && editingGroupName.trim()) {
       await updateGroup(editingGroupId, { name: editingGroupName.trim() });
+      // The new name may not match the active filter (#141).
+      setFilterText('');
     }
     setEditingGroupId(null);
     setEditingGroupName('');
@@ -415,6 +432,8 @@ const App: React.FC = () => {
   const handleFinishEditSession = async () => {
     if (editingSessionId && editingSessionName.trim()) {
       await updateSession(editingSessionId, { name: editingSessionName.trim() });
+      // The new name may not match the active filter (#141).
+      setFilterText('');
     }
     setEditingSessionId(null);
     setEditingSessionName('');
@@ -642,32 +661,12 @@ const App: React.FC = () => {
     }
   }, [groups, handleNewSession]);
 
-  // Build flat navigation list for keyboard navigation
-  const navItems = useMemo(() => {
-    const items: Array<{ id: string; type: 'group' | 'session'; parentId?: string }> = [];
-
-    getTopLevelGroups().forEach(group => {
-      items.push({ id: group.id, type: 'group' });
-
-      if (!group.collapsed) {
-        getSessionsByGroup(group.id).sort((a, b) => a.order - b.order).forEach(session => {
-          items.push({ id: session.id, type: 'session', parentId: group.id });
-        });
-
-        getSubGroups(group.id).forEach(subGroup => {
-          items.push({ id: subGroup.id, type: 'group', parentId: group.id });
-
-          if (!subGroup.collapsed) {
-            getSessionsByGroup(subGroup.id).sort((a, b) => a.order - b.order).forEach(session => {
-              items.push({ id: session.id, type: 'session', parentId: subGroup.id });
-            });
-          }
-        });
-      }
-    });
-
-    return items;
-  }, [groups, sessions, getTopLevelGroups, getSubGroups, getSessionsByGroup]);
+  // Flat navigation list for keyboard navigation. Mirrors the rendered rows,
+  // so it must stay filter-aware (#141).
+  const navItems = useMemo(
+    () => buildNavItems(groups, sessions, filter),
+    [groups, sessions, filter],
+  );
 
   const handleFocusSidebar = useCallback(() => {
     sidebarRef.current?.focus();
@@ -690,7 +689,7 @@ const App: React.FC = () => {
   }, []);
 
   const handleNavigateUp = useCallback(() => {
-    if (!sidebarFocused) return;
+    if (!sidebarFocused || navItems.length === 0) return;
     const currentIndex = navItems.findIndex(item => item.id === focusedItemId);
     const prevIndex = currentIndex > 0 ? currentIndex - 1 : navItems.length - 1;
     setFocusedItemId(navItems[prevIndex].id);
@@ -698,7 +697,7 @@ const App: React.FC = () => {
   }, [sidebarFocused, focusedItemId, navItems]);
 
   const handleNavigateDown = useCallback(() => {
-    if (!sidebarFocused) return;
+    if (!sidebarFocused || navItems.length === 0) return;
     const currentIndex = navItems.findIndex(item => item.id === focusedItemId);
     const nextIndex = currentIndex < navItems.length - 1 ? currentIndex + 1 : 0;
     setFocusedItemId(navItems[nextIndex].id);
@@ -706,7 +705,9 @@ const App: React.FC = () => {
   }, [sidebarFocused, focusedItemId, navItems]);
 
   const handleCollapse = useCallback(() => {
-    if (!sidebarFocused || !focusedItemId) return;
+    // Rows are force-expanded while filtering, so a collapse write would be an
+    // invisible, persisted change (#141).
+    if (!sidebarFocused || !focusedItemId || filter.active) return;
     if (focusedItemType === 'group') {
       const group = groups.find(g => g.id === focusedItemId);
       if (group && !group.collapsed) {
@@ -718,13 +719,13 @@ const App: React.FC = () => {
         toggleCollapse(session.groupId);
       }
     }
-  }, [sidebarFocused, focusedItemId, focusedItemType, groups, sessions, toggleCollapse]);
+  }, [sidebarFocused, focusedItemId, focusedItemType, groups, sessions, toggleCollapse, filter.active]);
 
   const handleExpand = useCallback(() => {
     if (!sidebarFocused || !focusedItemId) return;
     if (focusedItemType === 'group') {
       const group = groups.find(g => g.id === focusedItemId);
-      if (group && group.collapsed) {
+      if (group && group.collapsed && !filter.active) {
         toggleCollapse(focusedItemId);
       }
     } else if (focusedItemType === 'session') {
@@ -735,12 +736,12 @@ const App: React.FC = () => {
         window.dispatchEvent(new Event('focus-terminal'));
       }, 50);
     }
-  }, [sidebarFocused, focusedItemId, focusedItemType, groups, toggleCollapse, setActiveSessionId]);
+  }, [sidebarFocused, focusedItemId, focusedItemType, groups, toggleCollapse, setActiveSessionId, filter.active]);
 
   const handleSelect = useCallback(() => {
     if (!sidebarFocused || !focusedItemId) return;
     if (focusedItemType === 'group') {
-      toggleCollapse(focusedItemId);
+      if (!filter.active) toggleCollapse(focusedItemId);
     } else if (focusedItemType === 'session') {
       setActiveSessionId(focusedItemId);
       setSidebarFocused(false);
@@ -749,11 +750,12 @@ const App: React.FC = () => {
         window.dispatchEvent(new Event('focus-terminal'));
       }, 50);
     }
-  }, [sidebarFocused, focusedItemId, focusedItemType, toggleCollapse, setActiveSessionId]);
+  }, [sidebarFocused, focusedItemId, focusedItemType, toggleCollapse, setActiveSessionId, filter.active]);
 
   const handleNewGroup = useCallback(async () => {
     const name = `Group ${groups.filter(g => !g.parentId).length + 1}`;
     const newGroup = await createGroup(name);
+    setFilterText('');
 
     const dir = await window.electronAPI.selectDirectory();
     if (dir) {
@@ -957,6 +959,7 @@ const App: React.FC = () => {
         </div>
 
         <div className="sidebar-filter">
+          <div className="sidebar-filter-field">
           <input
             ref={filterInputRef}
             className="sidebar-filter-input"
@@ -966,9 +969,15 @@ const App: React.FC = () => {
             aria-label="Filter groups and sessions"
             onChange={(e) => setFilterText(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Escape') {
+              if (e.key !== 'Escape') return;
+              if (filterText) {
+                // Consume the first Escape to clear the query.
                 e.stopPropagation();
                 setFilterText('');
+              } else {
+                // Already empty: step out of the box so keyboard users have a
+                // route back, and let app-level dismiss handlers see the key.
+                filterInputRef.current?.blur();
               }
             }}
           />
@@ -985,20 +994,20 @@ const App: React.FC = () => {
               ×
             </button>
           )}
+          </div>
         </div>
 
-        {filter.active && filter.visibleGroupIds.size === 0 && (
-          <div className="sidebar-filter-empty">No groups or sessions match</div>
+        {filter.active && visibleTopLevelGroups.length === 0 && (
+          <div className="sidebar-filter-empty" role="status">No groups or sessions match</div>
         )}
 
-        {getTopLevelGroups()
-          .filter(group => !filter.active || filter.visibleGroupIds.has(group.id))
+        {visibleTopLevelGroups
           .map(group => (
           <div key={group.id} className="group-container">
             {/* Render main group */}
             <div
               className={`group ${draggedItem?.type === 'group' && draggedItem.id === group.id ? 'dragging' : ''} ${dropTarget?.type === 'group' && dropTarget.id === group.id ? `drop-${dropTarget.position}` : ''}`}
-              draggable
+              draggable={!filter.active}
               onDragStart={(e) => handleGroupDragStart(e, group.id)}
               onDragEnd={handleDragEnd}
               onDragOver={(e) => handleGroupDragOver(e, group.id)}
@@ -1015,8 +1024,13 @@ const App: React.FC = () => {
                     e.stopPropagation();
                     toggleCollapse(group.id);
                   }}
-                  title={group.collapsed ? 'Expand' : 'Collapse'}
-                  aria-label={group.collapsed ? 'Expand group' : 'Collapse group'}
+                  disabled={filter.active}
+                  title={filter.active
+                    ? 'Expanded while filtering'
+                    : (group.collapsed ? 'Expand' : 'Collapse')}
+                  aria-label={filter.active
+                    ? 'Group expanded while filtering'
+                    : (group.collapsed ? 'Expand group' : 'Collapse group')}
                 >
                   {group.collapsed && !filter.active ? '▶' : '▼'}
                 </button>
@@ -1110,7 +1124,7 @@ const App: React.FC = () => {
                     className={`session ${session.id === activeSessionId ? 'active' : ''} ${focusedItemType === 'session' && focusedItemId === session.id ? 'item-focused' : ''} ${draggedItem?.type === 'session' && draggedItem.id === session.id ? 'dragging' : ''} ${dropTarget?.type === 'session' && dropTarget.id === session.id ? `drop-${dropTarget.position}` : ''}`}
                     onClick={() => handleSessionClick(session.id)}
                     onContextMenu={(e) => handleSessionContextMenu(e, session.id, session.name)}
-                    draggable
+                    draggable={!filter.active}
                     onDragStart={(e) => handleSessionDragStart(e, session.id, group.id)}
                     onDragEnd={handleDragEnd}
                     onDragOver={(e) => handleSessionDragOver(e, session.id, group.id)}
@@ -1196,7 +1210,7 @@ const App: React.FC = () => {
               <div
                 key={subGroup.id}
                 className={`group sub-group ${draggedItem?.type === 'group' && draggedItem.id === subGroup.id ? 'dragging' : ''} ${dropTarget?.type === 'group' && dropTarget.id === subGroup.id ? `drop-${dropTarget.position}` : ''}`}
-                draggable
+                draggable={!filter.active}
                 onDragStart={(e) => handleGroupDragStart(e, subGroup.id)}
                 onDragEnd={handleDragEnd}
                 onDragOver={(e) => handleGroupDragOver(e, subGroup.id)}
@@ -1213,8 +1227,13 @@ const App: React.FC = () => {
                       e.stopPropagation();
                       toggleCollapse(subGroup.id);
                     }}
-                    title={subGroup.collapsed ? 'Expand' : 'Collapse'}
-                    aria-label={subGroup.collapsed ? 'Expand sub-group' : 'Collapse sub-group'}
+                    disabled={filter.active}
+                    title={filter.active
+                      ? 'Expanded while filtering'
+                      : (subGroup.collapsed ? 'Expand' : 'Collapse')}
+                    aria-label={filter.active
+                      ? 'Sub-group expanded while filtering'
+                      : (subGroup.collapsed ? 'Expand sub-group' : 'Collapse sub-group')}
                   >
                     {subGroup.collapsed && !filter.active ? '▶' : '▼'}
                   </button>
@@ -1305,7 +1324,7 @@ const App: React.FC = () => {
                       className={`session ${session.id === activeSessionId ? 'active' : ''} ${focusedItemType === 'session' && focusedItemId === session.id ? 'item-focused' : ''} ${draggedItem?.type === 'session' && draggedItem.id === session.id ? 'dragging' : ''} ${dropTarget?.type === 'session' && dropTarget.id === session.id ? `drop-${dropTarget.position}` : ''}`}
                       onClick={() => handleSessionClick(session.id)}
                       onContextMenu={(e) => handleSessionContextMenu(e, session.id, session.name)}
-                      draggable
+                      draggable={!filter.active}
                       onDragStart={(e) => handleSessionDragStart(e, session.id, subGroup.id)}
                       onDragEnd={handleDragEnd}
                       onDragOver={(e) => handleSessionDragOver(e, session.id, subGroup.id)}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,12 +6,13 @@ import { NamePromptModal } from './components/NamePromptModal';
 import { SettingsModal } from './components/SettingsModal';
 import { NewItemChoice } from './components/NewItemChoice';
 import { SidebarFilter } from './components/SidebarFilter';
+import { SessionRow } from './components/SessionRow';
+import { GroupColorPicker } from './components/GroupColorPicker';
 import { MemoryPanel } from './components/panels/MemoryPanel';
 import AnalyticsPanel from './components/panels/AnalyticsPanel';
 import { ArenaPanel } from './components/ArenaPanel';
-import { SessionStatsBadge } from './components/SessionStatsBadge';
 import { ClaudeAccountsModal } from './components/ClaudeAccountsModal';
-import { ClaudeAccount, PROVIDER_LABELS } from '../shared/types';
+import { ClaudeAccount, Session } from '../shared/types';
 import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
 import { computeGroupFilter, buildNavItems } from './store/groupFilter';
@@ -19,6 +20,20 @@ import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import './styles/global.css';
 import './styles/context-menu.css';
 import ErrorBoundary from './components/ErrorBoundary';
+
+/**
+ * Collapse-chevron labels. While a filter is active every row is force-expanded,
+ * so the control is disabled and says so rather than lying about state (#141).
+ */
+function chevronTitle(collapsed: boolean, filtering: boolean): string {
+  if (filtering) return 'Expanded while filtering';
+  return collapsed ? 'Expand' : 'Collapse';
+}
+
+function chevronAriaLabel(collapsed: boolean, filtering: boolean, kind: 'group' | 'sub-group'): string {
+  if (filtering) return `${kind} expanded while filtering`;
+  return collapsed ? `Expand ${kind}` : `Collapse ${kind}`;
+}
 
 const App: React.FC = () => {
   const {
@@ -673,6 +688,7 @@ const App: React.FC = () => {
     [groups, sessions, filter],
   );
 
+
   const handleFocusSidebar = useCallback(() => {
     sidebarRef.current?.focus();
     if (!focusedItemId && navItems.length > 0) {
@@ -767,6 +783,40 @@ const App: React.FC = () => {
       await updateGroup(newGroup.id, { workingDir: dir });
     }
   }, [createGroup, updateGroup, groups]);
+
+  // Wiring for one session row. Hoisted out of the JSX so the per-row callbacks
+  // are not nested five closures deep inside the group/sub-group maps.
+  const sessionRowProps = useCallback((session: Session, groupId: string) => ({
+    session,
+    groupId,
+    isActive: session.id === activeSessionId,
+    isFocused: focusedItemType === 'session' && focusedItemId === session.id,
+    isDragging: draggedItem?.type === 'session' && draggedItem.id === session.id,
+    dropPosition: dropTarget?.type === 'session' && dropTarget.id === session.id
+      ? dropTarget.position
+      : null,
+    draggable: !filter.active,
+    account: effectiveAccountForSession(session.id),
+    isEditing: editingSessionId === session.id,
+    editingName: editingSessionName,
+    onEditingNameChange: setEditingSessionName,
+    onStartEdit: () => handleStartEditSession(session.id, session.name),
+    onFinishEdit: handleFinishEditSession,
+    onCancelEdit: () => { setEditingSessionId(null); setEditingSessionName(''); },
+    onSelect: () => handleSessionClick(session.id),
+    onContextMenu: (e: React.MouseEvent) => handleSessionContextMenu(e, session.id, session.name),
+    onDragStart: (e: React.DragEvent) => handleSessionDragStart(e, session.id, groupId),
+    onDragEnd: handleDragEnd,
+    onDragOver: (e: React.DragEvent) => handleSessionDragOver(e, session.id, groupId),
+    onDrop: (e: React.DragEvent) => handleSessionDrop(e, session.id, groupId),
+    onClose: () => handleRemoveSession(session.id),
+  }), [
+    activeSessionId, focusedItemType, focusedItemId, draggedItem, dropTarget,
+    filter.active, effectiveAccountForSession, editingSessionId, editingSessionName,
+    handleFinishEditSession, handleSessionClick, handleSessionContextMenu,
+    handleSessionDragStart, handleDragEnd, handleSessionDragOver, handleSessionDrop,
+    handleRemoveSession,
+  ]);
 
   const getContextShortcuts = useCallback(() => {
     if (sidebarFocused) {
@@ -968,14 +1018,14 @@ const App: React.FC = () => {
         <SidebarFilter value={filterText} onChange={setFilterText} />
 
         {filter.active && visibleTopLevelGroups.length === 0 && (
-          <div className="sidebar-filter-empty" role="status">No groups or sessions match</div>
+          <output className="sidebar-filter-empty">No groups or sessions match</output>
         )}
 
         {visibleTopLevelGroups
           .map(group => (
-          <div key={group.id} className="group-container">
+          <ul key={group.id} className="group-container">
             {/* Render main group */}
-            <div
+            <li
               className={`group ${draggedItem?.type === 'group' && draggedItem.id === group.id ? 'dragging' : ''} ${dropTarget?.type === 'group' && dropTarget.id === group.id ? `drop-${dropTarget.position}` : ''}`}
               draggable={!filter.active}
               onDragStart={(e) => handleGroupDragStart(e, group.id)}
@@ -995,12 +1045,8 @@ const App: React.FC = () => {
                     toggleCollapse(group.id);
                   }}
                   disabled={filter.active}
-                  title={filter.active
-                    ? 'Expanded while filtering'
-                    : (group.collapsed ? 'Expand' : 'Collapse')}
-                  aria-label={filter.active
-                    ? 'Group expanded while filtering'
-                    : (group.collapsed ? 'Expand group' : 'Collapse group')}
+                  title={chevronTitle(group.collapsed, filter.active)}
+                  aria-label={chevronAriaLabel(group.collapsed, filter.active, 'group')}
                 >
                   {group.collapsed && !filter.active ? '▶' : '▼'}
                 </button>
@@ -1012,17 +1058,11 @@ const App: React.FC = () => {
                   aria-label="Change group color"
                 />
                 {colorPickerGroupId === group.id && (
-                  <div className="color-picker">
-                    {GROUP_COLORS.map(color => (
-                      <button
-                        key={color}
-                        className={`color-option ${color === group.color ? 'selected' : ''}`}
-                        style={{ background: color }}
-                        onClick={() => handleColorSelect(group.id, color)}
-                        aria-label={`Set color to ${color}`}
-                      />
-                    ))}
-                  </div>
+                  <GroupColorPicker
+                    colors={GROUP_COLORS}
+                    selected={group.color}
+                    onSelect={(color) => handleColorSelect(group.id, color)}
+                  />
                 )}
                 {editingGroupId === group.id ? (
                   <input
@@ -1089,95 +1129,17 @@ const App: React.FC = () => {
                 {getSessionsByGroup(group.id)
                   .filter(session => !filter.active || filter.visibleSessionIds.has(session.id))
                   .sort((a, b) => a.order - b.order).map(session => (
-                  <div
-                    key={session.id}
-                    className={`session ${session.id === activeSessionId ? 'active' : ''} ${focusedItemType === 'session' && focusedItemId === session.id ? 'item-focused' : ''} ${draggedItem?.type === 'session' && draggedItem.id === session.id ? 'dragging' : ''} ${dropTarget?.type === 'session' && dropTarget.id === session.id ? `drop-${dropTarget.position}` : ''}`}
-                    onClick={() => handleSessionClick(session.id)}
-                    onContextMenu={(e) => handleSessionContextMenu(e, session.id, session.name)}
-                    draggable={!filter.active}
-                    onDragStart={(e) => handleSessionDragStart(e, session.id, group.id)}
-                    onDragEnd={handleDragEnd}
-                    onDragOver={(e) => handleSessionDragOver(e, session.id, group.id)}
-                    onDrop={(e) => handleSessionDrop(e, session.id, group.id)}
-                  >
-                    {(() => {
-                      const acc = effectiveAccountForSession(session.id);
-                      if (!acc) return null;
-                      return (
-                        <span
-                          className="session-account-dot"
-                          style={{ background: acc.color || '#888888' }}
-                          title={`Claude account: ${acc.label}${acc.email ? ` (${acc.email})` : ''}${session.claudeAccountId ? ' — session override' : ' — inherited'}`}
-                          aria-label={`Account: ${acc.label}`}
-                          draggable={false}
-                        />
-                      );
-                    })()}
-                    <div className="session-info">
-                      {editingSessionId === session.id ? (
-                        <input
-                          className="session-name-input"
-                          value={editingSessionName}
-                          onChange={(e) => setEditingSessionName(e.target.value)}
-                          onBlur={handleFinishEditSession}
-                          onKeyDown={(e) => {
-                            e.stopPropagation();
-                            if (e.key === 'Enter') handleFinishEditSession();
-                            if (e.key === 'Escape') {
-                              setEditingSessionId(null);
-                              setEditingSessionName('');
-                            }
-                          }}
-                          onClick={(e) => e.stopPropagation()}
-                          autoFocus
-                        />
-                      ) : (
-                        <span
-                          className="session-name"
-                          onDoubleClick={(e) => {
-                            e.stopPropagation();
-                            handleStartEditSession(session.id, session.name);
-                          }}
-                          title="Double-click to rename"
-                        >
-                          {session.name}
-                        </span>
-                      )}
-                      <SessionStatsBadge sessionId={session.id} />
-                    </div>
-                    {session.shellType === 'claude' && session.provider !== 'claude' && (
-                      <span
-                        className="session-provider-badge"
-                        title={`Provider: ${PROVIDER_LABELS[session.provider] ?? session.provider}`}
-                        draggable={false}
-                      >
-                        {PROVIDER_LABELS[session.provider] ?? session.provider}
-                      </span>
-                    )}
-                    <span className={`status-pill ${session.state}`} draggable={false}>{session.state}</span>
-                    <button
-                      className="session-close"
-                      draggable={false}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleRemoveSession(session.id);
-                      }}
-                      title="Close session"
-                      aria-label="Close session"
-                    >
-                      ×
-                    </button>
-                  </div>
+                  <SessionRow key={session.id} {...sessionRowProps(session, group.id)} />
                   ))}
                 </div>
               )}
-            </div>
+            </li>
 
             {/* Render sub-groups when parent not collapsed */}
             {(filter.active || !group.collapsed) && getSubGroups(group.id)
               .filter(subGroup => !filter.active || filter.visibleGroupIds.has(subGroup.id))
               .map(subGroup => (
-              <div
+              <li
                 key={subGroup.id}
                 className={`group sub-group ${draggedItem?.type === 'group' && draggedItem.id === subGroup.id ? 'dragging' : ''} ${dropTarget?.type === 'group' && dropTarget.id === subGroup.id ? `drop-${dropTarget.position}` : ''}`}
                 draggable={!filter.active}
@@ -1198,12 +1160,8 @@ const App: React.FC = () => {
                       toggleCollapse(subGroup.id);
                     }}
                     disabled={filter.active}
-                    title={filter.active
-                      ? 'Expanded while filtering'
-                      : (subGroup.collapsed ? 'Expand' : 'Collapse')}
-                    aria-label={filter.active
-                      ? 'Sub-group expanded while filtering'
-                      : (subGroup.collapsed ? 'Expand sub-group' : 'Collapse sub-group')}
+                    title={chevronTitle(subGroup.collapsed, filter.active)}
+                    aria-label={chevronAriaLabel(subGroup.collapsed, filter.active, 'sub-group')}
                   >
                     {subGroup.collapsed && !filter.active ? '▶' : '▼'}
                   </button>
@@ -1215,17 +1173,7 @@ const App: React.FC = () => {
                     aria-label="Change sub-group color"
                   />
                   {colorPickerGroupId === subGroup.id && (
-                    <div className="color-picker">
-                      {GROUP_COLORS.map(color => (
-                        <button
-                          key={color}
-                          className={`color-option ${color === subGroup.color ? 'selected' : ''}`}
-                          style={{ background: color }}
-                          onClick={() => handleColorSelect(subGroup.id, color)}
-                          aria-label={`Set color to ${color}`}
-                        />
-                      ))}
-                    </div>
+                    <GroupColorPicker colors={GROUP_COLORS} selected={subGroup.color} onSelect={(color) => handleColorSelect(subGroup.id, color)} />
                   )}
                   {editingGroupId === subGroup.id ? (
                     <input
@@ -1289,80 +1237,13 @@ const App: React.FC = () => {
                   {getSessionsByGroup(subGroup.id)
                     .filter(session => !filter.active || filter.visibleSessionIds.has(session.id))
                     .sort((a, b) => a.order - b.order).map(session => (
-                    <div
-                      key={session.id}
-                      className={`session ${session.id === activeSessionId ? 'active' : ''} ${focusedItemType === 'session' && focusedItemId === session.id ? 'item-focused' : ''} ${draggedItem?.type === 'session' && draggedItem.id === session.id ? 'dragging' : ''} ${dropTarget?.type === 'session' && dropTarget.id === session.id ? `drop-${dropTarget.position}` : ''}`}
-                      onClick={() => handleSessionClick(session.id)}
-                      onContextMenu={(e) => handleSessionContextMenu(e, session.id, session.name)}
-                      draggable={!filter.active}
-                      onDragStart={(e) => handleSessionDragStart(e, session.id, subGroup.id)}
-                      onDragEnd={handleDragEnd}
-                      onDragOver={(e) => handleSessionDragOver(e, session.id, subGroup.id)}
-                      onDrop={(e) => handleSessionDrop(e, session.id, subGroup.id)}
-                    >
-                      {(() => {
-                        const acc = effectiveAccountForSession(session.id);
-                        if (!acc) return null;
-                        return (
-                          <span
-                            className="session-account-dot"
-                            style={{ background: acc.color || '#888888' }}
-                            title={`Claude account: ${acc.label}${acc.email ? ` (${acc.email})` : ''}${session.claudeAccountId ? ' — session override' : ' — inherited'}`}
-                            aria-label={`Account: ${acc.label}`}
-                          />
-                        );
-                      })()}
-                      <div className="session-info">
-                        {editingSessionId === session.id ? (
-                          <input
-                            className="session-name-input"
-                            value={editingSessionName}
-                            onChange={(e) => setEditingSessionName(e.target.value)}
-                            onBlur={handleFinishEditSession}
-                            onKeyDown={(e) => {
-                              e.stopPropagation();
-                              if (e.key === 'Enter') handleFinishEditSession();
-                              if (e.key === 'Escape') {
-                                setEditingSessionId(null);
-                                setEditingSessionName('');
-                              }
-                            }}
-                            onClick={(e) => e.stopPropagation()}
-                            autoFocus
-                          />
-                        ) : (
-                          <span
-                            className="session-name"
-                            onDoubleClick={(e) => {
-                              e.stopPropagation();
-                              handleStartEditSession(session.id, session.name);
-                            }}
-                            title="Double-click to rename"
-                          >
-                            {session.name}
-                          </span>
-                        )}
-                        <SessionStatsBadge sessionId={session.id} />
-                      </div>
-                      <span className={`status-pill ${session.state}`}>{session.state}</span>
-                      <button
-                        className="session-close"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleRemoveSession(session.id);
-                        }}
-                        title="Close session"
-                        aria-label="Close session"
-                      >
-                        ×
-                      </button>
-                    </div>
+                    <SessionRow key={session.id} {...sessionRowProps(session, subGroup.id)} />
                     ))}
                   </div>
                 )}
-              </div>
+              </li>
             ))}
-          </div>
+          </ul>
         ))}
 
       </aside>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -746,7 +746,7 @@ const App: React.FC = () => {
     if (!sidebarFocused || !focusedItemId) return;
     if (focusedItemType === 'group') {
       const group = groups.find(g => g.id === focusedItemId);
-      if (group && group.collapsed && !filter.active) {
+      if (group?.collapsed && !filter.active) {
         toggleCollapse(focusedItemId);
       }
     } else if (focusedItemType === 'session') {
@@ -788,7 +788,6 @@ const App: React.FC = () => {
   // are not nested five closures deep inside the group/sub-group maps.
   const sessionRowProps = useCallback((session: Session, groupId: string) => ({
     session,
-    groupId,
     isActive: session.id === activeSessionId,
     isFocused: focusedItemType === 'session' && focusedItemId === session.id,
     isDragging: draggedItem?.type === 'session' && draggedItem.id === session.id,
@@ -1123,6 +1122,8 @@ const App: React.FC = () => {
               {(filter.active || !group.collapsed) && (
                 <div
                   className={`group-sessions ${dropTarget?.id === `group:${group.id}` ? 'drop-target' : ''}`}
+                  role="listbox"
+                  aria-label="Sessions"
                   onDragOver={(e) => handleGroupAreaDragOver(e, group.id)}
                   onDrop={(e) => handleGroupAreaDrop(e, group.id)}
                 >
@@ -1231,6 +1232,8 @@ const App: React.FC = () => {
                 {(filter.active || !subGroup.collapsed) && (
                   <div
                     className={`group-sessions ${dropTarget?.id === `group:${subGroup.id}` ? 'drop-target' : ''}`}
+                  role="listbox"
+                  aria-label="Sessions"
                     onDragOver={(e) => handleGroupAreaDragOver(e, subGroup.id)}
                     onDrop={(e) => handleGroupAreaDrop(e, subGroup.id)}
                   >

--- a/src/renderer/components/GroupColorPicker.tsx
+++ b/src/renderer/components/GroupColorPicker.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface GroupColorPickerProps {
+  colors: string[];
+  /** Currently applied colour, highlighted in the swatch grid. */
+  selected: string;
+  onSelect: (color: string) => void;
+}
+
+/** Swatch grid shown under a group or sub-group's colour dot. */
+export const GroupColorPicker: React.FC<GroupColorPickerProps> = ({ colors, selected, onSelect }) => (
+  <div className="color-picker">
+    {colors.map(color => (
+      <button
+        key={color}
+        className={`color-option ${color === selected ? 'selected' : ''}`}
+        style={{ background: color }}
+        onClick={() => onSelect(color)}
+        aria-label={`Set color to ${color}`}
+      />
+    ))}
+  </div>
+);

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -89,7 +89,9 @@ export const SessionRow: React.FC<SessionRowProps> = ({
           className="session-select"
           onClick={onSelect}
           onDoubleClick={onStartEdit}
-          aria-current={isActive || undefined}
+          // Explicit ternary, not `||`/`??`: `isActive ?? undefined` would keep
+          // `false` (it is not nullish) and re-emit aria-current="false".
+          aria-current={isActive ? true : undefined}
           // The sidebar has its own roving navigation (Ctrl+Q then arrows), and
           // the close button is already a tab stop. Keeping this out of the tab
           // order avoids two stops per row (#141).

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -89,8 +89,12 @@ export const SessionRow: React.FC<SessionRowProps> = ({
           className="session-select"
           onClick={onSelect}
           onDoubleClick={onStartEdit}
-          aria-current={isActive}
-          title="Double-click to rename"
+          aria-current={isActive || undefined}
+          // The sidebar has its own roving navigation (Ctrl+Q then arrows), and
+          // the close button is already a tab stop. Keeping this out of the tab
+          // order avoids two stops per row (#141).
+          tabIndex={-1}
+          title="Double-click anywhere on the row to rename"
         >
           {account && (
             <span

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -4,8 +4,6 @@ import { SessionStatsBadge } from './SessionStatsBadge';
 
 interface SessionRowProps {
   session: Session;
-  /** Group the row is rendered under — top-level group or sub-group. */
-  groupId: string;
   isActive: boolean;
   isFocused: boolean;
   isDragging: boolean;
@@ -38,7 +36,9 @@ function accountTitle(account: ClaudeAccount, session: Session): string {
 
 /**
  * One session row in the sidebar. Rendered identically under top-level groups
- * and sub-groups; `groupId` is the only thing that differs.
+ * and sub-groups; only the drag handlers differ, and those arrive as props.
+ *
+ * Presented as an `option` inside the group's `listbox` (see `.group-sessions`).
  */
 export const SessionRow: React.FC<SessionRowProps> = ({
   session, isActive, isFocused, isDragging, dropPosition, draggable, account,
@@ -59,17 +59,19 @@ export const SessionRow: React.FC<SessionRowProps> = ({
   return (
     <div
       className={classes}
-      role="button"
+      // A selectable item in the group's session list. The sidebar drives focus
+      // itself (Ctrl+Q + arrows), so this row is not in the tab order.
+      role="option"
+      aria-selected={isActive}
       tabIndex={-1}
       onClick={onSelect}
       onKeyDown={(e) => {
-        // The sidebar drives focus itself (Ctrl+Q + arrows); this only handles
-        // activation once a row already has DOM focus.
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           onSelect();
         }
       }}
+      onDoubleClick={() => { if (!isEditing) onStartEdit(); }}
       onContextMenu={onContextMenu}
       draggable={draggable}
       onDragStart={onDragStart}
@@ -80,7 +82,7 @@ export const SessionRow: React.FC<SessionRowProps> = ({
       {account && (
         <span
           className="session-account-dot"
-          style={{ background: account.color || '#888888' }}
+          style={{ background: account.color ? account.color : '#888888' }}
           title={accountTitle(account, session)}
           aria-label={`Account: ${account.label}`}
           draggable={false}
@@ -102,14 +104,7 @@ export const SessionRow: React.FC<SessionRowProps> = ({
             autoFocus
           />
         ) : (
-          <span
-            className="session-name"
-            onDoubleClick={(e) => {
-              e.stopPropagation();
-              onStartEdit();
-            }}
-            title="Double-click to rename"
-          >
+          <span className="session-name" title="Double-click to rename">
             {session.name}
           </span>
         )}

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -35,10 +35,14 @@ function accountTitle(account: ClaudeAccount, session: Session): string {
 }
 
 /**
- * One session row in the sidebar. Rendered identically under top-level groups
- * and sub-groups; only the drag handlers differ, and those arrive as props.
+ * One session row in the sidebar — an `<li>` in the group's session list.
+ * Rendered identically under top-level groups and sub-groups; only the drag
+ * handlers differ, and those arrive as props.
  *
- * Presented as an `option` inside the group's `listbox` (see `.group-sessions`).
+ * Selection lives on a real `<button>` covering the row rather than a click
+ * handler on the container, so keyboard and screen-reader support come from the
+ * platform. The close button and the rename input stay outside it, since
+ * neither may nest inside a button.
  */
 export const SessionRow: React.FC<SessionRowProps> = ({
   session, isActive, isFocused, isDragging, dropPosition, draggable, account,
@@ -57,21 +61,8 @@ export const SessionRow: React.FC<SessionRowProps> = ({
   const showProvider = session.shellType === 'claude' && session.provider !== 'claude';
 
   return (
-    <div
+    <li
       className={classes}
-      // A selectable item in the group's session list. The sidebar drives focus
-      // itself (Ctrl+Q + arrows), so this row is not in the tab order.
-      role="option"
-      aria-selected={isActive}
-      tabIndex={-1}
-      onClick={onSelect}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onSelect();
-        }
-      }}
-      onDoubleClick={() => { if (!isEditing) onStartEdit(); }}
       onContextMenu={onContextMenu}
       draggable={draggable}
       onDragStart={onDragStart}
@@ -79,55 +70,59 @@ export const SessionRow: React.FC<SessionRowProps> = ({
       onDragOver={onDragOver}
       onDrop={onDrop}
     >
-      {account && (
-        <span
-          className="session-account-dot"
-          style={{ background: account.color ? account.color : '#888888' }}
-          title={accountTitle(account, session)}
-          aria-label={`Account: ${account.label}`}
-          draggable={false}
+      {isEditing ? (
+        <input
+          className="session-name-input"
+          value={editingName}
+          onChange={(e) => onEditingNameChange(e.target.value)}
+          onBlur={onFinishEdit}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === 'Enter') onFinishEdit();
+            if (e.key === 'Escape') onCancelEdit();
+          }}
+          autoFocus
         />
-      )}
-      <div className="session-info">
-        {isEditing ? (
-          <input
-            className="session-name-input"
-            value={editingName}
-            onChange={(e) => onEditingNameChange(e.target.value)}
-            onBlur={onFinishEdit}
-            onKeyDown={(e) => {
-              e.stopPropagation();
-              if (e.key === 'Enter') onFinishEdit();
-              if (e.key === 'Escape') onCancelEdit();
-            }}
-            onClick={(e) => e.stopPropagation()}
-            autoFocus
-          />
-        ) : (
-          <span className="session-name" title="Double-click to rename">
-            {session.name}
+      ) : (
+        <button
+          type="button"
+          className="session-select"
+          onClick={onSelect}
+          onDoubleClick={onStartEdit}
+          aria-current={isActive}
+          title="Double-click to rename"
+        >
+          {account && (
+            <span
+              className="session-account-dot"
+              style={{ background: account.color ?? '#888888' }}
+              title={accountTitle(account, session)}
+              aria-label={`Account: ${account.label}`}
+              draggable={false}
+            />
+          )}
+          <span className="session-info">
+            <span className="session-name">{session.name}</span>
+            <SessionStatsBadge sessionId={session.id} />
           </span>
-        )}
-        <SessionStatsBadge sessionId={session.id} />
-      </div>
-      {showProvider && (
-        <span className="session-provider-badge" title={`Provider: ${provider}`} draggable={false}>
-          {provider}
-        </span>
+          {showProvider && (
+            <span className="session-provider-badge" title={`Provider: ${provider}`} draggable={false}>
+              {provider}
+            </span>
+          )}
+          <span className={`status-pill ${session.state}`} draggable={false}>{session.state}</span>
+        </button>
       )}
-      <span className={`status-pill ${session.state}`} draggable={false}>{session.state}</span>
       <button
+        type="button"
         className="session-close"
         draggable={false}
-        onClick={(e) => {
-          e.stopPropagation();
-          onClose();
-        }}
+        onClick={onClose}
         title="Close session"
         aria-label="Close session"
       >
         ×
       </button>
-    </div>
+    </li>
   );
 };

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { ClaudeAccount, PROVIDER_LABELS, Session } from '../../shared/types';
+import { SessionStatsBadge } from './SessionStatsBadge';
+
+interface SessionRowProps {
+  session: Session;
+  /** Group the row is rendered under — top-level group or sub-group. */
+  groupId: string;
+  isActive: boolean;
+  isFocused: boolean;
+  isDragging: boolean;
+  /** 'before' | 'after' when this row is the current drop target. */
+  dropPosition: string | null;
+  draggable: boolean;
+  account: ClaudeAccount | null;
+
+  isEditing: boolean;
+  editingName: string;
+  onEditingNameChange: (name: string) => void;
+  onStartEdit: () => void;
+  onFinishEdit: () => void;
+  onCancelEdit: () => void;
+
+  onSelect: () => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+  onDragStart: (e: React.DragEvent) => void;
+  onDragEnd: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  onClose: () => void;
+}
+
+function accountTitle(account: ClaudeAccount, session: Session): string {
+  const email = account.email ? ` (${account.email})` : '';
+  const scope = session.claudeAccountId ? ' — session override' : ' — inherited';
+  return `Claude account: ${account.label}${email}${scope}`;
+}
+
+/**
+ * One session row in the sidebar. Rendered identically under top-level groups
+ * and sub-groups; `groupId` is the only thing that differs.
+ */
+export const SessionRow: React.FC<SessionRowProps> = ({
+  session, isActive, isFocused, isDragging, dropPosition, draggable, account,
+  isEditing, editingName, onEditingNameChange, onStartEdit, onFinishEdit, onCancelEdit,
+  onSelect, onContextMenu, onDragStart, onDragEnd, onDragOver, onDrop, onClose,
+}) => {
+  const classes = [
+    'session',
+    isActive ? 'active' : '',
+    isFocused ? 'item-focused' : '',
+    isDragging ? 'dragging' : '',
+    dropPosition ? `drop-${dropPosition}` : '',
+  ].filter(Boolean).join(' ');
+
+  const provider = PROVIDER_LABELS[session.provider] ?? session.provider;
+  const showProvider = session.shellType === 'claude' && session.provider !== 'claude';
+
+  return (
+    <div
+      className={classes}
+      role="button"
+      tabIndex={-1}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        // The sidebar drives focus itself (Ctrl+Q + arrows); this only handles
+        // activation once a row already has DOM focus.
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      onContextMenu={onContextMenu}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+    >
+      {account && (
+        <span
+          className="session-account-dot"
+          style={{ background: account.color || '#888888' }}
+          title={accountTitle(account, session)}
+          aria-label={`Account: ${account.label}`}
+          draggable={false}
+        />
+      )}
+      <div className="session-info">
+        {isEditing ? (
+          <input
+            className="session-name-input"
+            value={editingName}
+            onChange={(e) => onEditingNameChange(e.target.value)}
+            onBlur={onFinishEdit}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.key === 'Enter') onFinishEdit();
+              if (e.key === 'Escape') onCancelEdit();
+            }}
+            onClick={(e) => e.stopPropagation()}
+            autoFocus
+          />
+        ) : (
+          <span
+            className="session-name"
+            onDoubleClick={(e) => {
+              e.stopPropagation();
+              onStartEdit();
+            }}
+            title="Double-click to rename"
+          >
+            {session.name}
+          </span>
+        )}
+        <SessionStatsBadge sessionId={session.id} />
+      </div>
+      {showProvider && (
+        <span className="session-provider-badge" title={`Provider: ${provider}`} draggable={false}>
+          {provider}
+        </span>
+      )}
+      <span className={`status-pill ${session.state}`} draggable={false}>{session.state}</span>
+      <button
+        className="session-close"
+        draggable={false}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
+        title="Close session"
+        aria-label="Close session"
+      >
+        ×
+      </button>
+    </div>
+  );
+};

--- a/src/renderer/components/SidebarFilter.tsx
+++ b/src/renderer/components/SidebarFilter.tsx
@@ -1,0 +1,58 @@
+import React, { useRef } from 'react';
+
+interface SidebarFilterProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+/**
+ * Text box that narrows the sidebar to matching groups, sub-groups and
+ * sessions (#141).
+ *
+ * Ephemeral by design — the parent holds the value in plain component state so
+ * it resets on every launch.
+ */
+export const SidebarFilter: React.FC<SidebarFilterProps> = ({ value, onChange }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="sidebar-filter">
+      <div className="sidebar-filter-field">
+        <input
+          ref={inputRef}
+          className="sidebar-filter-input"
+          type="text"
+          value={value}
+          placeholder="Filter groups &amp; sessions…"
+          aria-label="Filter groups and sessions"
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key !== 'Escape') return;
+            if (value) {
+              // Consume the first Escape to clear the query.
+              e.stopPropagation();
+              onChange('');
+            } else {
+              // Already empty: step out so keyboard users have a route back,
+              // and let app-level dismiss handlers see the key.
+              inputRef.current?.blur();
+            }
+          }}
+        />
+        {value && (
+          <button
+            className="sidebar-filter-clear"
+            onClick={() => {
+              onChange('');
+              inputRef.current?.focus();
+            }}
+            title="Clear filter"
+            aria-label="Clear filter"
+          >
+            ×
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/components/__tests__/GroupColorPicker.test.tsx
+++ b/src/renderer/components/__tests__/GroupColorPicker.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * GroupColorPicker tests (#141).
+ *
+ * Run with: bun test src/renderer/components/__tests__/GroupColorPicker.test.tsx
+ */
+import React from 'react';
+import { describe, expect, test, afterEach } from 'bun:test';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { GroupColorPicker } from '../GroupColorPicker';
+
+afterEach(cleanup);
+
+const COLORS = ['#e06c75', '#98c379', '#61afef'];
+
+describe('GroupColorPicker', () => {
+  test('renders one labelled swatch per colour', () => {
+    render(<GroupColorPicker colors={COLORS} selected={COLORS[0]} onSelect={() => {}} />);
+    expect(document.querySelectorAll('.color-option').length).toBe(3);
+    expect(screen.getByLabelText('Set color to #98c379')).toBeTruthy();
+  });
+
+  test('only the applied colour is marked selected', () => {
+    render(<GroupColorPicker colors={COLORS} selected={COLORS[1]} onSelect={() => {}} />);
+    const selected = document.querySelectorAll('.color-option.selected');
+    expect(selected.length).toBe(1);
+    expect((selected[0] as HTMLElement).getAttribute('aria-label')).toBe('Set color to #98c379');
+  });
+
+  test('clicking a swatch reports that colour', () => {
+    const picked: string[] = [];
+    render(<GroupColorPicker colors={COLORS} selected={COLORS[0]} onSelect={(c) => picked.push(c)} />);
+    fireEvent.click(screen.getByLabelText('Set color to #61afef'));
+    expect(picked).toEqual(['#61afef']);
+  });
+
+  test('a colour matching nothing selects none', () => {
+    render(<GroupColorPicker colors={COLORS} selected="#000000" onSelect={() => {}} />);
+    expect(document.querySelectorAll('.color-option.selected').length).toBe(0);
+  });
+});

--- a/src/renderer/components/__tests__/SessionRow.test.tsx
+++ b/src/renderer/components/__tests__/SessionRow.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * SessionRow wiring tests (#141).
+ *
+ * Run with: bun test src/renderer/components/__tests__/SessionRow.test.tsx
+ */
+import React from 'react';
+import { describe, expect, test, afterEach } from 'bun:test';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { SessionRow } from '../SessionRow';
+import { ClaudeAccount, Session } from '../../../shared/types';
+
+afterEach(cleanup);
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 's1', name: 'login flow', groupId: 'g1', order: 0,
+    state: 'running', shellType: 'claude', provider: 'claude',
+    claudeAccountId: null,
+    ...overrides,
+  } as Session;
+}
+
+const noop = () => {};
+
+function renderRow(overrides: Record<string, unknown> = {}) {
+  const calls: Record<string, number> = {
+    select: 0, startEdit: 0, finishEdit: 0, cancelEdit: 0, close: 0, contextMenu: 0, dragStart: 0,
+  };
+  const props = {
+    session: session(),
+    isActive: false,
+    isFocused: false,
+    isDragging: false,
+    dropPosition: null,
+    draggable: true,
+    account: null as ClaudeAccount | null,
+    isEditing: false,
+    editingName: '',
+    onEditingNameChange: noop,
+    onStartEdit: () => { calls.startEdit++; },
+    onFinishEdit: () => { calls.finishEdit++; },
+    onCancelEdit: () => { calls.cancelEdit++; },
+    onSelect: () => { calls.select++; },
+    onContextMenu: () => { calls.contextMenu++; },
+    onDragStart: () => { calls.dragStart++; },
+    onDragEnd: noop,
+    onDragOver: noop,
+    onDrop: noop,
+    onClose: () => { calls.close++; },
+    ...overrides,
+  };
+  const utils = render(<SessionRow {...(props as never)} />);
+  return { calls, ...utils };
+}
+
+const row = () => document.querySelector('li.session') as HTMLLIElement;
+const selectButton = () => document.querySelector('button.session-select') as HTMLButtonElement;
+
+describe('SessionRow', () => {
+  test('renders the session name and state', () => {
+    renderRow();
+    expect(screen.getByText('login flow')).toBeTruthy();
+    expect(screen.getByText('running')).toBeTruthy();
+  });
+
+  test('is a list item so it can live in the group list', () => {
+    renderRow();
+    expect(row().tagName).toBe('LI');
+  });
+
+  test('clicking the row selects the session', () => {
+    const { calls } = renderRow();
+    fireEvent.click(selectButton());
+    expect(calls.select).toBe(1);
+  });
+
+  test('the close button closes without selecting', () => {
+    const { calls } = renderRow();
+    fireEvent.click(screen.getByLabelText('Close session'));
+    expect(calls.close).toBe(1);
+    expect(calls.select).toBe(0);
+  });
+
+  // The old markup scoped double-click to the name span only; the button now
+  // spans the account dot, name, provider badge and status pill.
+  test('double-click anywhere on the row starts a rename', () => {
+    const { calls } = renderRow();
+    fireEvent.doubleClick(screen.getByText('running')); // the status pill, not the name
+    expect(calls.startEdit).toBe(1);
+  });
+
+  test('double-click on the name also starts a rename', () => {
+    const { calls } = renderRow();
+    fireEvent.doubleClick(screen.getByText('login flow'));
+    expect(calls.startEdit).toBe(1);
+  });
+
+  test('editing swaps the row for an input and hides the select button', () => {
+    renderRow({ isEditing: true, editingName: 'login flow' });
+    expect(document.querySelector('input.session-name-input')).toBeTruthy();
+    expect(selectButton()).toBeNull();
+  });
+
+  test('Enter commits a rename and Escape cancels it', () => {
+    const { calls } = renderRow({ isEditing: true, editingName: 'new name' });
+    const input = document.querySelector('input.session-name-input')!;
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(calls.finishEdit).toBe(1);
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(calls.cancelEdit).toBe(1);
+  });
+
+  test('the active row is marked with aria-current', () => {
+    renderRow({ isActive: true });
+    expect(selectButton().getAttribute('aria-current')).toBe('true');
+    expect(row().className).toContain('active');
+  });
+
+  test('inactive rows omit aria-current entirely', () => {
+    renderRow({ isActive: false });
+    expect(selectButton().hasAttribute('aria-current')).toBe(false);
+  });
+
+  test('the row keeps a single tab stop — the close button', () => {
+    renderRow();
+    expect(selectButton().tabIndex).toBe(-1);
+    const close = screen.getByLabelText('Close session') as HTMLButtonElement;
+    expect(close.tabIndex).toBe(0);
+  });
+
+  test('drag is disabled when the caller says so', () => {
+    renderRow({ draggable: false });
+    expect(row().getAttribute('draggable')).toBe('false');
+  });
+
+  test('drag starts when enabled', () => {
+    const { calls } = renderRow({ draggable: true });
+    expect(row().getAttribute('draggable')).toBe('true');
+    fireEvent.dragStart(row());
+    expect(calls.dragStart).toBe(1);
+  });
+
+  test('right-click opens the context menu', () => {
+    const { calls } = renderRow();
+    fireEvent.contextMenu(row());
+    expect(calls.contextMenu).toBe(1);
+  });
+
+  test('drop-target position becomes a class', () => {
+    renderRow({ dropPosition: 'before' });
+    expect(row().className).toContain('drop-before');
+  });
+
+  test('the account dot appears only when an account resolves', () => {
+    renderRow();
+    expect(document.querySelector('.session-account-dot')).toBeNull();
+
+    cleanup();
+    renderRow({ account: { id: 'a1', label: 'Work', email: null, color: '#61afef' } });
+    const dot = document.querySelector('.session-account-dot') as HTMLElement;
+    expect(dot).toBeTruthy();
+    expect(dot.getAttribute('aria-label')).toBe('Account: Work');
+  });
+
+  test('the provider badge shows only for non-default providers', () => {
+    renderRow();
+    expect(document.querySelector('.session-provider-badge')).toBeNull();
+
+    cleanup();
+    renderRow({ session: session({ provider: 'codex' }) });
+    expect(document.querySelector('.session-provider-badge')).toBeTruthy();
+  });
+});

--- a/src/renderer/components/__tests__/SidebarFilter.test.tsx
+++ b/src/renderer/components/__tests__/SidebarFilter.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Sidebar filter UI acceptance tests (#141).
+ *
+ * Run with: bun test src/renderer/components/__tests__/SidebarFilter.test.tsx
+ */
+import React, { useState } from 'react';
+import { describe, expect, test, afterEach } from 'bun:test';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { SidebarFilter } from '../SidebarFilter';
+
+afterEach(cleanup);
+
+/** Mirrors how App.tsx owns the value, so tests exercise the real interaction. */
+function Harness({ initial = '' }: { initial?: string }) {
+  const [value, setValue] = useState(initial);
+  return (
+    <>
+      <SidebarFilter value={value} onChange={setValue} />
+      <span data-testid="value">{value}</span>
+    </>
+  );
+}
+
+const input = () => screen.getByLabelText('Filter groups and sessions') as HTMLInputElement;
+const currentValue = () => screen.getByTestId('value').textContent;
+
+describe('SidebarFilter', () => {
+  test('renders an empty, labelled input with a placeholder', () => {
+    render(<Harness />);
+    expect(input().value).toBe('');
+    expect(input().placeholder).toBe('Filter groups & sessions…');
+  });
+
+  test('typing updates the value', () => {
+    render(<Harness />);
+    fireEvent.change(input(), { target: { value: 'api' } });
+    expect(currentValue()).toBe('api');
+  });
+
+  test('the clear button is hidden while the box is empty', () => {
+    render(<Harness />);
+    expect(screen.queryByLabelText('Clear filter')).toBeNull();
+  });
+
+  test('the clear button appears once there is text', () => {
+    render(<Harness initial="api" />);
+    expect(screen.queryByLabelText('Clear filter')).not.toBeNull();
+  });
+
+  test('clicking clear empties the box and refocuses the input', () => {
+    render(<Harness initial="api" />);
+    fireEvent.click(screen.getByLabelText('Clear filter'));
+    expect(currentValue()).toBe('');
+    expect(document.activeElement).toBe(input());
+  });
+
+  test('Escape clears a non-empty box', () => {
+    render(<Harness initial="api" />);
+    fireEvent.keyDown(input(), { key: 'Escape' });
+    expect(currentValue()).toBe('');
+  });
+
+  test('Escape on a non-empty box does not reach app-level handlers', () => {
+    render(<Harness initial="api" />);
+    let sawEscape = false;
+    const listener = () => { sawEscape = true; };
+    document.addEventListener('keydown', listener);
+    fireEvent.keyDown(input(), { key: 'Escape', bubbles: true });
+    document.removeEventListener('keydown', listener);
+    expect(sawEscape).toBe(false);
+  });
+
+  test('Escape on an empty box blurs and still reaches app-level handlers', () => {
+    render(<Harness />);
+    input().focus();
+    let sawEscape = false;
+    const listener = () => { sawEscape = true; };
+    document.addEventListener('keydown', listener);
+    fireEvent.keyDown(input(), { key: 'Escape', bubbles: true });
+    document.removeEventListener('keydown', listener);
+    expect(sawEscape).toBe(true);
+    expect(document.activeElement).not.toBe(input());
+  });
+
+  test('other keys are left alone', () => {
+    render(<Harness initial="api" />);
+    fireEvent.keyDown(input(), { key: 'a' });
+    expect(currentValue()).toBe('api');
+  });
+});

--- a/src/renderer/hooks/__tests__/useKeyboardShortcuts.test.ts
+++ b/src/renderer/hooks/__tests__/useKeyboardShortcuts.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Keyboard-shortcut target guard tests (#141).
+ *
+ * Bare navigation keys must not fire while the user types in a text field —
+ * the sidebar's collapse/expand handlers persist `collapsed` to the database.
+ *
+ * Run with: bun test src/renderer/hooks/__tests__
+ */
+import { describe, expect, test } from 'bun:test';
+import { isEditableTarget } from '../useKeyboardShortcuts';
+
+function el(tagName: string, isContentEditable = false) {
+  return { tagName, isContentEditable } as unknown as EventTarget;
+}
+
+describe('isEditableTarget', () => {
+  test('text inputs are editable', () => {
+    expect(isEditableTarget(el('INPUT'))).toBe(true);
+  });
+
+  test('textareas are editable (covers the terminal hidden textarea)', () => {
+    expect(isEditableTarget(el('TEXTAREA'))).toBe(true);
+  });
+
+  test('selects are editable', () => {
+    expect(isEditableTarget(el('SELECT'))).toBe(true);
+  });
+
+  test('contenteditable elements are editable', () => {
+    expect(isEditableTarget(el('DIV', true))).toBe(true);
+  });
+
+  test('lowercase tag names are handled', () => {
+    expect(isEditableTarget(el('input'))).toBe(true);
+  });
+
+  test('ordinary elements are not editable', () => {
+    expect(isEditableTarget(el('DIV'))).toBe(false);
+    expect(isEditableTarget(el('BUTTON'))).toBe(false);
+  });
+
+  test('null and malformed targets are not editable', () => {
+    expect(isEditableTarget(null)).toBe(false);
+    expect(isEditableTarget({} as EventTarget)).toBe(false);
+    expect(isEditableTarget({ tagName: 42 } as unknown as EventTarget)).toBe(false);
+  });
+});

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -17,6 +17,22 @@ interface ShortcutHandlers {
   onToggleAnalytics?: () => void;
 }
 
+/**
+ * True when a keystroke originated inside a text-entry surface — the sidebar
+ * filter box, an inline rename input, or the terminal's hidden textarea.
+ *
+ * Such targets own the *unmodified* keys (arrows, Enter): stealing them would
+ * move the sidebar selection while the user is editing text, and the sidebar's
+ * arrow handlers persist `collapsed` to the database. Modifier shortcuts
+ * (Ctrl+N, Ctrl+W, …) are deliberately NOT affected and still work everywhere.
+ */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  const el = target as (HTMLElement & { tagName?: string }) | null;
+  if (!el || typeof el.tagName !== 'string') return false;
+  const tag = el.tagName.toUpperCase();
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable === true;
+}
+
 export function useKeyboardShortcuts(handlers: ShortcutHandlers) {
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     const isMod = e.ctrlKey || e.metaKey;
@@ -67,21 +83,25 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers) {
       handlers.onNewSubGroup?.();
     }
 
-    // Arrow keys (for sidebar navigation)
-    if (e.key === 'ArrowUp') {
-      handlers.onNavigateUp?.();
-    }
-    if (e.key === 'ArrowDown') {
-      handlers.onNavigateDown?.();
-    }
-    if (e.key === 'ArrowLeft') {
-      handlers.onCollapse?.();
-    }
-    if (e.key === 'ArrowRight') {
-      handlers.onExpand?.();
-    }
-    if (e.key === 'Enter' && handlers.onSelect) {
-      handlers.onSelect();
+    // Arrow keys / Enter (for sidebar navigation). These are unmodified keys, so
+    // they must never fire while the user is typing in a text field — the
+    // collapse/expand handlers persist `collapsed` to the database.
+    if (!isEditableTarget(e.target)) {
+      if (e.key === 'ArrowUp') {
+        handlers.onNavigateUp?.();
+      }
+      if (e.key === 'ArrowDown') {
+        handlers.onNavigateDown?.();
+      }
+      if (e.key === 'ArrowLeft') {
+        handlers.onCollapse?.();
+      }
+      if (e.key === 'ArrowRight') {
+        handlers.onExpand?.();
+      }
+      if (e.key === 'Enter' && handlers.onSelect) {
+        handlers.onSelect();
+      }
     }
 
     // Ctrl+Shift+A = Analytics dashboard

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -33,82 +33,54 @@ export function isEditableTarget(target: EventTarget | null): boolean {
   return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable === true;
 }
 
+/**
+ * Chord shortcuts (Ctrl/Cmd based). Keyed by `shift:key`, so each entry is a
+ * flat lookup rather than another branch in one long conditional.
+ *
+ * Every one of these calls preventDefault; navigation keys deliberately do not.
+ */
+const MODIFIER_SHORTCUTS: Record<string, (h: ShortcutHandlers) => void> = {
+  // Ctrl+N and Ctrl+Q previously ignored Shift, so both variants are listed to
+  // keep the existing behaviour exactly.
+  'false:n': h => h.onNewSession(),
+  'true:n': h => h.onNewSession(),
+  'false:q': h => h.onFocusSidebar(),
+  'true:q': h => h.onFocusSidebar(),
+  'false:tab': h => h.onNextSession(),
+  'true:tab': h => h.onPrevSession(),
+  'true:w': h => h.onNextWaiting(),
+  'false:w': h => h.onCloseSession(),
+  'false:g': h => h.onNewGroup(),
+  'true:g': h => h.onNewSubGroup?.(),
+  'true:a': h => h.onToggleAnalytics?.(),
+};
+
+/** Unmodified sidebar navigation keys. */
+const NAVIGATION_KEYS: Record<string, (h: ShortcutHandlers) => void> = {
+  ArrowUp: h => h.onNavigateUp?.(),
+  ArrowDown: h => h.onNavigateDown?.(),
+  ArrowLeft: h => h.onCollapse?.(),
+  ArrowRight: h => h.onExpand?.(),
+  Enter: h => h.onSelect?.(),
+};
+
 export function useKeyboardShortcuts(handlers: ShortcutHandlers) {
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    const isMod = e.ctrlKey || e.metaKey;
-    const key = e.key.toLowerCase();
-
-    if (isMod && key === 'n') {
-      e.preventDefault();
-      handlers.onNewSession();
-    }
-
-    if (isMod && e.key === 'Tab') {
-      e.preventDefault();
-      if (e.shiftKey) {
-        handlers.onPrevSession();
-      } else {
-        handlers.onNextSession();
+    if (e.ctrlKey || e.metaKey) {
+      const chord = MODIFIER_SHORTCUTS[`${e.shiftKey}:${e.key.toLowerCase()}`];
+      if (chord) {
+        e.preventDefault();
+        chord(handlers);
+        return;
       }
+      // No chord matched (e.g. Ctrl+ArrowUp) — fall through to navigation, as
+      // the original sequential checks did.
     }
 
-    // Ctrl+Shift+W = Next waiting (check before Ctrl+W)
-    if (isMod && e.shiftKey && key === 'w') {
-      e.preventDefault();
-      handlers.onNextWaiting();
-      return;
-    }
-
-    // Ctrl+W = Close session
-    if (isMod && key === 'w') {
-      e.preventDefault();
-      handlers.onCloseSession();
-    }
-
-    // Ctrl+Q = Focus sidebar
-    if (isMod && key === 'q') {
-      e.preventDefault();
-      handlers.onFocusSidebar();
-    }
-
-    // Ctrl+G = New group
-    if (isMod && !e.shiftKey && key === 'g') {
-      e.preventDefault();
-      handlers.onNewGroup();
-    }
-
-    // Ctrl+Shift+G = New sub-group
-    if (isMod && e.shiftKey && key === 'g') {
-      e.preventDefault();
-      handlers.onNewSubGroup?.();
-    }
-
-    // Arrow keys / Enter (for sidebar navigation). These are unmodified keys, so
-    // they must never fire while the user is typing in a text field — the
-    // collapse/expand handlers persist `collapsed` to the database.
-    if (!isEditableTarget(e.target)) {
-      if (e.key === 'ArrowUp') {
-        handlers.onNavigateUp?.();
-      }
-      if (e.key === 'ArrowDown') {
-        handlers.onNavigateDown?.();
-      }
-      if (e.key === 'ArrowLeft') {
-        handlers.onCollapse?.();
-      }
-      if (e.key === 'ArrowRight') {
-        handlers.onExpand?.();
-      }
-      if (e.key === 'Enter' && handlers.onSelect) {
-        handlers.onSelect();
-      }
-    }
-
-    // Ctrl+Shift+A = Analytics dashboard
-    if (isMod && e.shiftKey && key === 'a') {
-      e.preventDefault();
-      handlers.onToggleAnalytics?.();
-    }
+    // Unmodified keys must never fire while the user is typing in a text field —
+    // the collapse/expand handlers persist `collapsed` to the database.
+    if (isEditableTarget(e.target)) return;
+    NAVIGATION_KEYS[e.key]?.(handlers);
   }, [handlers]);
 
   useEffect(() => {

--- a/src/renderer/store/__tests__/groupFilter.test.ts
+++ b/src/renderer/store/__tests__/groupFilter.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Sidebar group/session filter tests (#141).
+ *
+ * Run with: bun test src/renderer/store/__tests__
+ */
+import { describe, expect, test } from 'bun:test';
+import { computeGroupFilter } from '../groupFilter';
+import { Group, Session } from '../../../shared/types';
+
+function group(id: string, name: string, parentId: string | null = null): Group {
+  return {
+    id,
+    name,
+    color: '#61afef',
+    workingDir: '',
+    order: 0,
+    createdAt: new Date(0),
+    parentId,
+    collapsed: false,
+    claudeAccountId: null,
+  } as Group;
+}
+
+function session(id: string, name: string, groupId: string): Session {
+  return { id, name, groupId } as Session;
+}
+
+// Tree used by most tests:
+//   API        (top)  -> sessions: s-api
+//     Auth     (sub)  -> sessions: s-login
+//     Billing  (sub)  -> sessions: s-invoice
+//   Web        (top)  -> sessions: s-home
+const GROUPS = [
+  group('api', 'API'),
+  group('api-auth', 'Auth', 'api'),
+  group('api-bill', 'Billing', 'api'),
+  group('web', 'Web'),
+];
+const SESSIONS = [
+  session('s-api', 'api scratch', 'api'),
+  session('s-login', 'login flow', 'api-auth'),
+  session('s-invoice', 'invoice bug', 'api-bill'),
+  session('s-home', 'homepage', 'web'),
+];
+
+describe('computeGroupFilter', () => {
+  test('empty query is inactive with empty sets', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, '');
+    expect(r.active).toBe(false);
+    expect(r.visibleGroupIds.size).toBe(0);
+    expect(r.visibleSessionIds.size).toBe(0);
+  });
+
+  test('whitespace-only query is inactive', () => {
+    expect(computeGroupFilter(GROUPS, SESSIONS, '   ').active).toBe(false);
+  });
+
+  test('matching a top-level group reveals its whole subtree', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, 'api');
+    expect(r.active).toBe(true);
+    expect([...r.visibleGroupIds].sort()).toEqual(['api', 'api-auth', 'api-bill']);
+    expect([...r.visibleSessionIds].sort()).toEqual(['s-api', 's-invoice', 's-login']);
+  });
+
+  test('match is case-insensitive and trims the query', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, '  WEB  ');
+    expect(r.visibleGroupIds.has('web')).toBe(true);
+    expect(r.visibleSessionIds.has('s-home')).toBe(true);
+  });
+
+  test('matching a sub-group keeps the parent visible but hides siblings', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, 'auth');
+    expect([...r.visibleGroupIds].sort()).toEqual(['api', 'api-auth']);
+    // parent is context only: its own session is not revealed
+    expect([...r.visibleSessionIds]).toEqual(['s-login']);
+  });
+
+  test('matching a session in a top-level group shows only that session', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, 'scratch');
+    expect([...r.visibleGroupIds]).toEqual(['api']);
+    expect([...r.visibleSessionIds]).toEqual(['s-api']);
+  });
+
+  test('matching a session in a sub-group reveals sub-group and parent', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, 'invoice');
+    expect([...r.visibleGroupIds].sort()).toEqual(['api', 'api-bill']);
+    expect([...r.visibleSessionIds]).toEqual(['s-invoice']);
+  });
+
+  test('no matches leaves active true with empty sets', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, 'zzzz');
+    expect(r.active).toBe(true);
+    expect(r.visibleGroupIds.size).toBe(0);
+    expect(r.visibleSessionIds.size).toBe(0);
+  });
+
+  test('a name-matched group reveals descendants whose names do not match', () => {
+    const r = computeGroupFilter(GROUPS, SESSIONS, 'billing');
+    expect([...r.visibleGroupIds].sort()).toEqual(['api', 'api-bill']);
+    // 'invoice bug' does not contain 'billing' but is revealed by its group
+    expect([...r.visibleSessionIds]).toEqual(['s-invoice']);
+  });
+
+  test('a session whose group is missing does not throw', () => {
+    const r = computeGroupFilter(GROUPS, [session('orphan', 'orphan', 'gone')], 'orphan');
+    expect(r.visibleSessionIds.has('orphan')).toBe(true);
+    expect(r.visibleGroupIds.size).toBe(0);
+  });
+
+  test('returns fresh sets on each call', () => {
+    const a = computeGroupFilter(GROUPS, SESSIONS, '');
+    const b = computeGroupFilter(GROUPS, SESSIONS, '');
+    expect(a.visibleGroupIds).not.toBe(b.visibleGroupIds);
+  });
+
+  test('does not mutate its inputs', () => {
+    const groups = [...GROUPS];
+    const sessions = [...SESSIONS];
+    computeGroupFilter(groups, sessions, 'api');
+    expect(groups).toEqual(GROUPS);
+    expect(sessions).toEqual(SESSIONS);
+  });
+
+  test('survives a cyclic parentId without infinite recursion', () => {
+    const a = group('a', 'Alpha', 'b');
+    const b = group('b', 'Beta', 'a');
+    const r = computeGroupFilter([a, b], [], 'alpha');
+    expect(r.visibleGroupIds.has('a')).toBe(true);
+    expect(r.visibleGroupIds.has('b')).toBe(true);
+  });
+});

--- a/src/renderer/store/__tests__/groupFilter.test.ts
+++ b/src/renderer/store/__tests__/groupFilter.test.ts
@@ -4,7 +4,7 @@
  * Run with: bun test src/renderer/store/__tests__
  */
 import { describe, expect, test } from 'bun:test';
-import { computeGroupFilter } from '../groupFilter';
+import { computeGroupFilter, buildNavItems } from '../groupFilter';
 import { Group, Session } from '../../../shared/types';
 
 function group(id: string, name: string, parentId: string | null = null): Group {
@@ -114,11 +114,17 @@ describe('computeGroupFilter', () => {
   });
 
   test('does not mutate its inputs', () => {
-    const groups = [...GROUPS];
-    const sessions = [...SESSIONS];
+    // Deep snapshots — a shallow [...copy] shares element references, so
+    // per-element mutation would go undetected.
+    const groups = GROUPS.map(g => ({ ...g }));
+    const sessions = SESSIONS.map(s => ({ ...s }));
+    const groupsBefore = JSON.stringify(groups);
+    const sessionsBefore = JSON.stringify(sessions);
+
     computeGroupFilter(groups, sessions, 'api');
-    expect(groups).toEqual(GROUPS);
-    expect(sessions).toEqual(SESSIONS);
+
+    expect(JSON.stringify(groups)).toBe(groupsBefore);
+    expect(JSON.stringify(sessions)).toBe(sessionsBefore);
   });
 
   test('survives a cyclic parentId without infinite recursion', () => {
@@ -127,5 +133,53 @@ describe('computeGroupFilter', () => {
     const r = computeGroupFilter([a, b], [], 'alpha');
     expect(r.visibleGroupIds.has('a')).toBe(true);
     expect(r.visibleGroupIds.has('b')).toBe(true);
+  });
+});
+
+describe('buildNavItems', () => {
+  const noFilter = () => computeGroupFilter(GROUPS, SESSIONS, '');
+
+  test('unfiltered list walks groups, their sessions, then sub-groups', () => {
+    const items = buildNavItems(GROUPS, SESSIONS, noFilter());
+    expect(items.map(i => i.id)).toEqual([
+      'api', 's-api', 'api-auth', 's-login', 'api-bill', 's-invoice',
+      'web', 's-home',
+    ]);
+  });
+
+  test('collapsed group hides its children when no filter is active', () => {
+    const collapsed = GROUPS.map(g => (g.id === 'api' ? { ...g, collapsed: true } : g));
+    const items = buildNavItems(collapsed, SESSIONS, computeGroupFilter(collapsed, SESSIONS, ''));
+    expect(items.map(i => i.id)).toEqual(['api', 'web', 's-home']);
+  });
+
+  test('only rendered rows are navigable while filtering', () => {
+    const items = buildNavItems(GROUPS, SESSIONS, computeGroupFilter(GROUPS, SESSIONS, 'invoice'));
+    // parent shown as context, sub-group and its matching session navigable
+    expect(items.map(i => i.id)).toEqual(['api', 'api-bill', 's-invoice']);
+  });
+
+  test('a collapsed group is navigable while filtering (matches auto-expand)', () => {
+    const collapsed = GROUPS.map(g => (g.id === 'api' ? { ...g, collapsed: true } : g));
+    const items = buildNavItems(collapsed, SESSIONS, computeGroupFilter(collapsed, SESSIONS, 'invoice'));
+    // force-expanded on screen, so the row must be reachable by keyboard
+    expect(items.map(i => i.id)).toEqual(['api', 'api-bill', 's-invoice']);
+  });
+
+  test('no matches yields an empty nav list', () => {
+    const items = buildNavItems(GROUPS, SESSIONS, computeGroupFilter(GROUPS, SESSIONS, 'zzzz'));
+    expect(items).toEqual([]);
+  });
+
+  test('rows are ordered by their order field', () => {
+    const groups = [group('g', 'G')];
+    const sessions = [
+      session('s2', 'second', 'g'),
+      session('s1', 'first', 'g'),
+    ];
+    sessions[0].order = 2;
+    sessions[1].order = 1;
+    const items = buildNavItems(groups, sessions, computeGroupFilter(groups, sessions, ''));
+    expect(items.map(i => i.id)).toEqual(['g', 's1', 's2']);
   });
 });

--- a/src/renderer/store/groupFilter.ts
+++ b/src/renderer/store/groupFilter.ts
@@ -94,3 +94,59 @@ export function computeGroupFilter(
 
   return { active: true, visibleGroupIds, visibleSessionIds };
 }
+
+export interface NavItem {
+  id: string;
+  type: 'group' | 'session';
+  parentId?: string;
+}
+
+const byOrder = <T extends { order: number }>(a: T, b: T) => a.order - b.order;
+
+/**
+ * Flat top-to-bottom list of the sidebar rows that are actually rendered.
+ *
+ * Keyboard navigation walks this list, so it must mirror the render pass
+ * exactly: rows hidden by the filter are excluded, and a collapsed group is
+ * treated as expanded while the filter is active (matching the view-only
+ * auto-expand). Otherwise arrow keys land on invisible rows, or skip rows the
+ * user can plainly see.
+ */
+export function buildNavItems(
+  groups: Group[],
+  sessions: Session[],
+  filter: GroupFilterResult,
+): NavItem[] {
+  const items: NavItem[] = [];
+
+  const groupVisible = (g: Group) => !filter.active || filter.visibleGroupIds.has(g.id);
+  const sessionVisible = (s: Session) => !filter.active || filter.visibleSessionIds.has(s.id);
+  const expanded = (g: Group) => filter.active || !g.collapsed;
+
+  const sessionsOf = (groupId: string) =>
+    sessions.filter(s => s.groupId === groupId && sessionVisible(s)).sort(byOrder);
+
+  const subGroupsOf = (parentId: string) =>
+    groups.filter(g => g.parentId === parentId && groupVisible(g)).sort(byOrder);
+
+  const topLevel = groups.filter(g => !g.parentId && groupVisible(g)).sort(byOrder);
+
+  for (const group of topLevel) {
+    items.push({ id: group.id, type: 'group' });
+    if (!expanded(group)) continue;
+
+    for (const s of sessionsOf(group.id)) {
+      items.push({ id: s.id, type: 'session', parentId: group.id });
+    }
+
+    for (const subGroup of subGroupsOf(group.id)) {
+      items.push({ id: subGroup.id, type: 'group', parentId: group.id });
+      if (!expanded(subGroup)) continue;
+      for (const s of sessionsOf(subGroup.id)) {
+        items.push({ id: s.id, type: 'session', parentId: subGroup.id });
+      }
+    }
+  }
+
+  return items;
+}

--- a/src/renderer/store/groupFilter.ts
+++ b/src/renderer/store/groupFilter.ts
@@ -1,0 +1,96 @@
+import { Group, Session } from '../../shared/types';
+
+/**
+ * Result of applying the sidebar filter (#141).
+ *
+ * `visibleGroupIds` covers both top-level groups and sub-groups; the renderer
+ * only ever asks "should this row render?", so one set serves both levels.
+ */
+export interface GroupFilterResult {
+  /** False when the query is empty/whitespace — callers render everything. */
+  active: boolean;
+  visibleGroupIds: Set<string>;
+  visibleSessionIds: Set<string>;
+}
+
+/**
+ * Decide which groups, sub-groups and sessions survive a text filter.
+ *
+ * Rules:
+ *  - A group matched by name reveals its entire subtree (sub-groups + sessions).
+ *  - A matching sub-group or session keeps its ancestors visible as context,
+ *    without revealing that ancestor's other children.
+ *  - Anything with no match in its subtree is omitted.
+ *
+ * Pure and total: no I/O, no mutation of the inputs.
+ */
+export function computeGroupFilter(
+  groups: Group[],
+  sessions: Session[],
+  rawQuery: string,
+): GroupFilterResult {
+  const visibleGroupIds = new Set<string>();
+  const visibleSessionIds = new Set<string>();
+
+  const query = rawQuery.trim().toLowerCase();
+  if (!query) {
+    return { active: false, visibleGroupIds, visibleSessionIds };
+  }
+
+  const byId = new Map(groups.map(g => [g.id, g]));
+
+  const childrenOf = new Map<string, Group[]>();
+  for (const g of groups) {
+    if (!g.parentId) continue;
+    const siblings = childrenOf.get(g.parentId);
+    if (siblings) siblings.push(g);
+    else childrenOf.set(g.parentId, [g]);
+  }
+
+  const sessionsOf = new Map<string, Session[]>();
+  for (const s of sessions) {
+    const existing = sessionsOf.get(s.groupId);
+    if (existing) existing.push(s);
+    else sessionsOf.set(s.groupId, [s]);
+  }
+
+  const matches = (name: string) => name.toLowerCase().includes(query);
+
+  // Guards against re-walking a subtree, and against infinite recursion if a
+  // malformed parentId ever produced a cycle.
+  const revealed = new Set<string>();
+
+  /** Reveal a matched group and everything beneath it. */
+  const revealSubtree = (group: Group) => {
+    if (revealed.has(group.id)) return;
+    revealed.add(group.id);
+    visibleGroupIds.add(group.id);
+    for (const s of sessionsOf.get(group.id) ?? []) visibleSessionIds.add(s.id);
+    for (const child of childrenOf.get(group.id) ?? []) revealSubtree(child);
+  };
+
+  /** Reveal a group and its ancestors as context (their children untouched). */
+  const revealAncestry = (groupId: string | null | undefined) => {
+    const seen = new Set<string>();
+    let current = groupId ? byId.get(groupId) : undefined;
+    while (current && !seen.has(current.id)) {
+      seen.add(current.id);
+      visibleGroupIds.add(current.id);
+      current = current.parentId ? byId.get(current.parentId) : undefined;
+    }
+  };
+
+  for (const group of groups) {
+    if (!matches(group.name)) continue;
+    revealSubtree(group);
+    revealAncestry(group.parentId);
+  }
+
+  for (const s of sessions) {
+    if (!matches(s.name)) continue;
+    visibleSessionIds.add(s.id);
+    revealAncestry(s.groupId);
+  }
+
+  return { active: true, visibleGroupIds, visibleSessionIds };
+}

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -240,6 +240,7 @@ body {
 }
 
 .sidebar-filter-empty {
+  display: block;
   color: #666;
   font-size: 12px;
   font-style: italic;
@@ -279,6 +280,9 @@ body {
 
 /* Groups */
 .group {
+  /* Rendered as <li> inside .group-container <ul> for semantics; no marker. */
+  list-style: none;
+  display: block;
   margin-bottom: 16px;
 }
 
@@ -788,6 +792,7 @@ body {
 
 /* Sub-groups */
 .group-container {
+  list-style: none;
   margin-bottom: 8px;
 }
 

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -177,11 +177,22 @@ body {
 
 /* Sidebar text filter (#141) */
 .sidebar-filter {
+  /* Sticky so the box stays reachable when the list is long — which is the
+     whole reason the filter exists. */
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: #252526;
+  padding-bottom: 8px;
+  margin-bottom: 2px;
+}
+
+.sidebar-filter-field {
   position: relative;
-  margin-bottom: 10px;
 }
 
 .sidebar-filter-input {
+  display: block;
   width: 100%;
   box-sizing: border-box;
   background: #1e1e1e;
@@ -296,8 +307,14 @@ body {
   flex-shrink: 0;
 }
 
-.group-chevron:hover {
+.group-chevron:hover:not(:disabled) {
   color: #d4d4d4;
+}
+
+/* Collapse is unavailable while filtering — rows are force-expanded (#141). */
+.group-chevron:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 
 .color-picker {

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -183,6 +183,12 @@ body {
   top: 0;
   z-index: 5;
   background: #252526;
+  /* The scrollport is the sidebar's padding box, so a bare `top: 0` would let
+     the box slide up into the 12px top padding. Pulling it up by that amount
+     and re-adding it as padding keeps the unstuck layout identical while
+     preserving an opaque top gutter once it sticks. */
+  margin-top: -12px;
+  padding-top: 12px;
   padding-bottom: 8px;
   margin-bottom: 2px;
 }

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -239,6 +239,32 @@ body {
   color: #ddd;
 }
 
+.group-sessions {
+  list-style: none;
+}
+
+/* The whole row is one native button so keyboard/AT support is free. */
+.session-select {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.session-select:focus-visible {
+  outline: 1px solid #5a7aff;
+  outline-offset: -1px;
+}
+
 .sidebar-filter-empty {
   display: block;
   color: #666;
@@ -438,6 +464,8 @@ body {
 
 /* Sessions */
 .session {
+  /* Rendered as <li> inside the .group-sessions <ul>; no marker. */
+  list-style: none;
   display: flex;
   align-items: center;
   gap: 8px;

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -69,7 +69,10 @@ body {
   grid-area: sidebar;
   background: #252526;
   border-right: 1px solid #3c3c3c;
-  padding: 12px;
+  /* No top padding: it would push the sticky filter's containing block down,
+     letting scrolled rows leak into the gap above it (#141). The gutter lives
+     on .sidebar-header instead. */
+  padding: 0 12px 12px;
   position: relative;
   overflow-y: auto;
   overflow-x: hidden;
@@ -167,7 +170,8 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
+  padding-top: 12px;
+  margin-bottom: 0;
 }
 
 .sidebar-header-actions {
@@ -183,12 +187,10 @@ body {
   top: 0;
   z-index: 5;
   background: #252526;
-  /* The scrollport is the sidebar's padding box, so a bare `top: 0` would let
-     the box slide up into the 12px top padding. Pulling it up by that amount
-     and re-adding it as padding keeps the unstuck layout identical while
-     preserving an opaque top gutter once it sticks. */
-  margin-top: -12px;
-  padding-top: 12px;
+  /* Its own padding supplies the gap under the header when unstuck, and an
+     opaque gutter above the input once stuck. No negative margin — that would
+     paint over the header's buttons. */
+  padding-top: 8px;
   padding-bottom: 8px;
   margin-bottom: 2px;
 }

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -175,6 +175,58 @@ body {
   gap: 4px;
 }
 
+/* Sidebar text filter (#141) */
+.sidebar-filter {
+  position: relative;
+  margin-bottom: 10px;
+}
+
+.sidebar-filter-input {
+  width: 100%;
+  box-sizing: border-box;
+  background: #1e1e1e;
+  border: 1px solid #3c3c3c;
+  border-radius: 3px;
+  color: #ddd;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 5px 22px 5px 8px;
+}
+
+.sidebar-filter-input::placeholder {
+  color: #666;
+}
+
+.sidebar-filter-input:focus {
+  outline: none;
+  border-color: #5a7aff;
+}
+
+.sidebar-filter-clear {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 3px;
+}
+
+.sidebar-filter-clear:hover {
+  color: #ddd;
+}
+
+.sidebar-filter-empty {
+  color: #666;
+  font-size: 12px;
+  font-style: italic;
+  padding: 8px 2px;
+}
+
 .sidebar-account {
   margin-bottom: 12px;
   padding-bottom: 12px;

--- a/test-setup/happydom.ts
+++ b/test-setup/happydom.ts
@@ -1,0 +1,8 @@
+/**
+ * Registers a DOM implementation so component tests can render React.
+ *
+ * Wired in via `bunfig.toml` -> [test] preload. Pure-logic tests are unaffected.
+ */
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+
+GlobalRegistrator.register();

--- a/test-setup/happydom.ts
+++ b/test-setup/happydom.ts
@@ -1,8 +1,39 @@
 /**
  * Registers a DOM implementation so component tests can render React.
  *
- * Wired in via `bunfig.toml` -> [test] preload. Pure-logic tests are unaffected.
+ * Wired in via `bunfig.toml` -> [test] preload, which Bun applies to EVERY test
+ * file in the repo — including `relay/`, which has no DOM but does exercise
+ * fetch/WebSocket. happy-dom overwrites those network globals with its own
+ * implementations (its `Headers`, for one, strips `cookie` as a forbidden
+ * header), which breaks those suites.
+ *
+ * So: register happy-dom for the DOM, then put Bun's native network/crypto
+ * globals back. Component tests only need document/window/HTMLElement.
  */
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 
+// Capture Bun's natives before happy-dom replaces them.
+// Network/crypto only. DOM-side globals (Event, EventTarget, MessageEvent, …)
+// must stay happy-dom's, or its event dispatch and React's synthetic events
+// stop agreeing.
+const preserved = [
+  'fetch', 'Request', 'Response', 'Headers', 'FormData', 'Blob', 'File',
+  'WebSocket', 'crypto', 'TextEncoder', 'TextDecoder',
+  'ReadableStream', 'WritableStream', 'TransformStream',
+] as const;
+
+const natives = new Map<string, unknown>();
+for (const name of preserved) {
+  if (name in globalThis) natives.set(name, (globalThis as Record<string, unknown>)[name]);
+}
+
 GlobalRegistrator.register();
+
+// Restore the non-DOM globals happy-dom shadowed.
+for (const [name, value] of natives) {
+  Object.defineProperty(globalThis, name, {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
Closes #141

Adds a text box at the top of the sidebar that narrows the tree as you type — for users with enough groups/sub-groups that scrolling to find one is painful.

## Behaviour

- Matches **group, sub-group and session names** (case-insensitive substring).
- A group matched by name reveals its **whole subtree**.
- A matching sub-group or session keeps its **parent visible as context**, without revealing the parent's other children.
- Subtrees with no match are hidden; an empty query renders the sidebar exactly as before.
- Collapsed groups render expanded while filtering — **view-only**, the persisted `collapsed` flag is never written.
- Ephemeral (clears on restart), sticky so it stays reachable, with a `×` button and Escape-to-clear.

## Implementation

Matching lives in a pure, unit-tested module (`src/renderer/store/groupFilter.ts`); `App.tsx` consumes two id sets. The filter input is its own component (`SidebarFilter.tsx`).

`buildNavItems` replaces the inline nav list so **keyboard navigation walks exactly the rendered rows** — previously it would have walked hidden rows and skipped auto-expanded ones.

## Fixes to existing behaviour found along the way

- **`useKeyboardShortcuts` had no target guard.** Bare Arrow/Enter keys on `window` fired sidebar navigation while typing in *any* input — and the arrow handlers persist `collapsed` to the database. Now guarded via `isEditableTarget`; modifier shortcuts (Ctrl+N/W/Q/G/Tab) are deliberately unaffected, including in the terminal.
- **Arrow keys crashed the renderer on an empty sidebar** (`navItems[-1]`). Guarded.
- Drag is disabled while filtering, since drop position is computed against unfiltered neighbours.

## Testing

- **285 tests, 284 passing.** The one failure (`ChatParser snapshot fixtures > 06-response`) is pre-existing — verified by stashing this branch and reproducing it on a clean tree.
- New: 19 pure unit tests for the filter and nav builder, 7 for the keyboard guard, 9 DOM tests for the filter UI (happy-dom + @testing-library/react, added as devDependencies).
- `tsc --noEmit` clean; `bun run build` passes end to end.
- Sticky-positioning behaviour verified by measuring hit-testing in Chromium.

## Review

Three adversarial review layers plus two verification rounds. Every finding is closed — including two defects the verification rounds caught in my own fixes (a rename path that wiped the filter on a mere click, and a DOM test preload that broke 9 relay tests).

> Note: `node_modules` was missing three declared deps (`@xterm/headless`, `@xterm/addon-serialize`, `web-push`), so `bun run build:renderer` failed on `development` too. `bun install` fixed it; no dependency versions were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)