### PR TITLE
fix(accounts): make a session account switch apply to the running session

### DIFF
--- a/src/main/__tests__/account-switch.test.ts
+++ b/src/main/__tests__/account-switch.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Account-switch tests (BDHLNDR-31) — reassigning a session or group's Claude
+ * account has to report which ptys need respawning (CLAUDE_CONFIG_DIR is fixed
+ * at spawn time) and carry the in-flight conversation transcript into the new
+ * account's config dir so the respawn can still --resume it.
+ *
+ * Uses bun:sqlite (API-compatible with better-sqlite3 for the statements the
+ * repos issue) so no native build is required to run the suite.
+ *
+ * Run with: bun test src/main/__tests__
+ */
+import { describe, expect, test, beforeEach, afterEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+let db: Database;
+
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
+}));
+
+mock.module('../database', () => ({
+  getDatabase: () => db,
+}));
+
+const accountSwitch = await import('../account-switch');
+
+let tmp: string;
+
+function freshDb(): Database {
+  const d = new Database(':memory:');
+  d.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      group_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      working_dir TEXT,
+      state TEXT,
+      shell_type TEXT DEFAULT 'bash',
+      "order" INTEGER DEFAULT 0,
+      created_at TEXT,
+      last_activity_at TEXT,
+      claude_session_id TEXT DEFAULT NULL,
+      ended_at TEXT DEFAULT NULL,
+      duration_seconds REAL DEFAULT 0,
+      claude_account_id TEXT DEFAULT NULL,
+      provider TEXT NOT NULL DEFAULT 'claude'
+    );
+    CREATE TABLE groups (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      color TEXT,
+      working_dir TEXT,
+      "order" INTEGER DEFAULT 0,
+      created_at TEXT,
+      parent_id TEXT DEFAULT NULL,
+      collapsed INTEGER DEFAULT 0,
+      claude_account_id TEXT DEFAULT NULL
+    );
+    CREATE TABLE claude_accounts (
+      id TEXT PRIMARY KEY,
+      label TEXT NOT NULL,
+      config_dir TEXT NOT NULL,
+      email TEXT,
+      color TEXT,
+      is_default INTEGER DEFAULT 0,
+      created_at TEXT,
+      last_used_at TEXT
+    );
+  `);
+  return d;
+}
+
+/** Register an account backed by a real (empty) config dir under tmp. */
+function addAccount(id: string, isDefault = false): string {
+  const configDir = path.join(tmp, id, '.claude');
+  fs.mkdirSync(configDir, { recursive: true });
+  db.prepare(`
+    INSERT INTO claude_accounts (id, label, config_dir, email, color, is_default, created_at, last_used_at)
+    VALUES (?, ?, ?, NULL, '#888888', ?, '2026-07-31T00:00:00Z', NULL)
+  `).run(id, id, configDir, isDefault ? 1 : 0);
+  return configDir;
+}
+
+function addGroup(id: string, accountId: string | null = null): void {
+  db.prepare(`
+    INSERT INTO groups (id, name, color, working_dir, "order", created_at, parent_id, collapsed, claude_account_id)
+    VALUES (?, ?, '#fff', '/tmp', 0, '2026-07-31T00:00:00Z', NULL, 0, ?)
+  `).run(id, id, accountId);
+}
+
+function addSession(
+  id: string,
+  groupId: string,
+  opts: { accountId?: string | null; claudeSessionId?: string | null } = {},
+): void {
+  db.prepare(`
+    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order",
+                          created_at, last_activity_at, claude_session_id, claude_account_id, provider)
+    VALUES (?, ?, ?, '/tmp', 'idle', 'claude', 0, '2026-07-31T00:00:00Z', '2026-07-31T00:00:00Z', ?, ?, 'claude')
+  `).run(id, groupId, id, opts.claudeSessionId ?? null, opts.accountId ?? null);
+}
+
+function writeTranscript(configDir: string, project: string, uuid: string): string {
+  const dir = path.join(configDir, 'projects', project);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${uuid}.jsonl`);
+  fs.writeFileSync(file, '{"type":"conversation"}\n');
+  return file;
+}
+
+function storedUuid(sessionId: string): string | null {
+  const row = db.prepare('SELECT claude_session_id FROM sessions WHERE id = ?').get(sessionId) as
+    { claude_session_id: string | null } | undefined;
+  return row?.claude_session_id ?? null;
+}
+
+function storedAccount(sessionId: string): string | null {
+  const row = db.prepare('SELECT claude_account_id FROM sessions WHERE id = ?').get(sessionId) as
+    { claude_account_id: string | null } | undefined;
+  return row?.claude_account_id ?? null;
+}
+
+beforeEach(() => {
+  db = freshDb();
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'account-switch-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('assignSessionAccount', () => {
+  test('persists the override and reports the session for restart', () => {
+    addAccount('acct-a', true);
+    addAccount('acct-b');
+    addGroup('g1');
+    addSession('s1', 'g1');
+
+    const result = accountSwitch.assignSessionAccount('s1', 'acct-b');
+
+    expect(storedAccount('s1')).toBe('acct-b');
+    expect(result.affectedSessionIds).toEqual(['s1']);
+  });
+
+  test('reports nothing when the effective account is unchanged', () => {
+    addAccount('acct-a', true);
+    addGroup('g1', 'acct-a');
+    addSession('s1', 'g1', { accountId: 'acct-a' });
+
+    // Clearing the override falls back to the group's account — same account,
+    // so the live pty is already correct and must not be disturbed.
+    const result = accountSwitch.assignSessionAccount('s1', null);
+
+    expect(storedAccount('s1')).toBeNull();
+    expect(result.affectedSessionIds).toEqual([]);
+  });
+
+  test('carries the conversation transcript into the new config dir', () => {
+    const dirA = addAccount('acct-a', true);
+    const dirB = addAccount('acct-b');
+    addGroup('g1');
+    addSession('s1', 'g1', { accountId: 'acct-a', claudeSessionId: 'uuid-1' });
+    writeTranscript(dirA, '-Users-x-repo', 'uuid-1');
+
+    accountSwitch.assignSessionAccount('s1', 'acct-b');
+
+    const copied = path.join(dirB, 'projects', '-Users-x-repo', 'uuid-1.jsonl');
+    expect(fs.existsSync(copied)).toBe(true);
+    expect(fs.readFileSync(copied, 'utf-8')).toContain('conversation');
+    // Transcript is readable from the new account, so the resume UUID survives.
+    expect(storedUuid('s1')).toBe('uuid-1');
+  });
+
+  test('drops the resume UUID when no transcript can be carried over', () => {
+    addAccount('acct-a', true);
+    addAccount('acct-b');
+    addGroup('g1');
+    addSession('s1', 'g1', { accountId: 'acct-a', claudeSessionId: 'uuid-missing' });
+
+    accountSwitch.assignSessionAccount('s1', 'acct-b');
+
+    // A stale UUID would burn a doomed --resume on the next spawn.
+    expect(storedUuid('s1')).toBeNull();
+  });
+
+  test('leaves an existing transcript in the target dir untouched', () => {
+    const dirA = addAccount('acct-a', true);
+    const dirB = addAccount('acct-b');
+    addGroup('g1');
+    addSession('s1', 'g1', { accountId: 'acct-a', claudeSessionId: 'uuid-1' });
+    writeTranscript(dirA, '-Users-x-repo', 'uuid-1');
+    const target = writeTranscript(dirB, '-Users-x-repo', 'uuid-1');
+    fs.writeFileSync(target, '{"type":"newer"}\n');
+
+    accountSwitch.assignSessionAccount('s1', 'acct-b');
+
+    expect(fs.readFileSync(target, 'utf-8')).toContain('newer');
+    expect(storedUuid('s1')).toBe('uuid-1');
+  });
+});
+
+describe('assignGroupAccount', () => {
+  test('restarts inheriting sessions and leaves overridden ones alone', () => {
+    addAccount('acct-a', true);
+    addAccount('acct-b');
+    addGroup('g1');
+    addSession('inherits', 'g1');
+    addSession('overrides', 'g1', { accountId: 'acct-a' });
+    addSession('elsewhere', 'g2');
+
+    const result = accountSwitch.assignGroupAccount('g1', 'acct-b');
+
+    expect(result.affectedSessionIds).toEqual(['inherits']);
+  });
+
+  test('carries transcripts for every inheriting session', () => {
+    const dirA = addAccount('acct-a', true);
+    const dirB = addAccount('acct-b');
+    addGroup('g1');
+    addSession('s1', 'g1', { claudeSessionId: 'uuid-1' });
+    addSession('s2', 'g1', { claudeSessionId: 'uuid-2' });
+    writeTranscript(dirA, '-Users-x-repo', 'uuid-1');
+    writeTranscript(dirA, '-Users-x-repo', 'uuid-2');
+
+    accountSwitch.assignGroupAccount('g1', 'acct-b');
+
+    expect(fs.existsSync(path.join(dirB, 'projects', '-Users-x-repo', 'uuid-1.jsonl'))).toBe(true);
+    expect(fs.existsSync(path.join(dirB, 'projects', '-Users-x-repo', 'uuid-2.jsonl'))).toBe(true);
+    expect(storedUuid('s1')).toBe('uuid-1');
+    expect(storedUuid('s2')).toBe('uuid-2');
+  });
+
+  test('falling back to the default account is a no-op when it already applies', () => {
+    addAccount('acct-a', true);
+    addGroup('g1', 'acct-a');
+    addSession('s1', 'g1');
+
+    const result = accountSwitch.assignGroupAccount('g1', null);
+
+    expect(result.affectedSessionIds).toEqual([]);
+  });
+});

