### PR TITLE
Add sidebar toggle to show only groups with active sessions

### DIFF
--- a/docs/superpowers/plans/2026-07-30-active-sessions-toggle.md
+++ b/docs/superpowers/plans/2026-07-30-active-sessions-toggle.md
@@ -1,0 +1,407 @@
+# Active-Sessions Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement task-by-task.
+
+**Goal:** A persisted sidebar toggle that hides every group without an active session, combining with the text filter as AND.
+
+**Architecture:** Extend the pure `computeGroupFilter` with a fourth `activeOnly` param; `App.tsx` holds a persisted `showActiveOnly` state and passes it through. The toggle button lives inside `SidebarFilter`.
+
+## Global Constraints
+
+- `bun:test`; test files in `__tests__/` next to code; run `bun test <path>`.
+- `Session.state: 'idle' | 'working' | 'waiting' | 'error' | 'stopped'`. Active = `!== 'stopped'`.
+- Preferences: `window.electronAPI.getPreference(key): Promise<string|null>` / `setPreference(key, value): Promise<void>`. Key `sidebar.showActiveOnly`, `'true'`/`'false'`.
+- Toggle off ⇒ `computeGroupFilter` output identical to today (all existing tests stay green).
+- Branch `feature/149-active-sessions-toggle`; every commit references #149.
+
+---
+
+### Task 1: Extend `computeGroupFilter` with `activeOnly`
+
+**Files:**
+- Modify: `src/renderer/store/groupFilter.ts`
+- Test: `src/renderer/store/__tests__/groupFilter.test.ts`
+
+**Interfaces:**
+- Produces: `computeGroupFilter(groups, sessions, rawQuery, activeOnly = false)`; `GroupFilterResult.active` becomes `qActive || activeOnly`.
+
+- [ ] **Step 1: Add failing tests** — append an `describe('computeGroupFilter — activeOnly', ...)` block:
+
+```ts
+// helper `session(id, name, groupId, state = 'idle')` — extend the existing factory
+// with a state arg defaulting to 'idle'.
+test('activeOnly with no query hides groups whose sessions are all stopped', () => {
+  const groups = [group('a', 'Alpha'), group('b', 'Beta')];
+  const sessions = [
+    session('s1', 'x', 'a', 'working'),
+    session('s2', 'y', 'b', 'stopped'),
+  ];
+  const r = computeGroupFilter(groups, sessions, '', true);
+  expect(r.active).toBe(true);
+  expect([...r.visibleGroupIds]).toEqual(['a']);
+  expect([...r.visibleSessionIds]).toEqual(['s1']);
+});
+
+test('error counts as active', () => {
+  const groups = [group('a', 'Alpha')];
+  const sessions = [session('s1', 'x', 'a', 'error')];
+  const r = computeGroupFilter(groups, sessions, '', true);
+  expect(r.visibleSessionIds.has('s1')).toBe(true);
+});
+
+test('an active sub-group keeps its parent visible', () => {
+  const groups = [group('a', 'Alpha'), group('a1', 'Child', 'a')];
+  const sessions = [session('s1', 'x', 'a1', 'waiting')];
+  const r = computeGroupFilter(groups, sessions, '', true);
+  expect([...r.visibleGroupIds].sort()).toEqual(['a', 'a1']);
+});
+
+test('activeOnly + text is AND: only active sessions matching text', () => {
+  const groups = [group('a', 'Alpha')];
+  const sessions = [
+    session('s1', 'login', 'a', 'working'),
+    session('s2', 'login', 'a', 'stopped'),
+    session('s3', 'logout', 'a', 'working'),
+  ];
+  const r = computeGroupFilter(groups, sessions, 'login', true);
+  expect([...r.visibleSessionIds]).toEqual(['s1']);
+});
+
+test('name-matched group with only stopped sessions is hidden when activeOnly', () => {
+  const groups = [group('a', 'Alpha')];
+  const sessions = [session('s1', 'x', 'a', 'stopped')];
+  const r = computeGroupFilter(groups, sessions, 'alpha', true);
+  expect(r.visibleGroupIds.size).toBe(0);
+  expect(r.visibleSessionIds.size).toBe(0);
+});
+
+test('name-matched group reveals its active sessions when activeOnly', () => {
+  const groups = [group('a', 'Alpha')];
+  const sessions = [
+    session('s1', 'x', 'a', 'idle'),
+    session('s2', 'y', 'a', 'stopped'),
+  ];
+  const r = computeGroupFilter(groups, sessions, 'alpha', true);
+  expect([...r.visibleGroupIds]).toEqual(['a']);
+  expect([...r.visibleSessionIds]).toEqual(['s1']);
+});
+
+test('activeOnly off leaves the result identical to a plain text filter', () => {
+  const groups = [group('a', 'Alpha')];
+  const sessions = [session('s1', 'x', 'a', 'stopped')];
+  const withFlag = computeGroupFilter(groups, sessions, 'alpha', false);
+  const plain = computeGroupFilter(groups, sessions, 'alpha');
+  expect([...withFlag.visibleGroupIds]).toEqual([...plain.visibleGroupIds]);
+  expect([...withFlag.visibleSessionIds]).toEqual([...plain.visibleSessionIds]);
+});
+
+test('empty query and activeOnly off is inactive', () => {
+  const r = computeGroupFilter([group('a', 'Alpha')], [], '', false);
+  expect(r.active).toBe(false);
+});
+```
+
+Also update the existing `session()` factory to accept an optional `state` arg (default `'idle'`), leaving all current call sites unchanged.
+
+- [ ] **Step 2: Run — expect FAIL** (`activeOnly` param not yet honored).
+
+Run: `bun test src/renderer/store/__tests__/groupFilter.test.ts`
+
+- [ ] **Step 3: Implement.** Replace the body of `computeGroupFilter`:
+
+```ts
+export function computeGroupFilter(
+  groups: Group[],
+  sessions: Session[],
+  rawQuery: string,
+  activeOnly = false,
+): GroupFilterResult {
+  const visibleGroupIds = new Set<string>();
+  const visibleSessionIds = new Set<string>();
+
+  const query = rawQuery.trim().toLowerCase();
+  const qActive = query !== '';
+  if (!qActive && !activeOnly) {
+    return { active: false, visibleGroupIds, visibleSessionIds };
+  }
+
+  const byId = new Map(groups.map(g => [g.id, g]));
+
+  const childrenOf = new Map<string, Group[]>();
+  for (const g of groups) {
+    if (!g.parentId) continue;
+    (childrenOf.get(g.parentId) ?? childrenOf.set(g.parentId, []).get(g.parentId)!).push(g);
+  }
+
+  const sessionsOf = new Map<string, Session[]>();
+  for (const s of sessions) {
+    (sessionsOf.get(s.groupId) ?? sessionsOf.set(s.groupId, []).get(s.groupId)!).push(s);
+  }
+
+  const nameMatches = (name: string) => name.toLowerCase().includes(query);
+  const isActive = (s: Session) => s.state !== 'stopped';
+
+  // True when g lies in the subtree of a name-matched group (g itself or any
+  // ancestor name-matches) — the "a name match reveals its whole subtree" rule.
+  const chainMatchesInclusive = (start: Group | undefined): boolean => {
+    const seen = new Set<string>();
+    let cur = start;
+    while (cur && !seen.has(cur.id)) {
+      seen.add(cur.id);
+      if (nameMatches(cur.name)) return true;
+      cur = cur.parentId ? byId.get(cur.parentId) : undefined;
+    }
+    return false;
+  };
+
+  const revealAncestry = (groupId: string | null | undefined) => {
+    const seen = new Set<string>();
+    let cur = groupId ? byId.get(groupId) : undefined;
+    while (cur && !seen.has(cur.id)) {
+      seen.add(cur.id);
+      visibleGroupIds.add(cur.id);
+      cur = cur.parentId ? byId.get(cur.parentId) : undefined;
+    }
+  };
+
+  // Pass 1: session visibility.
+  for (const s of sessions) {
+    if (activeOnly && !isActive(s)) continue;
+    const g = byId.get(s.groupId);
+    const textOK = !qActive || nameMatches(s.name) || chainMatchesInclusive(g);
+    if (!textOK) continue;
+    visibleSessionIds.add(s.id);
+    revealAncestry(s.groupId);
+  }
+
+  // Pass 2: groups revealed by a name match even when they have no visible
+  // session — preserved only when NOT requiring active sessions.
+  if (qActive && !activeOnly) {
+    for (const g of groups) {
+      if (chainMatchesInclusive(g)) {
+        visibleGroupIds.add(g.id);
+        revealAncestry(g.parentId);
+      }
+    }
+  }
+
+  return { active: true, visibleGroupIds, visibleSessionIds };
+}
+```
+
+Note: the `childrenOf` map is retained only if used elsewhere; if `buildNavItems` is the sole consumer of subtree structure, the local `childrenOf` here can be dropped. Keep the implementation minimal — remove any binding this function no longer reads (the two-pass form above does not need `childrenOf`; delete it to avoid an unused-var lint).
+
+- [ ] **Step 4: Run — expect PASS** (new + all existing `groupFilter` tests).
+
+Run: `bun test src/renderer/store/__tests__/groupFilter.test.ts`
+
+- [ ] **Step 5: Typecheck.** `bunx tsc --noEmit -p tsconfig.json` (ignore pre-existing errors, if any).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/renderer/store/groupFilter.ts src/renderer/store/__tests__/groupFilter.test.ts
+git commit -m "feat(sidebar): activeOnly narrowing in the pure filter module (#149)"
+```
+
+---
+
+### Task 2: Toggle button in `SidebarFilter`
+
+**Files:**
+- Modify: `src/renderer/components/SidebarFilter.tsx`
+- Modify: `src/renderer/styles/global.css`
+- Test: `src/renderer/components/__tests__/SidebarFilter.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `SidebarFilter` gains `activeOnly: boolean` and `onActiveOnlyChange: (v: boolean) => void` props.
+
+- [ ] **Step 1: Add failing tests** to `SidebarFilter.test.tsx` (the `Harness` must thread the new props; default them in the harness):
+
+```ts
+test('the active-only toggle reflects its state via aria-pressed', () => {
+  render(<Harness activeOnly={false} />);
+  expect(screen.getByLabelText('Show only groups with active sessions').getAttribute('aria-pressed')).toBe('false');
+});
+
+test('clicking the toggle flips it', () => {
+  const seen: boolean[] = [];
+  render(<Harness activeOnly={false} onActiveOnlyChange={(v) => seen.push(v)} />);
+  fireEvent.click(screen.getByLabelText('Show only groups with active sessions'));
+  expect(seen).toEqual([true]);
+});
+```
+
+Update `Harness` to own `activeOnly` state (like it owns `value`) and pass `activeOnly` / `onActiveOnlyChange` to `SidebarFilter`, defaulting `activeOnly` to the prop and `onActiveOnlyChange` to a state setter so the aria-pressed test can also assert the flipped DOM if desired.
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+Run: `bun test src/renderer/components/__tests__/SidebarFilter.test.tsx`
+
+- [ ] **Step 3: Implement.** Add the props and render the button as the first child of `.sidebar-filter`, before `.sidebar-filter-field`:
+
+```tsx
+interface SidebarFilterProps {
+  value: string;
+  onChange: (value: string) => void;
+  activeOnly: boolean;
+  onActiveOnlyChange: (value: boolean) => void;
+}
+
+export const SidebarFilter: React.FC<SidebarFilterProps> = ({
+  value, onChange, activeOnly, onActiveOnlyChange,
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <div className="sidebar-filter">
+      <button
+        type="button"
+        className={`sidebar-filter-toggle ${activeOnly ? 'active' : ''}`}
+        aria-pressed={activeOnly}
+        title="Show only groups with active sessions"
+        aria-label="Show only groups with active sessions"
+        onClick={() => onActiveOnlyChange(!activeOnly)}
+      >
+        ⚡
+      </button>
+      <div className="sidebar-filter-field">
+        {/* …existing input + clear button unchanged… */}
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: CSS.** In `global.css`, make `.sidebar-filter` a flex row and style the toggle:
+
+```css
+.sidebar-filter {
+  /* existing sticky rules stay; add: */
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+}
+.sidebar-filter-field { flex: 1; }
+
+.sidebar-filter-toggle {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  background: #1e1e1e;
+  border: 1px solid #3c3c3c;
+  border-radius: 3px;
+  color: #888;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+}
+.sidebar-filter-toggle:hover { color: #ddd; }
+.sidebar-filter-toggle.active {
+  color: #e5c07b;
+  border-color: #5a7aff;
+  background: #2a2d3a;
+}
+.sidebar-filter-toggle:focus-visible {
+  outline: 1px solid #5a7aff;
+  outline-offset: -1px;
+}
+```
+
+Confirm `.sidebar-filter-field` still has `position: relative` (the clear button anchors to it) — it does; keep it.
+
+- [ ] **Step 5: Run — expect PASS.**
+
+Run: `bun test src/renderer/components/__tests__/SidebarFilter.test.tsx`
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/renderer/components/SidebarFilter.tsx src/renderer/styles/global.css src/renderer/components/__tests__/SidebarFilter.test.tsx
+git commit -m "feat(sidebar): active-only toggle button in the filter row (#149)"
+```
+
+---
+
+### Task 3: Wire persistence and filtering into `App.tsx`
+
+**Files:**
+- Modify: `src/renderer/App.tsx`
+
+**Interfaces:**
+- Consumes: Task 1's 4-arg `computeGroupFilter`; Task 2's `SidebarFilter` props.
+
+- [ ] **Step 1: State + load.** Near `const [filterText, setFilterText] = useState('')`:
+
+```tsx
+const [showActiveOnly, setShowActiveOnly] = useState(false);
+
+useEffect(() => {
+  window.electronAPI.getPreference('sidebar.showActiveOnly')
+    .then(v => { if (v === 'true') setShowActiveOnly(true); })
+    .catch(() => { /* preference unavailable — stay off */ });
+}, []);
+
+const handleActiveOnlyChange = useCallback((next: boolean) => {
+  setShowActiveOnly(next);
+  window.electronAPI.setPreference('sidebar.showActiveOnly', String(next))
+    .catch(err => console.error('Failed to persist showActiveOnly:', err));
+}, []);
+```
+
+- [ ] **Step 2: Thread into the filter memo.**
+
+```tsx
+const filter = useMemo(
+  () => computeGroupFilter(groups, sessions, filterText, showActiveOnly),
+  [groups, sessions, filterText, showActiveOnly],
+);
+```
+
+- [ ] **Step 3: Pass props to the component.**
+
+```tsx
+<SidebarFilter
+  value={filterText}
+  onChange={setFilterText}
+  activeOnly={showActiveOnly}
+  onActiveOnlyChange={handleActiveOnlyChange}
+/>
+```
+
+- [ ] **Step 4: Adapt the empty state.**
+
+```tsx
+{filter.active && visibleTopLevelGroups.length === 0 && (
+  <output className="sidebar-filter-empty">
+    {showActiveOnly && !filterText.trim()
+      ? 'No groups have active sessions'
+      : 'No groups or sessions match'}
+  </output>
+)}
+```
+
+- [ ] **Step 5: Typecheck + full renderer suite + build.**
+
+```bash
+bunx tsc --noEmit -p tsconfig.json
+bun test src/renderer
+bun run build:renderer
+```
+
+Expected: no new type errors; all tests pass; webpack compiles.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/renderer/App.tsx
+git commit -m "feat(sidebar): persist and apply the active-only toggle (#149)"
+```
+
+---
+
+## Verification
+
+Manual (`bun run dev`): toggle hides groups with no non-stopped session; stopping the last active session in a group drops it live; toggle + text narrows to active AND matching; state survives a restart; clearing shows the adaptive empty message; keyboard nav walks only visible rows.

--- a/docs/superpowers/specs/2026-07-30-active-sessions-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-30-active-sessions-toggle-design.md
@@ -88,13 +88,24 @@ The `!activeOnly` guard on the second clause is the AND: with the toggle on, a n
 - parent name-matches, child has one active + one stopped session, toggle on → parent + child visible, only the active session renders.
 - parent name-matches, all descendant sessions stopped, toggle on → hidden.
 
-`buildNavItems` is unchanged: it already derives rows from `visibleGroupIds` / `visibleSessionIds` and treats a collapsed group as expanded while `active`, so it follows the combined result automatically.
+### Search-mode vs. row-filtering (revised during review)
+
+`filter.active` originally drove two things at once: *row filtering* and the *search-mode locks* — force-expanding collapsed groups, disabling collapse chevrons, and disabling drag-reorder. That conflation is safe only while `active` means a transient text query. The active-only toggle is **persisted**, so keeping the locks on `filter.active` would disable collapse and drag app-wide across launches (a real bug caught in review).
+
+So the two concerns are split:
+
+- **Row filtering** stays on `filter.active` (text OR active-only) — `visibleTopLevelGroups`, the session/sub-group visibility filters, and the empty-state gate.
+- **Search-mode locks** move to a separate `isSearching = filterText.trim().length > 0` (text query only) — force-expand, chevron `disabled`, `draggable`, the keyboard collapse/expand/select guards, and the collapse hint.
+
+`buildNavItems` therefore takes an explicit `forceExpand` parameter (defaulting to `filter.active` for back-compat) which `App.tsx` passes `isSearching`, so keyboard navigation mirrors exactly what renders: under the toggle a collapsed group is still collapsed (its sessions neither rendered nor navigable), while under a text search collapsed groups force-expand as before.
+
+**Consequence — the collapse asymmetry:** with the active-only toggle on (and no text query), a collapsed group that contains an active session shows in the list but stays collapsed; you expand it to see which session is live. This differs from the text filter, which force-expands. It is deliberate: the toggle is persistent and must not override the user's collapse state or lock collapse/drag. (Confirmed by the `activeOnly does NOT force-expand` nav test.)
 
 ## App.tsx integration
 
-1. `const [showActiveOnly, setShowActiveOnly] = useState(false)`; load from `getPreference('sidebar.showActiveOnly')` in a mount effect; on toggle, set state and `setPreference(...)`.
+1. Persistence lives in a `useActiveOnlyPreference` hook: loads `getPreference('sidebar.showActiveOnly')` once on mount, persists via `setPreference` on toggle, and ignores a stale mount-read once the user has interacted (closes a load race).
 2. `filter = useMemo(() => computeGroupFilter(groups, sessions, filterText, showActiveOnly), [groups, sessions, filterText, showActiveOnly])`.
-3. `visibleTopLevelGroups` and the auto-expand (`filter.active || !group.collapsed`) are unchanged — they already key off `filter.active`, which now also reflects the toggle.
+3. `const isSearching = filterText.trim().length > 0` gates the search-mode locks (see above); `visibleTopLevelGroups` and the render-time filters stay on `filter.active`.
 4. Render the toggle button in the `.sidebar-filter` row, left of the input.
 5. Empty state adapts: when `filter.active` and nothing renders — "No groups have active sessions" if `showActiveOnly && !filterText.trim()`, otherwise the existing "No groups or sessions match".
 
@@ -107,7 +118,9 @@ The selected session (`activeSessionId`) can be filtered out of the sidebar whil
 ## Testing
 
 - **`groupFilter.test.ts`** (bun): existing tests stay green (toggle defaults off). New cases: active-only with no query; active-only + text AND; descendant counting across sub-groups; name-matched group intersected with active-only (all-stopped subtree hidden); `error` counts as active; `stopped` excluded; empty query + toggle off returns inactive.
-- **DOM test** for the toggle button: renders with correct `aria-pressed`, flips on click, invokes the persist callback. (Persistence itself — the `getPreference`/`setPreference` round trip — is exercised via a mocked `electronAPI` in the button's harness, matching the `SidebarFilter` test style.)
+- **`useActiveOnlyPreference.test.ts`**: the persistence round trip against a mocked `electronAPI` — load `'true'`/`null`, persist `'true'`/`'false'`, and the toggle-before-load race.
+- **`SidebarFilter.test.tsx`**: the toggle button — `aria-pressed` in both states, click flips it, it is a real `<button>`.
+- **`buildNavItems` nav tests**: active-only respects collapse (does not force-expand); a text search still force-expands.
 
 ## Rollout
 

--- a/docs/superpowers/specs/2026-07-30-active-sessions-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-30-active-sessions-toggle-design.md
@@ -1,0 +1,114 @@
+# Sidebar "Show only active" Toggle — Design
+
+**Issue:** [#149](https://github.com/Software-Development-LLC/Bodhilander/issues/149)
+**Date:** 2026-07-30
+
+## Problem
+
+Users with many groups want to collapse the sidebar down to just what is live. The text filter (#141) narrows by name; this adds an orthogonal narrowing by session activity.
+
+## Definition
+
+A session is **active** when `state !== 'stopped'`. All of `idle`, `working`, `waiting`, and `error` count as active — an errored session is a live pane the user likely wants to see. Only `stopped` is inactive.
+
+A group (top-level or sub-group) is **active** when it, or any descendant in its subtree, has at least one active session.
+
+## Scope
+
+**In scope:** a persisted toggle in the sidebar; extending the pure filter module so it narrows by activity, combined with the text query as AND; the empty-state wording.
+
+**Out of scope (unchanged):** drag-drop, keyboard navigation, the text filter's own matching, and every panel.
+
+## UI
+
+An icon toggle button sits inline to the **left of the filter input**, on the `.sidebar-filter` row, so the two filter controls read as one cluster:
+
+`[⚡ toggle] [ Filter groups & sessions… ]`
+
+- Pressed/active visual state when on (accent border + background), `aria-pressed={showActiveOnly}`, `title`/`aria-label` "Show only groups with active sessions".
+- Clicking flips the state and persists it.
+
+## Persistence
+
+Stored via the existing preferences API (`window.electronAPI.getPreference` / `setPreference`, SQLite-backed — the same mechanism as the update channel):
+
+- Key: `sidebar.showActiveOnly`, value `'true'` / `'false'`.
+- Loaded once on mount; default **off** when unset.
+- Async read means the sidebar briefly renders unfiltered on launch before the stored value applies. Acceptable and consistent with how the update-channel setting loads.
+
+## Filter logic
+
+`computeGroupFilter` gains a fourth parameter and the result reports both flags:
+
+```ts
+export interface GroupFilterResult {
+  active: boolean;                 // query non-empty OR activeOnly — callers use this to gate filtering + auto-expand
+  visibleGroupIds: Set<string>;
+  visibleSessionIds: Set<string>;
+}
+
+export function computeGroupFilter(
+  groups: Group[],
+  sessions: Session[],
+  rawQuery: string,
+  activeOnly = false,
+): GroupFilterResult;
+```
+
+Let `q = rawQuery.trim().toLowerCase()`, `qActive = q !== ''`.
+
+- If `!qActive && !activeOnly` → `active: false`, empty sets (callers render everything, exactly as today).
+- `isActive(s) = s.state !== 'stopped'`.
+- `nameMatches(name) = name.toLowerCase().includes(q)`.
+- `chainMatchesInclusive(g)` = `nameMatches(g.name)` OR any ancestor of `g` name-matches — i.e. `g` lies in the subtree of a name-matched group. This is what the current `revealSubtree` expresses (a name-matched group reveals its whole subtree).
+
+**Session visibility** (`visibleSessionIds`):
+
+```
+for each session s (g = its group):
+  if activeOnly && !isActive(s): hidden
+  else if !qActive:              visible          # active-only mode: every active session shows
+  else if nameMatches(s.name) || chainMatchesInclusive(g): visible
+  else:                          hidden
+```
+
+**Group visibility** (`visibleGroupIds`, both levels):
+
+```
+group g is visible if:
+  its subtree contains a visible session, OR
+  (qActive && !activeOnly && chainMatchesInclusive(g))   # preserves today's "name-matched (or under a name-matched) group shows even when empty"
+then: every ancestor of a visible group is also visible (context)
+```
+
+The `!activeOnly` guard on the second clause is the AND: with the toggle on, a name-matched group whose subtree has no active session is hidden. With the toggle off, behavior is byte-identical to #141 (verified by keeping every existing `groupFilter` test green).
+
+**Faithfulness check** (worked in tests):
+- toggle off → identical to current text filter, including empty name-matched groups and empty sub-groups under a name-matched parent still showing.
+- parent name-matches, child has one active + one stopped session, toggle on → parent + child visible, only the active session renders.
+- parent name-matches, all descendant sessions stopped, toggle on → hidden.
+
+`buildNavItems` is unchanged: it already derives rows from `visibleGroupIds` / `visibleSessionIds` and treats a collapsed group as expanded while `active`, so it follows the combined result automatically.
+
+## App.tsx integration
+
+1. `const [showActiveOnly, setShowActiveOnly] = useState(false)`; load from `getPreference('sidebar.showActiveOnly')` in a mount effect; on toggle, set state and `setPreference(...)`.
+2. `filter = useMemo(() => computeGroupFilter(groups, sessions, filterText, showActiveOnly), [groups, sessions, filterText, showActiveOnly])`.
+3. `visibleTopLevelGroups` and the auto-expand (`filter.active || !group.collapsed`) are unchanged — they already key off `filter.active`, which now also reflects the toggle.
+4. Render the toggle button in the `.sidebar-filter` row, left of the input.
+5. Empty state adapts: when `filter.active` and nothing renders — "No groups have active sessions" if `showActiveOnly && !filterText.trim()`, otherwise the existing "No groups or sessions match".
+
+## Reactivity
+
+Sessions are already reactive; the `filter` memo depends on `sessions`, so the view updates live — a session stopping drops its group out if it was the last active one, and starting one brings the group back. That is the feature's point.
+
+The selected session (`activeSessionId`) can be filtered out of the sidebar while still open in the terminal — same as the text filter today. No special handling.
+
+## Testing
+
+- **`groupFilter.test.ts`** (bun): existing tests stay green (toggle defaults off). New cases: active-only with no query; active-only + text AND; descendant counting across sub-groups; name-matched group intersected with active-only (all-stopped subtree hidden); `error` counts as active; `stopped` excluded; empty query + toggle off returns inactive.
+- **DOM test** for the toggle button: renders with correct `aria-pressed`, flips on click, invokes the persist callback. (Persistence itself — the `getPreference`/`setPreference` round trip — is exercised via a mocked `electronAPI` in the button's harness, matching the `SidebarFilter` test style.)
+
+## Rollout
+
+Single PR to `development`, closing #149. No schema change (preferences table already exists), no version/channel implications.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -695,7 +695,7 @@ const App: React.FC = () => {
   // so it must stay filter-aware (#141).
   const navItems = useMemo(
     () => buildNavItems(groups, sessions, filter, isSearching),
-    [groups, sessions, filter],
+    [groups, sessions, filter, isSearching],
   );
 
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -77,6 +77,8 @@ const App: React.FC = () => {
 
   // Sidebar text filter (#141). Ephemeral — never persisted.
   const [filterText, setFilterText] = useState('');
+  // "Show only active" toggle (#149). Persisted via the preferences table.
+  const [showActiveOnly, setShowActiveOnly] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
 
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -145,9 +147,22 @@ const App: React.FC = () => {
 
   // Which sidebar rows survive the text filter (#141).
   const filter = useMemo(
-    () => computeGroupFilter(groups, sessions, filterText),
-    [groups, sessions, filterText],
+    () => computeGroupFilter(groups, sessions, filterText, showActiveOnly),
+    [groups, sessions, filterText, showActiveOnly],
   );
+
+  // Load the persisted toggle once; stay off if the preference is unavailable.
+  useEffect(() => {
+    window.electronAPI.getPreference('sidebar.showActiveOnly')
+      .then(v => { if (v === 'true') setShowActiveOnly(true); })
+      .catch(() => { /* preferences unavailable — leave off */ });
+  }, []);
+
+  const handleActiveOnlyChange = useCallback((next: boolean) => {
+    setShowActiveOnly(next);
+    window.electronAPI.setPreference('sidebar.showActiveOnly', String(next))
+      .catch(err => console.error('Failed to persist showActiveOnly:', err));
+  }, []);
 
   // The top-level rows actually rendered. Drives both the list and the empty
   // state, so the two can never disagree.
@@ -998,10 +1013,19 @@ const App: React.FC = () => {
           </button>
         </div>
 
-        <SidebarFilter value={filterText} onChange={setFilterText} />
+        <SidebarFilter
+          value={filterText}
+          onChange={setFilterText}
+          activeOnly={showActiveOnly}
+          onActiveOnlyChange={handleActiveOnlyChange}
+        />
 
         {filter.active && visibleTopLevelGroups.length === 0 && (
-          <output className="sidebar-filter-empty">No groups or sessions match</output>
+          <output className="sidebar-filter-empty">
+            {showActiveOnly && !filterText.trim()
+              ? 'No groups have active sessions'
+              : 'No groups or sessions match'}
+          </output>
         )}
 
         {visibleTopLevelGroups

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -16,6 +16,7 @@ import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
 import { computeGroupFilter, buildNavItems } from './store/groupFilter';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
+import { useActiveOnlyPreference } from './hooks/useActiveOnlyPreference';
 import './styles/global.css';
 import './styles/context-menu.css';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -78,7 +79,7 @@ const App: React.FC = () => {
   // Sidebar text filter (#141). Ephemeral — never persisted.
   const [filterText, setFilterText] = useState('');
   // "Show only active" toggle (#149). Persisted via the preferences table.
-  const [showActiveOnly, setShowActiveOnly] = useState(false);
+  const [showActiveOnly, handleActiveOnlyChange] = useActiveOnlyPreference();
   const [isResizing, setIsResizing] = useState(false);
 
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -151,18 +152,12 @@ const App: React.FC = () => {
     [groups, sessions, filterText, showActiveOnly],
   );
 
-  // Load the persisted toggle once; stay off if the preference is unavailable.
-  useEffect(() => {
-    window.electronAPI.getPreference('sidebar.showActiveOnly')
-      .then(v => { if (v === 'true') setShowActiveOnly(true); })
-      .catch(() => { /* preferences unavailable — leave off */ });
-  }, []);
-
-  const handleActiveOnlyChange = useCallback((next: boolean) => {
-    setShowActiveOnly(next);
-    window.electronAPI.setPreference('sidebar.showActiveOnly', String(next))
-      .catch(err => console.error('Failed to persist showActiveOnly:', err));
-  }, []);
+  // "Search mode" is a text query only. It force-expands collapsed groups and
+  // suspends collapse/drag while you search — transient, cleared when the box
+  // empties. The active-only toggle must NOT do those things: it is persisted,
+  // so locking collapse/drag on it would disable them app-wide across launches
+  // (#149). It only prunes which rows render, via `filter`.
+  const isSearching = filterText.trim().length > 0;
 
   // The top-level rows actually rendered. Drives both the list and the empty
   // state, so the two can never disagree.
@@ -699,7 +694,7 @@ const App: React.FC = () => {
   // Flat navigation list for keyboard navigation. Mirrors the rendered rows,
   // so it must stay filter-aware (#141).
   const navItems = useMemo(
-    () => buildNavItems(groups, sessions, filter),
+    () => buildNavItems(groups, sessions, filter, isSearching),
     [groups, sessions, filter],
   );
 
@@ -743,7 +738,7 @@ const App: React.FC = () => {
   const handleCollapse = useCallback(() => {
     // Rows are force-expanded while filtering, so a collapse write would be an
     // invisible, persisted change (#141).
-    if (!sidebarFocused || !focusedItemId || filter.active) return;
+    if (!sidebarFocused || !focusedItemId || isSearching) return;
     if (focusedItemType === 'group') {
       const group = groups.find(g => g.id === focusedItemId);
       if (group && !group.collapsed) {
@@ -755,13 +750,13 @@ const App: React.FC = () => {
         toggleCollapse(session.groupId);
       }
     }
-  }, [sidebarFocused, focusedItemId, focusedItemType, groups, sessions, toggleCollapse, filter.active]);
+  }, [sidebarFocused, focusedItemId, focusedItemType, groups, sessions, toggleCollapse, isSearching]);
 
   const handleExpand = useCallback(() => {
     if (!sidebarFocused || !focusedItemId) return;
     if (focusedItemType === 'group') {
       const group = groups.find(g => g.id === focusedItemId);
-      if (group?.collapsed && !filter.active) {
+      if (group?.collapsed && !isSearching) {
         toggleCollapse(focusedItemId);
       }
     } else if (focusedItemType === 'session') {
@@ -772,12 +767,12 @@ const App: React.FC = () => {
         window.dispatchEvent(new Event('focus-terminal'));
       }, 50);
     }
-  }, [sidebarFocused, focusedItemId, focusedItemType, groups, toggleCollapse, setActiveSessionId, filter.active]);
+  }, [sidebarFocused, focusedItemId, focusedItemType, groups, toggleCollapse, setActiveSessionId, isSearching]);
 
   const handleSelect = useCallback(() => {
     if (!sidebarFocused || !focusedItemId) return;
     if (focusedItemType === 'group') {
-      if (!filter.active) toggleCollapse(focusedItemId);
+      if (!isSearching) toggleCollapse(focusedItemId);
     } else if (focusedItemType === 'session') {
       setActiveSessionId(focusedItemId);
       setSidebarFocused(false);
@@ -786,7 +781,7 @@ const App: React.FC = () => {
         window.dispatchEvent(new Event('focus-terminal'));
       }, 50);
     }
-  }, [sidebarFocused, focusedItemId, focusedItemType, toggleCollapse, setActiveSessionId, filter.active]);
+  }, [sidebarFocused, focusedItemId, focusedItemType, toggleCollapse, setActiveSessionId, isSearching]);
 
   const handleNewGroup = useCallback(async () => {
     const name = `Group ${groups.filter(g => !g.parentId).length + 1}`;
@@ -809,7 +804,7 @@ const App: React.FC = () => {
     dropPosition: dropTarget?.type === 'session' && dropTarget.id === session.id
       ? dropTarget.position
       : null,
-    draggable: !filter.active,
+    draggable: !isSearching,
     account: effectiveAccountForSession(session.id),
     isEditing: editingSessionId === session.id,
     editingName: editingSessionName,
@@ -826,7 +821,7 @@ const App: React.FC = () => {
     onClose: () => handleRemoveSession(session.id),
   }), [
     activeSessionId, focusedItemType, focusedItemId, draggedItem, dropTarget,
-    filter.active, effectiveAccountForSession, editingSessionId, editingSessionName,
+    isSearching, effectiveAccountForSession, editingSessionId, editingSessionName,
     handleStartEditSession, handleFinishEditSession, handleSessionClick, handleSessionContextMenu,
     handleSessionDragStart, handleDragEnd, handleSessionDragOver, handleSessionDrop,
     handleRemoveSession,
@@ -839,7 +834,7 @@ const App: React.FC = () => {
         { key: 'Enter', label: 'Select' },
         // Collapse/expand is unavailable while filtering — rows are
         // force-expanded, so advertising it would be a lie (#141).
-        ...(filter.active ? [] : [{ key: '←→', label: 'Collapse' }]),
+        ...(isSearching ? [] : [{ key: '←→', label: 'Collapse' }]),
         { key: `${appMod}G`, label: 'New Group' },
       ];
     }
@@ -850,7 +845,7 @@ const App: React.FC = () => {
       { key: 'Ctrl+Tab', label: 'Next' },
       { key: `${appMod}W`, label: 'Close' },
     ];
-  }, [sidebarFocused, appMod, filter.active]);
+  }, [sidebarFocused, appMod, isSearching]);
 
   const handleNewSubGroup = useCallback(async () => {
     if (focusedItemType === 'group' && focusedItemId) {
@@ -1034,7 +1029,7 @@ const App: React.FC = () => {
             {/* Render main group */}
             <li
               className={`group ${draggedItem?.type === 'group' && draggedItem.id === group.id ? 'dragging' : ''} ${dropTarget?.type === 'group' && dropTarget.id === group.id ? `drop-${dropTarget.position}` : ''}`}
-              draggable={!filter.active}
+              draggable={!isSearching}
               onDragStart={(e) => handleGroupDragStart(e, group.id)}
               onDragEnd={handleDragEnd}
               onDragOver={(e) => handleGroupDragOver(e, group.id)}
@@ -1051,11 +1046,11 @@ const App: React.FC = () => {
                     e.stopPropagation();
                     toggleCollapse(group.id);
                   }}
-                  disabled={filter.active}
-                  title={chevronTitle(group.collapsed, filter.active)}
-                  aria-label={chevronAriaLabel(group.collapsed, filter.active, 'group')}
+                  disabled={isSearching}
+                  title={chevronTitle(group.collapsed, isSearching)}
+                  aria-label={chevronAriaLabel(group.collapsed, isSearching, 'group')}
                 >
-                  {group.collapsed && !filter.active ? '▶' : '▼'}
+                  {group.collapsed && !isSearching ? '▶' : '▼'}
                 </button>
                 <button
                   className="group-color"
@@ -1127,7 +1122,7 @@ const App: React.FC = () => {
                   +
                 </button>
               </div>
-              {(filter.active || !group.collapsed) && (
+              {(isSearching || !group.collapsed) && (
                 <ul
                   className={`group-sessions ${dropTarget?.id === `group:${group.id}` ? 'drop-target' : ''}`}
                   onDragOver={(e) => handleGroupAreaDragOver(e, group.id)}
@@ -1143,13 +1138,13 @@ const App: React.FC = () => {
             </li>
 
             {/* Render sub-groups when parent not collapsed */}
-            {(filter.active || !group.collapsed) && getSubGroups(group.id)
+            {(isSearching || !group.collapsed) && getSubGroups(group.id)
               .filter(subGroup => !filter.active || filter.visibleGroupIds.has(subGroup.id))
               .map(subGroup => (
               <li
                 key={subGroup.id}
                 className={`group sub-group ${draggedItem?.type === 'group' && draggedItem.id === subGroup.id ? 'dragging' : ''} ${dropTarget?.type === 'group' && dropTarget.id === subGroup.id ? `drop-${dropTarget.position}` : ''}`}
-                draggable={!filter.active}
+                draggable={!isSearching}
                 onDragStart={(e) => handleGroupDragStart(e, subGroup.id)}
                 onDragEnd={handleDragEnd}
                 onDragOver={(e) => handleGroupDragOver(e, subGroup.id)}
@@ -1166,11 +1161,11 @@ const App: React.FC = () => {
                       e.stopPropagation();
                       toggleCollapse(subGroup.id);
                     }}
-                    disabled={filter.active}
-                    title={chevronTitle(subGroup.collapsed, filter.active)}
-                    aria-label={chevronAriaLabel(subGroup.collapsed, filter.active, 'sub-group')}
+                    disabled={isSearching}
+                    title={chevronTitle(subGroup.collapsed, isSearching)}
+                    aria-label={chevronAriaLabel(subGroup.collapsed, isSearching, 'sub-group')}
                   >
-                    {subGroup.collapsed && !filter.active ? '▶' : '▼'}
+                    {subGroup.collapsed && !isSearching ? '▶' : '▼'}
                   </button>
                   <button
                     className="group-color sub-group-color"
@@ -1235,7 +1230,7 @@ const App: React.FC = () => {
                     +
                   </button>
                 </div>
-                {(filter.active || !subGroup.collapsed) && (
+                {(isSearching || !subGroup.collapsed) && (
                   <ul
                     className={`group-sessions ${dropTarget?.id === `group:${subGroup.id}` ? 'drop-target' : ''}`}
                     onDragOver={(e) => handleGroupAreaDragOver(e, subGroup.id)}

--- a/src/renderer/components/SidebarFilter.tsx
+++ b/src/renderer/components/SidebarFilter.tsx
@@ -3,20 +3,35 @@ import React, { useRef } from 'react';
 interface SidebarFilterProps {
   value: string;
   onChange: (value: string) => void;
+  /** When true, the sidebar shows only groups with an active session (#149). */
+  activeOnly: boolean;
+  onActiveOnlyChange: (value: boolean) => void;
 }
 
 /**
- * Text box that narrows the sidebar to matching groups, sub-groups and
- * sessions (#141).
+ * The sidebar's filter controls: an active-only toggle and a text box that
+ * narrow the group/session tree (#141, #149).
  *
- * Ephemeral by design — the parent holds the value in plain component state so
- * it resets on every launch.
+ * The text query is ephemeral (parent state, resets each launch); the toggle is
+ * persisted by the parent.
  */
-export const SidebarFilter: React.FC<SidebarFilterProps> = ({ value, onChange }) => {
+export const SidebarFilter: React.FC<SidebarFilterProps> = ({
+  value, onChange, activeOnly, onActiveOnlyChange,
+}) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   return (
     <div className="sidebar-filter">
+      <button
+        type="button"
+        className={`sidebar-filter-toggle ${activeOnly ? 'active' : ''}`}
+        aria-pressed={activeOnly}
+        title="Show only groups with active sessions"
+        aria-label="Show only groups with active sessions"
+        onClick={() => onActiveOnlyChange(!activeOnly)}
+      >
+        ⚡
+      </button>
       <div className="sidebar-filter-field">
         <input
           ref={inputRef}

--- a/src/renderer/components/__tests__/SidebarFilter.test.tsx
+++ b/src/renderer/components/__tests__/SidebarFilter.test.tsx
@@ -11,17 +11,32 @@ import { SidebarFilter } from '../SidebarFilter';
 afterEach(cleanup);
 
 /** Mirrors how App.tsx owns the value, so tests exercise the real interaction. */
-function Harness({ initial = '' }: { initial?: string }) {
+function Harness({
+  initial = '',
+  activeOnly: initialActiveOnly = false,
+  onActiveOnlyChange,
+}: {
+  initial?: string;
+  activeOnly?: boolean;
+  onActiveOnlyChange?: (v: boolean) => void;
+}) {
   const [value, setValue] = useState(initial);
+  const [activeOnly, setActiveOnly] = useState(initialActiveOnly);
   return (
     <>
-      <SidebarFilter value={value} onChange={setValue} />
+      <SidebarFilter
+        value={value}
+        onChange={setValue}
+        activeOnly={activeOnly}
+        onActiveOnlyChange={(v) => { setActiveOnly(v); onActiveOnlyChange?.(v); }}
+      />
       <span data-testid="value">{value}</span>
     </>
   );
 }
 
 const input = () => screen.getByLabelText('Filter groups and sessions') as HTMLInputElement;
+const toggle = () => screen.getByLabelText('Show only groups with active sessions') as HTMLButtonElement;
 const currentValue = () => screen.getByTestId('value').textContent;
 
 describe('SidebarFilter', () => {
@@ -87,4 +102,30 @@ describe('SidebarFilter', () => {
     fireEvent.keyDown(input(), { key: 'a' });
     expect(currentValue()).toBe('api');
   });
+
+  test('the active-only toggle is off by default and reports aria-pressed', () => {
+    render(<Harness />);
+    expect(toggle().getAttribute('aria-pressed')).toBe('false');
+  });
+
+  test('the toggle reflects an initial on state', () => {
+    render(<Harness activeOnly={true} />);
+    expect(toggle().getAttribute('aria-pressed')).toBe('true');
+    expect(toggle().className).toContain('active');
+  });
+
+  test('clicking the toggle flips it and reports the new value', () => {
+    const seen: boolean[] = [];
+    render(<Harness onActiveOnlyChange={(v) => seen.push(v)} />);
+    fireEvent.click(toggle());
+    expect(seen).toEqual([true]);
+    expect(toggle().getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('the toggle is a real button (keyboard + AT support from the platform)', () => {
+    render(<Harness />);
+    expect(toggle().tagName).toBe('BUTTON');
+    expect(toggle().getAttribute('type')).toBe('button');
+  });
+
 });

--- a/src/renderer/hooks/__tests__/useActiveOnlyPreference.test.ts
+++ b/src/renderer/hooks/__tests__/useActiveOnlyPreference.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Persistence round-trip for the active-only toggle (#149).
+ *
+ * Run with: bun test src/renderer/hooks/__tests__/useActiveOnlyPreference.test.ts
+ */
+import { describe, test, expect, afterEach, mock } from 'bun:test';
+import { renderHook, act, cleanup, waitFor } from '@testing-library/react';
+import { useActiveOnlyPreference, ACTIVE_ONLY_PREF_KEY } from '../useActiveOnlyPreference';
+
+afterEach(() => {
+  cleanup();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+});
+
+/** Installs a mock electronAPI whose getPreference resolves only when told. */
+function installApi(stored: string | null) {
+  let release!: () => void;
+  const gate = new Promise<void>(r => { release = r; });
+  const getPreference = mock(() => gate.then(() => stored));
+  const setPreference = mock(() => Promise.resolve());
+  (window as unknown as { electronAPI: unknown }).electronAPI = { getPreference, setPreference };
+  return { getPreference, setPreference, resolveLoad: release };
+}
+
+describe('useActiveOnlyPreference', () => {
+  test('defaults to off before the preference loads', () => {
+    installApi('true');
+    const { result } = renderHook(() => useActiveOnlyPreference());
+    expect(result.current[0]).toBe(false);
+  });
+
+  test('adopts a stored "true" once the read resolves', async () => {
+    const api = installApi('true');
+    const { result } = renderHook(() => useActiveOnlyPreference());
+    await act(async () => { api.resolveLoad(); await Promise.resolve(); });
+    await waitFor(() => expect(result.current[0]).toBe(true));
+    expect(api.getPreference).toHaveBeenCalledWith(ACTIVE_ONLY_PREF_KEY);
+  });
+
+  test('a missing preference stays off', async () => {
+    const api = installApi(null);
+    const { result } = renderHook(() => useActiveOnlyPreference());
+    await act(async () => { api.resolveLoad(); await Promise.resolve(); });
+    expect(result.current[0]).toBe(false);
+  });
+
+  test('setting it persists the string value', async () => {
+    const api = installApi(null);
+    const { result } = renderHook(() => useActiveOnlyPreference());
+    act(() => { result.current[1](true); });
+    expect(result.current[0]).toBe(true);
+    expect(api.setPreference).toHaveBeenCalledWith(ACTIVE_ONLY_PREF_KEY, 'true');
+    act(() => { result.current[1](false); });
+    expect(api.setPreference).toHaveBeenLastCalledWith(ACTIVE_ONLY_PREF_KEY, 'false');
+  });
+
+  test('a user toggle before the load resolves is not clobbered by the stale read', async () => {
+    const api = installApi('true');           // stored ON
+    const { result } = renderHook(() => useActiveOnlyPreference());
+    // User turns it OFF while the read is still in flight.
+    act(() => { result.current[1](false); });
+    expect(result.current[0]).toBe(false);
+    // Now the stale 'true' read resolves — it must be ignored.
+    await act(async () => { api.resolveLoad(); await Promise.resolve(); });
+    expect(result.current[0]).toBe(false);
+    expect(api.setPreference).toHaveBeenCalledWith(ACTIVE_ONLY_PREF_KEY, 'false');
+  });
+});

--- a/src/renderer/hooks/useActiveOnlyPreference.ts
+++ b/src/renderer/hooks/useActiveOnlyPreference.ts
@@ -1,0 +1,37 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+export const ACTIVE_ONLY_PREF_KEY = 'sidebar.showActiveOnly';
+
+/**
+ * Persisted "show only active sessions" toggle (#149), backed by the
+ * preferences table via `getPreference` / `setPreference`.
+ *
+ * Loads once on mount. A user interaction that happens before that async read
+ * resolves wins — the stale read is ignored — so in-memory state and storage
+ * never diverge. Missing/unreadable preference ⇒ off.
+ */
+export function useActiveOnlyPreference(): [boolean, (next: boolean) => void] {
+  const [showActiveOnly, setShowActiveOnly] = useState(false);
+  const touched = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.electronAPI.getPreference(ACTIVE_ONLY_PREF_KEY)
+      .then(v => {
+        // Don't clobber a value the user already set while the read was in flight.
+        if (cancelled || touched.current) return;
+        setShowActiveOnly(v === 'true');
+      })
+      .catch(() => { /* preferences unavailable — leave off */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  const setActiveOnly = useCallback((next: boolean) => {
+    touched.current = true;
+    setShowActiveOnly(next);
+    window.electronAPI.setPreference(ACTIVE_ONLY_PREF_KEY, String(next))
+      .catch(err => console.error('Failed to persist showActiveOnly:', err));
+  }, []);
+
+  return [showActiveOnly, setActiveOnly];
+}

--- a/src/renderer/store/__tests__/groupFilter.test.ts
+++ b/src/renderer/store/__tests__/groupFilter.test.ts
@@ -171,6 +171,32 @@ describe('buildNavItems', () => {
     expect(items.map(i => i.id)).toEqual(['api', 'api-bill', 's-invoice']);
   });
 
+  test('activeOnly does NOT force-expand: a collapsed group keeps its sessions off the nav list (#149)', () => {
+    const groups = [
+      { ...group('a', 'Alpha'), collapsed: true },
+      { ...group('b', 'Beta') },
+    ];
+    const sessions = [
+      session('s1', 'x', 'a', 'working'),
+      session('s2', 'y', 'b', 'working'),
+    ];
+    // forceExpand defaults to filter.active; pass `false` as the caller (App)
+    // does for the active-only toggle (no text search).
+    const f = computeGroupFilter(groups, sessions, '', true);
+    const items = buildNavItems(groups, sessions, f, false);
+    // 'a' is visible (has an active session) but collapsed, so its session is
+    // not walked; 'b' is expanded so its session is.
+    expect(items.map(i => i.id)).toEqual(['a', 'b', 's2']);
+  });
+
+  test('a text search still force-expands (forceExpand defaults to filter.active)', () => {
+    const groups = [{ ...group('a', 'Alpha'), collapsed: true }];
+    const sessions = [session('s1', 'x', 'a', 'working')];
+    const f = computeGroupFilter(groups, sessions, 'alpha');
+    const items = buildNavItems(groups, sessions, f); // default forceExpand
+    expect(items.map(i => i.id)).toEqual(['a', 's1']);
+  });
+
   test('no matches yields an empty nav list', () => {
     const items = buildNavItems(GROUPS, SESSIONS, computeGroupFilter(GROUPS, SESSIONS, 'zzzz'));
     expect(items).toEqual([]);

--- a/src/renderer/store/__tests__/groupFilter.test.ts
+++ b/src/renderer/store/__tests__/groupFilter.test.ts
@@ -21,8 +21,13 @@ function group(id: string, name: string, parentId: string | null = null): Group 
   } as Group;
 }
 
-function session(id: string, name: string, groupId: string): Session {
-  return { id, name, groupId } as Session;
+function session(
+  id: string,
+  name: string,
+  groupId: string,
+  state: Session['state'] = 'idle',
+): Session {
+  return { id, name, groupId, state } as Session;
 }
 
 // Tree used by most tests:
@@ -181,5 +186,94 @@ describe('buildNavItems', () => {
     sessions[1].order = 1;
     const items = buildNavItems(groups, sessions, computeGroupFilter(groups, sessions, ''));
     expect(items.map(i => i.id)).toEqual(['g', 's1', 's2']);
+  });
+});
+
+describe('computeGroupFilter — activeOnly (#149)', () => {
+  test('with no query, hides groups whose sessions are all stopped', () => {
+    const groups = [group('a', 'Alpha'), group('b', 'Beta')];
+    const sessions = [
+      session('s1', 'x', 'a', 'working'),
+      session('s2', 'y', 'b', 'stopped'),
+    ];
+    const r = computeGroupFilter(groups, sessions, '', true);
+    expect(r.active).toBe(true);
+    expect([...r.visibleGroupIds]).toEqual(['a']);
+    expect([...r.visibleSessionIds]).toEqual(['s1']);
+  });
+
+  test('error counts as active', () => {
+    const r = computeGroupFilter([group('a', 'Alpha')], [session('s1', 'x', 'a', 'error')], '', true);
+    expect(r.visibleSessionIds.has('s1')).toBe(true);
+    expect(r.visibleGroupIds.has('a')).toBe(true);
+  });
+
+  test('every non-stopped state counts as active', () => {
+    const groups = [group('a', 'Alpha')];
+    for (const st of ['idle', 'working', 'waiting', 'error'] as const) {
+      const r = computeGroupFilter(groups, [session('s', 'x', 'a', st)], '', true);
+      expect(r.visibleSessionIds.has('s')).toBe(true);
+    }
+    const stopped = computeGroupFilter(groups, [session('s', 'x', 'a', 'stopped')], '', true);
+    expect(stopped.visibleSessionIds.size).toBe(0);
+  });
+
+  test('an active sub-group keeps its parent visible', () => {
+    const groups = [group('a', 'Alpha'), group('a1', 'Child', 'a')];
+    const sessions = [session('s1', 'x', 'a1', 'waiting')];
+    const r = computeGroupFilter(groups, sessions, '', true);
+    expect([...r.visibleGroupIds].sort()).toEqual(['a', 'a1']);
+  });
+
+  test('a stopped sub-group under an active parent is hidden', () => {
+    const groups = [group('a', 'Alpha'), group('a1', 'Child', 'a'), group('a2', 'Other', 'a')];
+    const sessions = [
+      session('s1', 'x', 'a1', 'working'),
+      session('s2', 'y', 'a2', 'stopped'),
+    ];
+    const r = computeGroupFilter(groups, sessions, '', true);
+    expect([...r.visibleGroupIds].sort()).toEqual(['a', 'a1']);
+    expect([...r.visibleSessionIds]).toEqual(['s1']);
+  });
+
+  test('activeOnly + text is AND: only active sessions matching text', () => {
+    const groups = [group('a', 'Alpha')];
+    const sessions = [
+      session('s1', 'login', 'a', 'working'),
+      session('s2', 'login', 'a', 'stopped'),
+      session('s3', 'logout', 'a', 'working'),
+    ];
+    const r = computeGroupFilter(groups, sessions, 'login', true);
+    expect([...r.visibleSessionIds]).toEqual(['s1']);
+    expect([...r.visibleGroupIds]).toEqual(['a']);
+  });
+
+  test('name-matched group with only stopped sessions is hidden when activeOnly', () => {
+    const r = computeGroupFilter([group('a', 'Alpha')], [session('s1', 'x', 'a', 'stopped')], 'alpha', true);
+    expect(r.visibleGroupIds.size).toBe(0);
+    expect(r.visibleSessionIds.size).toBe(0);
+  });
+
+  test('name-matched group reveals its active sessions when activeOnly', () => {
+    const groups = [group('a', 'Alpha')];
+    const sessions = [session('s1', 'x', 'a', 'idle'), session('s2', 'y', 'a', 'stopped')];
+    const r = computeGroupFilter(groups, sessions, 'alpha', true);
+    expect([...r.visibleGroupIds]).toEqual(['a']);
+    expect([...r.visibleSessionIds]).toEqual(['s1']);
+  });
+
+  test('activeOnly off leaves the result identical to a plain text filter', () => {
+    const groups = [group('a', 'Alpha'), group('a1', 'Child', 'a')];
+    const sessions = [session('s1', 'x', 'a', 'stopped'), session('s2', 'y', 'a1', 'stopped')];
+    const withFlag = computeGroupFilter(groups, sessions, 'alpha', false);
+    const plain = computeGroupFilter(groups, sessions, 'alpha');
+    expect([...withFlag.visibleGroupIds].sort()).toEqual([...plain.visibleGroupIds].sort());
+    expect([...withFlag.visibleSessionIds].sort()).toEqual([...plain.visibleSessionIds].sort());
+  });
+
+  test('empty query and activeOnly off is inactive', () => {
+    const r = computeGroupFilter([group('a', 'Alpha')], [], '', false);
+    expect(r.active).toBe(false);
+    expect(r.visibleGroupIds.size).toBe(0);
   });
 });

--- a/src/renderer/store/groupFilter.ts
+++ b/src/renderer/store/groupFilter.ts
@@ -115,12 +115,17 @@ export function buildNavItems(
   groups: Group[],
   sessions: Session[],
   filter: GroupFilterResult,
+  forceExpand: boolean = filter.active,
 ): NavItem[] {
   const items: NavItem[] = [];
 
+  // Row visibility follows the filter (text OR active-only). Expansion is a
+  // separate concern: only a text search force-expands collapsed groups, so
+  // callers pass `forceExpand` independently (#149). The default keeps the
+  // pre-#149 behavior for callers that don't distinguish the two.
   const groupVisible = (g: Group) => !filter.active || filter.visibleGroupIds.has(g.id);
   const sessionVisible = (s: Session) => !filter.active || filter.visibleSessionIds.has(s.id);
-  const expanded = (g: Group) => filter.active || !g.collapsed;
+  const expanded = (g: Group) => forceExpand || !g.collapsed;
 
   const sessionsOf = (groupId: string) =>
     sessions.filter(s => s.groupId === groupId && sessionVisible(s)).sort(byOrder);

--- a/src/renderer/store/groupFilter.ts
+++ b/src/renderer/store/groupFilter.ts
@@ -14,82 +14,81 @@ export interface GroupFilterResult {
 }
 
 /**
- * Decide which groups, sub-groups and sessions survive a text filter.
+ * Decide which groups, sub-groups and sessions survive the sidebar filters.
  *
- * Rules:
- *  - A group matched by name reveals its entire subtree (sub-groups + sessions).
- *  - A matching sub-group or session keeps its ancestors visible as context,
- *    without revealing that ancestor's other children.
- *  - Anything with no match in its subtree is omitted.
+ * Two orthogonal narrowings, combined as AND:
+ *  - Text query (#141): a group matched by name reveals its whole subtree; a
+ *    matching sub-group or session keeps its ancestors visible as context.
+ *  - `activeOnly` (#149): a session counts only when `state !== 'stopped'`, and
+ *    a group survives only if its subtree holds at least one such session. A
+ *    name-matched-but-all-stopped group is therefore hidden while it is on.
  *
+ * With `activeOnly` false the output is identical to the pure text filter.
  * Pure and total: no I/O, no mutation of the inputs.
  */
 export function computeGroupFilter(
   groups: Group[],
   sessions: Session[],
   rawQuery: string,
+  activeOnly = false,
 ): GroupFilterResult {
   const visibleGroupIds = new Set<string>();
   const visibleSessionIds = new Set<string>();
 
   const query = rawQuery.trim().toLowerCase();
-  if (!query) {
+  const qActive = query !== '';
+  if (!qActive && !activeOnly) {
     return { active: false, visibleGroupIds, visibleSessionIds };
   }
 
   const byId = new Map(groups.map(g => [g.id, g]));
 
-  const childrenOf = new Map<string, Group[]>();
-  for (const g of groups) {
-    if (!g.parentId) continue;
-    const siblings = childrenOf.get(g.parentId);
-    if (siblings) siblings.push(g);
-    else childrenOf.set(g.parentId, [g]);
-  }
+  const nameMatches = (name: string) => name.toLowerCase().includes(query);
+  const isActive = (s: Session) => s.state !== 'stopped';
 
-  const sessionsOf = new Map<string, Session[]>();
-  for (const s of sessions) {
-    const existing = sessionsOf.get(s.groupId);
-    if (existing) existing.push(s);
-    else sessionsOf.set(s.groupId, [s]);
-  }
-
-  const matches = (name: string) => name.toLowerCase().includes(query);
-
-  // Guards against re-walking a subtree, and against infinite recursion if a
-  // malformed parentId ever produced a cycle.
-  const revealed = new Set<string>();
-
-  /** Reveal a matched group and everything beneath it. */
-  const revealSubtree = (group: Group) => {
-    if (revealed.has(group.id)) return;
-    revealed.add(group.id);
-    visibleGroupIds.add(group.id);
-    for (const s of sessionsOf.get(group.id) ?? []) visibleSessionIds.add(s.id);
-    for (const child of childrenOf.get(group.id) ?? []) revealSubtree(child);
+  // True when `start` lies in the subtree of a name-matched group (itself or an
+  // ancestor name-matches) — the "a name match reveals its whole subtree" rule.
+  // The `seen` guard also stops a malformed parentId cycle.
+  const chainMatchesInclusive = (start: Group | undefined): boolean => {
+    const seen = new Set<string>();
+    let cur = start;
+    while (cur && !seen.has(cur.id)) {
+      seen.add(cur.id);
+      if (nameMatches(cur.name)) return true;
+      cur = cur.parentId ? byId.get(cur.parentId) : undefined;
+    }
+    return false;
   };
 
   /** Reveal a group and its ancestors as context (their children untouched). */
   const revealAncestry = (groupId: string | null | undefined) => {
     const seen = new Set<string>();
-    let current = groupId ? byId.get(groupId) : undefined;
-    while (current && !seen.has(current.id)) {
-      seen.add(current.id);
-      visibleGroupIds.add(current.id);
-      current = current.parentId ? byId.get(current.parentId) : undefined;
+    let cur = groupId ? byId.get(groupId) : undefined;
+    while (cur && !seen.has(cur.id)) {
+      seen.add(cur.id);
+      visibleGroupIds.add(cur.id);
+      cur = cur.parentId ? byId.get(cur.parentId) : undefined;
     }
   };
 
-  for (const group of groups) {
-    if (!matches(group.name)) continue;
-    revealSubtree(group);
-    revealAncestry(group.parentId);
-  }
-
+  // Pass 1 — session visibility, intersecting the text and active filters.
   for (const s of sessions) {
-    if (!matches(s.name)) continue;
+    if (activeOnly && !isActive(s)) continue;
+    const textOK = !qActive || nameMatches(s.name) || chainMatchesInclusive(byId.get(s.groupId));
+    if (!textOK) continue;
     visibleSessionIds.add(s.id);
     revealAncestry(s.groupId);
+  }
+
+  // Pass 2 — a name-matched group (or one under a name-matched group) is
+  // revealed even with no visible session, but only when we are NOT requiring
+  // active sessions. This preserves #141's "empty matched group still shows".
+  if (qActive && !activeOnly) {
+    for (const g of groups) {
+      if (!chainMatchesInclusive(g)) continue;
+      visibleGroupIds.add(g.id);
+      revealAncestry(g.parentId);
+    }
   }
 
   return { active: true, visibleGroupIds, visibleSessionIds };

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -340,10 +340,46 @@ body {
   padding-top: 8px;
   padding-bottom: 8px;
   margin-bottom: 2px;
+  /* Toggle + text field on one row (#149). */
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
 }
 
 .sidebar-filter-field {
   position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.sidebar-filter-toggle {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  background: #1e1e1e;
+  border: 1px solid #3c3c3c;
+  border-radius: 3px;
+  color: #888;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.sidebar-filter-toggle:hover {
+  color: #ddd;
+}
+
+.sidebar-filter-toggle.active {
+  color: #e5c07b;
+  border-color: #5a7aff;
+  background: #2a2d3a;
+}
+
+.sidebar-filter-toggle:focus-visible {
+  outline: 1px solid #5a7aff;
+  outline-offset: -1px;
 }
 
 .sidebar-filter-input {


### PR DESCRIPTION
Closes #149

A ⚡ toggle in the sidebar filter row that hides every group without an active session. Pairs with the text filter (#141).

## Behaviour

- **Active = `state !== 'stopped'`** — idle, working, waiting, and error all count; only stopped is hidden.
- A group (or sub-group) shows if it, or any descendant, has an active session.
- **Combines with the text filter as AND**: a session must match the text *and* be active; a name-matched group whose sessions are all stopped is hidden while the toggle is on.
- **Persisted** across restarts (`sidebar.showActiveOnly`, via the existing preferences table), default off.
- Live: a session stopping drops its group out if it was the last active one, and vice versa.
- Empty-state message adapts.

## Key design point (from review)

`filter.active` previously drove both *row filtering* and *search-mode locks* (force-expand, disabled collapse chevrons, disabled drag) — fine when it only ever meant a transient text query. The active-only toggle is **persisted**, so overloading `filter.active` with it would have disabled collapse and drag app-wide across launches. This PR splits the two: a new `isSearching` (text query only) drives the locks; the toggle only prunes which rows render. So with the toggle on you can still collapse groups and drag-reorder normally — it just narrows the list.

## Implementation

- `computeGroupFilter` gains a 4th `activeOnly` param; toggle-off output is byte-identical to #141 (all prior tests green).
- `buildNavItems` takes an explicit `forceExpand` so keyboard nav mirrors the render under the toggle.
- Persistence lives in a small `useActiveOnlyPreference` hook that ignores a stale mount-read once the user has interacted (closes a load race).

## Testing

- `groupFilter` unit tests extended (active-only, AND, descendant counting, name-match intersection, every state value, and the nav decoupling that proves active-only respects collapse).
- `useActiveOnlyPreference` unit-tested against a mocked `electronAPI` (load true/null, persist true/false, and the toggle-before-load race).
- `SidebarFilter` DOM tests for the toggle (aria-pressed, flip, real button).
- 185 renderer tests pass; typecheck clean; `build:renderer` compiles.

> Note: the Electron visual-probe environment broke mid-session (module-loader error unrelated to this code), so I couldn't re-measure the toggle row in Chromium. It's a plain flexbox row (fixed-width button + `flex:1` field); flagging in case a reviewer wants to eyeball it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)