### PR TITLE
fix(relay): harden the tunnel before sharing (M5.0)

### DIFF
--- a/docs/designs/session-sharing.md
+++ b/docs/designs/session-sharing.md
@@ -1,0 +1,489 @@
+# Session Sharing — Multi-User Access to a Relayed Machine
+
+**Branch:** `feature/session-sharing` · **Status:** design · **Extends:**
+[`remote-hosting-relay.md`](./remote-hosting-relay.md) §4–§5, §8
+
+Lets a machine owner share **one named session** with another relay user, who can
+**watch**, or (with a much heavier consent step) **watch and type**. The relay decides
+*who may open a channel*; the desktop agent decides *what they may do*. This makes real
+the split §4 of the relay design already pre-committed to — "enforced by the **agent**
+(the relay can't, since it can't read the frames)."
+
+> **Read §1 first.** Two findings reframe this feature: there is a **live replay flaw in
+> the shipped M3 tunnel** that must be fixed before a second user exists, and
+> **"watch and type" is a machine-trust decision, not a session-scoped one.** Neither is
+> negotiable by UI copy.
+
+## Decisions
+
+1. **Harden before sharing.** M5.0 ships security fixes to the *existing single-user*
+   tunnel with no user-visible change. Sharing multiplies channels per machine and puts
+   channel establishment under untrusted control; today's defects are survivable with one
+   owner and are not with guests.
+2. **Session-scoped, never machine-scoped.** A grant names an explicit session list. There
+   is no "share my machine" option.
+3. **The relay is a coarse gate, not an authority.** `ws.ts:159`'s ownership check becomes
+   `getMachineAccess(machineId, userId)`, and its answer only decides whether a socket is
+   worth brokering. The agent re-derives every capability from a certificate it signed.
+4. **Grants are keyed by `grantId`, not by (machine, person).** Sharing a second session
+   with the same colleague is the first thing anyone will do; it must be a second grant,
+   never an in-place widening of the first.
+5. **No stored owner certificate.** The owner path stays an explicit branch gated by a
+   desktop-latched owner id (§3). A machine-wide bearer cert sitting in the relay's DB is
+   a skeleton key, not a simplification.
+6. **Guests are structurally invisible to the relay's session list.** No session id ever
+   reaches the relay; scope lives in the desktop's own tables.
+7. **Presence ships with the first guest, not after.** Silent read access to a live
+   terminal is the same class of harm as silent write access.
+
+## Non-goals (v1)
+
+Machine-wide grants · guest-initiated sharing · sharing scrollback history · guest-driven
+`terminal:resize` · `session:create` / `group:create` / `dirs:list` for any guest, ever ·
+browser-held guest device keys · session recording · federation of grants between relays.
+
+---
+
+## 1. Two findings that shape everything
+
+### 1.1 The shipped tunnel is replayable (fix before sharing)
+
+The M3 handshake derives the session key from the machine's **long-lived** X25519 key, and
+the Ed25519 proof signs only the two public keys:
+
+```
+buildHandshakeProof → `e2e-handshake:v1\n<clientPub>\n<agentPub>`   (e2e.ts:86)
+deriveSharedSecret  → ECDH(static agent X25519 priv, clientPub)    (relay-identity.ts:111)
+recvCounter          = -1 on every new channel                      (session-tunnel.ts:97)
+```
+
+Nothing binds a channel to a moment in time. A relay that logs one session can later open a
+fresh client socket, present the **same** `clientX25519Pub`, and replay the recorded
+ciphertext frames in order. The agent derives an identical key, `recvCounter` starts fresh,
+every frame authenticates, and `dispatch()` executes it — re-running the owner's past
+`terminal:input` and `session:create` verbatim. No cryptography is broken.
+
+The same root cause gives **AES-GCM nonce reuse**: two concurrent channels sharing a
+`clientX25519Pub` share a key and both start `sendCounter` at 0, so XOR of the two output
+streams leaks plaintext. That is a direct break of the zero-knowledge property the relay
+design promises, reachable by the exact party it names as untrusted.
+
+**The fix is small and wire-compatible.** `relay/web/src/connection.ts:69-78` pins only
+`machineEd25519Pub` and derives from whatever `agentX25519Pub` the *signed* proof carries.
+So the agent switches to a **per-channel ephemeral X25519 keypair** with no web-client
+change and no wire-format break — and it buys forward secrecy the design currently lacks.
+
+> **Superseded (implemented in M5.0):** an earlier draft of this section also added a
+> `channelNonce` to the proof and bumped it to `e2e-handshake:v2`. That is unnecessary and
+> was dropped. Once the agent's key is per-channel, the proof already covers a value that
+> is fresh every time, so a replayed proof carries an ephemeral public key whose private
+> half no longer exists — the channel simply fails to establish. Keeping v1 also avoids a
+> coordinated relay/desktop deploy and the version-negotiation field it would need, which
+> would itself have been a relay-selectable downgrade path.
+
+`machines.x25519_pubkey` becomes vestigial (it is already unused by the client) and stays
+only for link-time display. `deriveSharedSecret` is **deleted** rather than left exported —
+it is precisely the primitive whose reintroduction would undo this.
+
+### 1.2 "Watch and type" is machine trust wearing session-scope clothing
+
+The tempting claim — *a guest can watch, or watch and type, and nothing else* — is false
+the moment the shared session is an agentic CLI, which is the entire product. Blocking
+`session:create`, `group:create` and `dirs:list` guards the side door while the granted
+primitive walks through the front one: the guest types a prompt and **the CLI's own Bash
+tool runs it**.
+
+The blast radius is concrete. `pty-manager.ts:418` builds
+
+```ts
+const processEnv = { ...process.env, ...launch.env, ...vaultEnv };
+```
+
+so a shared PTY carries the whole Electron process environment, plus `vaultEnvFor(provider)`
+API keys when the user opted that provider into key auth, plus the owner's resolved Claude
+account config. A typing guest can therefore read `~/.ssh`, `~/.aws`, any repo on disk, and
+spend the owner's Claude account.
+
+We do not fix this with a capability table, because the capability *is* the grant. We fix it
+with honesty:
+
+- **Watch-only is the safe, default, session-scoped product** and ships first (M5.2).
+- **Watch-and-type is gated behind high-friction consent** (§6) whose copy says plainly that
+  it is equivalent to lending the machine, and ships later (M5.3).
+- The threat model — not the marketing copy — carries the statement.
+
+## 2. Trust model
+
+```mermaid
+flowchart LR
+  subgraph Owner["Owner desktop — the AUTHORITY"]
+    LAT["latched ownerUserId"]
+    GR[("relay_grants\n+ relay_grant_sessions\n(session lists live HERE)")]
+    SIG["mints grant:v1\nsigned by machine Ed25519"]
+  end
+  subgraph Relay["Relay — a COARSE GATE"]
+    GATE["getMachineAccess(machineId, userId)"]
+    CERT[("machine_grants\ncertificate = opaque TEXT")]
+  end
+  subgraph Guest["Guest browser"]
+    CH["presents certificate\nin client:open"]
+  end
+  Owner -->|"share:bind {grantId, certificate}"| Relay
+  Relay -->|"re-serves certificate"| Guest
+  Guest -->|"client:open + certificate"| Relay
+  Relay -->|"forwards + relay-asserted principal"| Owner
+  Owner -->|"verify sig · grantId · exp · principal match"| Owner
+```
+
+**What a malicious relay can still do:** serve malicious web-client JS (it hosts the
+bundle — this dominates every browser-side defence and is not fixable in v1); deny service;
+learn metadata; and present a legitimately-issued certificate on a socket whose `userId` it
+lied about, handing an existing guest's access to a user of its choosing.
+
+**What it cannot do:** mint a certificate, escalate a role, add a session to a scope, extend
+an expiry, or read terminal content.
+
+**What it must not be able to do, and how:** the relay must not be able to acquire *owner*
+capability. That is why there is no persisted owner certificate (§3) and why the agent
+latches its owner id.
+
+## 3. The owner path (no skeleton key)
+
+The desktop cannot learn its own relay user id from anywhere but the relay — `agent:ready`
+carries `machineId` only. So "mint an owner certificate at link time" would have the agent
+signing a machine-wide credential for whatever id the untrusted party asserted.
+
+Instead: **the human confirms it once.** On first link (and any owner change) the desktop
+shows a one-time modal — *"This machine is now linked to @dana-k (dana@example.com). Is that
+you?"* — persists the confirmed id as `relay.ownerUserId`, and thereafter treats
+`principal.userId === relay.ownerUserId` as the owner branch. Re-minting for a different id
+requires a fresh confirmation.
+
+This is not weaker than today (the relay already decides which sockets reach the agent) and
+it avoids a stored bearer credential that would survive an hour-long relay compromise or a
+leaked DB backup.
+
+**Version skew is a hard requirement, not an open question.** `relay-client.ts:262`
+dispatches on `msg.clientId` and ignores unknown fields, and `session-tunnel.open()` reads
+only `clientX25519Pub`. So an **old desktop build receiving a guest `client:open` grants all
+nine commands** — total machine compromise of a user who never opted into sharing. Because
+the relay redeploys independently of shipped Electron builds, this *will* happen. Therefore:
+
+- the agent advertises `caps: ['grants:v1']` in `agent:auth`;
+- the relay refuses to create invites for, or route any guest `client:open` to, a machine
+  whose live agent has not advertised it;
+- the agent keeps a **one-way latch**: once it has enforced a certificate for this machine it
+  never again accepts a certificate-less non-owner open.
+
+The latch, not a deletion date, is what makes the beta window safe.
+
+## 4. Data model
+
+`relay/src/db/migrations/002_sharing.sql` — the relay stores routing and an opaque blob:
+
+```sql
+CREATE TABLE IF NOT EXISTS share_invites (
+  id TEXT PRIMARY KEY,
+  machine_id TEXT NOT NULL REFERENCES machines(id) ON DELETE CASCADE,
+  code_hash TEXT NOT NULL UNIQUE,
+  expected_github_login TEXT,          -- addressed invites (§6); NULL = open link
+  role TEXT NOT NULL CHECK(role IN ('viewer','operator')),
+  label TEXT,
+  grant_ttl_seconds INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','redeemed','revoked')),
+  redeemed_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  redeemed_at INTEGER,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS machine_grants (
+  id TEXT PRIMARY KEY,                 -- grantId, generated by the DESKTOP
+  machine_id TEXT NOT NULL REFERENCES machines(id) ON DELETE CASCADE,
+  grantee_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  invite_id TEXT REFERENCES share_invites(id) ON DELETE SET NULL,
+  certificate TEXT,                    -- NULL until the agent countersigns; opaque here
+  role TEXT NOT NULL CHECK(role IN ('viewer','operator')),
+  label TEXT,                          -- display hint only, NEVER authorization
+  status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','active','revoked')),
+  created_at INTEGER NOT NULL, bound_at INTEGER,
+  expires_at INTEGER, revoked_at INTEGER, last_used_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_machine_grants_grantee ON machine_grants(grantee_user_id, status);
+CREATE INDEX IF NOT EXISTS idx_machine_grants_machine ON machine_grants(machine_id, status);
+CREATE INDEX IF NOT EXISTS idx_machine_grants_expires_at ON machine_grants(expires_at);
+CREATE INDEX IF NOT EXISTS idx_share_invites_machine ON share_invites(machine_id, status);
+CREATE INDEX IF NOT EXISTS idx_share_invites_expires_at ON share_invites(expires_at);
+```
+
+**No `UNIQUE(machine_id, grantee_user_id)`.** Many grants per person is the normal case;
+the effective scope of a client is the **union** of the certificates it presents, resolved
+locally by the agent. A reused `grantId` would silently hand one grant's holder another
+grant's session set, so the desktop generates the id and the agent refuses any certificate
+whose `grantId` is not in its own table.
+
+**Do not bundle the `link_codes` FK repair into this migration.** `runMigrations` wraps each
+file in a transaction and SQLite makes `PRAGMA foreign_keys` a no-op inside one, so the
+standard 12-step table rebuild does not apply cleanly. It is an unrelated pre-existing
+defect; ship it separately with a volume snapshot in the runbook.
+
+`relay/src/relay.test.ts:45` asserts `user_version === 1` and must bump to `2`.
+
+**Desktop side** (`database.ts` `initializeTables()` — eagerly, not the lazy
+`paired_devices` pattern):
+
+```sql
+relay_grants(id, relay_origin, grantee_user_id, grantee_login, role, status,
+             created_at, bound_at, expires_at, revoked_at, revoke_pending)
+relay_grant_sessions(grant_id REFERENCES relay_grants(id) ON DELETE CASCADE,
+                     session_id REFERENCES sessions(id) ON DELETE CASCADE,
+                     pty_epoch INTEGER NOT NULL,
+                     PRIMARY KEY(grant_id, session_id))
+```
+
+`relay_origin` is in the signed byte string and checked at dispatch: `relayUrl` is a
+user-settable preference, so a certificate minted against relay A must not verify on relay B
+(whose operator controls its own `users` table and could assign a matching id). Wipe
+`relay_grants` on `relayUrl` change, on `clearIdentity()`, and on re-link, with a visible
+notice.
+
+`pty_epoch` binds the grant to the **PTY instance**, not the session row. `sessions.id`
+survives stop/restart (`pty-manager.ts:316`), so without it a share of "Auth refactor"
+follows the row into whatever it becomes weeks later. On restart the entry goes stale, the
+agent denies `terminal:subscribe`, and the owner gets one re-approval prompt.
+
+## 5. Wire protocol
+
+Certificate: `grant:v1.<base64url(payload)>.<base64url(ed25519 sig)>`, signed over
+
+```
+grant:v1\n<grantId>\n<machineId>\n<relayOrigin>\n<granteeUserId>\n<role>\n<issuedAt>\n<expiresAt>
+```
+
+Protocol builders are hand-duplicated across three trees, so land a **fixed test vector**
+(payload + known-good signature) asserted in `relay/src/sharing.test.ts` *and*
+`src/main/api/relay/__tests__/grants.test.ts` — and a checked-in **policy fixture**
+(role → caps, command → required cap) asserted in all three. The certificate format will not
+drift; the policy will, the moment `operator` lands.
+
+| Direction | Message |
+| --- | --- |
+| relay→agent | `share:pending {grants:[…]}` · `share:sync {grants:[…]}` on `agent:ready` · `client:open {clientId, principal:{userId, githubLogin, githubId}, payload}` · `grant:revoked {grantId}` |
+| agent→relay | `share:bind {grantId, certificate, expiresAt}` · `share:deny {grantId, reason}` · `share:reconcile {…}` · `client:kick {clientId, code, reason}` |
+| client→relay | `client:open` payload gains optional `certificate` |
+| agent→client | `{type:'denied', reason}` — **sealed** whenever a key exists |
+
+`principal` is relay-asserted and named so that no branch reads it as authorization.
+`share:sync` + `share:reconcile` close the split-brain: the relay holds the certificate and
+routes, the desktop holds the session list and revocation status, and without reconciliation
+a relay volume loss leaves ghosts in the owner's settings while a desktop reinstall leaves
+guests connecting to a `DENY_ALL` with no explanation. **The agent's local `status` is the
+authority on revocation**, consulted at every `client:open`, not only for live sockets.
+
+Revocation must survive a disconnected agent: queue it in `relay_grants.revoke_pending`,
+flush on reconnect, and make the UI honest — *"Revoked — takes effect when this machine
+reconnects."*
+
+`denied` frames are **sealed**. An unsealed one is forgeable by the relay, which turns
+*"Will ended your access"* into a clean phishing lever.
+
+**HTTP:** `POST /api/machines/:id/shares` (Ed25519-signed, mirrors `/link`) ·
+`GET|DELETE /api/machines/:id/shares[/:inviteId]` · `POST /api/shares/redeem` ·
+`GET /api/shares` · `DELETE /api/shares/:grantId` (owner **or** grantee) · `GET /api/machines`
+gains `relation`, `ownerName`, `grantId`, `role`, `certificate`. `web.ts` serves
+`index.html` for `/i/*`.
+
+**The relay never authors the invite URL.** If it did, it could put its own fingerprint in
+the `#fp=` fragment and serve the matching `ed25519Pub`, making the guest's three-way check
+agree perfectly and manufacture a false `✓ Verified`. The desktop composes the URL locally
+from `identityFingerprint()` and the configured relay origin; the share-create response
+carries only the code, asserted by a test.
+
+## 6. Agent-side enforcement
+
+`ClientSession` gains `grant: Grant`, initialised to a frozen `DENY_ALL` (empty caps, empty
+session set, `expiresAt: 0`). `dispatch()`'s `switch` becomes a declarative table so the gate
+exists exactly once and complexity stays flat — this file was already rewritten once (d4d08de)
+purely to clear the Sonar gate.
+
+```ts
+export const ROLE_CAPS = Object.freeze({
+  owner:    new Set(['view', 'list', 'input', 'resize', 'create', 'browse']),
+  operator: new Set(['view', 'list', 'input']),
+  viewer:   new Set(['view', 'list']),
+});
+// 'create' and 'browse' appear in no guest role, and mintGrant() refuses to emit them.
+```
+
+Concretely in `session-tunnel.ts`:
+
+- delete the `sendSessions()` call from `open()` (`:107`) and the "authenticated as the
+  machine owner" comment (`:149`);
+- **verify the certificate before `deriveSharedSecret` and before attaching PTY listeners** —
+  fail-closed ordering;
+- reject a `client:open` for a live `clientId` (today it silently leaks three PTY listeners
+  per repeat, and `PtyManager` never raises its default max of 10);
+- replace the three per-client listeners with **one tunnel-level set** fanning out over the
+  client map;
+- gate `terminal:subscribe` on scope *before* `getSerializedBuffer`, and skip history entirely
+  for guests — seal `\x1b[2J\x1b[3J\x1b[H` plus `── shared from here ──`;
+- filter `sendSessions`/`sendGroups` to scope and strip `workingDir`;
+- `revokeGrant()` → `DENY_ALL`, clear subs, detach, sealed `denied`, `client:kick`;
+- cache decrypted key material in memory — `deriveSharedSecret` and `signWithIdentity` each
+  hit `safeStorage.decryptString` on **every** call, which is a remotely-triggered keychain
+  drain once channel churn is under untrusted control.
+
+**Testability is a prerequisite, not a follow-up.** `session-tunnel.ts` imports
+`electron-log`, the `ptyManager` singleton and `../../repositories/*` at module scope, so the
+deny-path tests that matter cannot be written without `mock.module()` — which is process-wide
+in bun and will break `pty-manager.test.ts` in a load-order-dependent way. Refactor
+`SessionTunnel`'s constructor to take injected `{ pty, sessionsRepo, groupsRepo, grantsRepo }`
+defaulting to the singletons, matching the repo's existing injectable-database convention.
+Testing an extracted pure policy module proves the table is right but not that `dispatch()`
+consults it — which is the bug class this feature must not ship.
+
+## 7. UX
+
+### Owner
+
+Entry is **per-session** — "Share…" on the session row menu and a person-plus button in
+`TerminalHeader.tsx` — and it is **stateful**: once shared, the same control becomes the
+management surface (`Shared with dana-k · watching` → Pause / Take away typing / Stop
+sharing this session / Share with someone else). A persistent glyph+count badge on
+`SessionRow` answers "is this one shared?" at a glance. Settings remains the cross-machine
+roll-up, not the only route.
+
+`ShareSessionModal.tsx` (reusing `NamePromptModal`'s overlay and focus trap) asks:
+
+- **Who's it for?** `[ @dana-k ]` — *only this GitHub account can use the link*, binding
+  `expected_github_login` so redemption by anyone else fails closed. A secondary *"Or make an
+  open link"* covers the case where the owner doesn't know the handle. An addressed invite
+  turns the approval modal into a confirmation instead of a stranger-check.
+- **What they can do?**
+  - **Watch** — *"They see this session's live output. They can't type."*
+  - **Watch and type** — *"They can run any command you can, read any file you can, and spend
+    your Claude account and saved API keys. Only give this to someone you'd hand your laptop
+    to."* Behind a type-the-machine-name confirmation, not a radio button.
+- **How long?** Both clocks stated separately, because they mean different things:
+  *"This link works for 1 hour if nobody uses it. Once dana-k joins, they have access for 4
+  hours."*
+
+The created state shows the URL, a QR, the readable code, and `🔑 This link is the key. Send
+it over something private.`
+
+**Approval.** `GuestJoinRequestModal` fires on `relay:join-request`, bypassing
+`shouldNotify()` (which suppresses precisely when the owner is at their desk) **and** firing
+an Electron `Notification` whose click restores and focuses the window — a renderer modal in
+a minimized window is invisible, and the codebase has no notification action buttons. A
+pending-requests row in `RemoteHostingSettings.tsx` makes a missed prompt recoverable.
+
+The modal shows the **immutable** GitHub login and numeric id, not a display name or avatar,
+and when the invite was addressed it shows a mismatch banner if the asserted login differs —
+`mintGrant()` refuses outright in that case. Buttons: `[ Don't let them in ]` (focused
+always) `[ Let them in ]`. Not `[ Not now ]`, which reads as a snooze and isn't one.
+
+**Presence, shipping with the first guest:** a 2px accent rule on the terminal pane whenever
+a guest is attached; a real `<button>` pill in `TerminalHeader.tsx` — `👁 dana-k watching` —
+opening Pause / Take away typing / Stop sharing; a glyph+count chip on `SessionRow`; a tray
+section. `RelayStatus` gains `attachedGuests: {grantId, login, sessionId, role}[]`.
+
+**Pause** is the control that makes the feature feel safe to use at all — the everyday need
+is "hold on a second", not revocation. Mechanically it is nearly free once listeners are
+tunnel-level: stop sealing output and drop input for that client, keeping grant, socket and
+certificate alive. It must blank the guest's rendered screen, not merely stop the stream.
+
+**Revoke** is instant and irreversible — no 8-second Undo, which buys the owner nothing (the
+guest has already been told) and re-admits on a mis-click. The revoked person stays as a
+dimmed row with one-tap **Share again** for the same known, already-approved user.
+
+### Guest (mobile-first)
+
+`/i/:code` is a **full-page screen** (`.screen-center`/`.card-center`), not a bottom sheet —
+`.sheet` is `max-height:88dvh; overflow-y:auto` with no sticky footer, so the primary action
+lands below the fold on a small phone. It stashes `location.hash` in `sessionStorage` before
+OAuth, because the fragment does not survive the round trip.
+
+A guest with exactly one grant **lands directly in the terminal** — title = session name,
+subtitle = `Shared by Will · watch only`. The machine picker appears only at ≥2 grants,
+sectioned `SHARED WITH ME — Will's laptop` (label by person; "machine" is owner vocabulary).
+The empty state gets guest-specific copy and an **Enter an invite code** action posting to
+`/api/shares/redeem` — never `/link/claim`, which would attempt an ownership transfer.
+
+**Waiting states must exist**, because this is the most-travelled path and the guest's whole
+first impression: *"Waiting for Will to let you in… Keep this page open — it'll update on its
+own."* · *"Will's machine is offline right now. We'll ask again as soon as it's back."* ·
+*"Will didn't accept this invite."*
+
+**Watch-only is never expressed by absence alone.** `#screen` stays focusable with
+`aria-readonly="true"` and keyboard scrolling (PageUp/PageDown/Home/End → `term.scrollLines`;
+today's scroll path is a touch-only `touchmove` handler), plus a persistent
+`role="status"` strip where the compose bar was: *"Watch only. You can read and scroll this
+session. You can't type into it."* The strip occupies the compose bar's exact height so an
+upgrade swaps in place.
+
+**Sizing.** Guests never send `terminal:resize` — a phone must not reflow the owner's PTY.
+But `scaleTerm()` CSS-downscales rather than reflows, so a 160-column desktop session becomes
+unreadable on a phone and an `A+` stepper makes it *worse*. Ship instead: render at true cell
+size with horizontal panning (`overflow-x:auto`, two-axis drag) plus an honest banner —
+*"Sized for Will's screen (164 columns). Drag sideways to read."* — and a **Fit to my screen**
+request that surfaces on the owner's desktop as a one-tap `[ Resize once ] [ Keep my size ]`.
+If neither lands, cut phone guests from M5.2 rather than ship an illegible primary surface.
+
+**Ending states get distinct copy**, driven by a reason enum the agent already knows —
+`revoked` / `expired` / `session_ended` / `machine_unlinked`. Telling a guest *"Will revoked
+your access"* when Will merely closed a terminal is a false, socially loaded story.
+
+**Identity** is shown as a 4-word phrase derived from the fingerprint hash, with *Show full
+fingerprint* revealing the `SHA256:` string — nobody compares 44 base64 characters on a
+phone. Verdict is glyph + word, never colour alone. When the fragment was stripped, say so
+specifically instead of showing a generic not-verified chip. Word it as **provenance**
+("this matches the link Will sent you"), not verification — the relay serves the JS doing
+the checking.
+
+**Copy discipline:** two user-visible role words everywhere, including tray, notifications
+and audit — **Watching** and **Watching and typing**. Never render `viewer`, `operator`,
+`grantee`, `scope`, or `grant`. Forbid `--faint` (≈3.35:1 on `--surface`) for any string
+carrying meaning; use `--muted`. 44×44 minimum on every new control.
+
+## 8. Milestones
+
+| M | Scope | Estimate |
+| --- | --- | --- |
+| **M5.0** | **Harden, no sharing.** Ephemeral per-channel X25519 (§1.1) · `to-client` machine binding · duplicate-`clientId` and duplicate-`client:open` guards · agent socket replacement · tunnel-level PTY listeners · chunked history frames · browser keepalive · rate limiting keyed on the trusted `X-Forwarded-For` hop · session/link-code reapers. **Done** — `fix/relay-hardening-m5.0`. | 3–4 d |
+| **M5.1** | **Grants plumbing, owner-only.** 002 migration · `getMachineAccess` · cert mint/verify · capability advertisement + latch (§3) · owner-id confirmation modal · `SessionTunnel` DI refactor · command table · policy + cert fixtures · scoped disclosure. | 4–5 d |
+| **M5.2** | **Watch-only guest.** Addressed invites · approval + notification · full presence set · guest surfaces incl. waiting/ending states and sizing · `share:sync`/`reconcile`. | 5–7 d |
+| **M5.3** | **Watch and type.** High-friction consent · typing attribution · pause · re-mint path. | 3–4 d |
+| **M5.4** | Desktop-authoritative audit log · expiry hygiene (T-5min warnings, Extend) · a11y sweep · quotas. | 2–3 d |
+
+**≈3.5–5 weeks.** The two-day version exists but is not safe, and the unsafe parts are
+exactly the ones a demo wouldn't reveal.
+
+Hard gates: **M5.2 must not ship without M5.0 and M5.1.** **M5.2 must not ship without
+attach/detach presence.** **M5.3 must not ship without typing attribution.**
+
+Two process costs the estimate carries explicitly: `relay/` is **not** Sonar-scanned
+(`sonar.sources=src`), so the incentive runs toward putting decisions on the unscanned side —
+compensate with mandatory deny-path tests; and the new `crypto.verify` in scanned `src/` will
+raise a **Security Hotspot** needing a UI review plus `gh run rerun` on the same sha, so land
+all code before starting the review loop.
+
+## 9. Open questions
+
+1. Does `#fp=` survive the messaging apps owners actually use? Detect-and-say, not silent
+   degrade — but measure on beta.
+2. Should a view-only guest be able to answer a `waiting` prompt? The client is
+   attention-first (`Needs you` badges, `attnBanner`); a watcher who structurally cannot
+   respond is shown a call to action they can't satisfy. A third **Watch and reply** role —
+   composed text only, only while `waiting` — matches the real use case, but it is not
+   meaningfully safer than typing and must not be sold as such.
+3. Should an `operator` grant be refused outright for a session whose provider has vaulted
+   API-key auth enabled, or should `vaultEnv` be scrubbed from any session that has ever been
+   shared?
+4. Pending-grant TTL shorter than active TTL (proposed: 1 h to bind, then auto-revoke)?
+5. Two browsers under one grant is fine post-§1.1, but the desktop list must group by person
+   or it becomes a wall of devices.
+6. `ALLOWED_ORIGINS` is empty in the deployed `.env` and parsed to `[]`. Treat empty as
+   allow-all (and add setting it to the deploy runbook), or the first enforcement deploy takes
+   the dev relay down.

--- a/relay/src/http.ts
+++ b/relay/src/http.ts
@@ -20,6 +20,7 @@ import {
 } from './auth/cookies';
 import { createDevRoutes } from './dev';
 import { createWebClient } from './web';
+import { clientIp, createRateLimiter, type RateLimiter } from './rate-limit';
 
 /**
  * HTTP surface of the relay (M2), as a `fetch`-style handler for `Bun.serve`.
@@ -41,12 +42,22 @@ export interface RelayContext {
   repos: Repositories;
   /** Injectable for tests; defaults to global fetch (used for GitHub calls). */
   fetchImpl?: typeof fetch;
+  /** Injectable so the caller can sweep it from the reaper; defaults to a fresh one. */
+  rateLimiter?: RateLimiter;
 }
 
 const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 
+/** Abuse limits on the two routes that mint or consume a secret. */
+const RATE_WINDOW_MS = 10 * 60 * 1000;
+const LINK_PER_IP = 10;
+const LINK_PER_KEY = 5;
+/** Tighter: this is where a link code would be guessed at. */
+const CLAIM_PER_IP = 20;
+
 export function createRouter(ctx: RelayContext) {
   const { config, logger, repos } = ctx;
+  const limiter = ctx.rateLimiter ?? createRateLimiter();
   const version = pkg.version ?? '0.0.0';
   const secure = config.isProduction || config.trustProxy;
 
@@ -69,7 +80,22 @@ export function createRouter(ctx: RelayContext) {
     return token ? repos.getUserBySessionToken(token) : null;
   }
 
-  return async function route(req: Request): Promise<Response> {
+  /**
+   * Charge one hit against `bucket` for this caller. Returns a 429 when the
+   * window is exhausted, otherwise null. Fails OPEN when no address can be
+   * resolved — bucketing every anonymous caller together would turn one abuser
+   * into a global outage.
+   */
+  function limited(req: Request, peerIp: string | null, bucket: string, limit: number): Response | null {
+    const ip = clientIp(req, peerIp, config.trustProxy);
+    if (!ip) return null;
+    const result = limiter.check(`${bucket}:${ip}`, limit, RATE_WINDOW_MS);
+    if (result.allowed) return null;
+    logger.warn('rate limited', { bucket, path: new URL(req.url).pathname });
+    return json({ error: 'rate_limited' }, 429, { 'retry-after': String(result.retryAfter) });
+  }
+
+  return async function route(req: Request, peerIp: string | null = null): Promise<Response> {
     const url = new URL(req.url);
     const { pathname } = url;
     const method = req.method;
@@ -125,11 +151,11 @@ export function createRouter(ctx: RelayContext) {
       }
 
       if (pathname === '/link' && method === 'POST') {
-        return handleLink(req);
+        return limited(req, peerIp, 'link', LINK_PER_IP) ?? (await handleLink(req));
       }
 
       if (pathname === '/link/claim' && method === 'POST') {
-        return handleClaim(req);
+        return limited(req, peerIp, 'claim', CLAIM_PER_IP) ?? (await handleClaim(req));
       }
 
       return json({ error: 'not_found' }, 404);
@@ -220,6 +246,15 @@ export function createRouter(ctx: RelayContext) {
     const verified = await verifyEd25519(edBytes, sigBytes, message);
     if (!verified) return json({ error: 'bad_signature' }, 401);
 
+    // Charged only after the signature verifies, so nobody can exhaust someone
+    // else's budget by naming their key. Bounds the unclaimed rows one keypair
+    // can accumulate, independent of how many addresses it comes from.
+    const perKey = limiter.check(`link:key:${ed25519Pub}`, LINK_PER_KEY, RATE_WINDOW_MS);
+    if (!perKey.allowed) {
+      logger.warn('rate limited', { bucket: 'link:key' });
+      return json({ error: 'rate_limited' }, 429, { 'retry-after': String(perKey.retryAfter) });
+    }
+
     const { code, expiresAt } = repos.createLinkCode(machineName, edBytes, xBytes, config.linkCodeTtlSeconds);
     logger.info('link code issued', { machineName });
     return json({ code, expiresAt });
@@ -271,9 +306,9 @@ async function readJson(req: Request): Promise<unknown | null> {
   }
 }
 
-function json(body: unknown, status = 200): Response {
+function json(body: unknown, status = 200, extraHeaders: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...extraHeaders },
   });
 }

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -5,6 +5,19 @@ import { createLogger } from './logger';
 import { createRepositories } from './repositories';
 import { createGateway, newAgentSocketData, newClientSocketData } from './ws';
 import { parseCookies, SESSION_COOKIE } from './auth/cookies';
+import { createRateLimiter } from './rate-limit';
+
+/** How often expired sessions / link codes / rate-limit windows are swept. */
+const REAP_INTERVAL_MS = 10 * 60 * 1000;
+
+/**
+ * Largest frame the relay will forward. Deliberately generous: desktop agents
+ * update on their own schedule, and builds before scrollback chunking landed
+ * seal an entire serialized buffer into ONE frame (megabytes on a busy
+ * session). Lowering this would silently break history replay for clients no
+ * relay-side change can fix — revisit once those builds have aged out.
+ */
+const MAX_WS_PAYLOAD_BYTES = 16 * 1024 * 1024;
 
 function main(): void {
   const { config, warnings } = loadConfig();
@@ -17,11 +30,13 @@ function main(): void {
   logger.info('database ready', { path: config.dbPath });
 
   const repos = createRepositories(db);
-  const route = createRouter({ config, logger, repos });
+  const rateLimiter = createRateLimiter();
+  const route = createRouter({ config, logger, repos, rateLimiter });
   const gateway = createGateway({ repos, logger });
 
   const server = Bun.serve({
     port: config.port,
+    maxRequestBodySize: 1024 * 1024,
     fetch(req, srv) {
       const url = new URL(req.url);
       // Agents connect at /ws and authenticate with an Ed25519-signed nonce.
@@ -38,10 +53,25 @@ function main(): void {
         if (srv.upgrade(req, { data: newClientSocketData(user.id) })) return undefined;
         return new Response('expected a websocket upgrade', { status: 426 });
       }
-      return route(req);
+      return route(req, srv.requestIP(req)?.address ?? null);
     },
-    websocket: gateway,
+    websocket: { ...gateway, maxPayloadLength: MAX_WS_PAYLOAD_BYTES },
   });
+
+  // Nothing purged expired sessions or link codes before — `purgeExpiredSessions`
+  // was on the repository interface but had no caller, so both tables grew
+  // without bound. `unref` so a pending tick can't hold shutdown open.
+  const reaper = setInterval(() => {
+    try {
+      repos.purgeExpiredSessions();
+      const codes = repos.purgeExpiredLinkCodes();
+      rateLimiter.sweep();
+      if (codes > 0) logger.debug('reaped expired link codes', { count: codes });
+    } catch (err) {
+      logger.error('reaper failed', { err: err instanceof Error ? err.message : String(err) });
+    }
+  }, REAP_INTERVAL_MS);
+  reaper.unref();
 
   logger.info('relay listening', {
     port: server.port,
@@ -53,6 +83,7 @@ function main(): void {
   const shutdown = (signal: string): void => {
     if (shuttingDown) return;
     shuttingDown = true;
+    clearInterval(reaper);
     logger.info('shutdown requested', { signal });
     // Stop accepting connections, then drain. `true` closes active sockets so
     // keep-alive connections can't hold the process open past the timeout.

--- a/relay/src/m2.test.ts
+++ b/relay/src/m2.test.ts
@@ -204,6 +204,73 @@ describe('router: /link + /link/claim (end to end)', () => {
 });
 
 // ---------------------------------------------------------------------------
+describe('router: rate limiting', () => {
+  const { config } = loadConfig({});
+  const PEER = '198.51.100.4';
+
+  const claim = (route: ReturnType<typeof createRouter>, peerIp: string | null) =>
+    route(
+      new Request('http://relay.test/link/claim', { method: 'POST', body: JSON.stringify({ code: 'K7Q2-9F3D' }) }),
+      peerIp,
+    );
+
+  test('a caller guessing link codes is cut off with 429 and a Retry-After', async () => {
+    const route = createRouter({ config, logger, repos: freshRepos() });
+
+    // Unauthenticated claims 401 all day; the limiter is what stops the guessing.
+    for (let i = 0; i < 20; i++) {
+      expect((await claim(route, PEER)).status).toBe(401);
+    }
+
+    const blocked = await claim(route, PEER);
+    expect(blocked.status).toBe(429);
+    expect(Number(blocked.headers.get('retry-after'))).toBeGreaterThan(0);
+  });
+
+  test('one caller being limited does not affect another address', async () => {
+    const route = createRouter({ config, logger, repos: freshRepos() });
+    for (let i = 0; i < 21; i++) await claim(route, PEER);
+
+    expect((await claim(route, '203.0.113.9')).status).toBe(401);
+  });
+
+  test('a keypair is capped across addresses, so rotating IPs does not help', async () => {
+    const repos = freshRepos();
+    const route = createRouter({ config, logger, repos });
+    const { pub, sign } = await ed25519Keypair();
+
+    const linkOnce = async (from: string) => {
+      const issuedAt = Date.now();
+      const ed25519Pub = b64(pub);
+      const x25519Pub = b64(new Uint8Array(32).fill(3));
+      const signature = b64(
+        await sign(buildLinkMessage({ ed25519PubB64: ed25519Pub, x25519PubB64: x25519Pub, machineName: 'm', issuedAt })),
+      );
+      return route(
+        new Request('http://relay.test/link', {
+          method: 'POST',
+          body: JSON.stringify({ machineName: 'm', ed25519Pub, x25519Pub, issuedAt, signature }),
+        }),
+        from,
+      );
+    };
+
+    for (let i = 0; i < 5; i++) {
+      expect((await linkOnce(`198.51.100.${i}`)).status).toBe(200);
+    }
+    // Sixth attempt from yet another address: the per-key budget is spent.
+    expect((await linkOnce('198.51.100.99')).status).toBe(429);
+  });
+
+  test('fails open when no address can be resolved', async () => {
+    const route = createRouter({ config, logger, repos: freshRepos() });
+
+    for (let i = 0; i < 25; i++) {
+      expect((await claim(route, null)).status).toBe(401);
+    }
+  });
+});
+
 describe('router: GitHub OAuth', () => {
   // `membership`: 'active' → member, 'none' → 404 (not a member), undefined → org not checked.
   function makeMockFetch(membership?: 'active' | 'none') {

--- a/relay/src/rate-limit.test.ts
+++ b/relay/src/rate-limit.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test';
+import { clientIp, createRateLimiter } from './rate-limit';
+
+/** A limiter driven by a clock the test controls. */
+function fixedClock(start = 1_000_000) {
+  let now = start;
+  return { now: () => now, advance: (ms: number) => (now += ms) };
+}
+
+const req = (headers: Record<string, string> = {}) => new Request('https://relay.example.com/link', { headers });
+
+describe('createRateLimiter', () => {
+  test('allows up to the limit, then refuses', () => {
+    const limiter = createRateLimiter(fixedClock().now);
+
+    for (let i = 0; i < 3; i++) {
+      expect(limiter.check('a', 3, 60_000).allowed).toBe(true);
+    }
+    expect(limiter.check('a', 3, 60_000).allowed).toBe(false);
+  });
+
+  test('reports the seconds remaining in the window', () => {
+    const clock = fixedClock();
+    const limiter = createRateLimiter(clock.now);
+
+    limiter.check('a', 1, 60_000);
+    clock.advance(20_000);
+    const result = limiter.check('a', 1, 60_000);
+
+    expect(result.allowed).toBe(false);
+    expect(result.allowed === false && result.retryAfter).toBe(40);
+  });
+
+  test('keys are independent', () => {
+    const limiter = createRateLimiter(fixedClock().now);
+
+    expect(limiter.check('a', 1, 60_000).allowed).toBe(true);
+    expect(limiter.check('a', 1, 60_000).allowed).toBe(false);
+    expect(limiter.check('b', 1, 60_000).allowed).toBe(true);
+  });
+
+  test('the window reopens once it elapses', () => {
+    const clock = fixedClock();
+    const limiter = createRateLimiter(clock.now);
+
+    limiter.check('a', 1, 60_000);
+    expect(limiter.check('a', 1, 60_000).allowed).toBe(false);
+
+    clock.advance(60_001);
+    expect(limiter.check('a', 1, 60_000).allowed).toBe(true);
+  });
+
+  test('sweep drops elapsed windows but keeps live ones', () => {
+    const clock = fixedClock();
+    const limiter = createRateLimiter(clock.now);
+
+    limiter.check('old', 1, 10_000);
+    clock.advance(20_000);
+    limiter.check('fresh', 1, 60_000);
+    limiter.sweep();
+
+    // 'old' was forgotten, so its budget is available again...
+    expect(limiter.check('old', 1, 10_000).allowed).toBe(true);
+    // ...while 'fresh' is still being counted.
+    expect(limiter.check('fresh', 1, 60_000).allowed).toBe(false);
+  });
+});
+
+describe('clientIp', () => {
+  test('uses the socket peer when the proxy is not trusted', () => {
+    expect(clientIp(req({ 'x-forwarded-for': '9.9.9.9' }), '10.0.0.1', false)).toBe('10.0.0.1');
+  });
+
+  test('uses X-Forwarded-For when the proxy is trusted', () => {
+    expect(clientIp(req({ 'x-forwarded-for': '203.0.113.7' }), '127.0.0.1', true)).toBe('203.0.113.7');
+  });
+
+  test('takes the RIGHTMOST hop, so a client-supplied header cannot forge a bucket', () => {
+    // Our proxy appends the address it actually saw, so the last entry is the
+    // only trustworthy one. Honouring the leftmost would let one caller mint
+    // unlimited buckets and evade every limit.
+    expect(clientIp(req({ 'x-forwarded-for': '1.2.3.4, 203.0.113.7' }), '127.0.0.1', true)).toBe('203.0.113.7');
+  });
+
+  test('tolerates whitespace and empty entries', () => {
+    expect(clientIp(req({ 'x-forwarded-for': ' 1.2.3.4 ,  203.0.113.7 , ' }), '127.0.0.1', true)).toBe('203.0.113.7');
+  });
+
+  test('falls back to the peer when the trusted proxy sent no header', () => {
+    expect(clientIp(req(), '127.0.0.1', true)).toBe('127.0.0.1');
+  });
+
+  test('returns null when nothing is available, so callers can fail open', () => {
+    expect(clientIp(req(), null, true)).toBeNull();
+    expect(clientIp(req({ 'x-forwarded-for': '' }), null, true)).toBeNull();
+  });
+});

--- a/relay/src/rate-limit.ts
+++ b/relay/src/rate-limit.ts
@@ -1,0 +1,80 @@
+/**
+ * Fixed-window rate limiting, plus the proxy-aware client-IP resolution it
+ * depends on.
+ *
+ * The relay's abuse-sensitive routes are the ones that accept a secret: `/link`
+ * mints link codes for anyone holding a keypair, and `/link/claim` is where a
+ * code is guessed at. Both were previously unbounded.
+ */
+
+export interface RateLimiter {
+  /**
+   * Record a hit against `key` and report whether it is allowed. Returns the
+   * seconds until the window resets when it is not, for `Retry-After`.
+   */
+  check(key: string, limit: number, windowMs: number): { allowed: true } | { allowed: false; retryAfter: number };
+  /** Drop expired windows. Cheap; call from the periodic reaper. */
+  sweep(): void;
+}
+
+interface Window {
+  count: number;
+  resetAt: number;
+}
+
+export function createRateLimiter(now: () => number = Date.now): RateLimiter {
+  const windows = new Map<string, Window>();
+
+  return {
+    check(key, limit, windowMs) {
+      const ts = now();
+      const existing = windows.get(key);
+      if (!existing || existing.resetAt <= ts) {
+        windows.set(key, { count: 1, resetAt: ts + windowMs });
+        return { allowed: true };
+      }
+      if (existing.count >= limit) {
+        return { allowed: false, retryAfter: Math.max(1, Math.ceil((existing.resetAt - ts) / 1000)) };
+      }
+      existing.count += 1;
+      return { allowed: true };
+    },
+
+    sweep() {
+      const ts = now();
+      for (const [key, window] of windows) {
+        if (window.resetAt <= ts) windows.delete(key);
+      }
+    },
+  };
+}
+
+/**
+ * The client address to bucket a request under.
+ *
+ * When `trustProxy` is off, the socket peer is the only trustworthy source.
+ * When it is on we take the **rightmost** `X-Forwarded-For` entry, not the
+ * leftmost: each proxy appends the peer it saw, so the last entry is the one
+ * our own trusted proxy wrote. The leftmost is attacker-controlled — a client
+ * that sends its own `X-Forwarded-For` gets it preserved ahead of the real
+ * address, which would let one caller mint unlimited buckets and evade every
+ * limit. This assumes exactly one trusted hop in front of the relay, which is
+ * the documented deployment (Caddy → 127.0.0.1:47393).
+ *
+ * Returns null when nothing usable is available, and callers should fail open
+ * rather than lump every anonymous request into a single bucket.
+ */
+export function clientIp(req: Request, peerIp: string | null, trustProxy: boolean): string | null {
+  if (trustProxy) {
+    const forwarded = req.headers.get('x-forwarded-for');
+    if (forwarded) {
+      const hops = forwarded
+        .split(',')
+        .map((hop) => hop.trim())
+        .filter((hop) => hop.length > 0);
+      const rightmost = hops[hops.length - 1];
+      if (rightmost) return rightmost;
+    }
+  }
+  return peerIp;
+}

--- a/relay/src/repositories.ts
+++ b/relay/src/repositories.ts
@@ -53,6 +53,7 @@ export interface Repositories {
     ttlSeconds: number,
   ): { code: string; expiresAt: number };
   claimLinkCode(code: string, userId: string): ClaimResult;
+  purgeExpiredLinkCodes(): number;
 
   listMachines(userId: string): Machine[];
   getMachine(id: string): Machine | null;
@@ -184,6 +185,15 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
       })();
 
       return { ok: true, machine };
+    },
+
+    purgeExpiredLinkCodes() {
+      // Only unclaimed rows: a completed code is the audit trail of a link and
+      // is kept. Nothing deleted these before, so they accumulated forever.
+      const result = db
+        .query("DELETE FROM link_codes WHERE status = 'pending' AND expires_at <= ?")
+        .run(now());
+      return Number(result.changes ?? 0);
     },
 
     listMachines(userId) {

--- a/relay/src/ws.test.ts
+++ b/relay/src/ws.test.ts
@@ -60,10 +60,10 @@ function connect(url: string, headers?: Record<string, string>) {
   return { ws, opened, closed, next };
 }
 
-async function registerMachine(repos: Repositories) {
+async function registerMachine(repos: Repositories, providerUserId = '1') {
   const kp = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify'])) as unknown as CryptoKeyPair;
   const pub = new Uint8Array(await crypto.subtle.exportKey('raw', kp.publicKey));
-  const user = repos.upsertGithubUser({ providerUserId: '1', displayName: 'U', email: null, avatarUrl: null });
+  const user = repos.upsertGithubUser({ providerUserId, displayName: 'U', email: null, avatarUrl: null });
   const claim = repos.claimLinkCode(repos.createLinkCode('m', pub, new Uint8Array(32).fill(1), 600).code, user.id);
   const machineId = claim.ok ? claim.machine.id : '';
   const sign = async (m: Uint8Array) => new Uint8Array(await crypto.subtle.sign({ name: 'Ed25519' }, kp.privateKey, toArrayBuffer(m)));
@@ -219,6 +219,97 @@ describe('client ↔ agent brokering (M3)', () => {
       await client.opened;
       client.ws.send(JSON.stringify({ type: 'client:open', machineId }));
       expect((await client.next()).type).toBe('agent:offline');
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('an agent cannot push frames into another machine\'s client channel', async () => {
+    const repos = freshRepos();
+    const a = await registerMachine(repos, 'user-a');
+    const b = await registerMachine(repos, 'user-b');
+    const server = startServer(repos);
+    try {
+      const agentA = await onlineAgent(server.port!, a.pub, a.sign);
+      const agentB = await onlineAgent(server.port!, b.pub, b.sign);
+
+      const { token } = repos.createSession(b.userId, 3600);
+      const clientB = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
+      await clientB.opened;
+      clientB.ws.send(JSON.stringify({ type: 'client:open', machineId: b.machineId }));
+      const clientId = (await agentB.next()).clientId;
+      expect((await clientB.next()).type).toBe('channel:open');
+
+      // Agent A names a client id that belongs to machine B's channel.
+      agentA.ws.send(JSON.stringify({ type: 'to-client', clientId, payload: 'injected' }));
+      // ...then B's own agent sends a legitimate frame. Both traverse the same
+      // server, so if the injection were routed it would arrive first.
+      agentB.ws.send(JSON.stringify({ type: 'to-client', clientId, payload: 'legitimate' }));
+
+      expect(await clientB.next()).toMatchObject({ type: 'from-agent', payload: 'legitimate' });
+
+      clientB.ws.close();
+      agentA.ws.close();
+      agentB.ws.close();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('a second client:open on the same socket is refused (4400)', async () => {
+    const repos = freshRepos();
+    const { pub, sign, machineId, userId } = await registerMachine(repos);
+    const server = startServer(repos);
+    try {
+      const agent = await onlineAgent(server.port!, pub, sign);
+      const { token } = repos.createSession(userId, 3600);
+      const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
+      await client.opened;
+
+      client.ws.send(JSON.stringify({ type: 'client:open', machineId }));
+      await agent.next();
+      expect((await client.next()).type).toBe('channel:open');
+
+      // Re-opening would strand the agent's state for this client id.
+      client.ws.send(JSON.stringify({ type: 'client:open', machineId }));
+      expect((await client.closed).code).toBe(4400);
+
+      agent.ws.close();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('a client ping is answered with a pong (browser keepalive)', async () => {
+    const repos = freshRepos();
+    const { userId } = await registerMachine(repos);
+    const server = startServer(repos);
+    try {
+      const { token } = repos.createSession(userId, 3600);
+      const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
+      await client.opened;
+
+      client.ws.send(JSON.stringify({ type: 'ping' }));
+      expect((await client.next()).type).toBe('pong');
+
+      client.ws.close();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('reconnecting an agent closes the socket it replaces', async () => {
+    const repos = freshRepos();
+    const { pub, sign } = await registerMachine(repos);
+    const server = startServer(repos);
+    try {
+      const first = await onlineAgent(server.port!, pub, sign);
+      const second = await onlineAgent(server.port!, pub, sign);
+
+      // The stale socket is closed rather than silently dropped from the table.
+      expect((await first.closed).code).toBe(4409);
+
+      second.ws.close();
     } finally {
       server.stop(true);
     }

--- a/relay/src/ws.ts
+++ b/relay/src/ws.ts
@@ -28,6 +28,8 @@ export interface AgentSocketData {
   nonce: string;
   authed: boolean;
   machineId: string | null;
+  /** Reaper for a socket that connects but never answers the challenge. */
+  authTimer: ReturnType<typeof setTimeout> | null;
 }
 
 export interface ClientSocketData {
@@ -45,9 +47,12 @@ export interface WsGatewayContext {
   logger: Logger;
 }
 
+/** How long an agent socket may sit unauthenticated before it is closed. */
+export const AGENT_AUTH_TIMEOUT_MS = 30_000;
+
 /** Per-connection state for an agent (`server.upgrade(req, { data })`). */
 export function newAgentSocketData(): AgentSocketData {
-  return { role: 'agent', nonce: randomToken(32), authed: false, machineId: null };
+  return { role: 'agent', nonce: randomToken(32), authed: false, machineId: null, authTimer: null };
 }
 
 /** Per-connection state for an authenticated web client. */
@@ -69,7 +74,14 @@ export function createGateway(ctx: WsGatewayContext) {
   return {
     open(ws: ServerWebSocket<SocketData>) {
       if (ws.data.role === 'agent') {
-        send(ws, { type: 'challenge', nonce: ws.data.nonce });
+        const data = ws.data;
+        send(ws, { type: 'challenge', nonce: data.nonce });
+        // Don't let an unauthenticated socket linger: it costs a connection
+        // slot and nothing can ever be routed over it.
+        data.authTimer = setTimeout(() => {
+          data.authTimer = null;
+          if (!data.authed) ws.close(4401, 'auth timeout');
+        }, AGENT_AUTH_TIMEOUT_MS);
       }
       // Clients speak first (client:open), so nothing to send on open.
     },
@@ -88,7 +100,11 @@ export function createGateway(ctx: WsGatewayContext) {
 
     close(ws: ServerWebSocket<SocketData>) {
       if (ws.data.role === 'agent') {
-        const { machineId } = ws.data;
+        const { machineId, authTimer } = ws.data;
+        if (authTimer) {
+          clearTimeout(authTimer);
+          ws.data.authTimer = null;
+        }
         if (machineId && agents.get(machineId) === ws) {
           agents.delete(machineId);
           logger.info('agent offline', { machineId });
@@ -132,7 +148,20 @@ export function createGateway(ctx: WsGatewayContext) {
       }
       data.authed = true;
       data.machineId = machine.id;
+      if (data.authTimer) {
+        clearTimeout(data.authTimer);
+        data.authTimer = null;
+      }
+      // One live socket per machine. Publish the new socket BEFORE closing the
+      // old one: the close handler only touches `agents` when the map still
+      // points at the socket that closed, so this ordering guarantees it can't
+      // delete the live entry or announce a spurious `agent:offline` to clients.
+      const previous = agents.get(machine.id);
       agents.set(machine.id, ws);
+      if (previous && previous !== ws) {
+        logger.info('replacing an existing agent socket', { machineId: machine.id });
+        previous.close(4409, 'replaced by a newer connection');
+      }
       repos.touchMachine(machine.id);
       send(ws, { type: 'agent:ready', machineId: machine.id });
       logger.info('agent online', { machineId: machine.id });
@@ -145,16 +174,32 @@ export function createGateway(ctx: WsGatewayContext) {
       send(ws, { type: 'pong' });
       return;
     }
-    // Route an opaque frame back to a specific client.
+    // Route an opaque frame back to a specific client. The target must be bound
+    // to THIS agent's machine — without that check an agent could name any
+    // client id in the table and inject frames into someone else's channel.
     if (msg.type === 'to-client' && typeof msg.clientId === 'string') {
       const client = clients.get(msg.clientId);
-      if (client) send(client, { type: 'from-agent', payload: msg.payload });
+      if (client && (client.data as ClientSocketData).machineId === data.machineId) {
+        send(client, { type: 'from-agent', payload: msg.payload });
+      }
     }
   }
 
   function handleClient(ws: ServerWebSocket<SocketData>, data: ClientSocketData, msg: Record<string, unknown>) {
+    // Browser keepalive. Browsers can't send WS control frames from script, so
+    // an idle viewer looks dead to any intermediary; the client pings instead.
+    if (msg.type === 'ping') {
+      send(ws, { type: 'pong' });
+      return;
+    }
     // Open a channel to one of the user's machines.
     if (msg.type === 'client:open' && typeof msg.machineId === 'string') {
+      // One channel per socket. Re-opening would strand the agent's state for
+      // this client id and could re-point the socket at a different machine.
+      if (data.machineId) {
+        ws.close(4400, 'channel already open');
+        return;
+      }
       const machine = repos.getMachine(msg.machineId);
       if (!machine || machine.user_id !== data.userId) {
         ws.close(4403, 'not your machine');

--- a/relay/web/src/connection.ts
+++ b/relay/web/src/connection.ts
@@ -25,12 +25,20 @@ function wsUrl(path: string): string {
   return `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}${path}`;
 }
 
+/**
+ * Browser keepalive interval. Script can't send WebSocket control frames, so a
+ * viewer that is only reading produces no upstream traffic at all and looks
+ * idle to the relay and to anything between. Matches the agent's 30s ping.
+ */
+const PING_INTERVAL_MS = 30_000;
+
 export class RelayConnection {
   private ws: WebSocket | null = null;
   private key: CryptoKey | null = null;
   private clientKeys: ClientKeys | null = null;
   private sendCounter = 0;
   private recvCounter = -1;
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
 
   onState: (s: ConnState, detail?: string) => void = () => {};
   onMessage: (m: Inner) => void = () => {};
@@ -52,8 +60,23 @@ export class RelayConnection {
       this.onState('handshaking');
     };
     ws.onmessage = (e) => void this.handle(JSON.parse(String(e.data)));
-    ws.onclose = () => this.onState('closed');
+    ws.onclose = () => {
+      this.stopPing();
+      this.onState('closed');
+    };
     ws.onerror = () => this.onState('error');
+    this.startPing();
+  }
+
+  private startPing(): void {
+    this.stopPing();
+    this.pingTimer = setInterval(() => this.send({ type: 'ping' }), PING_INTERVAL_MS);
+  }
+
+  private stopPing(): void {
+    if (this.pingTimer === null) return;
+    clearInterval(this.pingTimer);
+    this.pingTimer = null;
   }
 
   private async handle(msg: Inner): Promise<void> {
@@ -109,6 +132,7 @@ export class RelayConnection {
     const ws = this.ws;
     this.ws = null;
     this.key = null;
+    this.stopPing();
     if (ws) {
       // Detach handlers first so this deliberate close doesn't surface as a
       // 'closed' state event (which the caller uses to schedule a reconnect).

--- a/src/main/api/relay/chunking.test.ts
+++ b/src/main/api/relay/chunking.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for chunkText — the split applied to scrollback replay so a long
+ * history can't be sealed into one multi-megabyte frame.
+ *
+ * Run with: bun test src/main/api/relay/chunking.test.ts
+ */
+import { describe, expect, test } from 'bun:test';
+import { chunkText, MAX_CHUNK_CHARS } from './chunking';
+
+describe('chunkText', () => {
+  test('an empty history produces no frames at all', () => {
+    expect(chunkText('')).toEqual([]);
+  });
+
+  test('passes a short history through as a single chunk', () => {
+    expect(chunkText('hello world', 64)).toEqual(['hello world']);
+  });
+
+  test('splits at the limit and loses nothing', () => {
+    const text = 'abcdefghij'.repeat(10); // 100 chars
+    const chunks = chunkText(text, 30);
+
+    expect(chunks).toHaveLength(4);
+    expect(chunks.every((c) => c.length <= 30)).toBe(true);
+    expect(chunks.join('')).toBe(text);
+  });
+
+  test('an exact multiple of the limit does not emit a trailing empty chunk', () => {
+    const chunks = chunkText('x'.repeat(60), 30);
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks.join('')).toBe('x'.repeat(60));
+  });
+
+  test('never splits a surrogate pair', () => {
+    // '😀' is two UTF-16 units, so a naive slice at an odd boundary would cut
+    // it in half and produce a lone surrogate that survives sealing and only
+    // corrupts at the renderer.
+    const text = '😀'.repeat(10);
+    const chunks = chunkText(text, 5);
+
+    expect(chunks.join('')).toBe(text);
+    for (const chunk of chunks) {
+      expect(chunk).not.toMatch(/[\uD800-\uDBFF]$/); // no trailing high surrogate
+      expect(chunk).not.toMatch(/^[\uDC00-\uDFFF]/); // no leading low surrogate
+    }
+  });
+
+  test('handles a realistic scrollback above the default limit', () => {
+    const text = 'line of terminal output\n'.repeat(20_000);
+    const chunks = chunkText(text);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((c) => c.length <= MAX_CHUNK_CHARS)).toBe(true);
+    expect(chunks.join('')).toBe(text);
+  });
+});

--- a/src/main/api/relay/chunking.ts
+++ b/src/main/api/relay/chunking.ts
@@ -1,0 +1,48 @@
+/**
+ * Splitting oversized terminal payloads into transport-sized frames.
+ *
+ * Scrollback replay (`ptyManager.getSerializedBuffer`) can return a very large
+ * string — the headless terminal keeps 20k lines — and it was previously sealed
+ * into a SINGLE frame. After base64 of AES-GCM that is ~1.37x the source, so a
+ * busy session could put multi-megabyte messages on the wire and left the relay
+ * unable to set any sane `maxPayloadLength`.
+ *
+ * Splitting is safe for both consumers: xterm.js keeps parser state across
+ * `write()` calls, so an escape sequence straddling a chunk boundary is still
+ * interpreted correctly, and the frames are sealed and sent in order under a
+ * monotonic counter the receiver already enforces.
+ */
+
+/**
+ * Source characters per chunk. Terminal output is overwhelmingly ASCII, so this
+ * is ~64 KiB of source → ~88 KB of base64 ciphertext per frame.
+ */
+export const MAX_CHUNK_CHARS = 64 * 1024;
+
+/**
+ * Split `text` into chunks of at most `maxChars`, never splitting a surrogate
+ * pair (which would corrupt the character and, once sealed, be undetectable
+ * until it reached the renderer).
+ *
+ * An empty input yields an empty array — callers should send nothing rather
+ * than an empty frame.
+ */
+export function chunkText(text: string, maxChars: number = MAX_CHUNK_CHARS): string[] {
+  if (!text) return [];
+  if (text.length <= maxChars) return [text];
+
+  const chunks: string[] = [];
+  let start = 0;
+  while (start < text.length) {
+    let end = Math.min(start + maxChars, text.length);
+    // Don't cut between a high and low surrogate; retreat one unit so the pair
+    // travels together in the next chunk.
+    if (end < text.length) {
+      const code = text.charCodeAt(end - 1);
+      if (code >= 0xd800 && code <= 0xdbff) end -= 1;
+    }
+    chunks.push(text.slice(start, end));
+    start = end;
+  }
+  return chunks;
+}

--- a/src/main/api/relay/e2e.test.ts
+++ b/src/main/api/relay/e2e.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for the E2E channel crypto, with particular attention to the
+ * per-channel key agreement that makes recorded channels unreplayable.
+ *
+ * Run with: bun test src/main/api/relay/e2e.test.ts
+ */
+import { describe, expect, test } from 'bun:test';
+import crypto from 'crypto';
+import {
+  deriveEphemeral,
+  deriveSessionKey,
+  nonceFromCounter,
+  seal,
+  open,
+  sealJson,
+  openJson,
+  buildHandshakeProof,
+} from './e2e';
+
+/** Stand in for the browser: a fresh X25519 keypair and its raw public key. */
+function clientKeypair() {
+  const kp = crypto.generateKeyPairSync('x25519');
+  const { x } = kp.publicKey.export({ format: 'jwk' }) as { x: string };
+  return { privateKey: kp.privateKey, pubRaw: new Uint8Array(Buffer.from(x, 'base64url')) };
+}
+
+/** The client half of the ECDH, against the agent's advertised ephemeral key. */
+function clientDerive(privateKey: crypto.KeyObject, agentPubB64: string): Buffer {
+  const publicKey = crypto.createPublicKey({
+    key: { kty: 'OKP', crv: 'X25519', x: Buffer.from(agentPubB64, 'base64').toString('base64url') },
+    format: 'jwk',
+  });
+  return crypto.diffieHellman({ privateKey, publicKey });
+}
+
+describe('deriveEphemeral', () => {
+  test('both sides derive the same shared secret', () => {
+    const client = clientKeypair();
+    const { sharedSecret, ephemeralPubB64 } = deriveEphemeral(client.pubRaw);
+
+    expect(clientDerive(client.privateKey, ephemeralPubB64).equals(sharedSecret)).toBe(true);
+  });
+
+  test('advertises a 32-byte X25519 public key as standard base64', () => {
+    const { ephemeralPubB64 } = deriveEphemeral(clientKeypair().pubRaw);
+
+    expect(Buffer.from(ephemeralPubB64, 'base64')).toHaveLength(32);
+    // Standard base64, not base64url — it goes on the wire and into the signed
+    // handshake proof, where the browser compares the exact string.
+    expect(ephemeralPubB64).not.toContain('-');
+    expect(ephemeralPubB64).not.toContain('_');
+  });
+
+  test('the SAME peer key yields a different channel key every time', () => {
+    // The replay defence. With a long-lived agent key this was a pure function
+    // of the client's public key, so anyone who could open a channel could
+    // re-present a recorded clientX25519Pub and get the same session key back.
+    const client = clientKeypair();
+
+    const first = deriveEphemeral(client.pubRaw);
+    const second = deriveEphemeral(client.pubRaw);
+
+    expect(second.ephemeralPubB64).not.toBe(first.ephemeralPubB64);
+    expect(second.sharedSecret.equals(first.sharedSecret)).toBe(false);
+  });
+
+  test('frames recorded from one channel do not open on a replayed one', () => {
+    // End-to-end statement of the same property: capture a sealed frame, then
+    // re-open a channel with the identical client key and try to replay it.
+    const client = clientKeypair();
+    const recorded = deriveEphemeral(client.pubRaw);
+    const captured = sealJson(deriveSessionKey(recorded.sharedSecret), 0, { type: 'terminal:input', data: 'rm -rf ~' });
+
+    const replayed = deriveSessionKey(deriveEphemeral(client.pubRaw).sharedSecret);
+
+    expect(() => openJson(replayed, captured)).toThrow();
+  });
+
+  test('rejects a peer key that is not 32 bytes', () => {
+    expect(() => deriveEphemeral(new Uint8Array(31))).toThrow();
+    expect(() => deriveEphemeral(new Uint8Array(0))).toThrow();
+  });
+});
+
+describe('seal / open', () => {
+  const key = deriveSessionKey(deriveEphemeral(clientKeypair().pubRaw).sharedSecret);
+
+  test('round-trips a JSON value', () => {
+    const frame = sealJson(key, 7, { type: 'terminal:output', data: 'hello' });
+
+    expect(frame.n).toBe(7);
+    expect(openJson(key, frame)).toEqual({ type: 'terminal:output', data: 'hello' });
+  });
+
+  test('rejects a tampered ciphertext', () => {
+    const frame = seal(key, 0, new TextEncoder().encode('secret'));
+    const raw = Buffer.from(frame.ct, 'base64');
+    raw[0] ^= 0xff;
+
+    expect(() => open(key, { n: 0, ct: raw.toString('base64') })).toThrow();
+  });
+
+  test('rejects a frame opened at the wrong counter', () => {
+    const frame = sealJson(key, 3, { ok: true });
+
+    expect(() => openJson(key, { ...frame, n: 4 })).toThrow();
+  });
+
+  test('nonces are a 96-bit big-endian counter', () => {
+    expect(nonceFromCounter(0).toString('hex')).toBe('000000000000000000000000');
+    expect(nonceFromCounter(1).toString('hex')).toBe('000000000000000000000001');
+    expect(nonceFromCounter(258).toString('hex')).toBe('000000000000000000000102');
+    // Distinct counters must never collide — that is what keeps AES-GCM safe.
+    expect(nonceFromCounter(5).equals(nonceFromCounter(6))).toBe(false);
+  });
+});
+
+describe('buildHandshakeProof', () => {
+  test('binds both public keys, so a signature cannot be moved between exchanges', () => {
+    const proof = Buffer.from(buildHandshakeProof('CLIENT_PUB', 'AGENT_PUB')).toString('utf8');
+
+    expect(proof).toBe('e2e-handshake:v1\nCLIENT_PUB\nAGENT_PUB');
+    // Swapping the keys must change the signed bytes.
+    expect(Buffer.from(buildHandshakeProof('AGENT_PUB', 'CLIENT_PUB')).toString('utf8')).not.toBe(proof);
+  });
+});

--- a/src/main/api/relay/e2e.ts
+++ b/src/main/api/relay/e2e.ts
@@ -14,6 +14,16 @@
  * Nonces are a 96-bit big-endian counter, one sequence per direction, so a
  * (key, nonce) pair is never reused. Receivers must reject non-increasing
  * counters to prevent replay/reorder.
+ *
+ * The agent's half of the exchange is an EPHEMERAL keypair, freshly generated
+ * for every channel (see `deriveEphemeral`). This is what makes the counter
+ * discipline sound: with a long-lived agent key, ECDH(agent_static, client_pub)
+ * is a pure function of the client's public key, so anyone able to open a
+ * channel — notably the relay — could re-present a recorded `clientX25519Pub`,
+ * get the same session key back, and replay recorded frames into a fresh
+ * counter sequence. A per-channel key makes every channel's key unique, kills
+ * that replay, removes the two-time-pad risk when two channels share a client
+ * key, and buys forward secrecy for free.
  */
 
 import crypto from 'crypto';
@@ -27,6 +37,37 @@ const HKDF_SALT = 'bodhilander-relay-salt:v1';
 const HKDF_INFO = 'bodhilander-relay-e2e:v1';
 /** Handshake proof version — must match the web client exactly. */
 const HANDSHAKE_VERSION = 'e2e-handshake:v1';
+
+/** base64url (from a JWK field) → standard base64, for on-the-wire use. */
+function b64urlToB64(b64url: string): string {
+  return Buffer.from(b64url, 'base64url').toString('base64');
+}
+
+/**
+ * One channel's X25519 key agreement, using a keypair generated here and thrown
+ * away with the channel. Returns the shared secret plus the ephemeral public
+ * key to advertise to the client (which the caller signs with the machine's
+ * long-lived Ed25519 identity, so the client can still prove the key came from
+ * this machine).
+ *
+ * The private key never leaves this function, so a channel's key material is
+ * unrecoverable once the channel is gone.
+ */
+export function deriveEphemeral(peerX25519PubRaw: Uint8Array): {
+  sharedSecret: Buffer;
+  ephemeralPubB64: string;
+} {
+  if (peerX25519PubRaw.length !== 32) throw new Error('peer X25519 public key must be 32 bytes');
+
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('x25519');
+  const peerKey = crypto.createPublicKey({
+    key: { kty: 'OKP', crv: 'X25519', x: Buffer.from(peerX25519PubRaw).toString('base64url') },
+    format: 'jwk',
+  });
+  const sharedSecret = crypto.diffieHellman({ privateKey, publicKey: peerKey });
+  const { x } = publicKey.export({ format: 'jwk' }) as { x: string };
+  return { sharedSecret, ephemeralPubB64: b64urlToB64(x) };
+}
 
 /** Derive the 32-byte AES key from an X25519 shared secret (HKDF-SHA256). */
 export function deriveSessionKey(sharedSecret: Uint8Array): Buffer {

--- a/src/main/api/relay/relay-identity.ts
+++ b/src/main/api/relay/relay-identity.ts
@@ -2,11 +2,17 @@
  * Relay machine identity (remote hosting, Slice B).
  *
  * A machine's identity is an Ed25519 keypair (proves who it is) plus an X25519
- * keypair (future end-to-end key agreement with a web client). The raw public
- * keys are non-secret and live as plaintext preferences; the private keys are
- * encrypted with Electron `safeStorage` (OS keychain) and persisted as base64
- * blobs in the `preferences` table — the exact pattern used by `key-vault.ts`.
- * Plaintext private keys never touch the DB, logs, or the renderer.
+ * keypair registered with the relay at link time. The raw public keys are
+ * non-secret and live as plaintext preferences; the private keys are encrypted
+ * with Electron `safeStorage` (OS keychain) and persisted as base64 blobs in
+ * the `preferences` table — the exact pattern used by `key-vault.ts`. Plaintext
+ * private keys never touch the DB, logs, or the renderer.
+ *
+ * NOTE: the X25519 keypair here is only the machine's registered identity key
+ * (`machines.x25519_pubkey`). Terminal channels do NOT use it — each one runs
+ * ECDH against a throwaway keypair instead (`e2e.ts` `deriveEphemeral`), so a
+ * recorded channel can't be replayed into a fresh one. Reintroducing a
+ * long-lived ECDH here would undo that.
  */
 
 import crypto from 'crypto';
@@ -101,30 +107,6 @@ export function signWithIdentity(message: Uint8Array): Buffer {
     format: 'jwk',
   });
   return crypto.sign(null, Buffer.from(message), key);
-}
-
-/**
- * X25519 ECDH: derive the raw shared secret between this machine's X25519 key
- * and a peer's raw 32-byte X25519 public key. The private key never leaves this
- * module. Used to establish the E2E session key with a web client (see e2e.ts).
- */
-export function deriveSharedSecret(peerX25519PubRaw: Uint8Array): Buffer {
-  const xPubB64 = getPreference(PREF.x25519Pub);
-  const encPriv = getPreference(PREF.x25519Priv);
-  if (!xPubB64 || !encPriv) throw new Error('no relay identity for key agreement');
-  if (!vaultAvailable()) throw new Error('secure storage unavailable; cannot access X25519 key');
-  if (peerX25519PubRaw.length !== 32) throw new Error('peer X25519 public key must be 32 bytes');
-
-  const privB64url = safeStorage.decryptString(Buffer.from(encPriv, 'base64'));
-  const privateKey = crypto.createPrivateKey({
-    key: { kty: 'OKP', crv: 'X25519', x: Buffer.from(xPubB64, 'base64').toString('base64url'), d: privB64url },
-    format: 'jwk',
-  });
-  const publicKey = crypto.createPublicKey({
-    key: { kty: 'OKP', crv: 'X25519', x: Buffer.from(peerX25519PubRaw).toString('base64url') },
-    format: 'jwk',
-  });
-  return crypto.diffieHellman({ privateKey, publicKey });
 }
 
 /**

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -21,8 +21,16 @@ import { ptyManager } from '../../pty-manager';
 import { getAllSessions } from '../../repositories/sessions';
 import { getAllGroups } from '../../repositories/groups';
 import { createRemoteSession, createRemoteGroup } from './remote-sessions';
-import { deriveSharedSecret, ensureIdentity, signWithIdentity } from './relay-identity';
-import { deriveSessionKey, sealJson, openJson, buildHandshakeProof, type SealedFrame } from './e2e';
+import { ensureIdentity, signWithIdentity } from './relay-identity';
+import {
+  deriveEphemeral,
+  deriveSessionKey,
+  sealJson,
+  openJson,
+  buildHandshakeProof,
+  type SealedFrame,
+} from './e2e';
+import { chunkText } from './chunking';
 import { sanitizeSize } from './terminal-size';
 
 /** Expand a leading `~` to the user's home directory. */
@@ -39,9 +47,6 @@ interface ClientSession {
   recvCounter: number;
   /** Session ids this client is streaming. */
   subs: Set<string>;
-  onData: (e: { id: string; data: string }) => void;
-  onExit: (e: { id: string; exitCode: number }) => void;
-  onResize: (e: { id: string; cols: number; rows: number }) => void;
 }
 
 /** Decrypted command from a web client (union of every message's fields). */
@@ -62,9 +67,58 @@ interface ClientFrame {
 
 export class SessionTunnel {
   private readonly sessions = new Map<string, ClientSession>();
+  /** Whether the shared PTY listeners below are currently attached. */
+  private listening = false;
 
   /** `route` sends an outbound payload to a client id via the relay. */
   constructor(private readonly route: (clientId: string, payload: unknown) => void) {}
+
+  // One listener per PTY event for the whole tunnel, fanned out to subscribed
+  // clients. Previously each client attached its own three, which leaked a set
+  // per duplicate `client:open` and tripped EventEmitter's default max of 10
+  // listeners once a handful of viewers were connected.
+  private readonly onPtyData = (e: { id: string; data: string }): void => {
+    this.fanOut(e.id, (clientId) => this.sealTo(clientId, { type: 'terminal:output', sessionId: e.id, data: e.data }));
+  };
+
+  private readonly onPtyExit = (e: { id: string; exitCode: number }): void => {
+    this.fanOut(e.id, (clientId) =>
+      this.sealTo(clientId, { type: 'terminal:exit', sessionId: e.id, exitCode: e.exitCode }),
+    );
+  };
+
+  // Dynamic sizing: when the PTY is resized (by any viewer), tell subscribed
+  // clients the new size so they re-render at it.
+  private readonly onPtyResize = (e: { id: string; cols: number; rows: number }): void => {
+    this.fanOut(e.id, (clientId) =>
+      this.sealTo(clientId, { type: 'terminal:size', sessionId: e.id, cols: e.cols, rows: e.rows }),
+    );
+  };
+
+  /** Run `send` for every client subscribed to `sessionId`. */
+  private fanOut(sessionId: string, send: (clientId: string) => void): void {
+    for (const [clientId, s] of this.sessions) {
+      if (s.subs.has(sessionId)) send(clientId);
+    }
+  }
+
+  /** Attach the shared PTY listeners once, on the first connected client. */
+  private startListening(): void {
+    if (this.listening) return;
+    ptyManager.on('data', this.onPtyData);
+    ptyManager.on('exit', this.onPtyExit);
+    ptyManager.on('resize', this.onPtyResize);
+    this.listening = true;
+  }
+
+  /** Release them again once the last client goes away. */
+  private stopListeningIfIdle(): void {
+    if (!this.listening || this.sessions.size > 0) return;
+    ptyManager.off('data', this.onPtyData);
+    ptyManager.off('exit', this.onPtyExit);
+    ptyManager.off('resize', this.onPtyResize);
+    this.listening = false;
+  }
 
   /** A web client opened a channel — complete the E2E handshake. */
   open(clientId: string, payload: unknown): void {
@@ -72,35 +126,33 @@ export class SessionTunnel {
       const clientX25519Pub = (payload as { clientX25519Pub?: unknown })?.clientX25519Pub;
       if (typeof clientX25519Pub !== 'string') return;
 
-      const shared = deriveSharedSecret(new Uint8Array(Buffer.from(clientX25519Pub, 'base64')));
-      const key = deriveSessionKey(shared);
+      // The relay mints a fresh client id per socket, so a repeat means a
+      // client sent `client:open` twice. Refuse rather than replace: replacing
+      // would orphan the first channel's state and hand a second key to the
+      // same id.
+      if (this.sessions.has(clientId)) {
+        log.warn('[Relay] ignoring duplicate client:open', { clientId });
+        return;
+      }
+
+      // A per-channel ephemeral keypair (see e2e.ts) — never the machine's
+      // long-lived X25519 key, which would make this exchange replayable.
+      const { sharedSecret, ephemeralPubB64 } = deriveEphemeral(
+        new Uint8Array(Buffer.from(clientX25519Pub, 'base64')),
+      );
+      const key = deriveSessionKey(sharedSecret);
       const identity = ensureIdentity();
-      const signature = signWithIdentity(buildHandshakeProof(clientX25519Pub, identity.x25519Pub)).toString('base64');
+      const signature = signWithIdentity(buildHandshakeProof(clientX25519Pub, ephemeralPubB64)).toString('base64');
 
-      const onData = (e: { id: string; data: string }) => {
-        const s = this.sessions.get(clientId);
-        if (s?.subs.has(e.id)) this.sealTo(clientId, { type: 'terminal:output', sessionId: e.id, data: e.data });
-      };
-      const onExit = (e: { id: string; exitCode: number }) => {
-        const s = this.sessions.get(clientId);
-        if (s?.subs.has(e.id)) this.sealTo(clientId, { type: 'terminal:exit', sessionId: e.id, exitCode: e.exitCode });
-      };
-      // Dynamic sizing: when the PTY is resized (by this or any other viewer),
-      // tell subscribed clients the new size so they re-render at it.
-      const onResize = (e: { id: string; cols: number; rows: number }) => {
-        const s = this.sessions.get(clientId);
-        if (s?.subs.has(e.id)) this.sealTo(clientId, { type: 'terminal:size', sessionId: e.id, cols: e.cols, rows: e.rows });
-      };
-      ptyManager.on('data', onData);
-      ptyManager.on('exit', onExit);
-      ptyManager.on('resize', onResize);
-      this.sessions.set(clientId, { key, sendCounter: 0, recvCounter: -1, subs: new Set(), onData, onExit, onResize });
+      this.sessions.set(clientId, { key, sendCounter: 0, recvCounter: -1, subs: new Set() });
+      this.startListening();
 
-      // Unsealed handshake reply: client verifies `signature` against the
-      // machine's known Ed25519 pubkey, then derives the same session key.
+      // Unsealed handshake reply: the client verifies `signature` against the
+      // machine's known Ed25519 pubkey — which is what binds this throwaway
+      // X25519 key to this machine — then derives the same session key.
       this.route(clientId, {
         type: 'handshake',
-        agentX25519Pub: identity.x25519Pub,
+        agentX25519Pub: ephemeralPubB64,
         ed25519Pub: identity.ed25519Pub,
         signature,
       });
@@ -201,9 +253,13 @@ export class SessionTunnel {
     this.sealTo(clientId, { type: 'terminal:size', sessionId, cols: size.cols, rows: size.rows });
     // Replay history as RENDERED TEXT (reflow-safe) so a phone can resize the
     // shared terminal without the scrollback garbling. Then live output streams.
+    // Chunked so a long scrollback can't put a multi-megabyte frame on the wire
+    // (xterm.js carries parser state across writes, so splitting is safe).
     const history = await ptyManager.getSerializedBuffer(sessionId);
-    if (s.subs.has(sessionId)) {
-      this.sealTo(clientId, { type: 'terminal:output', sessionId, data: history });
+    for (const data of chunkText(history)) {
+      // Re-check every chunk: the client may unsubscribe or drop mid-replay.
+      if (!s.subs.has(sessionId) || this.sessions.get(clientId) !== s) return;
+      this.sealTo(clientId, { type: 'terminal:output', sessionId, data });
     }
   }
 
@@ -237,14 +293,10 @@ export class SessionTunnel {
     }
   }
 
-  /** A web client disconnected — drop its state and PTY listeners. */
+  /** A web client disconnected — drop its state. */
   closeClient(clientId: string): void {
-    const s = this.sessions.get(clientId);
-    if (!s) return;
-    ptyManager.off('data', s.onData);
-    ptyManager.off('exit', s.onExit);
-    ptyManager.off('resize', s.onResize);
-    this.sessions.delete(clientId);
+    if (!this.sessions.delete(clientId)) return;
+    this.stopListeningIfIdle();
   }
 
   /** Tear down every client (agent WebSocket dropped). */


### PR DESCRIPTION
Closes #154

M5.0 of `docs/designs/session-sharing.md` — the hardening pass that has to land before any sharing code does. No user-visible change; every fix here is to the *existing single-user* tunnel.

The design doc is included in this branch (first commit) because the reasoning for several of these fixes only makes sense against it.

## The headline: channel keys were derived from a static key

`relay-identity.ts` derived the channel secret from the agent's **long-lived** X25519 identity key, so the channel key was a pure function of the client's key — and the signed handshake proof covered no per-channel-fresh value. The relay could record a session, replay the proof to a new browser, and every captured frame would decrypt (`recvCounter` starts at `-1` per channel). Both sides would then seal *new* traffic under an already-used key with counters restarting at zero — AES-GCM key + nonce reuse, which leaks plaintext to anyone who XORs two frames.

**The fix came out smaller than the design specified.** §1.1 originally also added a `channelNonce` and bumped the proof to `e2e-handshake:v2`. Reading `connection.ts:69-78` closely, that is unnecessary and worse than unnecessary. The client derives from whatever `agentX25519Pub` the *signed* proof carries and pins only `machineEd25519Pub`, so making the agent's half ephemeral is a **pure agent-side change** — no wire format bump, no client change, no deploy ordering. And once the agent's key is fresh per channel, the proof already covers a fresh value: a replayed proof names an ephemeral public key whose private half no longer exists, so the channel simply fails to establish. A v2 bump would have needed a coordinated relay/desktop deploy plus a version-negotiation field that is itself a relay-selectable downgrade path. The doc now marks that recommendation **Superseded**.

Forward secrecy falls out for free — recovering the machine identity key no longer decrypts any recorded channel.

`deriveEphemeral` lives in `e2e.ts` rather than `relay-identity.ts` deliberately: `e2e.ts` imports only `crypto`, no Electron, so it is unit-testable. `deriveSharedSecret` is **deleted** rather than left exported — it is precisely the primitive whose reintroduction would undo this.

## Also in this branch

**`to-client` was unbound** (`ws.ts:180`). An authenticated agent could name any `clientId` in the relay's routing table and inject frames into a different machine's channel. Now scoped to the sender's own machine.

**PTY listeners are per-tunnel, not per-client.** `ClientSession` held three closures each registered on `ptyManager`, against an `EventEmitter` whose default max-listeners is 10 — four viewers already produced a leak warning, and a duplicate `client:open` leaked a whole set with no path to removal. One listener set now registers on the first client and unregisters when the last one leaves, fanning out over subscriptions.

**Rate limiting** on `/link` (per address *and* per keypair, so rotating IPs doesn't buy anything) and `/link/claim`. Client-IP resolution takes the **rightmost** `X-Forwarded-For` hop when `trustProxy` is set — the leftmost is caller-supplied, and honoring it lets one caller mint unlimited buckets. It returns `null` rather than a placeholder when nothing resolves, so callers **fail open**: bucketing every unresolvable request together would turn one abuser into an outage for everyone behind that path.

**The reapers.** `purgeExpiredSessions` was on the repository interface with no caller anywhere in the tree, and nothing ever deleted expired link codes. `purgeExpiredLinkCodes` deletes only `status = 'pending'` rows — a claimed code's row is the audit trail of the claim.

**History replay is chunked** at 64 KiB. It previously sealed an entire serialized scrollback buffer into one frame. Chunking is safe because xterm's parser is stateful across `write()` calls; `chunkText` splits without breaking surrogate pairs, and the loop re-checks the subscription between chunks so a client that unsubscribes mid-replay stops receiving.

**Smaller ones:** duplicate `client:open` refused (`4400`) instead of re-pointing a socket at a different machine · duplicate `clientId` refused at the tunnel · agent socket replacement closes the socket it supersedes, publishing the new socket *before* closing the old one so a synchronous close handler can't delete the live entry or emit a spurious `agent:offline` · unauthenticated agent sockets reaped at 30s · browser keepalive ping, since browsers can't send WS control frames from script and an idle viewer otherwise looks dead to any intermediary.

## One thing deliberately left alone

`maxPayloadLength` is now set explicitly but left at 16 MB. Agents auto-update on their own schedule, and a pre-chunking agent still seals a whole serialized buffer into one frame. Tightening it now would break history replay for clients that no relay-side change can reach. It comes down once chunking has shipped long enough.

## Testing

`e2e.test.ts` states the property directly rather than testing the implementation: the **same** peer key yields a different channel key every time, and a frame sealed on one channel no longer opens after re-deriving. Plus `chunking.test.ts` (surrogate pairs, boundaries) and `rate-limit.test.ts` (windows, per-key isolation, XFF resolution incl. the spoofed-leftmost case).

The cross-machine injection test proves the drop by **ordering** rather than a sleep — it sends the injection, then a legitimate frame, and asserts the legitimate one arrives first with nothing before it.

- Desktop: **489 pass, 0 fail** (1131 assertions, 41 files)
- Relay: **62 pass, 0 fail** (225 assertions, 5 files)
- `tsc -p tsconfig.main.json --noEmit`, relay `tsc --noEmit`, `tsc -p web/tsconfig.json` all clean
- `bun run build:web` bundles

## For the reviewer

Two things worth knowing before this goes near production.

**The relay tree is not Sonar-scanned.** `sonar.sources=src`, so `relay/src/rate-limit.ts` and the `ws.ts` changes get no quality gate — the desktop files do. Human review is the only gate on the relay half of this PR.

**Deploying needs a rebuild and recreate, not a restart.** `--env-file` and the image are read at `docker run` time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