--- a/src/main/account-resolver.ts
+++ b/src/main/account-resolver.ts
@@ -1,0 +1,36 @@
+import { ClaudeAccount } from '../shared/types';
+import { getDatabase } from './database';
+import { mapAccountRow } from './repositories/account-row';
+
+/**
+ * Resolve which Claude account a given session should launch under (BDHLNDR-31).
+ * Fallback chain: session → group → default → null (legacy ~/.claude behavior).
+ * Returns null if no accounts are configured, preserving pre-feature behavior.
+ *
+ * Lives outside repositories/accounts, and queries rather than calling into it,
+ * so that both spawn-time resolution (pty-manager) and switch-time resolution
+ * (account-switch) share one copy of this policy independently of that
+ * repository's module shape.
+ */
+export function resolveAccountForSession(sessionId: string): ClaudeAccount | null {
+  const db = getDatabase();
+
+  // COALESCE encodes the session-overrides-group precedence; the join drops to
+  // NULL when the referenced account no longer exists, which falls through to
+  // the default below exactly as a missing assignment does.
+  const row = db.prepare(`
+    SELECT a.*
+    FROM sessions s
+    LEFT JOIN groups g ON g.id = s.group_id
+    LEFT JOIN claude_accounts a
+      ON a.id = COALESCE(s.claude_account_id, g.claude_account_id)
+    WHERE s.id = ?
+  `).get(sessionId) as any;
+
+  if (row?.id) return mapAccountRow(row);
+
+  const fallback = db.prepare(
+    'SELECT * FROM claude_accounts WHERE is_default = 1 LIMIT 1'
+  ).get() as any;
+  return fallback ? mapAccountRow(fallback) : null;
+}

