### PR TITLE
fix(accounts): address review follow-ups on the account switch

### DIFF
--- a/src/main/__tests__/account-switch.test.ts
+++ b/src/main/__tests__/account-switch.test.ts
@@ -186,6 +186,36 @@ describe('assignSessionAccount', () => {
     expect(storedUuid('s1')).toBeNull();
   });
 
+  test('refuses to build a transcript path from an unexpected id format', () => {
+    const dirA = addAccount('acct-a', true);
+    const dirB = addAccount('acct-b');
+    addGroup('g1');
+    // Nothing in the app writes an id like this — the guard exists so the
+    // path build never depends on that staying true.
+    addSession('s1', 'g1', { accountId: 'acct-a', claudeSessionId: '../../escape' });
+    writeTranscript(dirA, '-Users-x-repo', 'uuid-1');
+
+    accountSwitch.assignSessionAccount('s1', 'acct-b');
+
+    expect(fs.existsSync(path.join(tmp, 'escape.jsonl'))).toBe(false);
+    expect(fs.existsSync(path.join(dirB, 'escape.jsonl'))).toBe(false);
+    // Nothing was carried, so the id is dropped and the respawn starts fresh.
+    expect(storedUuid('s1')).toBeNull();
+  });
+
+  test('an unreadable projects dir degrades to a fresh conversation', () => {
+    const dirA = addAccount('acct-a', true);
+    addAccount('acct-b');
+    addGroup('g1');
+    addSession('s1', 'g1', { accountId: 'acct-a', claudeSessionId: 'uuid-1' });
+    // projects/ as a file, not a directory — readdir fails with ENOTDIR, the
+    // "real environment problem" branch rather than the benign ENOENT one.
+    fs.writeFileSync(path.join(dirA, 'projects'), 'not a directory');
+
+    expect(() => accountSwitch.assignSessionAccount('s1', 'acct-b')).not.toThrow();
+    expect(storedUuid('s1')).toBeNull();
+  });
+
   test('leaves an existing transcript in the target dir untouched', () => {
     const dirA = addAccount('acct-a', true);
     const dirB = addAccount('acct-b');

--- a/src/main/account-switch.ts
+++ b/src/main/account-switch.ts
@@ -108,8 +108,30 @@ function rehomeConversation(
   }
 }
 
+/**
+ * A conversation id we're willing to interpolate into a filesystem path.
+ *
+ * Today these are always crypto.randomUUID() output written by this app, so
+ * nothing in the current flow can produce a hostile value — but the id reaches
+ * us from a database column and is used to build a path, and that pairing
+ * shouldn't rest on an assumption about the writer. Rejecting separators and
+ * traversal makes the containment local and checkable.
+ */
+const PATH_SAFE_CONVERSATION_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+function isPathSafeConversationId(uuid: string): boolean {
+  return PATH_SAFE_CONVERSATION_ID.test(uuid) && !uuid.includes('..');
+}
+
 /** @returns true when the transcript is readable from the target config dir. */
 function carryTranscript(uuid: string, fromDir: string, toDir: string): boolean {
+  if (!isPathSafeConversationId(uuid)) {
+    // Not a shape we'd ever have written — refuse to build a path from it and
+    // let the caller drop the id, which restarts on a fresh conversation.
+    log.warn(`[Accounts] Refusing to carry conversation with unexpected id format: ${uuid}`);
+    return false;
+  }
+
   try {
     const source = findTranscript(fromDir, uuid);
     if (!source) return false;
@@ -137,8 +159,15 @@ function findTranscript(configDir: string, uuid: string): string | null {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(projects, { withFileTypes: true });
-  } catch {
-    return null; // No transcripts yet for this account.
+  } catch (err) {
+    // A missing projects/ dir is the ordinary "no transcripts yet" case and
+    // stays quiet. Anything else — permissions, I/O — is an environment
+    // problem, and silently reading it as "nothing to carry" would present a
+    // broken machine as a routine fresh conversation.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      log.warn(`[Accounts] Could not read ${projects} while carrying a conversation:`, err);
+    }
+    return null;
   }
 
   for (const entry of entries) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1497,7 +1497,10 @@ const App: React.FC = () => {
               <button className="btn btn-secondary" onClick={() => setConfirmAction(null)}>
                 {confirmAction.type === 'restartForAccountSwitch' ? 'Not now' : 'Cancel'}
               </button>
-              <button className="btn btn-danger" onClick={() => {
+              {/* Closing a session or deleting a group destroys something; a
+                  restart to apply an account switch just re-runs it, so it
+                  shouldn't wear the danger styling that says otherwise. */}
+              <button className={`btn ${confirmAction.type === 'restartForAccountSwitch' ? 'btn-primary' : 'btn-danger'}`} onClick={() => {
                 if (confirmAction.type === 'closeSession') doRemoveSession(confirmAction.id);
                 if (confirmAction.type === 'deleteGroup') doDeleteGroup(confirmAction.id);
                 if (confirmAction.type === 'restartForAccountSwitch') restartSessions(confirmAction.sessionIds ?? []);


### PR DESCRIPTION
Follow-up to #151, covering the three non-blocking points @brannon-bowden raised in that review.

### 1. Validate the conversation id before it becomes a path (`account-switch.ts:112`)

The transcript path interpolated `claude_session_id` straight into `${uuid}.jsonl`. These ids are always `crypto.randomUUID()` output written by this app, so nothing in the current flow can produce a hostile value — but the id arrives from a database column and is used to build a filesystem path, and that pairing shouldn't rest on an assumption about the writer.

Ids must now match `/^[A-Za-z0-9][A-Za-z0-9._-]*$/` and contain no `..`. One that fails carries nothing, which drops the id and restarts on a fresh conversation — the same degradation as a missing transcript.

### 2. Distinguish "no transcripts yet" from a broken environment (`account-switch.ts:145`)

`findTranscript` swallowed every `readdirSync` failure identically. A missing `projects/` dir is the ordinary case and stays quiet; anything else (permissions, I/O) is now logged, so a broken machine stops presenting itself as a routine fresh conversation.

### 3. Restart confirmation is not a destructive action (`App.tsx:1500`)

The confirm button reused `btn-danger`. Closing a session or deleting a group destroys something; restarting a session to apply an account switch just re-runs it. It now uses `btn-primary` in that case, `btn-danger` for the two genuinely destructive ones.

## Testing

Two new tests in `account-switch.test.ts`:
- a traversal-shaped id (`../../escape`) writes nothing outside the target dir and drops the stored id
- a `projects/` path that is a file, not a directory (`ENOTDIR` — the "real problem" branch) degrades without throwing

Full suite: 454 pass, 0 fail. Both tsconfigs typecheck.

## Still open from that review

The renderer-side orchestration (`liveSessionsAmong`, both assign handlers, the confirm-dialog restart path) still has no direct test coverage — not addressed here, since it wants a renderer-testing approach rather than a one-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)