### PR TITLE
Fix duplicate .group-sessions selector failing the quality gate on development

### DIFF
--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -239,10 +239,6 @@ body {
   color: #ddd;
 }
 
-.group-sessions {
-  list-style: none;
-}
-
 /* The whole row is one native button so keyboard/AT support is free. */
 .session-select {
   flex: 1;
@@ -460,6 +456,8 @@ body {
 
 .group-sessions {
   margin-left: 16px;
+  /* Rendered as a <ul> of session <li>s; no markers. */
+  list-style: none;
 }
 
 /* Sessions */


### PR DESCRIPTION
Closes #144

`development` has been red since #143 merged:

```
DEVELOPMENT GATE: ERROR
  FAIL new_violations: actual=1 GT 0

src/renderer/styles/global.css:461 [css:S4666 MAJOR]
Unexpected duplicate selector ".group-sessions", first used at line 242
```

#143 added a second `.group-sessions` block rather than extending the one already at line 461. This folds `list-style: none` into that existing rule and drops the duplicate.

**Why the PR gate didn't catch it:** `css:S4666` reports on the *second* occurrence — line 461, which is unchanged pre-existing code attributed to another author. That put it outside the PR's new-code set, so it only surfaced once `development` was analysed as a branch.

**No visual change.** The two declarations are non-overlapping and both were already taking effect. Confirmed in Chromium after the merge:

```
{"marginLeft":"16px","listStyleType":"none"}
```

Renderer suite 78/78, `build:renderer` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)