--- a/src/main/account-switch.ts
+++ b/src/main/account-switch.ts
@@ -1,0 +1,150 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import log from 'electron-log';
+
+import { AccountSwitchResult, ClaudeAccount } from '../shared/types';
+import { getDatabase } from './database';
+import { resolveAccountForSession } from './account-resolver';
+import * as groupsRepo from './repositories/groups';
+import * as sessionsRepo from './repositories/sessions';
+
+/**
+ * Reassigning a session's Claude account (BDHLNDR-31) is more than a column
+ * write: the account only reaches the CLI as CLAUDE_CONFIG_DIR, and that env
+ * var is baked into the pty at spawn time (see PtyManager.buildAgentSpawn). A
+ * live session therefore keeps billing the old account until its pty respawns.
+ *
+ * This module owns the two follow-ups the column write can't do on its own:
+ *   1. carry the in-flight conversation transcript into the new account's
+ *      config dir, so the respawn can still `--resume` it, and
+ *   2. report which sessions changed effective account, so the renderer knows
+ *      which ptys to restart.
+ */
+
+/** Config dir a session runs under when no account resolves (pre-accounts behavior). */
+function configDirOf(account: ClaudeAccount | null): string {
+  return account?.configDir ?? path.join(os.homedir(), '.claude');
+}
+
+/**
+ * Point a single session at `accountId` (null = inherit from its group).
+ * Returns the sessions needing a pty restart — empty when the effective
+ * account didn't actually move (e.g. clearing an override that already
+ * matched the group's account).
+ */
+export function assignSessionAccount(
+  sessionId: string,
+  accountId: string | null,
+): AccountSwitchResult {
+  const before = resolveAccountForSession(sessionId);
+  sessionsRepo.updateSession(sessionId, { claudeAccountId: accountId });
+  const after = resolveAccountForSession(sessionId);
+
+  if ((before?.id ?? null) === (after?.id ?? null)) {
+    return { affectedSessionIds: [] };
+  }
+
+  rehomeConversation(sessionId, before, after);
+  return { affectedSessionIds: [sessionId] };
+}
+
+/**
+ * Point a group at `accountId` (null = fall back to the default account).
+ * Sessions carrying their own override are unaffected; the rest inherit the
+ * change and are returned for restart.
+ */
+export function assignGroupAccount(
+  groupId: string,
+  accountId: string | null,
+): AccountSwitchResult {
+  const db = getDatabase();
+  const ids = (db.prepare('SELECT id FROM sessions WHERE group_id = ?').all(groupId) as
+    { id: string }[]).map(row => row.id);
+
+  const before = new Map(ids.map(id => [id, resolveAccountForSession(id)]));
+  groupsRepo.updateGroup(groupId, { claudeAccountId: accountId });
+
+  const affectedSessionIds: string[] = [];
+  for (const id of ids) {
+    const prev = before.get(id) ?? null;
+    const next = resolveAccountForSession(id);
+    if ((prev?.id ?? null) === (next?.id ?? null)) continue;
+    rehomeConversation(id, prev, next);
+    affectedSessionIds.push(id);
+  }
+
+  return { affectedSessionIds };
+}
+
+/**
+ * Keep a session's conversation alive across an account change.
+ *
+ * Claude Code stores transcripts under <configDir>/projects/<cwd-slug>/<uuid>.jsonl
+ * and reads that tree on `--resume`. After a switch the stored UUID points into
+ * the *old* account's tree, so the next launch would fail to resume and land in
+ * PtyManager's resume-failure fallback — a fresh conversation, history orphaned.
+ * Copying the transcript across preserves continuity, which is the whole point
+ * of switching mid-task when an account runs out.
+ *
+ * When the transcript can't be carried over (missing, unreadable, copy failed)
+ * we drop the stored UUID instead, so the respawn starts a clean conversation
+ * rather than burning a doomed `--resume` attempt.
+ */
+function rehomeConversation(
+  sessionId: string,
+  from: ClaudeAccount | null,
+  to: ClaudeAccount | null,
+): void {
+  const uuid = sessionsRepo.getClaudeSessionId(sessionId);
+  if (!uuid) return; // Never launched — nothing to carry.
+
+  if (carryTranscript(uuid, configDirOf(from), configDirOf(to))) return;
+
+  try {
+    sessionsRepo.clearClaudeSessionId(sessionId);
+  } catch (err) {
+    log.error(`[Accounts] Failed to clear claude_session_id for ${sessionId}:`, err);
+  }
+}
+
+/** @returns true when the transcript is readable from the target config dir. */
+function carryTranscript(uuid: string, fromDir: string, toDir: string): boolean {
+  try {
+    const source = findTranscript(fromDir, uuid);
+    if (!source) return false;
+
+    // Mirror the source's project-slug dir; the slug is derived from the
+    // session cwd, which the switch doesn't change.
+    const slug = path.basename(path.dirname(source));
+    const targetDir = path.join(toDir, 'projects', slug);
+    const target = path.join(targetDir, `${uuid}.jsonl`);
+    if (fs.existsSync(target)) return true;
+
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.copyFileSync(source, target);
+    log.info(`[Accounts] Carried conversation ${uuid} to ${targetDir}`);
+    return true;
+  } catch (err) {
+    log.warn(`[Accounts] Could not carry conversation ${uuid} across accounts:`, err);
+    return false;
+  }
+}
+
+/** Locate <configDir>/projects/<any-slug>/<uuid>.jsonl without recomputing the slug. */
+function findTranscript(configDir: string, uuid: string): string | null {
+  const projects = path.join(configDir, 'projects');
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(projects, { withFileTypes: true });
+  } catch {
+    return null; // No transcripts yet for this account.
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const candidate = path.join(projects, entry.name, `${uuid}.jsonl`);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,7 @@ import * as chatEventsRepo from './repositories/chat-events';
 import { ChatParser } from './api/chat-parser';
 import * as accountsRepo from './repositories/accounts';
 import * as accountAuth from './account-auth';
+import * as accountSwitch from './account-switch';
 import { exportSessions, ExportFormat } from './session-export';
 import { exportGroupsAndSessions, importGroupsAndSessions, importFromClaudeLander } from './group-import-export';
 import { StateMonitor } from './state-monitor';
@@ -793,6 +794,23 @@ safeHandle('accounts:update', (
 
 safeHandle('accounts:setDefault', (id: string) => {
   accountsRepo.setDefaultAccount(id);
+});
+
+// Assigning an account is routed through account-switch (not db:sessions:update)
+// so the conversation transcript follows the session into the new account's
+// config dir, and the renderer learns which ptys to respawn — CLAUDE_CONFIG_DIR
+// is fixed at spawn time, so a live session ignores the column write otherwise.
+safeHandle('accounts:assignToSession', (sessionId: string, accountId: string | null) => {
+  const result = accountSwitch.assignSessionAccount(sessionId, accountId);
+  getApiServer().broadcastSessionsUpdated();
+  return result;
+});
+
+safeHandle('accounts:assignToGroup', (groupId: string, accountId: string | null) => {
+  const result = accountSwitch.assignGroupAccount(groupId, accountId);
+  getApiServer().broadcastGroupsUpdated();
+  getApiServer().broadcastSessionsUpdated();
+  return result;
 });
 
 // Database IPC Handlers - Session Events (BDHLNDR-17)

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus } from '../shared/types';
+import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -321,6 +321,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('accounts:update', id, updates),
   setDefaultAccount: (id: string): Promise<void> =>
     ipcRenderer.invoke('accounts:setDefault', id),
+  assignAccountToSession: (sessionId: string, accountId: string | null): Promise<AccountSwitchResult> =>
+    ipcRenderer.invoke('accounts:assignToSession', sessionId, accountId),
+  assignAccountToGroup: (groupId: string, accountId: string | null): Promise<AccountSwitchResult> =>
+    ipcRenderer.invoke('accounts:assignToGroup', groupId, accountId),
   onAccountLoginCompleted: (callback: (data: { accountId: string; email: string | null }) => void) => {
     const listener = (_: Electron.IpcRendererEvent, data: { accountId: string; email: string | null }) => callback(data);
     ipcRenderer.on('accounts:login-completed', listener);

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -25,7 +25,8 @@ import {
   setClaudeSessionId as storeClaudeSessionId,
   clearClaudeSessionId as clearStoredClaudeSessionId,
 } from './repositories/sessions';
-import { resolveAccountForSession, touchAccount } from './repositories/accounts';
+import { touchAccount } from './repositories/accounts';
+import { resolveAccountForSession } from './account-resolver';
 import { vaultEnvFor } from './key-vault';
 import { redactEnv } from './redact-env';
 import log from 'electron-log';

--- a/src/main/repositories/account-row.ts
+++ b/src/main/repositories/account-row.ts
@@ -1,0 +1,16 @@
+import { ClaudeAccount } from '../../shared/types';
+
+/** claude_accounts row → domain object. Shared by the accounts repository and
+ *  the account resolver so both agree on defaults for nullable columns. */
+export function mapAccountRow(row: any): ClaudeAccount {
+  return {
+    id: row.id,
+    label: row.label,
+    configDir: row.config_dir,
+    email: row.email ?? null,
+    color: row.color ?? '#888888',
+    isDefault: Boolean(row.is_default),
+    createdAt: new Date(row.created_at),
+    lastUsedAt: row.last_used_at ? new Date(row.last_used_at) : null,
+  };
+}

--- a/src/main/repositories/accounts.ts
+++ b/src/main/repositories/accounts.ts
@@ -1,18 +1,6 @@
 import { getDatabase } from '../database';
 import { ClaudeAccount } from '../../shared/types';
-
-function mapRow(row: any): ClaudeAccount {
-  return {
-    id: row.id,
-    label: row.label,
-    configDir: row.config_dir,
-    email: row.email ?? null,
-    color: row.color ?? '#888888',
-    isDefault: Boolean(row.is_default),
-    createdAt: new Date(row.created_at),
-    lastUsedAt: row.last_used_at ? new Date(row.last_used_at) : null,
-  };
-}
+import { mapAccountRow as mapRow } from './account-row';
 
 export function getAllAccounts(): ClaudeAccount[] {
   const db = getDatabase();
@@ -137,27 +125,5 @@ export function deleteAccount(id: string): void {
   tx();
 }
 
-/**
- * Resolve which Claude account a given session should launch under (BDHLNDR-31).
- * Fallback chain: session → group → default → null (legacy ~/.claude behavior).
- * Returns null if no accounts are configured, preserving pre-feature behavior.
- */
-export function resolveAccountForSession(sessionId: string): ClaudeAccount | null {
-  const db = getDatabase();
-
-  const row = db.prepare(`
-    SELECT
-      s.claude_account_id AS session_account_id,
-      g.claude_account_id AS group_account_id
-    FROM sessions s
-    LEFT JOIN groups g ON g.id = s.group_id
-    WHERE s.id = ?
-  `).get(sessionId) as { session_account_id: string | null; group_account_id: string | null } | undefined;
-
-  const candidateId = row?.session_account_id ?? row?.group_account_id ?? null;
-  if (candidateId) {
-    const account = getAccount(candidateId);
-    if (account) return account;
-  }
-  return getDefaultAccount();
-}
+// resolveAccountForSession() lives in ../account-resolver — it reads sessions
+// and groups as well as accounts, so it isn't this repository's to own.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -399,7 +399,7 @@ const App: React.FC = () => {
     if (sessionIds.length === 0) return;
     setRestartKeys(prev => {
       const next = { ...prev };
-      for (const id of sessionIds) next[id] = (next[id] || 0) + 1;
+      for (const id of sessionIds) next[id] = (next[id] ?? 0) + 1;
       return next;
     });
   };
@@ -443,13 +443,15 @@ const App: React.FC = () => {
       items.push({ label: 'separator', onClick: () => {}, separator: true });
       items.push({
         label: `${currentAccountId === null ? '✓ ' : '   '}Inherit account from group`,
-        onClick: () => handleAssignSessionAccount(sessionId, null),
+        // Fire-and-forget: the menu closes on click and the store logs its own
+        // failures, so there's nothing for the caller to await.
+        onClick: () => { void handleAssignSessionAccount(sessionId, null); },
       });
       for (const acc of claudeAccounts) {
         const isCurrent = currentAccountId === acc.id;
         items.push({
           label: `${isCurrent ? '✓ ' : '   '}Use "${acc.label}"${acc.isDefault ? ' (default)' : ''}`,
-          onClick: () => handleAssignSessionAccount(sessionId, acc.id),
+          onClick: () => { void handleAssignSessionAccount(sessionId, acc.id); },
         });
       }
     }
@@ -487,13 +489,15 @@ const App: React.FC = () => {
       items.push({ label: 'separator', onClick: () => {}, separator: true });
       items.push({
         label: `${currentAccountId === null ? '✓ ' : '   '}Use default account`,
-        onClick: () => handleAssignGroupAccount(groupId, null),
+        // Fire-and-forget, as above — the restart prompt is raised from inside
+        // the handler once main reports which sessions moved.
+        onClick: () => { void handleAssignGroupAccount(groupId, null); },
       });
       for (const acc of claudeAccounts) {
         const isCurrent = currentAccountId === acc.id;
         items.push({
           label: `${isCurrent ? '✓ ' : '   '}Use "${acc.label}"${acc.isDefault ? ' (default)' : ''}`,
-          onClick: () => handleAssignGroupAccount(groupId, acc.id),
+          onClick: () => { void handleAssignGroupAccount(groupId, acc.id); },
         });
       }
     }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -41,6 +41,7 @@ const App: React.FC = () => {
     loading: groupsLoading,
     createGroup,
     updateGroup,
+    setGroupAccount,
     removeGroup,
     reorderGroup,
     toggleCollapse,
@@ -114,9 +115,11 @@ const App: React.FC = () => {
 
   // Destructive action confirmation state
   const [confirmAction, setConfirmAction] = useState<{
-    type: 'closeSession' | 'deleteGroup';
+    type: 'closeSession' | 'deleteGroup' | 'restartForAccountSwitch';
     id: string;
     message: string;
+    /** Sessions to respawn, for 'restartForAccountSwitch'. */
+    sessionIds?: string[];
   } | null>(null);
 
   const GROUP_COLORS = [
@@ -130,6 +133,7 @@ const App: React.FC = () => {
     setActiveSessionId,
     createSession,
     updateSession,
+    setSessionAccount,
     removeSession,
     getSessionsByGroup,
     getStateCounts,
@@ -376,6 +380,55 @@ const App: React.FC = () => {
     setColorPickerGroupId(null);
   };
 
+  /**
+   * Of the sessions whose account just changed, the ones with a pty to replace.
+   * Stopped sessions are skipped — they have nothing running under the old
+   * account and pick the new one up whenever the user starts them.
+   */
+  const liveSessionsAmong = (sessionIds: string[]) =>
+    sessionIds.filter(id => sessions.find(s => s.id === id)?.state !== 'stopped');
+
+  /**
+   * Respawn the ptys of sessions whose account just changed (BDHLNDR-31).
+   * The account only reaches the CLI as CLAUDE_CONFIG_DIR, which is fixed when
+   * the pty spawns — without this the picked account applies to nothing until
+   * the user restarts by hand. Main has already carried the conversation
+   * transcript over, so the relaunch resumes where the old account left off.
+   */
+  const restartSessions = (sessionIds: string[]) => {
+    if (sessionIds.length === 0) return;
+    setRestartKeys(prev => {
+      const next = { ...prev };
+      for (const id of sessionIds) next[id] = (next[id] || 0) + 1;
+      return next;
+    });
+  };
+
+  // Switching one session's account restarts it outright: the user pointed at
+  // that session and picked an account, so the restart is the thing they asked
+  // for.
+  const handleAssignSessionAccount = async (sessionId: string, accountId: string | null) => {
+    restartSessions(liveSessionsAmong(await setSessionAccount(sessionId, accountId)));
+  };
+
+  // A group switch can sweep several running sessions at once, which is a much
+  // bigger action than the click implies — so the restart is opt-in. Declining
+  // still persists the assignment; those sessions move over on their next
+  // restart.
+  const handleAssignGroupAccount = async (groupId: string, accountId: string | null) => {
+    const live = liveSessionsAmong(await setGroupAccount(groupId, accountId));
+    if (live.length === 0) return;
+    const count = live.length === 1 ? '1 running session' : `${live.length} running sessions`;
+    setConfirmAction({
+      type: 'restartForAccountSwitch',
+      id: groupId,
+      sessionIds: live,
+      message: `${count} in this group ${live.length === 1 ? 'is' : 'are'} still on the previous `
+        + `account. Restart ${live.length === 1 ? 'it' : 'them'} now to apply the switch? `
+        + `Conversations resume where they left off. Skipping applies the switch on their next restart.`,
+    });
+  };
+
   const handleSessionContextMenu = (e: React.MouseEvent, sessionId: string, sessionName: string) => {
     e.preventDefault();
     const session = sessions.find(s => s.id === sessionId);
@@ -390,13 +443,13 @@ const App: React.FC = () => {
       items.push({ label: 'separator', onClick: () => {}, separator: true });
       items.push({
         label: `${currentAccountId === null ? '✓ ' : '   '}Inherit account from group`,
-        onClick: () => updateSession(sessionId, { claudeAccountId: null }),
+        onClick: () => handleAssignSessionAccount(sessionId, null),
       });
       for (const acc of claudeAccounts) {
         const isCurrent = currentAccountId === acc.id;
         items.push({
           label: `${isCurrent ? '✓ ' : '   '}Use "${acc.label}"${acc.isDefault ? ' (default)' : ''}`,
-          onClick: () => updateSession(sessionId, { claudeAccountId: acc.id }),
+          onClick: () => handleAssignSessionAccount(sessionId, acc.id),
         });
       }
     }
@@ -434,13 +487,13 @@ const App: React.FC = () => {
       items.push({ label: 'separator', onClick: () => {}, separator: true });
       items.push({
         label: `${currentAccountId === null ? '✓ ' : '   '}Use default account`,
-        onClick: () => updateGroup(groupId, { claudeAccountId: null }),
+        onClick: () => handleAssignGroupAccount(groupId, null),
       });
       for (const acc of claudeAccounts) {
         const isCurrent = currentAccountId === acc.id;
         items.push({
           label: `${isCurrent ? '✓ ' : '   '}Use "${acc.label}"${acc.isDefault ? ' (default)' : ''}`,
-          onClick: () => updateGroup(groupId, { claudeAccountId: acc.id }),
+          onClick: () => handleAssignGroupAccount(groupId, acc.id),
         });
       }
     }
@@ -1437,12 +1490,17 @@ const App: React.FC = () => {
           >
             <p id="confirm-message">{confirmAction.message}</p>
             <div className="confirm-actions">
-              <button className="btn btn-secondary" onClick={() => setConfirmAction(null)}>Cancel</button>
+              <button className="btn btn-secondary" onClick={() => setConfirmAction(null)}>
+                {confirmAction.type === 'restartForAccountSwitch' ? 'Not now' : 'Cancel'}
+              </button>
               <button className="btn btn-danger" onClick={() => {
                 if (confirmAction.type === 'closeSession') doRemoveSession(confirmAction.id);
                 if (confirmAction.type === 'deleteGroup') doDeleteGroup(confirmAction.id);
+                if (confirmAction.type === 'restartForAccountSwitch') restartSessions(confirmAction.sessionIds ?? []);
                 setConfirmAction(null);
-              }}>Confirm</button>
+              }}>
+                {confirmAction.type === 'restartForAccountSwitch' ? 'Restart' : 'Confirm'}
+              </button>
             </div>
           </div>
         </div>

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus } from '../shared/types';
+import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -157,6 +157,8 @@ interface ElectronAPI {
   deleteAccount: (id: string) => Promise<void>;
   updateAccount: (id: string, updates: { label?: string; color?: string; email?: string | null }) => Promise<void>;
   setDefaultAccount: (id: string) => Promise<void>;
+  assignAccountToSession: (sessionId: string, accountId: string | null) => Promise<AccountSwitchResult>;
+  assignAccountToGroup: (groupId: string, accountId: string | null) => Promise<AccountSwitchResult>;
   onAccountLoginCompleted: (callback: (data: { accountId: string; email: string | null }) => void) => () => void;
   onAccountLoginExited: (callback: (data: { accountId: string; exitCode: number }) => void) => () => void;
 

--- a/src/renderer/store/groups.ts
+++ b/src/renderer/store/groups.ts
@@ -85,6 +85,25 @@ export function useGroups() {
     }
   }, []);
 
+  /**
+   * Reassign a group's Claude account (BDHLNDR-31). Returns the sessions that
+   * inherited the change and therefore need a pty restart — see
+   * useSessions().setSessionAccount for why the plain updateGroup path isn't
+   * enough.
+   */
+  const setGroupAccount = useCallback(async (id: string, accountId: string | null): Promise<string[]> => {
+    try {
+      const { affectedSessionIds } = await window.electronAPI.assignAccountToGroup(id, accountId);
+      setGroups(prev => prev.map(g =>
+        g.id === id ? { ...g, claudeAccountId: accountId } : g
+      ));
+      return affectedSessionIds;
+    } catch (error) {
+      console.error('Failed to assign account to group:', error);
+      return [];
+    }
+  }, []);
+
   const removeGroup = useCallback(async (id: string) => {
     try {
       await window.electronAPI.deleteGroup(id);
@@ -172,6 +191,7 @@ export function useGroups() {
     loading,
     createGroup,
     updateGroup,
+    setGroupAccount,
     removeGroup,
     reorderGroup,
     toggleCollapse,

--- a/src/renderer/store/sessions.ts
+++ b/src/renderer/store/sessions.ts
@@ -122,6 +122,26 @@ export function useSessions() {
     }
   }, []);
 
+  /**
+   * Reassign a session's Claude account (BDHLNDR-31). Goes through the
+   * dedicated channel rather than updateSession because main has to carry the
+   * conversation transcript into the new account's config dir and tell us which
+   * ptys need restarting — the column write alone leaves a live session on the
+   * old account.
+   */
+  const setSessionAccount = useCallback(async (id: string, accountId: string | null): Promise<string[]> => {
+    try {
+      const { affectedSessionIds } = await window.electronAPI.assignAccountToSession(id, accountId);
+      setSessions(prev => prev.map(s =>
+        s.id === id ? { ...s, claudeAccountId: accountId } : s
+      ));
+      return affectedSessionIds;
+    } catch (error) {
+      console.error('Failed to assign account to session:', error);
+      return [];
+    }
+  }, []);
+
   const removeSession = useCallback(async (id: string) => {
     try {
       await window.electronAPI.deleteDbSession(id);
@@ -190,6 +210,7 @@ export function useSessions() {
     createSession,
     updateSession,
     updateSessionState,
+    setSessionAccount,
     removeSession,
     getSessionsByGroup,
     getStateCounts,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -220,6 +220,15 @@ export interface ClaudeAccount {
   lastUsedAt: Date | null;
 }
 
+/**
+ * Outcome of reassigning a Claude account to a session or group (BDHLNDR-31).
+ * CLAUDE_CONFIG_DIR is fixed when a pty spawns, so the listed sessions must be
+ * restarted before the switch takes effect on them.
+ */
+export interface AccountSwitchResult {
+  affectedSessionIds: string[];
+}
+
 export interface AppState {
   groups: Group[];
   sessions: Session[];


### PR DESCRIPTION
## The bug

Right-clicking a session and picking a different Claude account had no effect on that session — it kept running under the old account. You reach for this menu precisely when an account is used up, so "no effect" is the worst possible outcome.

**Cause:** the menu item only wrote `claude_account_id` to the DB. The account reaches the CLI solely as `CLAUDE_CONFIG_DIR`, which `PtyManager.buildAgentSpawn` resolves **once, at spawn time** (`src/main/pty-manager.ts:388`). A live session therefore ignores the column write until its pty is respawned.

## The fix

New `src/main/account-switch.ts` owns the assignment and does the two things the column write can't:

1. **Reports which sessions actually moved** — resolves the effective account before and after, so clearing a session override that already matched its group's account doesn't needlessly kill a pty. The renderer respawns the reported sessions, which is what makes the picked account take effect.
2. **Carries the conversation across** — the stored resume UUID points into the *old* account's `projects/` tree, so a naive restart fails `--resume` and drops into the resume-failure fallback, silently orphaning the conversation. The transcript is now copied into the new account's config dir (same idea as the existing `seedLegacyConversations`). When it can't be carried over, the stale UUID is cleared so the respawn starts clean rather than burning a doomed `--resume`.

## Restart behavior

- **Session switch** — restarts immediately. You pointed at one session and picked an account; the restart is the request.
- **Group switch** — opt-in. The assignment persists right away, then a confirm dialog asks before respawning ("3 running sessions in this group are still on the previous account…"). Declining leaves them to pick it up on their next restart. Sessions with their own override are never touched.

## Refactor note

`resolveAccountForSession` moves from `repositories/accounts` to a new `account-resolver` module. It reads sessions and groups as well as accounts, so it was never that repository's to own — and the move keeps it clear of the module `pty-manager.test.ts` stubs process-wide, which was making the new tests pass alone and fail in the full suite. The shared row mapper lands in `repositories/account-row.ts`.

## Testing

- 8 new tests in `src/main/__tests__/account-switch.test.ts`: restart reporting, the unchanged-account no-op, transcript carry-over, stale-UUID invalidation, not clobbering an existing target transcript, and the group-inheritance path.
- Full suite: 452 pass, 0 fail. Both tsconfigs typecheck. `bun run build` succeeds.
- **Not covered by tests:** the new group confirm dialog is UI-only — worth a click-through on a group with two or three live sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)