### PR TITLE
feat(sharing): watch-only guest, with presence (M5.2)

### DIFF
--- a/relay/src/auth/github.ts
+++ b/relay/src/auth/github.ts
@@ -99,6 +99,10 @@ export async function exchangeCodeForProfile(
   return {
     providerUserId: String(user.id),
     displayName: user.name?.trim() || user.login,
+    // The handle itself, kept separately from displayName. Sharing needs an
+    // identifier the account holder cannot choose to impersonate someone else
+    // with, and `name` is free text.
+    login: user.login,
     email: email ?? null,
     avatarUrl: user.avatar_url,
   };

--- a/relay/src/db/migrations/003_github_login.sql
+++ b/relay/src/db/migrations/003_github_login.sql
@@ -1,0 +1,26 @@
+-- 003_github_login.sql — persist the GitHub handle (Milestone 5.2).
+--
+-- The login is fetched during OAuth and then discarded: `displayName` prefers
+-- the profile *name* and only falls back to the handle, so it is not the
+-- handle. Sharing needs the handle itself for two things that cannot use a
+-- display name:
+--
+--   * addressed invites, which bind `share_invites.expected_github_login` so a
+--     code redeemed by anyone else fails closed;
+--   * the owner's approval prompt, which must show an immutable identifier —
+--     a display name is attacker-chosen and can be set to impersonate someone
+--     the owner trusts.
+--
+-- Separate from 002 rather than an edit to it: 002 is already applied in
+-- production, and `runMigrations` skips any file whose version is not greater
+-- than the current `user_version`. Editing it would be a silent no-op on every
+-- existing database.
+--
+-- Nullable with no backfill: existing users acquire it on their next sign-in.
+-- Nothing may treat a NULL login as a match — see `redeemShareInvite`.
+
+ALTER TABLE users ADD COLUMN github_login TEXT;
+
+-- Case-insensitive, because GitHub logins are compared that way and an invite
+-- addressed to `Dana-K` must match a session for `dana-k`.
+CREATE INDEX IF NOT EXISTS idx_users_github_login ON users(github_login COLLATE NOCASE);

--- a/relay/src/db/migrations/003_github_login.sql
+++ b/relay/src/db/migrations/003_github_login.sql
@@ -21,6 +21,15 @@
 
 ALTER TABLE users ADD COLUMN github_login TEXT;
 
+-- How long the grant should last once the owner approves it, carried over
+-- from the invite at redemption.
+--
+-- `machine_grants.expires_at` is NULL until the agent countersigns, so without
+-- this the agent has nothing to compute a certificate lifetime from at the
+-- moment of approval — the one moment it needs it. Copied rather than joined
+-- because the invite is deletable and the grant must outlive it.
+ALTER TABLE machine_grants ADD COLUMN grant_ttl_seconds INTEGER;
+
 -- Case-insensitive, because GitHub logins are compared that way and an invite
 -- addressed to `Dana-K` must match a session for `dana-k`.
 CREATE INDEX IF NOT EXISTS idx_users_github_login ON users(github_login COLLATE NOCASE);

--- a/relay/src/dev.ts
+++ b/relay/src/dev.ts
@@ -17,7 +17,8 @@ export function createDevRoutes(_config: RelayConfig, repos: Repositories) {
     if (url.pathname === '/dev/login' && req.method === 'POST') {
       const user = repos.upsertGithubUser({
         providerUserId: 'dev-user',
-        displayName: 'Dev User', login: 'devuser',
+        displayName: 'Dev User',
+        login: 'devuser',
         email: 'dev@localhost',
         avatarUrl: null,
       });

--- a/relay/src/dev.ts
+++ b/relay/src/dev.ts
@@ -17,7 +17,7 @@ export function createDevRoutes(_config: RelayConfig, repos: Repositories) {
     if (url.pathname === '/dev/login' && req.method === 'POST') {
       const user = repos.upsertGithubUser({
         providerUserId: 'dev-user',
-        displayName: 'Dev User',
+        displayName: 'Dev User', login: 'devuser',
         email: 'dev@localhost',
         avatarUrl: null,
       });

--- a/relay/src/http.ts
+++ b/relay/src/http.ts
@@ -1,9 +1,9 @@
 import pkg from '../package.json';
 import type { RelayConfig } from './config';
 import type { Logger } from './logger';
-import type { Machine, Repositories, User } from './repositories';
+import type { Machine, MachineGrant, Repositories, ShareInvite, User } from './repositories';
 import { fromBase64, randomToken, verifyEd25519 } from './crypto';
-import { buildLinkMessage, LINK_MAX_SKEW_MS } from './protocol';
+import { buildLinkMessage, buildShareCreateMessage, LINK_MAX_SKEW_MS, MINTABLE_ROLES } from './protocol';
 import {
   buildAuthorizeUrl,
   exchangeCodeForProfile,
@@ -35,6 +35,12 @@ import { clientIp, createRateLimiter, type RateLimiter } from './rate-limit';
  *   GET  /api/machines                — user's linked machines (session)
  *   POST /link                        — agent registers a machine (Ed25519-signed)
  *   POST /link/claim                  — user claims a link code (session)
+ *   POST /api/machines/:id/shares     — owner mints an invite (Ed25519-signed)
+ *   GET  /api/machines/:id/shares     — owner lists invites + grants (session)
+ *   DEL  /api/machines/:id/shares/:id — owner revokes an invite (session)
+ *   POST /api/shares/redeem           — guest redeems a code (session)
+ *   GET  /api/shares                  — guest lists their grants (session)
+ *   DEL  /api/shares/:grantId         — owner OR grantee ends a grant (session)
  */
 export interface RelayContext {
   config: RelayConfig;
@@ -44,6 +50,14 @@ export interface RelayContext {
   fetchImpl?: typeof fetch;
   /** Injectable so the caller can sweep it from the reaper; defaults to a fresh one. */
   rateLimiter?: RateLimiter;
+  /**
+   * Called when a guest redeems an invite, so the gateway can wake the owner's
+   * agent. HTTP and WebSocket are separate surfaces; this is the seam between
+   * them rather than a shared mutable table.
+   */
+  onGrantRedeemed?: (grant: MachineGrant) => void;
+  /** Called when a grant is revoked over HTTP, so live sockets can be cut. */
+  onGrantRevoked?: (grant: MachineGrant) => void;
 }
 
 const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
@@ -54,9 +68,19 @@ const LINK_PER_IP = 10;
 const LINK_PER_KEY = 5;
 /** Tighter: this is where a link code would be guessed at. */
 const CLAIM_PER_IP = 20;
+/** Minting invites is cheap for an owner and pointless to do in bulk. */
+const SHARE_PER_IP = 20;
+
+/**
+ * Ceilings on what an invite may ask for. The desktop offers far shorter
+ * defaults; these exist so a malformed or hostile request cannot produce a
+ * grant that outlives any reasonable session.
+ */
+const MAX_GRANT_TTL_SECONDS = 24 * 60 * 60;
+const MAX_INVITE_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 export function createRouter(ctx: RelayContext) {
-  const { config, logger, repos } = ctx;
+  const { config, logger, repos, onGrantRedeemed, onGrantRevoked } = ctx;
   const limiter = ctx.rateLimiter ?? createRateLimiter();
   const version = pkg.version ?? '0.0.0';
   const secure = config.isProduction || config.trustProxy;
@@ -147,7 +171,7 @@ export function createRouter(ctx: RelayContext) {
       if (pathname === '/api/machines' && method === 'GET') {
         const user = currentUser(req);
         if (!user) return json({ error: 'unauthorized' }, 401);
-        return json({ machines: repos.listMachines(user.id).map(publicMachine) });
+        return json({ machines: machinesFor(user) });
       }
 
       if (pathname === '/link' && method === 'POST') {
@@ -157,6 +181,31 @@ export function createRouter(ctx: RelayContext) {
       if (pathname === '/link/claim' && method === 'POST') {
         return limited(req, peerIp, 'claim', CLAIM_PER_IP) ?? (await handleClaim(req));
       }
+
+      // --- sharing (M5.2) ---
+
+      const shares = matchMachineShares(pathname);
+      if (shares) {
+        if (method === 'POST' && !shares.inviteId) {
+          return limited(req, peerIp, 'share', SHARE_PER_IP) ?? (await handleCreateShare(req, shares.machineId));
+        }
+        if (method === 'GET' && !shares.inviteId) return handleListShares(req, shares.machineId);
+        if (method === 'DELETE' && shares.inviteId) {
+          return handleRevokeInvite(req, shares.machineId, shares.inviteId);
+        }
+      }
+
+      if (pathname === '/api/shares' && method === 'GET') {
+        return handleListMyShares(req);
+      }
+
+      if (pathname === '/api/shares/redeem' && method === 'POST') {
+        // Code-guessing surface, same as /link/claim.
+        return limited(req, peerIp, 'redeem', CLAIM_PER_IP) ?? (await handleRedeem(req));
+      }
+
+      const grantId = matchShareGrant(pathname);
+      if (grantId && method === 'DELETE') return handleRevokeGrant(req, grantId);
 
       return json({ error: 'not_found' }, 404);
     } catch (err) {
@@ -276,6 +325,236 @@ export function createRouter(ctx: RelayContext) {
     logger.info('machine linked', { userId: user.id, machineId: result.machine.id });
     return json({ machine: publicMachine(result.machine) });
   }
+
+  // --- sharing (M5.2) ---
+
+  /**
+   * Every machine this user can reach, owned and shared-with, in one list.
+   *
+   * A guest's entry carries the certificate it must present. The relay holds
+   * that blob but cannot read it — and cannot mint one, which is the whole
+   * point of the agent countersigning.
+   */
+  function machinesFor(user: User) {
+    const owned = repos.listMachines(user.id).map((m) => ({
+      ...publicMachine(m),
+      relation: 'owner' as const,
+      ownerName: null as string | null,
+      grantId: null as string | null,
+      role: null as string | null,
+      certificate: null as string | null,
+    }));
+
+    const shared = [];
+    for (const grant of repos.listGrantsForUser(user.id)) {
+      // Only grants the agent has actually countersigned are usable; a pending
+      // one is a request the owner has not answered.
+      if (grant.status !== 'active' || !grant.certificate) continue;
+      const machine = repos.getMachine(grant.machine_id);
+      if (!machine) continue;
+      const owner = repos.getUser(machine.user_id);
+      shared.push({
+        ...publicMachine(machine),
+        relation: 'grantee' as const,
+        // Label by person: "machine" is owner vocabulary.
+        ownerName: owner?.display_name ?? null,
+        grantId: grant.id,
+        role: grant.role,
+        certificate: grant.certificate,
+      });
+    }
+    return [...owned, ...shared];
+  }
+
+  /**
+   * Create an invite. Ed25519-signed by the machine, not session-authenticated:
+   * only the machine can countersign a grant, so only the machine may offer
+   * one — a stolen session cookie cannot mint invites.
+   */
+  async function handleCreateShare(req: Request, machineId: string): Promise<Response> {
+    const body = await readJson(req);
+    if (!body) return json({ error: 'invalid_json' }, 400);
+
+    const { expectedGithubLogin, role, grantTtlSeconds, inviteTtlSeconds, issuedAt, signature, label } =
+      body as Record<string, unknown>;
+
+    if (
+      typeof role !== 'string' ||
+      typeof grantTtlSeconds !== 'number' ||
+      typeof inviteTtlSeconds !== 'number' ||
+      typeof issuedAt !== 'number' ||
+      typeof signature !== 'string' ||
+      (expectedGithubLogin !== null && typeof expectedGithubLogin !== 'string') ||
+      (label !== undefined && label !== null && typeof label !== 'string')
+    ) {
+      return json({ error: 'invalid_request' }, 400);
+    }
+    if (!(MINTABLE_ROLES as readonly string[]).includes(role)) return json({ error: 'invalid_role' }, 400);
+    if (grantTtlSeconds <= 0 || grantTtlSeconds > MAX_GRANT_TTL_SECONDS) return json({ error: 'invalid_ttl' }, 400);
+    if (inviteTtlSeconds <= 0 || inviteTtlSeconds > MAX_INVITE_TTL_SECONDS) return json({ error: 'invalid_ttl' }, 400);
+    if (Math.abs(Date.now() - issuedAt) > LINK_MAX_SKEW_MS) return json({ error: 'stale_request' }, 400);
+
+    const machine = repos.getMachine(machineId);
+    if (!machine) return json({ error: 'not_found' }, 404);
+
+    const sigBytes = fromBase64(signature);
+    if (!sigBytes) return json({ error: 'invalid_request' }, 400);
+    const message = buildShareCreateMessage({
+      machineId,
+      expectedGithubLogin: expectedGithubLogin ?? '',
+      role,
+      grantTtlSeconds,
+      inviteTtlSeconds,
+      issuedAt,
+    });
+    if (!(await verifyEd25519(new Uint8Array(machine.ed25519_pubkey), sigBytes, message))) {
+      return json({ error: 'bad_signature' }, 401);
+    }
+
+    const { invite, code } = repos.createShareInvite({
+      machineId,
+      expectedGithubLogin: (expectedGithubLogin as string | null) ?? null,
+      role: role as 'viewer' | 'operator',
+      label: (label as string | undefined) ?? null,
+      grantTtlSeconds,
+      inviteTtlSeconds,
+    });
+
+    logger.info('share invite created', { machineId, addressed: !!invite.expected_github_login });
+    // The CODE only — never a URL. If the relay authored the invite link it
+    // could put its own fingerprint in the `#fp=` fragment and serve the
+    // matching key, making the guest's three-way check agree perfectly and
+    // manufacturing a false "verified". The desktop composes the URL locally.
+    return json({ inviteId: invite.id, code, expiresAt: invite.expires_at });
+  }
+
+  function handleListShares(req: Request, machineId: string): Response {
+    const user = currentUser(req);
+    if (!user) return json({ error: 'unauthorized' }, 401);
+    const machine = repos.getMachine(machineId);
+    if (!machine || machine.user_id !== user.id) return json({ error: 'not_found' }, 404);
+    return json({
+      invites: repos.listShareInvites(machineId).map(publicInvite),
+      grants: repos.listGrantsForMachine(machineId).map((g) => publicGrant(g, repos.getUser(g.grantee_user_id))),
+    });
+  }
+
+  function handleRevokeInvite(req: Request, machineId: string, inviteId: string): Response {
+    const user = currentUser(req);
+    if (!user) return json({ error: 'unauthorized' }, 401);
+    const machine = repos.getMachine(machineId);
+    if (!machine || machine.user_id !== user.id) return json({ error: 'not_found' }, 404);
+    if (!repos.revokeShareInvite(machineId, inviteId)) return json({ error: 'not_found' }, 404);
+    return new Response(null, { status: 204 });
+  }
+
+  function handleListMyShares(req: Request): Response {
+    const user = currentUser(req);
+    if (!user) return json({ error: 'unauthorized' }, 401);
+    const grants = repos.listGrantsForUser(user.id).map((g) => {
+      const machine = repos.getMachine(g.machine_id);
+      const owner = machine ? repos.getUser(machine.user_id) : null;
+      return {
+        ...publicGrant(g, user),
+        machineId: g.machine_id,
+        machineName: machine?.name ?? null,
+        ownerName: owner?.display_name ?? null,
+      };
+    });
+    return json({ grants });
+  }
+
+  async function handleRedeem(req: Request): Promise<Response> {
+    const user = currentUser(req);
+    if (!user) return json({ error: 'unauthorized' }, 401);
+
+    const body = await readJson(req);
+    const code = body && typeof (body as Record<string, unknown>).code === 'string' ? (body as { code: string }).code : null;
+    if (!code) return json({ error: 'invalid_request' }, 400);
+
+    // The desktop generates grant ids so a reused one cannot silently hand one
+    // grant's holder another grant's sessions — but redemption happens here,
+    // before the desktop is involved. A UUID minted here is still opaque to
+    // the guest, and the agent refuses any grantId absent from its own table,
+    // so a collision fails closed rather than widening anything.
+    const result = repos.redeemShareInvite(code, user, crypto.randomUUID());
+    if (!result.ok) {
+      const status = result.reason === 'not_found' ? 404 : 409;
+      return json({ error: `invite_${result.reason}` }, status);
+    }
+
+    logger.info('share invite redeemed', { machineId: result.grant.machine_id, grantId: result.grant.id });
+    onGrantRedeemed?.(result.grant);
+    // Pending, deliberately: the guest is waiting on the owner, and the client
+    // must render that rather than a broken terminal.
+    return json({ grant: publicGrant(result.grant, user), status: 'pending' });
+  }
+
+  function handleRevokeGrant(req: Request, grantId: string): Response {
+    const user = currentUser(req);
+    if (!user) return json({ error: 'unauthorized' }, 401);
+    const grant = repos.getGrant(grantId);
+    if (!grant) return json({ error: 'not_found' }, 404);
+
+    const machine = repos.getMachine(grant.machine_id);
+    const isOwner = !!machine && machine.user_id === user.id;
+    const isGrantee = grant.grantee_user_id === user.id;
+    // A grantee may hand access back; anyone else gets the same answer as a
+    // grant that does not exist.
+    if (!isOwner && !isGrantee) return json({ error: 'not_found' }, 404);
+
+    repos.revokeGrant(grantId);
+    logger.info('grant revoked', { grantId, by: isOwner ? 'owner' : 'grantee' });
+    onGrantRevoked?.(grant);
+    return new Response(null, { status: 204 });
+  }
+}
+
+/** `/api/machines/:machineId/shares[/:inviteId]` */
+function matchMachineShares(pathname: string): { machineId: string; inviteId: string | null } | null {
+  const parts = pathname.split('/').filter(Boolean);
+  if (parts.length < 4 || parts[0] !== 'api' || parts[1] !== 'machines' || parts[3] !== 'shares') return null;
+  if (parts.length > 5) return null;
+  return { machineId: parts[2]!, inviteId: parts[4] ?? null };
+}
+
+/** `/api/shares/:grantId`, excluding the fixed sub-routes. */
+function matchShareGrant(pathname: string): string | null {
+  const parts = pathname.split('/').filter(Boolean);
+  if (parts.length !== 3 || parts[0] !== 'api' || parts[1] !== 'shares') return null;
+  const id = parts[2]!;
+  return id === 'redeem' ? null : id;
+}
+
+function publicInvite(i: ShareInvite) {
+  return {
+    id: i.id,
+    expectedGithubLogin: i.expected_github_login,
+    role: i.role,
+    label: i.label,
+    status: i.status,
+    attemptCount: i.attempt_count,
+    createdAt: i.created_at,
+    expiresAt: i.expires_at,
+    grantTtlSeconds: i.grant_ttl_seconds,
+    // No code, and no hash: neither is useful to a client and the hash is a
+    // guessing target.
+  };
+}
+
+function publicGrant(g: MachineGrant, grantee: User | null) {
+  return {
+    id: g.id,
+    role: g.role,
+    status: g.status,
+    label: g.label,
+    granteeName: grantee?.display_name ?? null,
+    granteeLogin: grantee?.github_login ?? null,
+    createdAt: g.created_at,
+    boundAt: g.bound_at,
+    expiresAt: g.expires_at,
+    lastUsedAt: g.last_used_at,
+  };
 }
 
 function publicUser(user: User) {

--- a/relay/src/http.ts
+++ b/relay/src/http.ts
@@ -348,8 +348,12 @@ export function createRouter(ctx: RelayContext) {
     const shared = [];
     for (const grant of repos.listGrantsForUser(user.id)) {
       // Only grants the agent has actually countersigned are usable; a pending
-      // one is a request the owner has not answered.
+      // one is a request the owner has not answered. The expiry check matters
+      // because the reaper runs every ten minutes — without it a lapsed grant
+      // would keep being listed, certificate and all, until it happened to be
+      // swept.
       if (grant.status !== 'active' || !grant.certificate) continue;
+      if (grant.expires_at !== null && grant.expires_at <= Date.now()) continue;
       const machine = repos.getMachine(grant.machine_id);
       if (!machine) continue;
       const owner = repos.getUser(machine.user_id);

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -31,8 +31,18 @@ function main(): void {
 
   const repos = createRepositories(db);
   const rateLimiter = createRateLimiter();
-  const route = createRouter({ config, logger, repos, rateLimiter });
+  // The gateway is built first so the router can call into it. HTTP and
+  // WebSocket are separate surfaces; these two callbacks are the only seam
+  // between them, rather than a shared mutable table either side can corrupt.
   const gateway = createGateway({ repos, logger });
+  const route = createRouter({
+    config,
+    logger,
+    repos,
+    rateLimiter,
+    onGrantRedeemed: (grant) => gateway.notifyGrantRedeemed(grant),
+    onGrantRevoked: (grant) => gateway.notifyGrantRevoked(grant),
+  });
 
   const server = Bun.serve({
     port: config.port,
@@ -65,6 +75,10 @@ function main(): void {
     try {
       repos.purgeExpiredSessions();
       const codes = repos.purgeExpiredLinkCodes();
+      // Revoked/expired grants and stale unredeemed invites. The desktop keeps
+      // its own record, so nothing dropped here is the audit trail.
+      const shares = repos.purgeDeadShares();
+      if (shares > 0) logger.debug('reaped dead shares', { count: shares });
       rateLimiter.sweep();
       if (codes > 0) logger.debug('reaped expired link codes', { count: codes });
       // Only non-zero when someone is holding MAX_WINDOWS buckets at their

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -75,6 +75,11 @@ function main(): void {
     try {
       repos.purgeExpiredSessions();
       const codes = repos.purgeExpiredLinkCodes();
+      // Cut any live socket BEFORE dropping its row. The explicit-revoke path
+      // does this via onGrantRevoked; a grant that merely reached its TTL
+      // deserves the same treatment, or the guest keeps a channel open to a
+      // grant that no longer exists.
+      for (const dead of repos.listDeadShareGrants()) gateway.notifyGrantRevoked(dead);
       // Revoked/expired grants and stale unredeemed invites. The desktop keeps
       // its own record, so nothing dropped here is the audit trail.
       const shares = repos.purgeDeadShares();

--- a/relay/src/m2.test.ts
+++ b/relay/src/m2.test.ts
@@ -60,8 +60,8 @@ describe('crypto', () => {
 describe('repositories: users & sessions', () => {
   test('upsertGithubUser creates once, then refreshes profile on repeat', () => {
     const repos = freshRepos();
-    const a = repos.upsertGithubUser({ providerUserId: '42', displayName: 'Octo', email: 'o@gh.com', avatarUrl: null });
-    const b = repos.upsertGithubUser({ providerUserId: '42', displayName: 'Octo Renamed', email: 'o@gh.com', avatarUrl: 'x' });
+    const a = repos.upsertGithubUser({ providerUserId: '42', displayName: 'Octo', login: 'octo', email: 'o@gh.com', avatarUrl: null });
+    const b = repos.upsertGithubUser({ providerUserId: '42', displayName: 'Octo Renamed', login: 'octorenamed', email: 'o@gh.com', avatarUrl: 'x' });
     expect(b.id).toBe(a.id); // same identity → same user
     expect(b.display_name).toBe('Octo Renamed');
   });
@@ -69,7 +69,7 @@ describe('repositories: users & sessions', () => {
   test('session lifecycle: create → resolve → expire → delete', () => {
     let clock = 1_000_000;
     const repos = createRepositories(openDb(':memory:'), () => clock);
-    const user = repos.upsertGithubUser({ providerUserId: '1', displayName: 'U', email: null, avatarUrl: null });
+    const user = repos.upsertGithubUser({ providerUserId: '1', displayName: 'U', login: 'u', email: null, avatarUrl: null });
 
     const { token } = repos.createSession(user.id, 60);
     expect(repos.getUserBySessionToken(token)?.id).toBe(user.id);
@@ -91,7 +91,7 @@ describe('repositories: link codes & machines', () => {
 
   test('claim binds a pending code to a machine and lists it', () => {
     const repos = freshRepos();
-    const user = repos.upsertGithubUser({ providerUserId: '1', displayName: 'U', email: null, avatarUrl: null });
+    const user = repos.upsertGithubUser({ providerUserId: '1', displayName: 'U', login: 'u', email: null, avatarUrl: null });
     const { code } = repos.createLinkCode('Will-MBP', ed, x, 600);
 
     const result = repos.claimLinkCode(code, user.id);
@@ -102,7 +102,7 @@ describe('repositories: link codes & machines', () => {
 
   test('a code cannot be claimed twice', () => {
     const repos = freshRepos();
-    const user = repos.upsertGithubUser({ providerUserId: '1', displayName: 'U', email: null, avatarUrl: null });
+    const user = repos.upsertGithubUser({ providerUserId: '1', displayName: 'U', login: 'u', email: null, avatarUrl: null });
     const { code } = repos.createLinkCode('m', ed, x, 600);
     expect(repos.claimLinkCode(code, user.id).ok).toBe(true);
     const again = repos.claimLinkCode(code, user.id);
@@ -112,7 +112,7 @@ describe('repositories: link codes & machines', () => {
   test('expired and unknown codes are rejected', () => {
     let clock = 1_000_000;
     const repos = createRepositories(openDb(':memory:'), () => clock);
-    const user = repos.upsertGithubUser({ providerUserId: '1', displayName: 'U', email: null, avatarUrl: null });
+    const user = repos.upsertGithubUser({ providerUserId: '1', displayName: 'U', login: 'u', email: null, avatarUrl: null });
     const { code } = repos.createLinkCode('m', ed, x, 1);
     clock += 2_000;
     expect(repos.claimLinkCode(code, user.id)).toEqual({ ok: false, reason: 'expired' });
@@ -121,8 +121,8 @@ describe('repositories: link codes & machines', () => {
 
   test('re-linking the same ed25519 identity rebinds instead of duplicating', () => {
     const repos = freshRepos();
-    const u1 = repos.upsertGithubUser({ providerUserId: '1', displayName: 'A', email: null, avatarUrl: null });
-    const u2 = repos.upsertGithubUser({ providerUserId: '2', displayName: 'B', email: null, avatarUrl: null });
+    const u1 = repos.upsertGithubUser({ providerUserId: '1', displayName: 'A', login: 'a', email: null, avatarUrl: null });
+    const u2 = repos.upsertGithubUser({ providerUserId: '2', displayName: 'B', login: 'b', email: null, avatarUrl: null });
     repos.claimLinkCode(repos.createLinkCode('m', ed, x, 600).code, u1.id);
     repos.claimLinkCode(repos.createLinkCode('m-renamed', ed, x, 600).code, u2.id);
     expect(repos.listMachines(u1.id)).toHaveLength(0); // moved off u1
@@ -148,7 +148,7 @@ describe('router: /link + /link/claim (end to end)', () => {
   test('a valid signed request yields a code; a user claims it and sees the machine', async () => {
     const repos = freshRepos();
     const route = createRouter({ config, logger, repos });
-    const user = repos.upsertGithubUser({ providerUserId: '1', displayName: 'U', email: null, avatarUrl: null });
+    const user = repos.upsertGithubUser({ providerUserId: '1', displayName: 'U', login: 'u', email: null, avatarUrl: null });
     const { token } = repos.createSession(user.id, 3600);
 
     const linkRes = await route(

--- a/relay/src/protocol.ts
+++ b/relay/src/protocol.ts
@@ -47,6 +47,43 @@ export function buildAgentAuthMessage(nonce: string): Uint8Array {
  */
 export const CAP_GRANTS_V1 = 'grants:v1';
 
+/**
+ * Canonical message an agent signs to create a share invite.
+ *
+ * Signed rather than session-authenticated because invites originate on the
+ * **desktop**, not in a browser: only the machine can countersign a grant, so
+ * only the machine should be able to offer one. A stolen relay session cookie
+ * therefore cannot mint invites for a machine it does not hold the key to.
+ *
+ * `expectedGithubLogin` is included so the addressing cannot be stripped in
+ * transit — an open link is a materially different thing from an addressed
+ * one, and the relay must not be able to downgrade one into the other.
+ */
+export const SHARE_CREATE_VERSION = 'share-create:v1';
+
+export interface ShareCreateParts {
+  machineId: string;
+  /** Empty string for an open link. */
+  expectedGithubLogin: string;
+  role: string;
+  grantTtlSeconds: number;
+  inviteTtlSeconds: number;
+  issuedAt: number;
+}
+
+export function buildShareCreateMessage(p: ShareCreateParts): Uint8Array {
+  const line = [
+    SHARE_CREATE_VERSION,
+    p.machineId,
+    p.expectedGithubLogin,
+    p.role,
+    String(p.grantTtlSeconds),
+    String(p.inviteTtlSeconds),
+    String(p.issuedAt),
+  ].join('\n');
+  return new TextEncoder().encode(line);
+}
+
 // --- grant certificates (design §5) ---
 
 export const GRANT_VERSION = 'grant:v1';

--- a/relay/src/relay.test.ts
+++ b/relay/src/relay.test.ts
@@ -43,7 +43,7 @@ describe('openDb / migrations', () => {
     const db = openDb(':memory:');
     try {
       const { user_version } = db.query('PRAGMA user_version;').get() as { user_version: number };
-      expect(user_version).toBe(2);
+      expect(user_version).toBe(3);
 
       const tables = db
         .query("SELECT name FROM sqlite_master WHERE type='table';")

--- a/relay/src/repositories.ts
+++ b/relay/src/repositories.ts
@@ -14,6 +14,13 @@ export interface User {
   primary_email: string | null;
   avatar_url: string | null;
   created_at: number;
+  /**
+   * The GitHub handle. Distinct from `display_name`, which prefers the
+   * profile's free-text name — sharing needs an identifier the account holder
+   * cannot set to impersonate someone the owner trusts. NULL for users who
+   * have not signed in since migration 003.
+   */
+  github_login: string | null;
 }
 
 export interface Machine {
@@ -29,6 +36,8 @@ export interface Machine {
 export interface GithubProfile {
   providerUserId: string;
   displayName: string;
+  /** The handle, e.g. `dana-k`. */
+  login: string;
   email: string | null;
   avatarUrl: string | null;
 }
@@ -96,11 +105,62 @@ export interface Repositories {
    * capability from the certificate it signed.
    */
   getMachineAccess(machineId: string, userId: string): MachineAccess;
+
+  // --- sharing (M5.2) ---
+
+  createShareInvite(input: CreateShareInviteInput): { invite: ShareInvite; code: string };
+  listShareInvites(machineId: string): ShareInvite[];
+  revokeShareInvite(machineId: string, inviteId: string): boolean;
+  /**
+   * Redeem a code, creating a pending grant for `userId`.
+   *
+   * The grant is created here but carries no certificate: until the owner's
+   * agent countersigns it, `getMachineAccess` will not honour it. Redeeming is
+   * asking, not entering.
+   */
+  redeemShareInvite(code: string, user: User, grantId: string): RedeemResult;
+
+  getGrant(grantId: string): MachineGrant | null;
+  listGrantsForMachine(machineId: string): MachineGrant[];
+  listGrantsForUser(userId: string): MachineGrant[];
+  /** Attach the agent's countersigned certificate and activate the grant. */
+  bindGrantCertificate(grantId: string, certificate: string, expiresAt: number): boolean;
+  revokeGrant(grantId: string): boolean;
+  touchGrant(grantId: string): void;
+  /** Expired or revoked grants and dead invites, dropped by the reaper. */
+  purgeDeadShares(): number;
 }
-// The grant write path (bind / revoke / touch / reap) lands with M5.2, where
-// invite redemption first creates a grant for it to act on. Adding it now
-// would put another unreachable method on this interface — the same defect
-// `purgeExpiredSessions` was before #154.
+
+export interface ShareInvite {
+  id: string;
+  machine_id: string;
+  code_hash: string;
+  expected_github_login: string | null;
+  role: 'viewer' | 'operator';
+  label: string | null;
+  grant_ttl_seconds: number;
+  status: 'pending' | 'redeemed' | 'revoked';
+  redeemed_by: string | null;
+  redeemed_at: number | null;
+  attempt_count: number;
+  created_at: number;
+  expires_at: number;
+}
+
+export interface CreateShareInviteInput {
+  machineId: string;
+  /** NULL is an open link; a login binds redemption to that account. */
+  expectedGithubLogin: string | null;
+  role: 'viewer' | 'operator';
+  label: string | null;
+  grantTtlSeconds: number;
+  /** How long the *invite* is valid, distinct from the grant it produces. */
+  inviteTtlSeconds: number;
+}
+
+export type RedeemResult =
+  | { ok: true; grant: MachineGrant; invite: ShareInvite }
+  | { ok: false; reason: 'not_found' | 'expired' | 'already_used' | 'revoked' | 'wrong_account' | 'own_machine' };
 
 export function createRepositories(db: RelayDb, now: () => number = Date.now): Repositories {
   return {
@@ -111,12 +171,9 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
 
       if (existing) {
         // Refresh mutable profile fields on each login.
-        db.query('UPDATE users SET display_name = ?, primary_email = ?, avatar_url = ? WHERE id = ?').run(
-          profile.displayName,
-          profile.email,
-          profile.avatarUrl,
-          existing.user_id,
-        );
+        db.query(
+          'UPDATE users SET display_name = ?, primary_email = ?, avatar_url = ?, github_login = ? WHERE id = ?',
+        ).run(profile.displayName, profile.email, profile.avatarUrl, profile.login, existing.user_id);
         return this.getUser(existing.user_id)!;
       }
 
@@ -126,11 +183,13 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
         primary_email: profile.email,
         avatar_url: profile.avatarUrl,
         created_at: now(),
+        github_login: profile.login,
       };
       db.transaction(() => {
         db.query(
-          'INSERT INTO users (id, display_name, primary_email, avatar_url, created_at) VALUES (?, ?, ?, ?, ?)',
-        ).run(user.id, user.display_name, user.primary_email, user.avatar_url, user.created_at);
+          `INSERT INTO users (id, display_name, primary_email, avatar_url, created_at, github_login)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+        ).run(user.id, user.display_name, user.primary_email, user.avatar_url, user.created_at, user.github_login);
         db.query(
           'INSERT INTO oauth_identities (provider, provider_user_id, user_id, created_at) VALUES (?, ?, ?, ?)',
         ).run('github', profile.providerUserId, user.id, user.created_at);
@@ -273,6 +332,159 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
 
       if (!grant) return { relation: 'none' };
       return { relation: 'grantee', machine, grant };
+    },
+
+    createShareInvite(input) {
+      const code = generateLinkCode();
+      const createdAt = now();
+      const invite: ShareInvite = {
+        id: crypto.randomUUID(),
+        machine_id: input.machineId,
+        code_hash: sha256Hex(code),
+        // Stored lowercased so the case-insensitive comparison at redemption
+        // is a plain equality check rather than a per-row COLLATE.
+        expected_github_login: input.expectedGithubLogin?.trim().toLowerCase() || null,
+        role: input.role,
+        label: input.label,
+        grant_ttl_seconds: input.grantTtlSeconds,
+        status: 'pending',
+        redeemed_by: null,
+        redeemed_at: null,
+        attempt_count: 0,
+        created_at: createdAt,
+        expires_at: createdAt + input.inviteTtlSeconds * 1000,
+      };
+      db.query(
+        `INSERT INTO share_invites
+           (id, machine_id, code_hash, expected_github_login, role, label, grant_ttl_seconds,
+            status, attempt_count, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?)`,
+      ).run(
+        invite.id,
+        invite.machine_id,
+        invite.code_hash,
+        invite.expected_github_login,
+        invite.role,
+        invite.label,
+        invite.grant_ttl_seconds,
+        invite.created_at,
+        invite.expires_at,
+      );
+      // The raw code is returned once and never persisted — only its hash is.
+      return { invite, code };
+    },
+
+    listShareInvites(machineId) {
+      return db
+        .query('SELECT * FROM share_invites WHERE machine_id = ? ORDER BY created_at DESC')
+        .all(machineId) as ShareInvite[];
+    },
+
+    revokeShareInvite(machineId, inviteId) {
+      // Scoped by machine so an invite id alone is not enough to revoke
+      // someone else's invite.
+      const result = db
+        .query("UPDATE share_invites SET status = 'revoked' WHERE id = ? AND machine_id = ? AND status = 'pending'")
+        .run(inviteId, machineId);
+      return Number(result.changes ?? 0) > 0;
+    },
+
+    redeemShareInvite(code, user, grantId) {
+      const row = db.query('SELECT * FROM share_invites WHERE code_hash = ?').get(sha256Hex(code)) as
+        | ShareInvite
+        | null;
+      if (!row) return { ok: false, reason: 'not_found' };
+
+      // Count the attempt whatever the outcome, so guessing is visible.
+      db.query('UPDATE share_invites SET attempt_count = attempt_count + 1 WHERE id = ?').run(row.id);
+
+      if (row.status === 'revoked') return { ok: false, reason: 'revoked' };
+      if (row.status === 'redeemed') return { ok: false, reason: 'already_used' };
+      if (row.expires_at <= now()) return { ok: false, reason: 'expired' };
+
+      const machine = this.getMachine(row.machine_id);
+      if (!machine) return { ok: false, reason: 'not_found' };
+      // Redeeming your own machine's invite would create a grant that shadows
+      // ownership with something narrower. Nothing good comes of it.
+      if (machine.user_id === user.id) return { ok: false, reason: 'own_machine' };
+
+      if (row.expected_github_login) {
+        // A NULL login can never match: a user who has not signed in since
+        // migration 003 must not silently satisfy an addressed invite.
+        const login = user.github_login?.trim().toLowerCase();
+        if (!login || login !== row.expected_github_login) return { ok: false, reason: 'wrong_account' };
+      }
+
+      const ts = now();
+      const grant = db.transaction(() => {
+        db.query("UPDATE share_invites SET status = 'redeemed', redeemed_by = ?, redeemed_at = ? WHERE id = ?").run(
+          user.id,
+          ts,
+          row.id,
+        );
+        db.query(
+          `INSERT INTO machine_grants
+             (id, machine_id, grantee_user_id, invite_id, certificate, role, label, status, created_at)
+           VALUES (?, ?, ?, ?, NULL, ?, ?, 'pending', ?)`,
+        ).run(grantId, row.machine_id, user.id, row.id, row.role, row.label, ts);
+        return db.query('SELECT * FROM machine_grants WHERE id = ?').get(grantId) as MachineGrant;
+      })();
+
+      return { ok: true, grant, invite: { ...row, status: 'redeemed', redeemed_by: user.id, redeemed_at: ts } };
+    },
+
+    getGrant(grantId) {
+      return (db.query('SELECT * FROM machine_grants WHERE id = ?').get(grantId) as MachineGrant | null) ?? null;
+    },
+
+    listGrantsForMachine(machineId) {
+      return db
+        .query("SELECT * FROM machine_grants WHERE machine_id = ? AND status != 'revoked' ORDER BY created_at DESC")
+        .all(machineId) as MachineGrant[];
+    },
+
+    listGrantsForUser(userId) {
+      return db
+        .query("SELECT * FROM machine_grants WHERE grantee_user_id = ? AND status != 'revoked' ORDER BY created_at DESC")
+        .all(userId) as MachineGrant[];
+    },
+
+    bindGrantCertificate(grantId, certificate, expiresAt) {
+      // Only a pending grant may be bound. Re-binding an active one would let
+      // a replayed `share:bind` swap the certificate under a live guest, and
+      // re-binding a revoked one would resurrect it.
+      const result = db
+        .query(
+          `UPDATE machine_grants SET certificate = ?, expires_at = ?, status = 'active', bound_at = ?
+            WHERE id = ? AND status = 'pending'`,
+        )
+        .run(certificate, expiresAt, now(), grantId);
+      return Number(result.changes ?? 0) > 0;
+    },
+
+    revokeGrant(grantId) {
+      const result = db
+        .query("UPDATE machine_grants SET status = 'revoked', revoked_at = ? WHERE id = ? AND status != 'revoked'")
+        .run(now(), grantId);
+      return Number(result.changes ?? 0) > 0;
+    },
+
+    touchGrant(grantId) {
+      db.query('UPDATE machine_grants SET last_used_at = ? WHERE id = ?').run(now(), grantId);
+    },
+
+    purgeDeadShares() {
+      // Revoked grants go too: the DESKTOP is the authority on revocation and
+      // keeps its own record, so nothing here is the audit trail. Redeemed
+      // invites are kept while their grant lives, via the FK.
+      const ts = now();
+      const grants = db
+        .query("DELETE FROM machine_grants WHERE status = 'revoked' OR (expires_at IS NOT NULL AND expires_at <= ?)")
+        .run(ts);
+      const invites = db
+        .query("DELETE FROM share_invites WHERE status != 'redeemed' AND expires_at <= ?")
+        .run(ts);
+      return Number(grants.changes ?? 0) + Number(invites.changes ?? 0);
     },
   };
 }

--- a/relay/src/repositories.ts
+++ b/relay/src/repositories.ts
@@ -164,6 +164,9 @@ export type RedeemResult =
   | { ok: true; grant: MachineGrant; invite: ShareInvite }
   | { ok: false; reason: 'not_found' | 'expired' | 'already_used' | 'revoked' | 'wrong_account' | 'own_machine' };
 
+/** Thrown inside the redemption transaction to roll it back on a lost race. */
+class RedeemRaceError extends Error {}
+
 export function createRepositories(db: RelayDb, now: () => number = Date.now): Repositories {
   return {
     upsertGithubUser(profile) {
@@ -419,11 +422,18 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
 
       const ts = now();
       const grant = db.transaction(() => {
-        db.query("UPDATE share_invites SET status = 'redeemed', redeemed_by = ?, redeemed_at = ? WHERE id = ?").run(
-          user.id,
-          ts,
-          row.id,
-        );
+        // The `status = 'pending'` guard is repeated HERE, in SQL, rather than
+        // resting on the JS check above. That check is only safe because this
+        // method has no await and Bun cannot interleave two redemptions of the
+        // same code — which is a property of the runtime, not of the
+        // invariant. Enforced at the row, it holds regardless.
+        const claimed = db
+          .query(
+            `UPDATE share_invites SET status = 'redeemed', redeemed_by = ?, redeemed_at = ?
+              WHERE id = ? AND status = 'pending'`,
+          )
+          .run(user.id, ts, row.id);
+        if (Number(claimed.changes ?? 0) === 0) throw new RedeemRaceError();
         db.query(
           `INSERT INTO machine_grants
              (id, machine_id, grantee_user_id, invite_id, certificate, role, label, status,
@@ -431,9 +441,19 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
            VALUES (?, ?, ?, ?, NULL, ?, ?, 'pending', ?, ?)`,
         ).run(grantId, row.machine_id, user.id, row.id, row.role, row.label, ts, row.grant_ttl_seconds);
         return db.query('SELECT * FROM machine_grants WHERE id = ?').get(grantId) as MachineGrant;
-      })();
+      });
 
-      return { ok: true, grant, invite: { ...row, status: 'redeemed', redeemed_by: user.id, redeemed_at: ts } };
+      let grantRow: MachineGrant;
+      try {
+        grantRow = grant();
+      } catch (err) {
+        // Lost the race: someone else redeemed this code first. Same answer
+        // they would have got a moment later.
+        if (err instanceof RedeemRaceError) return { ok: false, reason: 'already_used' };
+        throw err;
+      }
+
+      return { ok: true, grant: grantRow, invite: { ...row, status: 'redeemed', redeemed_by: user.id, redeemed_at: ts } };
     },
 
     getGrant(grantId) {

--- a/relay/src/repositories.ts
+++ b/relay/src/repositories.ts
@@ -61,6 +61,8 @@ export interface MachineGrant {
   expires_at: number | null;
   revoked_at: number | null;
   last_used_at: number | null;
+  /** Carried from the invite so the agent can size the certificate it mints. */
+  grant_ttl_seconds: number | null;
 }
 
 /**
@@ -424,9 +426,10 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
         );
         db.query(
           `INSERT INTO machine_grants
-             (id, machine_id, grantee_user_id, invite_id, certificate, role, label, status, created_at)
-           VALUES (?, ?, ?, ?, NULL, ?, ?, 'pending', ?)`,
-        ).run(grantId, row.machine_id, user.id, row.id, row.role, row.label, ts);
+             (id, machine_id, grantee_user_id, invite_id, certificate, role, label, status,
+              created_at, grant_ttl_seconds)
+           VALUES (?, ?, ?, ?, NULL, ?, ?, 'pending', ?, ?)`,
+        ).run(grantId, row.machine_id, user.id, row.id, row.role, row.label, ts, row.grant_ttl_seconds);
         return db.query('SELECT * FROM machine_grants WHERE id = ?').get(grantId) as MachineGrant;
       })();
 

--- a/relay/src/repositories.ts
+++ b/relay/src/repositories.ts
@@ -129,6 +129,8 @@ export interface Repositories {
   bindGrantCertificate(grantId: string, certificate: string, expiresAt: number): boolean;
   revokeGrant(grantId: string): boolean;
   touchGrant(grantId: string): void;
+  /** Grants the next purge will drop — so their live sockets can be cut first. */
+  listDeadShareGrants(): MachineGrant[];
   /** Expired or revoked grants and dead invites, dropped by the reaper. */
   purgeDeadShares(): number;
 }
@@ -494,6 +496,18 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
 
     touchGrant(grantId) {
       db.query('UPDATE machine_grants SET last_used_at = ? WHERE id = ?').run(now(), grantId);
+    },
+
+    listDeadShareGrants() {
+      // Read the rows the next purge will drop, so the caller can cut their
+      // live sockets first. Otherwise a grant whose TTL elapsed would keep
+      // streaming until something else noticed.
+      const ts = now();
+      return db
+        .query(
+          "SELECT * FROM machine_grants WHERE status = 'revoked' OR (expires_at IS NOT NULL AND expires_at <= ?)",
+        )
+        .all(ts) as MachineGrant[];
     },
 
     purgeDeadShares() {

--- a/relay/src/repositories.ts
+++ b/relay/src/repositories.ts
@@ -167,7 +167,11 @@ export type RedeemResult =
   | { ok: false; reason: 'not_found' | 'expired' | 'already_used' | 'revoked' | 'wrong_account' | 'own_machine' };
 
 /** Thrown inside the redemption transaction to roll it back on a lost race. */
-class RedeemRaceError extends Error {}
+class RedeemRaceError extends Error {
+  // Named so it is identifiable in a stack trace or a log line, not just via
+  // `instanceof` at the one place that catches it today.
+  override name = 'RedeemRaceError';
+}
 
 export function createRepositories(db: RelayDb, now: () => number = Date.now): Repositories {
   return {

--- a/relay/src/shares-http.test.ts
+++ b/relay/src/shares-http.test.ts
@@ -1,0 +1,460 @@
+/**
+ * The sharing HTTP surface (M5.2).
+ *
+ * The tests that matter here are the boundaries: who may mint an invite, who
+ * may see one, who may redeem it, and what the responses are allowed to
+ * contain. The invite lifecycle itself is covered in `sharing.test.ts`.
+ */
+import { describe, expect, test } from 'bun:test';
+import { loadConfig } from './config';
+import { createLogger } from './logger';
+import { openDb, type RelayDb } from './db';
+import { createRepositories, type Repositories, type User } from './repositories';
+import { createRouter } from './http';
+import { buildShareCreateMessage } from './protocol';
+import { toArrayBuffer } from './crypto';
+
+const logger = createLogger('error');
+const { config } = loadConfig({ NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test' });
+
+interface Fixture {
+  db: RelayDb;
+  repos: Repositories;
+  route: ReturnType<typeof createRouter>;
+  owner: User;
+  guest: User;
+  machineId: string;
+  ownerCookie: string;
+  guestCookie: string;
+  sign: (m: Uint8Array) => Promise<Uint8Array>;
+  redeemed: string[];
+  revoked: string[];
+}
+
+async function fixture(): Promise<Fixture> {
+  const db = openDb(':memory:');
+  const repos = createRepositories(db);
+  const redeemed: string[] = [];
+  const revoked: string[] = [];
+  const route = createRouter({
+    config,
+    logger,
+    repos,
+    onGrantRedeemed: (g) => redeemed.push(g.id),
+    onGrantRevoked: (g) => revoked.push(g.id),
+  });
+
+  const kp = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify'])) as unknown as CryptoKeyPair;
+  const pub = new Uint8Array(await crypto.subtle.exportKey('raw', kp.publicKey));
+  const sign = async (m: Uint8Array) =>
+    new Uint8Array(await crypto.subtle.sign({ name: 'Ed25519' }, kp.privateKey, toArrayBuffer(m)));
+
+  const owner = repos.upsertGithubUser({
+    providerUserId: '1',
+    displayName: 'Will',
+    login: 'will-l',
+    email: null,
+    avatarUrl: null,
+  });
+  const guest = repos.upsertGithubUser({
+    providerUserId: '2',
+    displayName: 'Dana',
+    login: 'dana-k',
+    email: null,
+    avatarUrl: null,
+  });
+  const code = repos.createLinkCode('laptop', pub, new Uint8Array(32).fill(1), 600).code;
+  const claim = repos.claimLinkCode(code, owner.id);
+
+  return {
+    db,
+    repos,
+    route,
+    owner,
+    guest,
+    machineId: claim.ok ? claim.machine.id : '',
+    ownerCookie: `bdl_session=${repos.createSession(owner.id, 3600).token}`,
+    guestCookie: `bdl_session=${repos.createSession(guest.id, 3600).token}`,
+    sign,
+    redeemed,
+    revoked,
+  };
+}
+
+async function createInvite(f: Fixture, over: Record<string, unknown> = {}) {
+  const body = {
+    expectedGithubLogin: 'dana-k',
+    role: 'viewer',
+    grantTtlSeconds: 4 * 3600,
+    inviteTtlSeconds: 3600,
+    issuedAt: Date.now(),
+    ...over,
+  } as Record<string, unknown>;
+  const signature = Buffer.from(
+    await f.sign(
+      buildShareCreateMessage({
+        machineId: (over.machineId as string) ?? f.machineId,
+        expectedGithubLogin: (body.expectedGithubLogin as string | null) ?? '',
+        role: body.role as string,
+        grantTtlSeconds: body.grantTtlSeconds as number,
+        inviteTtlSeconds: body.inviteTtlSeconds as number,
+        issuedAt: body.issuedAt as number,
+      }),
+    ),
+  ).toString('base64');
+  delete over.machineId;
+  return f.route(
+    new Request(`http://relay.test/api/machines/${f.machineId}/shares`, {
+      method: 'POST',
+      body: JSON.stringify({ ...body, signature }),
+    }),
+  );
+}
+
+describe('POST /api/machines/:id/shares', () => {
+  test('returns the code and NEVER a URL', async () => {
+    // If the relay authored the invite link it could put its own fingerprint
+    // in the `#fp=` fragment and serve the matching key, making the guest's
+    // three-way check agree perfectly and manufacturing a false "verified".
+    // The desktop composes the URL locally.
+    const f = await fixture();
+    try {
+      const res = await createInvite(f);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(typeof body.code).toBe('string');
+      const serialised = JSON.stringify(body);
+      expect(serialised).not.toContain('http');
+      expect(serialised).not.toContain('#fp');
+      expect(Object.keys(body).sort()).toEqual(['code', 'expiresAt', 'inviteId']);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('a session cookie alone cannot mint an invite', async () => {
+    // Only the machine can countersign a grant, so only the machine may offer
+    // one — a stolen session cookie must not be enough.
+    const f = await fixture();
+    try {
+      const res = await f.route(
+        new Request(`http://relay.test/api/machines/${f.machineId}/shares`, {
+          method: 'POST',
+          headers: { cookie: f.ownerCookie },
+          body: JSON.stringify({
+            expectedGithubLogin: null,
+            role: 'viewer',
+            grantTtlSeconds: 3600,
+            inviteTtlSeconds: 3600,
+            issuedAt: Date.now(),
+            signature: Buffer.alloc(64).toString('base64'),
+          }),
+        }),
+      );
+      expect(res.status).toBe(401);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('the addressing is covered by the signature', async () => {
+    // An open link is a materially different thing from an addressed one; the
+    // relay must not be able to downgrade one into the other in transit.
+    const f = await fixture();
+    try {
+      const issuedAt = Date.now();
+      const signature = Buffer.from(
+        await f.sign(
+          buildShareCreateMessage({
+            machineId: f.machineId,
+            expectedGithubLogin: 'dana-k',
+            role: 'viewer',
+            grantTtlSeconds: 3600,
+            inviteTtlSeconds: 3600,
+            issuedAt,
+          }),
+        ),
+      ).toString('base64');
+      const res = await f.route(
+        new Request(`http://relay.test/api/machines/${f.machineId}/shares`, {
+          method: 'POST',
+          // Signed for dana-k, sent as an open link.
+          body: JSON.stringify({
+            expectedGithubLogin: null,
+            role: 'viewer',
+            grantTtlSeconds: 3600,
+            inviteTtlSeconds: 3600,
+            issuedAt,
+            signature,
+          }),
+        }),
+      );
+      expect(res.status).toBe(401);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('rejects a role outside the mintable set', async () => {
+    const f = await fixture();
+    try {
+      expect((await createInvite(f, { role: 'owner' })).status).toBe(400);
+      expect((await createInvite(f, { role: 'admin' })).status).toBe(400);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('rejects a TTL beyond the ceiling', async () => {
+    const f = await fixture();
+    try {
+      expect((await createInvite(f, { grantTtlSeconds: 400 * 24 * 3600 })).status).toBe(400);
+      expect((await createInvite(f, { inviteTtlSeconds: 400 * 24 * 3600 })).status).toBe(400);
+      expect((await createInvite(f, { grantTtlSeconds: 0 })).status).toBe(400);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('rejects a stale request', async () => {
+    const f = await fixture();
+    try {
+      expect((await createInvite(f, { issuedAt: Date.now() - 10 * 60 * 1000 })).status).toBe(400);
+    } finally {
+      f.db.close();
+    }
+  });
+});
+
+describe('GET /api/machines/:id/shares', () => {
+  test('the owner sees invites and grants, without codes or hashes', async () => {
+    const f = await fixture();
+    try {
+      await createInvite(f);
+      const res = await f.route(
+        new Request(`http://relay.test/api/machines/${f.machineId}/shares`, { headers: { cookie: f.ownerCookie } }),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { invites: Record<string, unknown>[] };
+      expect(body.invites).toHaveLength(1);
+      expect(body.invites[0]).not.toHaveProperty('code');
+      expect(body.invites[0]).not.toHaveProperty('code_hash');
+      expect(body.invites[0]!.expectedGithubLogin).toBe('dana-k');
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('someone else gets 404, not 403', async () => {
+    // A 403 would confirm the machine exists.
+    const f = await fixture();
+    try {
+      const res = await f.route(
+        new Request(`http://relay.test/api/machines/${f.machineId}/shares`, { headers: { cookie: f.guestCookie } }),
+      );
+      expect(res.status).toBe(404);
+    } finally {
+      f.db.close();
+    }
+  });
+});
+
+describe('POST /api/shares/redeem', () => {
+  async function codeFor(f: Fixture, over: Record<string, unknown> = {}) {
+    const res = await createInvite(f, over);
+    return ((await res.json()) as { code: string }).code;
+  }
+
+  test('the addressed account redeems into a PENDING grant and notifies the gateway', async () => {
+    const f = await fixture();
+    try {
+      const code = await codeFor(f);
+      const res = await f.route(
+        new Request('http://relay.test/api/shares/redeem', {
+          method: 'POST',
+          headers: { cookie: f.guestCookie },
+          body: JSON.stringify({ code }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string };
+      // The guest is waiting on the owner; the client must render that rather
+      // than a broken terminal.
+      expect(body.status).toBe('pending');
+      expect(f.redeemed).toHaveLength(1);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('a different account is refused', async () => {
+    const f = await fixture();
+    try {
+      const code = await codeFor(f);
+      const other = f.repos.upsertGithubUser({
+        providerUserId: '3',
+        displayName: 'Other',
+        login: 'other',
+        email: null,
+        avatarUrl: null,
+      });
+      const res = await f.route(
+        new Request('http://relay.test/api/shares/redeem', {
+          method: 'POST',
+          headers: { cookie: `bdl_session=${f.repos.createSession(other.id, 3600).token}` },
+          body: JSON.stringify({ code }),
+        }),
+      );
+      expect(res.status).toBe(409);
+      expect((await res.json()) as unknown).toEqual({ error: 'invite_wrong_account' });
+      expect(f.redeemed).toHaveLength(0);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('requires a session', async () => {
+    const f = await fixture();
+    try {
+      const code = await codeFor(f);
+      const res = await f.route(
+        new Request('http://relay.test/api/shares/redeem', { method: 'POST', body: JSON.stringify({ code }) }),
+      );
+      expect(res.status).toBe(401);
+    } finally {
+      f.db.close();
+    }
+  });
+});
+
+describe('GET /api/machines with a grant', () => {
+  test('a bound grant appears as a grantee entry carrying its certificate', async () => {
+    const f = await fixture();
+    try {
+      const code = ((await (await createInvite(f)).json()) as { code: string }).code;
+      await f.route(
+        new Request('http://relay.test/api/shares/redeem', {
+          method: 'POST',
+          headers: { cookie: f.guestCookie },
+          body: JSON.stringify({ code }),
+        }),
+      );
+      const grantId = f.repos.listGrantsForUser(f.guest.id)[0]!.id;
+
+      // Before the agent countersigns, there is nothing to present.
+      let res = await f.route(new Request('http://relay.test/api/machines', { headers: { cookie: f.guestCookie } }));
+      expect(((await res.json()) as { machines: unknown[] }).machines).toHaveLength(0);
+
+      f.repos.bindGrantCertificate(grantId, 'grant:v1.aa.bb', Date.now() + 3_600_000);
+      res = await f.route(new Request('http://relay.test/api/machines', { headers: { cookie: f.guestCookie } }));
+      const machines = ((await res.json()) as { machines: Record<string, unknown>[] }).machines;
+      expect(machines).toHaveLength(1);
+      expect(machines[0]).toMatchObject({
+        relation: 'grantee',
+        // Labelled by person: "machine" is owner vocabulary.
+        ownerName: 'Will',
+        role: 'viewer',
+        certificate: 'grant:v1.aa.bb',
+        grantId,
+      });
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('the owner still sees their own machine as owner', async () => {
+    const f = await fixture();
+    try {
+      const res = await f.route(new Request('http://relay.test/api/machines', { headers: { cookie: f.ownerCookie } }));
+      const machines = ((await res.json()) as { machines: Record<string, unknown>[] }).machines;
+      expect(machines).toHaveLength(1);
+      expect(machines[0]!.relation).toBe('owner');
+      expect(machines[0]!.certificate).toBeNull();
+    } finally {
+      f.db.close();
+    }
+  });
+});
+
+describe('DELETE /api/shares/:grantId', () => {
+  async function boundGrant(f: Fixture) {
+    const code = ((await (await createInvite(f)).json()) as { code: string }).code;
+    await f.route(
+      new Request('http://relay.test/api/shares/redeem', {
+        method: 'POST',
+        headers: { cookie: f.guestCookie },
+        body: JSON.stringify({ code }),
+      }),
+    );
+    const grantId = f.repos.listGrantsForUser(f.guest.id)[0]!.id;
+    f.repos.bindGrantCertificate(grantId, 'grant:v1.aa.bb', Date.now() + 3_600_000);
+    return grantId;
+  }
+
+  test('the owner may revoke', async () => {
+    const f = await fixture();
+    try {
+      const grantId = await boundGrant(f);
+      const res = await f.route(
+        new Request(`http://relay.test/api/shares/${grantId}`, { method: 'DELETE', headers: { cookie: f.ownerCookie } }),
+      );
+      expect(res.status).toBe(204);
+      expect(f.repos.getMachineAccess(f.machineId, f.guest.id)).toEqual({ relation: 'none' });
+      expect(f.revoked).toEqual([grantId]);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('the grantee may hand access back', async () => {
+    const f = await fixture();
+    try {
+      const grantId = await boundGrant(f);
+      const res = await f.route(
+        new Request(`http://relay.test/api/shares/${grantId}`, { method: 'DELETE', headers: { cookie: f.guestCookie } }),
+      );
+      expect(res.status).toBe(204);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('a third party gets 404, not 403', async () => {
+    const f = await fixture();
+    try {
+      const grantId = await boundGrant(f);
+      const other = f.repos.upsertGithubUser({
+        providerUserId: '3',
+        displayName: 'Other',
+        login: 'other',
+        email: null,
+        avatarUrl: null,
+      });
+      const res = await f.route(
+        new Request(`http://relay.test/api/shares/${grantId}`, {
+          method: 'DELETE',
+          headers: { cookie: `bdl_session=${f.repos.createSession(other.id, 3600).token}` },
+        }),
+      );
+      expect(res.status).toBe(404);
+      // And it really did not revoke.
+      expect(f.repos.getGrant(grantId)!.status).toBe('active');
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('/api/shares/redeem is not treated as a grant id', async () => {
+    // The two routes share a prefix; a careless matcher would let DELETE
+    // /api/shares/redeem look like a grant deletion.
+    const f = await fixture();
+    try {
+      const res = await f.route(
+        new Request('http://relay.test/api/shares/redeem', { method: 'DELETE', headers: { cookie: f.ownerCookie } }),
+      );
+      expect(res.status).toBe(404);
+    } finally {
+      f.db.close();
+    }
+  });
+});

--- a/relay/src/sharing.test.ts
+++ b/relay/src/sharing.test.ts
@@ -132,8 +132,8 @@ interface Fixture {
 function freshFixture(): Fixture {
   const db = openDb(':memory:');
   const repos = createRepositories(db);
-  const owner = repos.upsertGithubUser({ providerUserId: '1', displayName: 'Owner', email: null, avatarUrl: null });
-  const guest = repos.upsertGithubUser({ providerUserId: '2', displayName: 'Guest', email: null, avatarUrl: null });
+  const owner = repos.upsertGithubUser({ providerUserId: '1', displayName: 'Owner', login: 'owner', email: null, avatarUrl: null });
+  const guest = repos.upsertGithubUser({ providerUserId: '2', displayName: 'Guest', login: 'guest', email: null, avatarUrl: null });
   const code = repos.createLinkCode('m', new Uint8Array(32).fill(7), new Uint8Array(32).fill(8), 600).code;
   const claim = repos.claimLinkCode(code, owner.id);
   return { db, repos, ownerId: owner.id, guestId: guest.id, machineId: claim.ok ? claim.machine.id : '' };
@@ -292,6 +292,278 @@ describe('getMachineAccess', () => {
     try {
       insertGrant(f, { grantee_user_id: f.ownerId });
       expect(f.repos.getMachineAccess(f.machineId, f.ownerId).relation).toBe('owner');
+    } finally {
+      f.db.close();
+    }
+  });
+});
+
+// --- invite lifecycle (M5.2) ---
+
+function guestUser(f: Fixture, login: string | null, providerUserId = '900') {
+  const u = f.repos.upsertGithubUser({
+    providerUserId,
+    displayName: 'Guest',
+    login: login ?? '',
+    email: null,
+    avatarUrl: null,
+  });
+  if (login === null) f.db.query('UPDATE users SET github_login = NULL WHERE id = ?').run(u.id);
+  return f.repos.getUser(u.id)!;
+}
+
+const inviteInput = (f: Fixture, over: Partial<Parameters<Repositories['createShareInvite']>[0]> = {}) => ({
+  machineId: f.machineId,
+  expectedGithubLogin: 'dana-k',
+  role: 'viewer' as const,
+  label: null,
+  grantTtlSeconds: 4 * 3600,
+  inviteTtlSeconds: 3600,
+  ...over,
+});
+
+describe('createShareInvite', () => {
+  test('returns the raw code once and stores only its hash', () => {
+    // Same discipline as link codes: a database leak must not yield a usable
+    // invite.
+    const f = freshFixture();
+    try {
+      const { invite, code } = f.repos.createShareInvite(inviteInput(f));
+      expect(code).toMatch(/^[0-9A-Z]{4}-[0-9A-Z]{4}$/);
+      expect(invite.code_hash).not.toBe(code);
+      const raw = f.db.query('SELECT * FROM share_invites WHERE id = ?').get(invite.id) as Record<string, unknown>;
+      expect(JSON.stringify(raw)).not.toContain(code);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('normalises the addressed login to lowercase', () => {
+    // GitHub logins compare case-insensitively; an invite for `Dana-K` must
+    // match a session for `dana-k`.
+    const f = freshFixture();
+    try {
+      const { invite } = f.repos.createShareInvite(inviteInput(f, { expectedGithubLogin: '  Dana-K  ' }));
+      expect(invite.expected_github_login).toBe('dana-k');
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('an empty login is an open link, not an invite addressed to nobody', () => {
+    const f = freshFixture();
+    try {
+      expect(f.repos.createShareInvite(inviteInput(f, { expectedGithubLogin: '   ' })).invite.expected_github_login).toBeNull();
+    } finally {
+      f.db.close();
+    }
+  });
+});
+
+describe('redeemShareInvite', () => {
+  test('an addressed invite redeemed by the named account creates a PENDING grant', () => {
+    // Pending, not active: redeeming is asking. Until the owner's agent
+    // countersigns, getMachineAccess will not honour it.
+    const f = freshFixture();
+    try {
+      const { code } = f.repos.createShareInvite(inviteInput(f));
+      const guest = guestUser(f, 'dana-k');
+      const result = f.repos.redeemShareInvite(code, guest, crypto.randomUUID());
+
+      expect(result.ok).toBe(true);
+      expect(result.ok === true && result.grant.status).toBe('pending');
+      expect(result.ok === true && result.grant.certificate).toBeNull();
+      expect(f.repos.getMachineAccess(f.machineId, guest.id)).toEqual({ relation: 'none' });
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('a different account cannot redeem an addressed invite', () => {
+    // The whole point of addressing: a leaked link is not a working link.
+    const f = freshFixture();
+    try {
+      const { code } = f.repos.createShareInvite(inviteInput(f));
+      const result = f.repos.redeemShareInvite(code, guestUser(f, 'someone-else'), crypto.randomUUID());
+      expect(result).toEqual({ ok: false, reason: 'wrong_account' });
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('login matching is case-insensitive', () => {
+    const f = freshFixture();
+    try {
+      const { code } = f.repos.createShareInvite(inviteInput(f, { expectedGithubLogin: 'dana-k' }));
+      expect(f.repos.redeemShareInvite(code, guestUser(f, 'DANA-K'), crypto.randomUUID()).ok).toBe(true);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('a user with no stored login cannot satisfy an addressed invite', () => {
+    // Users predating migration 003 have a NULL login. A NULL must never read
+    // as "matches anything".
+    const f = freshFixture();
+    try {
+      const { code } = f.repos.createShareInvite(inviteInput(f));
+      const result = f.repos.redeemShareInvite(code, guestUser(f, null), crypto.randomUUID());
+      expect(result).toEqual({ ok: false, reason: 'wrong_account' });
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('an open link may be redeemed by anyone', () => {
+    const f = freshFixture();
+    try {
+      const { code } = f.repos.createShareInvite(inviteInput(f, { expectedGithubLogin: null }));
+      expect(f.repos.redeemShareInvite(code, guestUser(f, 'anyone'), crypto.randomUUID()).ok).toBe(true);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('the machine owner cannot redeem their own invite', () => {
+    // It would create a grant that shadows ownership with something narrower.
+    const f = freshFixture();
+    try {
+      const { code } = f.repos.createShareInvite(inviteInput(f, { expectedGithubLogin: null }));
+      const owner = f.repos.getUser(f.ownerId)!;
+      expect(f.repos.redeemShareInvite(code, owner, crypto.randomUUID())).toEqual({ ok: false, reason: 'own_machine' });
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('a code cannot be redeemed twice', () => {
+    const f = freshFixture();
+    try {
+      const { code } = f.repos.createShareInvite(inviteInput(f, { expectedGithubLogin: null }));
+      expect(f.repos.redeemShareInvite(code, guestUser(f, 'a', '901'), crypto.randomUUID()).ok).toBe(true);
+      expect(f.repos.redeemShareInvite(code, guestUser(f, 'b', '902'), crypto.randomUUID())).toEqual({
+        ok: false,
+        reason: 'already_used',
+      });
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('a revoked invite is refused, and says so distinctly from expired', () => {
+    // Distinct reasons because the guest-facing copy differs.
+    const f = freshFixture();
+    try {
+      const { invite, code } = f.repos.createShareInvite(inviteInput(f, { expectedGithubLogin: null }));
+      expect(f.repos.revokeShareInvite(f.machineId, invite.id)).toBe(true);
+      expect(f.repos.redeemShareInvite(code, guestUser(f, 'a'), crypto.randomUUID())).toEqual({
+        ok: false,
+        reason: 'revoked',
+      });
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('an unknown code is not distinguishable from a wrong one', () => {
+    const f = freshFixture();
+    try {
+      expect(f.repos.redeemShareInvite('ZZZZ-ZZZZ', guestUser(f, 'a'), crypto.randomUUID())).toEqual({
+        ok: false,
+        reason: 'not_found',
+      });
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('every attempt is counted, including failures', () => {
+    // Guessing should be visible rather than silent.
+    const f = freshFixture();
+    try {
+      const { invite, code } = f.repos.createShareInvite(inviteInput(f));
+      f.repos.redeemShareInvite(code, guestUser(f, 'wrong', '901'), crypto.randomUUID());
+      f.repos.redeemShareInvite(code, guestUser(f, 'also-wrong', '902'), crypto.randomUUID());
+      const row = f.db.query('SELECT attempt_count FROM share_invites WHERE id = ?').get(invite.id);
+      expect(row).toEqual({ attempt_count: 2 });
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('revoking an invite belonging to another machine does nothing', () => {
+    const f = freshFixture();
+    try {
+      const { invite } = f.repos.createShareInvite(inviteInput(f));
+      expect(f.repos.revokeShareInvite(crypto.randomUUID(), invite.id)).toBe(false);
+    } finally {
+      f.db.close();
+    }
+  });
+});
+
+describe('binding a redeemed grant', () => {
+  function redeemed(f: Fixture) {
+    const { code } = f.repos.createShareInvite(inviteInput(f, { expectedGithubLogin: null }));
+    const guest = guestUser(f, 'dana-k');
+    const result = f.repos.redeemShareInvite(code, guest, crypto.randomUUID());
+    if (!result.ok) throw new Error('redeem failed');
+    return { guest, grantId: result.grant.id };
+  }
+
+  test('binding a certificate makes the grantee reachable', () => {
+    const f = freshFixture();
+    try {
+      const { guest, grantId } = redeemed(f);
+      expect(f.repos.bindGrantCertificate(grantId, 'grant:v1.x.y', Date.now() + 3_600_000)).toBe(true);
+      expect(f.repos.getMachineAccess(f.machineId, guest.id).relation).toBe('grantee');
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('a grant cannot be bound twice', () => {
+    // A replayed share:bind must not swap the certificate under a live guest.
+    const f = freshFixture();
+    try {
+      const { grantId } = redeemed(f);
+      expect(f.repos.bindGrantCertificate(grantId, 'grant:v1.a.a', Date.now() + 3_600_000)).toBe(true);
+      expect(f.repos.bindGrantCertificate(grantId, 'grant:v1.b.b', Date.now() + 3_600_000)).toBe(false);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('a revoked grant cannot be resurrected by binding', () => {
+    const f = freshFixture();
+    try {
+      const { grantId } = redeemed(f);
+      expect(f.repos.revokeGrant(grantId)).toBe(true);
+      expect(f.repos.bindGrantCertificate(grantId, 'grant:v1.x.y', Date.now() + 3_600_000)).toBe(false);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('revoking ends access immediately', () => {
+    const f = freshFixture();
+    try {
+      const { guest, grantId } = redeemed(f);
+      f.repos.bindGrantCertificate(grantId, 'grant:v1.x.y', Date.now() + 3_600_000);
+      f.repos.revokeGrant(grantId);
+      expect(f.repos.getMachineAccess(f.machineId, guest.id)).toEqual({ relation: 'none' });
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('purgeDeadShares drops revoked grants and stale unredeemed invites', () => {
+    const f = freshFixture();
+    try {
+      const { grantId } = redeemed(f);
+      f.repos.revokeGrant(grantId);
+      f.repos.createShareInvite(inviteInput(f, { expectedGithubLogin: null, inviteTtlSeconds: -1 }));
+      expect(f.repos.purgeDeadShares()).toBeGreaterThanOrEqual(2);
     } finally {
       f.db.close();
     }

--- a/relay/src/web.ts
+++ b/relay/src/web.ts
@@ -26,8 +26,16 @@ export function createWebClient(config: RelayConfig) {
 
     if (p === '/app/main.js') return new Response(jsFile, { headers: { 'content-type': 'text/javascript; charset=utf-8', 'cache-control': 'no-cache' } });
     if (p === '/app/main.css') return new Response(cssFile, { headers: { 'content-type': 'text/css; charset=utf-8', 'cache-control': 'no-cache' } });
-    // SPA shell at the root; deeper client routes aren't used yet.
-    if (p === '/') return new Response(indexFile, { headers: { 'content-type': 'text/html; charset=utf-8' } });
+    // SPA shell at the root, and for invite links.
+    //
+    // `/i/:code` is a client route: the code lives in the path so it can be
+    // sent in a message, and the fingerprint rides in the `#fp=` fragment,
+    // which never reaches this server at all. Serving the shell here lets the
+    // client read both — a redirect to `/` would discard the code, and the
+    // fragment would not survive it either.
+    if (p === '/' || p === '/i' || p.startsWith('/i/')) {
+      return new Response(indexFile, { headers: { 'content-type': 'text/html; charset=utf-8' } });
+    }
 
     return null; // fall through to the API/auth/ws router
   };

--- a/relay/src/ws.test.ts
+++ b/relay/src/ws.test.ts
@@ -57,7 +57,20 @@ function connect(url: string, headers?: Record<string, string>) {
       if (m) res(m);
       else waiters.push(res);
     });
-  return { ws, opened, closed, next };
+  /**
+   * Skip forward to the next message of `type`.
+   *
+   * Position-independent on purpose: the relay gains notifications over time
+   * (share:sync now follows agent:ready), and a test that asserts "the third
+   * message" breaks on every one of them for no real reason.
+   */
+  const nextOfType = async (type: string) => {
+    for (;;) {
+      const m = await next();
+      if (m?.type === type) return m;
+    }
+  };
+  return { ws, opened, closed, next, nextOfType };
 }
 
 async function registerMachine(repos: Repositories, providerUserId = '1') {
@@ -84,7 +97,7 @@ async function onlineAgent(
   const auth: Record<string, unknown> = { type: 'agent:auth', ed25519Pub: b64(pub), signature: b64(sig) };
   if (caps) auth.caps = caps;
   c.ws.send(JSON.stringify(auth));
-  await c.next(); // agent:ready
+  await c.nextOfType('agent:ready');
   return c;
 }
 
@@ -140,7 +153,7 @@ describe('agent WebSocket handshake', () => {
       expect(machine.last_seen_at).toBeGreaterThan(0);
 
       c.ws.send(JSON.stringify({ type: 'ping' }));
-      expect((await c.next()).type).toBe('pong');
+      expect((await c.nextOfType('pong')).type).toBe('pong');
 
       c.ws.close();
     } finally {
@@ -218,7 +231,7 @@ describe('agent WebSocket handshake', () => {
       // round-trip that completes can only happen on an open socket.
       await Bun.sleep(120);
       c.ws.send(JSON.stringify({ type: 'ping' }));
-      expect(await c.next()).toMatchObject({ type: 'pong' });
+      expect(await c.nextOfType('pong')).toMatchObject({ type: 'pong' });
     } finally {
       server.stop(true);
     }
@@ -238,20 +251,20 @@ describe('client ↔ agent brokering (M3)', () => {
 
       // Open the channel; a handshake payload rides along.
       client.ws.send(JSON.stringify({ type: 'client:open', machineId, payload: 'handshake-hello' }));
-      const onAgent = await agent.next();
+      const onAgent = await agent.nextOfType('client:open');
       expect(onAgent.type).toBe('client:open');
       expect(onAgent.payload).toBe('handshake-hello');
       const clientId = onAgent.clientId;
-      expect((await client.next()).type).toBe('channel:open');
+      expect((await client.nextOfType('channel:open')).type).toBe('channel:open');
 
       // agent → client
       agent.ws.send(JSON.stringify({ type: 'to-client', clientId, payload: 'from-server' }));
-      const fromAgent = await client.next();
+      const fromAgent = await client.nextOfType('from-agent');
       expect(fromAgent).toMatchObject({ type: 'from-agent', payload: 'from-server' });
 
       // client → agent
       client.ws.send(JSON.stringify({ type: 'to-agent', payload: 'from-browser' }));
-      const fromClient = await agent.next();
+      const fromClient = await agent.nextOfType('from-client');
       expect(fromClient).toMatchObject({ type: 'from-client', clientId, payload: 'from-browser' });
 
       client.ws.close();
@@ -292,7 +305,7 @@ describe('client ↔ agent brokering (M3)', () => {
 
       // The agent checks a certificate against this; it is never authorization
       // on its own, which is why the field is named `principal`.
-      expect(await agent.next()).toMatchObject({ type: 'client:open', principal: { userId } });
+      expect(await agent.nextOfType('client:open')).toMatchObject({ type: 'client:open', principal: { userId } });
     } finally {
       server.stop(true);
     }
@@ -311,8 +324,8 @@ describe('client ↔ agent brokering (M3)', () => {
       await client.opened;
       client.ws.send(JSON.stringify({ type: 'client:open', machineId }));
 
-      expect(await agent.next()).toMatchObject({ type: 'client:open', principal: { userId: guest.id } });
-      expect((await client.next()).type).toBe('channel:open');
+      expect(await agent.nextOfType('client:open')).toMatchObject({ type: 'client:open', principal: { userId: guest.id } });
+      expect((await client.nextOfType('channel:open')).type).toBe('channel:open');
     } finally {
       db.close();
       server.stop(true);
@@ -337,7 +350,7 @@ describe('client ↔ agent brokering (M3)', () => {
       await client.opened;
       client.ws.send(JSON.stringify({ type: 'client:open', machineId }));
 
-      expect((await client.next()).type).toBe('share:unsupported');
+      expect((await client.nextOfType('share:unsupported')).type).toBe('share:unsupported');
 
       // And prove by ordering that nothing reached the agent: a later frame
       // from the owner must be the FIRST thing the agent sees.
@@ -348,7 +361,7 @@ describe('client ↔ agent brokering (M3)', () => {
       });
       await ownerClient.opened;
       ownerClient.ws.send(JSON.stringify({ type: 'client:open', machineId }));
-      expect(await agent.next()).toMatchObject({ type: 'client:open', principal: { userId: owner } });
+      expect(await agent.nextOfType('client:open')).toMatchObject({ type: 'client:open', principal: { userId: owner } });
     } finally {
       db.close();
       server.stop(true);
@@ -367,7 +380,7 @@ describe('client ↔ agent brokering (M3)', () => {
       const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
       await client.opened;
       client.ws.send(JSON.stringify({ type: 'client:open', machineId }));
-      expect((await client.next()).type).toBe('channel:open');
+      expect((await client.nextOfType('channel:open')).type).toBe('channel:open');
     } finally {
       server.stop(true);
     }
@@ -402,7 +415,7 @@ describe('client ↔ agent brokering (M3)', () => {
       const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
       await client.opened;
       client.ws.send(JSON.stringify({ type: 'client:open', machineId }));
-      expect((await client.next()).type).toBe('agent:offline');
+      expect((await client.nextOfType('agent:offline')).type).toBe('agent:offline');
     } finally {
       db.close();
       server.stop(true);
@@ -418,7 +431,7 @@ describe('client ↔ agent brokering (M3)', () => {
       const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
       await client.opened;
       client.ws.send(JSON.stringify({ type: 'client:open', machineId }));
-      expect((await client.next()).type).toBe('agent:offline');
+      expect((await client.nextOfType('agent:offline')).type).toBe('agent:offline');
     } finally {
       server.stop(true);
     }
@@ -437,8 +450,8 @@ describe('client ↔ agent brokering (M3)', () => {
       const clientB = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
       await clientB.opened;
       clientB.ws.send(JSON.stringify({ type: 'client:open', machineId: b.machineId }));
-      const clientId = (await agentB.next()).clientId;
-      expect((await clientB.next()).type).toBe('channel:open');
+      const clientId = (await agentB.nextOfType('client:open')).clientId;
+      expect((await clientB.nextOfType('channel:open')).type).toBe('channel:open');
 
       // Agent A names a client id that belongs to machine B's channel.
       agentA.ws.send(JSON.stringify({ type: 'to-client', clientId, payload: 'injected' }));
@@ -527,6 +540,268 @@ describe('client ↔ agent brokering (M3)', () => {
       ]);
       expect(outcome).toBe('closed');
     } finally {
+      server.stop(true);
+    }
+  });
+});
+
+describe('share:* messages (M5.2)', () => {
+  /** An agent online for `machineId`, plus a guest with a pending grant on it. */
+  async function shared(port: number, db: ReturnType<typeof openDb>, repos: Repositories, m: Awaited<ReturnType<typeof registerMachine>>) {
+    const agent = await onlineAgent(port, m.pub, m.sign, ['grants:v1']);
+    const guest = repos.upsertGithubUser({
+      providerUserId: '999',
+      displayName: 'Dana',
+      login: 'dana-k',
+      email: null,
+      avatarUrl: null,
+    });
+    const { code } = repos.createShareInvite({
+      machineId: m.machineId,
+      expectedGithubLogin: 'dana-k',
+      role: 'viewer',
+      label: null,
+      grantTtlSeconds: 3600,
+      inviteTtlSeconds: 3600,
+    });
+    const redeem = repos.redeemShareInvite(code, guest, crypto.randomUUID());
+    if (!redeem.ok) throw new Error('redeem failed');
+    void db;
+    return { agent, guest, grantId: redeem.grant.id };
+  }
+
+  test('agent:ready is followed by share:sync carrying the machine grants', async () => {
+    // Closes the split-brain on every reconnect: without it a relay restore
+    // leaves ghosts in the owner's settings and a desktop reinstall leaves
+    // guests connecting to a DENY_ALL with no explanation.
+    const { db, repos } = freshReposWithDb();
+    const m = await registerMachine(repos);
+    const server = startServer(repos);
+    try {
+      const { agent, grantId } = await shared(server.port!, db, repos, m);
+      // Reconnect and read the sync.
+      agent.ws.close();
+      const again = await onlineAgent(server.port!, m.pub, m.sign, ['grants:v1']);
+      const sync = await again.nextOfType('share:sync');
+      expect(sync.grants.map((g: { grantId: string }) => g.grantId)).toEqual([grantId]);
+      expect(sync.grants[0]).toMatchObject({ status: 'pending', role: 'viewer', granteeLogin: 'dana-k' });
+    } finally {
+      db.close();
+      server.stop(true);
+    }
+  });
+
+  test('share:sync never carries the certificate back to the agent', async () => {
+    // The agent signed it. Echoing it would put a credential on a wire that
+    // does not need to carry one.
+    const { db, repos } = freshReposWithDb();
+    const m = await registerMachine(repos);
+    const server = startServer(repos);
+    try {
+      const { grantId } = await shared(server.port!, db, repos, m);
+      repos.bindGrantCertificate(grantId, 'grant:v1.SECRET.SECRET', Date.now() + 3_600_000);
+      const again = await onlineAgent(server.port!, m.pub, m.sign, ['grants:v1']);
+      const sync = await again.nextOfType('share:sync');
+      expect(JSON.stringify(sync)).not.toContain('SECRET');
+    } finally {
+      db.close();
+      server.stop(true);
+    }
+  });
+
+  test('share:bind activates the grant so the guest becomes reachable', async () => {
+    const { db, repos } = freshReposWithDb();
+    const m = await registerMachine(repos);
+    const server = startServer(repos);
+    try {
+      const { agent, guest, grantId } = await shared(server.port!, db, repos, m);
+      expect(repos.getMachineAccess(m.machineId, guest.id)).toEqual({ relation: 'none' });
+
+      agent.ws.send(
+        JSON.stringify({ type: 'share:bind', grantId, certificate: 'grant:v1.a.b', expiresAt: Date.now() + 3_600_000 }),
+      );
+      await Bun.sleep(30);
+      expect(repos.getMachineAccess(m.machineId, guest.id).relation).toBe('grantee');
+    } finally {
+      db.close();
+      server.stop(true);
+    }
+  });
+
+  test('an agent cannot bind a grant belonging to another machine', async () => {
+    const { db, repos } = freshReposWithDb();
+    const a = await registerMachine(repos, 'user-a');
+    const b = await registerMachine(repos, 'user-b');
+    const server = startServer(repos);
+    try {
+      const { guest, grantId } = await shared(server.port!, db, repos, b);
+      const agentA = await onlineAgent(server.port!, a.pub, a.sign, ['grants:v1']);
+
+      agentA.ws.send(
+        JSON.stringify({ type: 'share:bind', grantId, certificate: 'grant:v1.a.b', expiresAt: Date.now() + 3_600_000 }),
+      );
+      await Bun.sleep(30);
+      expect(repos.getMachineAccess(b.machineId, guest.id)).toEqual({ relation: 'none' });
+      expect(repos.getGrant(grantId)!.status).toBe('pending');
+    } finally {
+      db.close();
+      server.stop(true);
+    }
+  });
+
+  test('share:bind with an already-elapsed expiry is refused', async () => {
+    const { db, repos } = freshReposWithDb();
+    const m = await registerMachine(repos);
+    const server = startServer(repos);
+    try {
+      const { agent, grantId } = await shared(server.port!, db, repos, m);
+      agent.ws.send(JSON.stringify({ type: 'share:bind', grantId, certificate: 'grant:v1.a.b', expiresAt: 1 }));
+      await Bun.sleep(30);
+      expect(repos.getGrant(grantId)!.status).toBe('pending');
+    } finally {
+      db.close();
+      server.stop(true);
+    }
+  });
+
+  test('share:deny revokes the grant', async () => {
+    const { db, repos } = freshReposWithDb();
+    const m = await registerMachine(repos);
+    const server = startServer(repos);
+    try {
+      const { agent, grantId } = await shared(server.port!, db, repos, m);
+      agent.ws.send(JSON.stringify({ type: 'share:deny', grantId, reason: 'declined' }));
+      await Bun.sleep(30);
+      expect(repos.getGrant(grantId)!.status).toBe('revoked');
+    } finally {
+      db.close();
+      server.stop(true);
+    }
+  });
+
+  test('share:reconcile revokes grants the desktop no longer knows about', async () => {
+    // The desktop is the authority on revocation. Anything the relay still
+    // holds that the agent does not name is a ghost — a relay restore, or a
+    // revocation queued while the agent was offline.
+    const { db, repos } = freshReposWithDb();
+    const m = await registerMachine(repos);
+    const server = startServer(repos);
+    try {
+      const { agent, grantId } = await shared(server.port!, db, repos, m);
+      repos.bindGrantCertificate(grantId, 'grant:v1.a.b', Date.now() + 3_600_000);
+
+      agent.ws.send(JSON.stringify({ type: 'share:reconcile', activeGrantIds: [] }));
+      await Bun.sleep(30);
+      expect(repos.getGrant(grantId)!.status).toBe('revoked');
+    } finally {
+      db.close();
+      server.stop(true);
+    }
+  });
+
+  test('share:reconcile keeps grants the desktop still names', async () => {
+    const { db, repos } = freshReposWithDb();
+    const m = await registerMachine(repos);
+    const server = startServer(repos);
+    try {
+      const { agent, grantId } = await shared(server.port!, db, repos, m);
+      agent.ws.send(JSON.stringify({ type: 'share:reconcile', activeGrantIds: [grantId] }));
+      await Bun.sleep(30);
+      expect(repos.getGrant(grantId)!.status).toBe('pending');
+    } finally {
+      db.close();
+      server.stop(true);
+    }
+  });
+
+  test('reconcile cannot reach another machine grants', async () => {
+    const { db, repos } = freshReposWithDb();
+    const a = await registerMachine(repos, 'user-a');
+    const b = await registerMachine(repos, 'user-b');
+    const server = startServer(repos);
+    try {
+      const { grantId } = await shared(server.port!, db, repos, b);
+      const agentA = await onlineAgent(server.port!, a.pub, a.sign, ['grants:v1']);
+      agentA.ws.send(JSON.stringify({ type: 'share:reconcile', activeGrantIds: [] }));
+      await Bun.sleep(30);
+      expect(repos.getGrant(grantId)!.status).toBe('pending');
+    } finally {
+      db.close();
+      server.stop(true);
+    }
+  });
+
+  test('revoking over HTTP cuts the guest socket immediately', async () => {
+    // Revocation must not wait for the guest to reconnect.
+    const { db, repos } = freshReposWithDb();
+    const m = await registerMachine(repos);
+    const gateway = createGateway({ repos, logger });
+    const server = Bun.serve({
+      port: 0,
+      fetch(req, srv) {
+        const path = new URL(req.url).pathname;
+        if (path === '/ws') return srv.upgrade(req, { data: newAgentSocketData() }) ? undefined : new Response('x', { status: 426 });
+        const token = parseCookies(req.headers.get('cookie'))[SESSION_COOKIE];
+        const user = token ? repos.getUserBySessionToken(token) : null;
+        if (!user) return new Response('unauthorized', { status: 401 });
+        return srv.upgrade(req, { data: newClientSocketData(user.id) }) ? undefined : new Response('x', { status: 426 });
+      },
+      websocket: gateway,
+    });
+    try {
+      const { grantId, guest } = await shared(server.port!, db, repos, m);
+      repos.bindGrantCertificate(grantId, 'grant:v1.a.b', Date.now() + 3_600_000);
+
+      const { token } = repos.createSession(guest.id, 3600);
+      const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
+      await client.opened;
+      client.ws.send(JSON.stringify({ type: 'client:open', machineId: m.machineId }));
+      await client.nextOfType('channel:open');
+
+      gateway.notifyGrantRevoked(repos.getGrant(grantId)!);
+      expect((await client.closed).code).toBe(4403);
+    } finally {
+      db.close();
+      server.stop(true);
+    }
+  });
+
+  test('a redemption wakes the owner agent with share:pending', async () => {
+    const { db, repos } = freshReposWithDb();
+    const m = await registerMachine(repos);
+    const gateway = createGateway({ repos, logger });
+    const server = Bun.serve({
+      port: 0,
+      fetch(req, srv) {
+        return srv.upgrade(req, { data: newAgentSocketData() }) ? undefined : new Response('x', { status: 426 });
+      },
+      websocket: gateway,
+    });
+    try {
+      const agent = await onlineAgent(server.port!, m.pub, m.sign, ['grants:v1']);
+      const guest = repos.upsertGithubUser({
+        providerUserId: '999',
+        displayName: 'Dana',
+        login: 'dana-k',
+        email: null,
+        avatarUrl: null,
+      });
+      const { code } = repos.createShareInvite({
+        machineId: m.machineId,
+        expectedGithubLogin: null,
+        role: 'viewer',
+        label: null,
+        grantTtlSeconds: 3600,
+        inviteTtlSeconds: 3600,
+      });
+      const redeem = repos.redeemShareInvite(code, guest, crypto.randomUUID());
+      if (!redeem.ok) throw new Error('redeem failed');
+
+      gateway.notifyGrantRedeemed(redeem.grant);
+      const pending = await agent.nextOfType('share:pending');
+      expect(pending.grants[0]).toMatchObject({ grantId: redeem.grant.id, granteeLogin: 'dana-k', status: 'pending' });
+    } finally {
+      db.close();
       server.stop(true);
     }
   });

--- a/relay/src/ws.test.ts
+++ b/relay/src/ws.test.ts
@@ -63,7 +63,7 @@ function connect(url: string, headers?: Record<string, string>) {
 async function registerMachine(repos: Repositories, providerUserId = '1') {
   const kp = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify'])) as unknown as CryptoKeyPair;
   const pub = new Uint8Array(await crypto.subtle.exportKey('raw', kp.publicKey));
-  const user = repos.upsertGithubUser({ providerUserId, displayName: 'U', email: null, avatarUrl: null });
+  const user = repos.upsertGithubUser({ providerUserId, displayName: 'U', login: 'u', email: null, avatarUrl: null });
   const claim = repos.claimLinkCode(repos.createLinkCode('m', pub, new Uint8Array(32).fill(1), 600).code, user.id);
   const machineId = claim.ok ? claim.machine.id : '';
   const sign = async (m: Uint8Array) => new Uint8Array(await crypto.subtle.sign({ name: 'Ed25519' }, kp.privateKey, toArrayBuffer(m)));
@@ -268,7 +268,7 @@ describe('client ↔ agent brokering (M3)', () => {
     try {
       await onlineAgent(server.port!, pub, sign);
       // A different user, not the machine owner.
-      const other = repos.upsertGithubUser({ providerUserId: '999', displayName: 'Other', email: null, avatarUrl: null });
+      const other = repos.upsertGithubUser({ providerUserId: '999', displayName: 'Other', login: 'other', email: null, avatarUrl: null });
       const { token } = repos.createSession(other.id, 3600);
       const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
       await client.opened;
@@ -304,7 +304,7 @@ describe('client ↔ agent brokering (M3)', () => {
     const server = startServer(repos);
     try {
       const agent = await onlineAgent(server.port!, pub, sign, ['grants:v1']);
-      const guest = repos.upsertGithubUser({ providerUserId: '999', displayName: 'G', email: null, avatarUrl: null });
+      const guest = repos.upsertGithubUser({ providerUserId: '999', displayName: 'G', login: 'g', email: null, avatarUrl: null });
       seedGrant(db, machineId, guest.id);
       const { token } = repos.createSession(guest.id, 3600);
       const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
@@ -330,7 +330,7 @@ describe('client ↔ agent brokering (M3)', () => {
     const server = startServer(repos);
     try {
       const agent = await onlineAgent(server.port!, pub, sign); // no caps — an old build
-      const guest = repos.upsertGithubUser({ providerUserId: '999', displayName: 'G', email: null, avatarUrl: null });
+      const guest = repos.upsertGithubUser({ providerUserId: '999', displayName: 'G', login: 'g', email: null, avatarUrl: null });
       seedGrant(db, machineId, guest.id);
       const { token } = repos.createSession(guest.id, 3600);
       const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
@@ -396,7 +396,7 @@ describe('client ↔ agent brokering (M3)', () => {
 
       // The claim left nothing behind: with no authenticated agent, a guest
       // gets agent:offline rather than a channel.
-      const guest = repos.upsertGithubUser({ providerUserId: '999', displayName: 'G', email: null, avatarUrl: null });
+      const guest = repos.upsertGithubUser({ providerUserId: '999', displayName: 'G', login: 'g', email: null, avatarUrl: null });
       seedGrant(db, machineId, guest.id);
       const { token } = repos.createSession(guest.id, 3600);
       const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });

--- a/relay/src/ws.test.ts
+++ b/relay/src/ws.test.ts
@@ -305,7 +305,14 @@ describe('client ↔ agent brokering (M3)', () => {
 
       // The agent checks a certificate against this; it is never authorization
       // on its own, which is why the field is named `principal`.
-      expect(await agent.nextOfType('client:open')).toMatchObject({ type: 'client:open', principal: { userId } });
+      // The handle specifically, not just the id: the owner's presence
+      // surfaces and approval prompt render it, and asserting only `userId`
+      // would pass whether or not it is sent — which is exactly how it went
+      // missing once already.
+      expect(await agent.nextOfType('client:open')).toMatchObject({
+        type: 'client:open',
+        principal: { userId, githubLogin: 'u', displayName: 'U' },
+      });
     } finally {
       server.stop(true);
     }

--- a/relay/src/ws.ts
+++ b/relay/src/ws.ts
@@ -327,6 +327,10 @@ export function createGateway(ctx: WsGatewayContext) {
       granteeName: grantee?.display_name ?? null,
       createdAt: g.created_at,
       expiresAt: g.expires_at,
+      // What the invite promised. `expires_at` is NULL until we countersign,
+      // so this is the only thing the agent can size a certificate from at the
+      // moment the owner approves.
+      grantTtlSeconds: g.grant_ttl_seconds,
     };
   }
 

--- a/relay/src/ws.ts
+++ b/relay/src/ws.ts
@@ -325,6 +325,9 @@ export function createGateway(ctx: WsGatewayContext) {
       granteeUserId: g.grantee_user_id,
       granteeLogin: grantee?.github_login ?? null,
       granteeName: grantee?.display_name ?? null,
+      // So the desktop can recover which session it offered — the relay never
+      // learns that, by design.
+      inviteId: g.invite_id,
       createdAt: g.created_at,
       expiresAt: g.expires_at,
       // What the invite promised. `expires_at` is NULL until we countersign,

--- a/relay/src/ws.ts
+++ b/relay/src/ws.ts
@@ -388,6 +388,7 @@ export function createGateway(ctx: WsGatewayContext) {
       data.grantId = access.relation === 'grantee' ? access.grant.id : null;
       if (access.relation === 'grantee') repos.touchGrant(access.grant.id);
       clients.set(data.clientId, ws);
+      const principalUser = repos.getUser(data.userId);
       // `principal` is relay-ASSERTED, and named so no branch downstream reads
       // it as authorization. The agent treats it as a claim to check a
       // certificate against, never as a grant in itself.
@@ -401,7 +402,14 @@ export function createGateway(ctx: WsGatewayContext) {
       send(agent, {
         type: 'client:open',
         clientId: data.clientId,
-        principal: { userId: data.userId },
+        principal: {
+          userId: data.userId,
+          // The handle is what the approval prompt and the presence surfaces
+          // show. A display name is free text the account holder chooses, so
+          // it is carried only as a secondary label, never as the identity.
+          githubLogin: principalUser?.github_login ?? null,
+          displayName: principalUser?.display_name ?? null,
+        },
         payload: msg.payload,
       });
       send(ws, { type: 'channel:open', clientId: data.clientId });

--- a/relay/src/ws.ts
+++ b/relay/src/ws.ts
@@ -1,6 +1,6 @@
 import type { ServerWebSocket } from 'bun';
 import type { Logger } from './logger';
-import type { Repositories } from './repositories';
+import type { MachineGrant, Repositories } from './repositories';
 import { fromBase64, randomToken, verifyEd25519 } from './crypto';
 import { buildAgentAuthMessage, CAP_GRANTS_V1 } from './protocol';
 
@@ -44,6 +44,12 @@ export interface ClientSocketData {
   clientId: string;
   /** Set once the client has opened a channel to a machine. */
   machineId: string | null;
+  /**
+   * The grant this socket connected under, for guests. Null for the owner.
+   * Recorded so a revocation can find and cut the live socket rather than
+   * waiting for the guest to reconnect.
+   */
+  grantId: string | null;
 }
 
 export type SocketData = AgentSocketData | ClientSocketData;
@@ -69,7 +75,7 @@ export function newAgentSocketData(): AgentSocketData {
 
 /** Per-connection state for an authenticated web client. */
 export function newClientSocketData(userId: string): ClientSocketData {
-  return { role: 'client', userId, clientId: crypto.randomUUID(), machineId: null };
+  return { role: 'client', userId, clientId: crypto.randomUUID(), machineId: null, grantId: null };
 }
 
 function send(ws: ServerWebSocket<SocketData>, obj: unknown): void {
@@ -110,6 +116,10 @@ export function createGateway(ctx: WsGatewayContext) {
       if (ws.data.role === 'agent') return handleAgent(ws, ws.data, msg);
       return handleClient(ws, ws.data, msg);
     },
+
+    /** HTTP-side seams: a guest redeemed, or a grant was revoked over REST. */
+    notifyGrantRedeemed,
+    notifyGrantRevoked,
 
     close(ws: ServerWebSocket<SocketData>) {
       if (ws.data.role === 'agent') {
@@ -192,6 +202,12 @@ export function createGateway(ctx: WsGatewayContext) {
           ? { userId: owner.id, displayName: owner.display_name, email: owner.primary_email }
           : null,
       });
+      // Close the split-brain on every reconnect: the relay holds certificates
+      // and routes, the desktop holds the session lists and revocation status.
+      // Without this a relay volume loss leaves ghosts in the owner's settings,
+      // and a desktop reinstall leaves guests connecting to a DENY_ALL with no
+      // explanation.
+      sendShareSync(ws, machine.id);
       logger.info('agent online', { machineId: machine.id });
       return;
     }
@@ -210,7 +226,108 @@ export function createGateway(ctx: WsGatewayContext) {
       if (client && (client.data as ClientSocketData).machineId === data.machineId) {
         send(client, { type: 'from-agent', payload: msg.payload });
       }
+      return;
     }
+
+    if (!data.machineId) return;
+
+    // The owner approved: attach the countersigned certificate. Scoped to this
+    // agent's own machine, so an agent cannot bind a grant on someone else's.
+    if (msg.type === 'share:bind' && typeof msg.grantId === 'string' && typeof msg.certificate === 'string') {
+      const grant = repos.getGrant(msg.grantId);
+      if (!grant || grant.machine_id !== data.machineId) return;
+      const expiresAt = typeof msg.expiresAt === 'number' ? msg.expiresAt : 0;
+      if (!Number.isSafeInteger(expiresAt) || expiresAt <= Date.now()) return;
+      if (repos.bindGrantCertificate(msg.grantId, msg.certificate, expiresAt)) {
+        logger.info('grant bound', { machineId: data.machineId, grantId: msg.grantId });
+      }
+      return;
+    }
+
+    // The owner said no, or the machine cannot honour it.
+    if (msg.type === 'share:deny' && typeof msg.grantId === 'string') {
+      const grant = repos.getGrant(msg.grantId);
+      if (!grant || grant.machine_id !== data.machineId) return;
+      repos.revokeGrant(msg.grantId);
+      kickGrant(msg.grantId, typeof msg.reason === 'string' ? msg.reason : 'denied');
+      logger.info('grant denied', { machineId: data.machineId, grantId: msg.grantId });
+      return;
+    }
+
+    // The desktop is the authority on revocation, so its list wins. Anything
+    // the relay still holds for this machine that the agent does not name is a
+    // ghost — from a relay restore, or a revocation queued while offline.
+    if (msg.type === 'share:reconcile' && Array.isArray(msg.activeGrantIds)) {
+      const live = new Set(msg.activeGrantIds.filter((id): id is string => typeof id === 'string'));
+      let dropped = 0;
+      for (const grant of repos.listGrantsForMachine(data.machineId)) {
+        if (live.has(grant.id)) continue;
+        repos.revokeGrant(grant.id);
+        kickGrant(grant.id, 'revoked');
+        dropped += 1;
+      }
+      if (dropped > 0) logger.info('reconciled away stale grants', { machineId: data.machineId, dropped });
+      return;
+    }
+
+    // Cut one live client without revoking its grant — used for pause and for
+    // ending a session the guest was watching.
+    if (msg.type === 'client:kick' && typeof msg.clientId === 'string') {
+      const client = clients.get(msg.clientId);
+      if (client && (client.data as ClientSocketData).machineId === data.machineId) {
+        client.close(4403, typeof msg.reason === 'string' ? msg.reason : 'ended');
+      }
+    }
+  }
+
+  /** Tell an agent about every grant the relay currently holds for its machine. */
+  function sendShareSync(agent: ServerWebSocket<SocketData>, machineId: string): void {
+    send(agent, { type: 'share:sync', grants: repos.listGrantsForMachine(machineId).map(wireGrant) });
+  }
+
+  /**
+   * A guest redeemed an invite. Wake the owner's agent if it is online; if it
+   * is not, `share:sync` on its next `agent:ready` carries the same pending
+   * grant, so nothing is lost by the owner being away.
+   */
+  function notifyGrantRedeemed(grant: MachineGrant): void {
+    const agent = agents.get(grant.machine_id);
+    if (!agent) return;
+    send(agent, { type: 'share:pending', grants: [wireGrant(grant)] });
+  }
+
+  /** A grant was revoked over HTTP — tell the agent and cut any live socket. */
+  function notifyGrantRevoked(grant: MachineGrant): void {
+    const agent = agents.get(grant.machine_id);
+    if (agent) send(agent, { type: 'grant:revoked', grantId: grant.id });
+    kickGrant(grant.id, 'revoked');
+  }
+
+  /** Close every client socket connected under `grantId`. */
+  function kickGrant(grantId: string, reason: string): void {
+    for (const client of clients.values()) {
+      if ((client.data as ClientSocketData).grantId === grantId) client.close(4403, reason);
+    }
+  }
+
+  /**
+   * A grant as the agent needs to see it. The certificate is omitted — the
+   * agent signed it and does not need it back, and echoing it would put a
+   * credential on a wire that does not need to carry one.
+   */
+  function wireGrant(g: MachineGrant) {
+    const grantee = repos.getUser(g.grantee_user_id);
+    return {
+      grantId: g.id,
+      status: g.status,
+      role: g.role,
+      label: g.label,
+      granteeUserId: g.grantee_user_id,
+      granteeLogin: grantee?.github_login ?? null,
+      granteeName: grantee?.display_name ?? null,
+      createdAt: g.created_at,
+      expiresAt: g.expires_at,
+    };
   }
 
   /** Whether the live agent socket for a machine enforces grant certificates. */
@@ -259,6 +376,10 @@ export function createGateway(ctx: WsGatewayContext) {
       }
 
       data.machineId = machine.id;
+      // Remember which grant let this socket in, so a revocation can cut it
+      // immediately instead of waiting for the guest to reconnect.
+      data.grantId = access.relation === 'grantee' ? access.grant.id : null;
+      if (access.relation === 'grantee') repos.touchGrant(access.grant.id);
       clients.set(data.clientId, ws);
       // `principal` is relay-ASSERTED, and named so no branch downstream reads
       // it as authorization. The agent treats it as a claim to check a

--- a/relay/web/src/connection.ts
+++ b/relay/web/src/connection.ts
@@ -15,7 +15,14 @@ import {
   type SealedFrame,
 } from './crypto';
 
-export type ConnState = 'connecting' | 'handshaking' | 'ready' | 'offline' | 'closed' | 'error';
+export type ConnState = 'connecting' | 'handshaking' | 'ready' | 'offline' | 'closed' | 'error' | 'denied';
+
+/**
+ * Why access ended. Distinct values because the copy differs and guessing
+ * tells people false stories — "Will revoked your access" when Will merely
+ * closed a terminal is socially loaded and untrue.
+ */
+export type DeniedReason = 'not_authorized' | 'revoked' | 'expired' | 'session_ended' | 'machine_unlinked';
 export interface Inner {
   type: string;
   [k: string]: unknown;
@@ -48,6 +55,12 @@ export class RelayConnection {
     private readonly machineId: string,
     /** The machine's Ed25519 pubkey (base64) as reported by /api/machines. */
     private readonly machineEd25519Pub: string,
+    /**
+     * A grant certificate, for a guest. Opaque here — the relay cannot read it
+     * and neither can we; the agent verifies its own signature and decides
+     * what it permits. Absent for the machine's owner.
+     */
+    private readonly certificate: string | null = null,
   ) {}
 
   connect(): void {
@@ -60,7 +73,14 @@ export class RelayConnection {
       // the timer to exist during a window where it can do nothing.
       this.startPing();
       this.clientKeys = await generateClientKeys();
-      this.send({ type: 'client:open', machineId: this.machineId, payload: { clientX25519Pub: this.clientKeys.pubB64 } });
+      this.send({
+        type: 'client:open',
+        machineId: this.machineId,
+        payload: {
+          clientX25519Pub: this.clientKeys.pubB64,
+          ...(this.certificate ? { certificate: this.certificate } : {}),
+        },
+      });
       this.onState('handshaking');
     };
     ws.onmessage = (e) => void this.handle(JSON.parse(String(e.data)));
@@ -84,6 +104,11 @@ export class RelayConnection {
 
   private async handle(msg: Inner): Promise<void> {
     if (msg.type === 'agent:offline') return this.onState('offline');
+    // The relay refuses to route a guest to an agent that does not enforce
+    // grants — an older desktop build would ignore the certificate entirely.
+    if (msg.type === 'share:unsupported') {
+      return this.onState('error', 'That machine is running an older version that cannot share sessions safely.');
+    }
     if (msg.type === 'channel:open') return; // relay ack
     if (msg.type !== 'from-agent') return;
 
@@ -108,12 +133,25 @@ export class RelayConnection {
       return;
     }
 
+    // An unsealed refusal, before any key exists. Only trusted to mean "you
+    // did not get in" — never to explain why, since nothing has authenticated
+    // it at this point.
+    if (payload?.type === 'denied' && !this.key) {
+      return this.onState('denied', 'not_authorized');
+    }
+
     // Sealed frame.
     const frame = payload as unknown as SealedFrame;
     if (!this.key || typeof frame?.n !== 'number' || frame.n <= this.recvCounter) return;
     try {
       const inner = await openJson<Inner>(this.key, frame);
       this.recvCounter = frame.n;
+      // A SEALED refusal is trustworthy: only the machine could have written
+      // it, so its reason can safely drive what the guest is told.
+      if (inner.type === 'denied') {
+        this.onState('denied', typeof inner.reason === 'string' ? inner.reason : 'revoked');
+        return;
+      }
       this.onMessage(inner);
     } catch {
       /* drop unauthenticatable frame */

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -12,7 +12,22 @@ import { createReconnectScheduler } from './reconnect';
 type SessionState = 'idle' | 'working' | 'waiting' | 'error' | 'stopped';
 interface RSession { id: string; name: string; state: SessionState; groupId: string; workingDir: string; provider: string; shellType: string; }
 interface RGroup { id: string; name: string; color: string; workingDir: string; parentId: string | null; }
-interface Machine { id: string; name: string; ed25519Pub: string; lastSeenAt: number | null; }
+interface Machine {
+  id: string;
+  name: string;
+  ed25519Pub: string;
+  lastSeenAt: number | null;
+  /** How you reach it. Guests get a certificate; owners get null. */
+  relation?: 'owner' | 'grantee';
+  /** Label by PERSON for a guest — "machine" is owner vocabulary. */
+  ownerName?: string | null;
+  grantId?: string | null;
+  role?: string | null;
+  certificate?: string | null;
+}
+
+/** True when the signed-in user is a guest on the machine they are viewing. */
+const isGuest = () => app.machine?.relation === 'grantee';
 
 // ---------------------------------------------------------------------------
 // Small DOM helpers
@@ -54,8 +69,30 @@ async function boot() {
   try {
     const cfg = (await api('/api/config').then((r) => (r.ok ? r.json() : {})).catch(() => ({}))) as { devLogin?: boolean };
     app.devLogin = !!cfg.devLogin;
+
+    const invite = inviteCodeFromPath();
     const me = await api('/api/me');
-    if (!me.ok) return renderSignIn();
+    if (!me.ok) {
+      // Stash the whole location before OAuth. The fragment carries the
+      // machine fingerprint and does NOT survive a redirect round trip, so
+      // without this the guest comes back unable to check provenance and we
+      // would have to either lie about it or nag them.
+      if (invite) sessionStorage.setItem(INVITE_STASH, location.pathname + location.hash);
+      return renderSignIn(!!invite);
+    }
+
+    // Back from OAuth on an invite link.
+    const stashed = sessionStorage.getItem(INVITE_STASH);
+    if (!invite && stashed) {
+      sessionStorage.removeItem(INVITE_STASH);
+      history.replaceState(null, '', stashed);
+      return boot();
+    }
+    if (invite) {
+      sessionStorage.removeItem(INVITE_STASH);
+      return renderRedeem(invite);
+    }
+
     const { machines } = await api('/api/machines').then((r) => r.json());
     renderApp(machines as Machine[]);
   } catch {
@@ -63,12 +100,120 @@ async function boot() {
   }
 }
 
-function renderSignIn() {
+// ---------------------------------------------------------------------------
+// Invite redemption (/i/:code)
+// ---------------------------------------------------------------------------
+
+const INVITE_STASH = 'bodhi.invite';
+
+function inviteCodeFromPath(): string | null {
+  const m = /^\/i\/([^/]+)\/?$/.exec(location.pathname);
+  return m ? decodeURIComponent(m[1]!) : null;
+}
+
+/** The fingerprint the sender put in the link, if any. */
+function invitedFingerprint(): string | null {
+  const m = /(?:^|&)fp=([^&]+)/.exec(location.hash.replace(/^#/, ''));
+  return m ? decodeURIComponent(m[1]!) : null;
+}
+
+/** Copy for each way an invite can fail. Never guesses. */
+const REDEEM_COPY: Record<string, { title: string; body: string }> = {
+  invite_not_found: { title: "That link doesn't work", body: 'Check you copied all of it, or ask for a new one.' },
+  invite_expired: { title: 'That link has expired', body: 'Ask for a new one — links stop working after a while on purpose.' },
+  invite_already_used: { title: 'That link has been used', body: 'Invite links work once. Ask for a new one.' },
+  invite_revoked: { title: 'That link was cancelled', body: 'Whoever sent it withdrew the invitation.' },
+  invite_wrong_account: {
+    title: "This link isn't for this account",
+    body: 'It was addressed to a specific GitHub account. Sign in as that account, or ask for a link addressed to you.',
+  },
+  invite_own_machine: { title: "That's your own machine", body: 'You already have full access to it — no invite needed.' },
+};
+
+async function renderRedeem(code: string): Promise<void> {
+  // A full-page screen, not a bottom sheet: `.sheet` is max-height:88dvh with
+  // no sticky footer, so on a small phone the primary action lands below the
+  // fold — on the one screen where the primary action is the entire point.
+  rootEl.innerHTML = `<div class="screen-center"><div class="card-center">
+    <div class="logo">🤝</div><h1>Joining…</h1>
+    <div class="spinner" style="margin:18px auto"></div>
+  </div></div>`;
+
+  let res: Response;
+  try {
+    res = await api('/api/shares/redeem', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ code }),
+    });
+  } catch {
+    rootEl.innerHTML = `<div class="screen-center"><div class="card-center">
+      <div class="logo">📡</div><h1>Couldn't reach the server</h1>
+      <p>Check your connection and try again.</p>
+      <button class="btn" onclick="location.reload()">Try again</button>
+    </div></div>`;
+    return;
+  }
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    const copy = REDEEM_COPY[body.error ?? ''] ?? {
+      title: "That link didn't work",
+      body: 'Ask whoever sent it for a new one.',
+    };
+    rootEl.innerHTML = `<div class="screen-center"><div class="card-center">
+      <div class="logo">🚫</div><h1>${esc(copy.title)}</h1>
+      <p>${esc(copy.body)}</p>
+      <a class="btn ghost" href="/">Go to my machines</a>
+    </div></div>`;
+    return;
+  }
+
+  history.replaceState(null, '', '/');
+  renderWaitingForApproval();
+}
+
+/**
+ * The most-travelled path in the whole feature, and the guest's entire first
+ * impression. It must say what is happening, that it is normal, and what to
+ * do — a spinner alone reads as broken.
+ */
+function renderWaitingForApproval(): void {
+  rootEl.innerHTML = `<div class="screen-center"><div class="card-center">
+    <div class="logo">⏳</div>
+    <h1>Waiting to be let in…</h1>
+    <p>They'll get a prompt on their machine. Keep this page open — it'll update on its own.</p>
+    <div class="spinner" style="margin:18px auto"></div>
+    <button class="btn ghost" id="checkNow">Check now</button>
+  </div></div>`;
+  $('#checkNow')!.onclick = () => void pollForGrant(true);
+  void pollForGrant(false);
+}
+
+let waitTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Poll until the owner answers. Cheap, and stops the moment it resolves. */
+async function pollForGrant(immediate: boolean): Promise<void> {
+  if (waitTimer) { clearTimeout(waitTimer); waitTimer = null; }
+  try {
+    const { machines } = (await api('/api/machines').then((r) => r.json())) as { machines: Machine[] };
+    if (machines.some((m) => m.relation === 'grantee')) return renderApp(machines);
+  } catch {
+    /* transient — keep waiting rather than declaring failure */
+  }
+  waitTimer = setTimeout(() => void pollForGrant(false), immediate ? 1500 : 4000);
+}
+
+function renderSignIn(fromInvite = false) {
   rootEl.innerHTML = `
     <div class="screen-center"><div class="card-center">
-      <div class="logo">🛰️</div>
-      <h1>Bodhilander Remote</h1>
-      <p>Reach your desktop's sessions from anywhere — end-to-end encrypted.</p>
+      <div class="logo">${fromInvite ? '🤝' : '🛰️'}</div>
+      <h1>${fromInvite ? "You've been invited" : 'Bodhilander Remote'}</h1>
+      <p>${
+        fromInvite
+          ? 'Sign in with GitHub to accept. The invitation may be addressed to a specific account.'
+          : "Reach your desktop's sessions from anywhere — end-to-end encrypted."
+      }</p>
       <a class="btn gh" href="/auth/github/login">Sign in with GitHub</a>
       ${app.devLogin ? '<button class="btn ghost" id="dev" style="margin-top:10px">Dev sign in</button>' : ''}
       ${new URLSearchParams(location.search).get('denied') === 'org' ? '<div class="banner err">Access is restricted to authorized members.</div>' : ''}
@@ -82,17 +227,32 @@ function renderSignIn() {
 function renderApp(machines: Machine[]) {
   app.machines = machines;
   if (!machines.length) {
+    // Two different empty states. Telling someone who was invited to a session
+    // to go and generate a link code in a desktop app they do not have is
+    // advice for a completely different person.
     rootEl.innerHTML = `<div class="screen-center"><div class="card-center">
-      <div class="logo">🖥️</div><h1>No machines linked</h1>
-      <p>In the desktop app, open <b>Settings → Remote Hosting → Generate link code</b>, then enter the code here to link it.</p>
-      <button class="btn" id="linkBtn">Link a machine</button>
+      <div class="logo">🖥️</div><h1>Nothing here yet</h1>
+      <p>If someone shared a session with you, open the link they sent. If this is your own machine, open
+         <b>Settings → Remote Hosting → Generate link code</b> in the desktop app.</p>
+      <button class="btn" id="inviteBtn">Enter an invite code</button>
+      <button class="btn ghost" style="margin-top:10px" id="linkBtn">Link my own machine</button>
       <button class="btn ghost" style="margin-top:10px" onclick="location.reload()">Refresh</button>
     </div></div>`;
     $('#linkBtn')!.onclick = openLinkMachine;
+    // Posts to /api/shares/redeem, never /link/claim — the latter would
+    // attempt an ownership transfer, which is a completely different act.
+    $('#inviteBtn')!.onclick = () => {
+      const code = prompt('Enter the invite code you were sent');
+      if (code?.trim()) void renderRedeem(code.trim());
+    };
     return;
   }
   // Pick the last machine the user chose here, else the first. A machine
   // switcher (the pill) lets them change it or link another.
+  //
+  // A guest with exactly one grant should never see a picker: choosing
+  // between one thing is not a choice, and "machine" is owner vocabulary
+  // anyway — they were invited to a session by a person.
   const preferredId = localStorage.getItem('bodhi.machineId');
   app.machine = machines.find((m) => m.id === preferredId) ?? machines[0]!;
 
@@ -103,7 +263,11 @@ function renderApp(machines: Machine[]) {
         <div class="brand grow"><span class="logo">🛰️</span> <span>Bodhilander</span></div>
         <button class="iconbtn" id="theme" aria-label="Toggle light/dark theme">◐</button>
       </header>
-      <div style="padding:12px 16px 0"><button class="machine-pill" id="machineBtn"><span class="dot off" id="mdot"></span> <span>${esc(app.machine.name)}</span></button></div>
+      <div style="padding:12px 16px 0"><button class="machine-pill" id="machineBtn"><span class="dot off" id="mdot"></span> <span>${esc(
+        app.machine.relation === 'grantee' && app.machine.ownerName
+          ? `${app.machine.ownerName}'s ${app.machine.name}`
+          : app.machine.name,
+      )}</span></button></div>
       <div class="list-head"><h2>Sessions</h2><span class="attn-count hidden" id="attn"></span></div>
       <ul class="sessions" id="sessions"><li class="empty-note"><div class="spinner"></div><p style="margin-top:14px">Connecting securely…</p></li></ul>
       <button class="fab" id="fab" aria-label="New session">＋</button>
@@ -135,16 +299,84 @@ function renderApp(machines: Machine[]) {
   $('#fpBtn')!.onclick = openFp; $('#fpBtn2')!.onclick = openFp;
   $('#machineBtn')!.onclick = openMachineMenu;
   $('#back')!.onclick = () => history.back();
-  buildKeys();
-  setupCompose();
+  if (isGuest()) applyWatchOnly();
+  else { buildKeys(); setupCompose(); }
   connect();
+}
+
+/**
+ * Turn the terminal pane into an honest read-only surface.
+ *
+ * Watch-only is never expressed by absence alone. Removing the compose bar
+ * and leaving a blank gap reads as broken or as a feature that failed to
+ * load; a person needs to be told what they CAN do, not left to infer what
+ * they cannot.
+ */
+function applyWatchOnly(): void {
+  const compose = $('.compose');
+  if (compose) {
+    // Occupies the compose bar's place so an upgrade to typing swaps in
+    // without the layout jumping.
+    compose.className = 'compose watch-only';
+    compose.innerHTML = `
+      <div class="attn-banner hidden" id="attnBanner">✻ This session is waiting for a response</div>
+      <div class="watch-strip" role="status">
+        <span aria-hidden="true">👁</span>
+        <span>Watch only. You can read and scroll this session. You can't type into it.</span>
+      </div>`;
+  }
+
+  const screen = $('#screen');
+  if (!screen) return;
+  // Focusable and announced read-only, so a keyboard or screen-reader user
+  // reaches the content at all — the pane is the entire point of the page.
+  screen.setAttribute('tabindex', '0');
+  screen.setAttribute('role', 'document');
+  screen.setAttribute('aria-readonly', 'true');
+  screen.setAttribute('aria-label', 'Shared terminal output, read only');
+
+  // The existing scroll path is a touch-only touchmove handler, so without
+  // this a keyboard user cannot move through the scrollback at all.
+  screen.addEventListener('keydown', (e) => {
+    const ev = e as KeyboardEvent;
+    if (!term) return;
+    const page = Math.max(1, term.rows - 1);
+    if (ev.key === 'PageUp') { term.scrollLines(-page); ev.preventDefault(); }
+    else if (ev.key === 'PageDown') { term.scrollLines(page); ev.preventDefault(); }
+    else if (ev.key === 'Home') { term.scrollToTop(); ev.preventDefault(); }
+    else if (ev.key === 'End') { term.scrollToBottom(); ev.preventDefault(); }
+    else if (ev.key === 'ArrowUp') { term.scrollLines(-1); ev.preventDefault(); }
+    else if (ev.key === 'ArrowDown') { term.scrollLines(1); ev.preventDefault(); }
+  });
+}
+
+/**
+ * Tell a guest their view is wider than their screen, and whose screen it is
+ * sized for. Without this the horizontal cut-off reads as a rendering bug.
+ */
+function updateWideBanner(screenEl: HTMLElement): void {
+  const id = 'wideBanner';
+  const cols = term?.cols ?? 0;
+  const overflows = screenEl.scrollWidth > screenEl.clientWidth + 4;
+  let banner = document.getElementById(id);
+
+  if (!overflows || !cols) {
+    banner?.remove();
+    return;
+  }
+  if (!banner) {
+    banner = h('div', { id, class: 'wide-banner', role: 'status' });
+    screenEl.parentElement?.insertBefore(banner, screenEl);
+  }
+  const owner = app.machine?.ownerName;
+  banner.textContent = `Sized for ${owner ? `${owner}'s` : 'their'} screen (${cols} columns). Drag sideways to read.`;
 }
 
 // ---------------------------------------------------------------------------
 // Connection + presence
 // ---------------------------------------------------------------------------
 function connect() {
-  const conn = new RelayConnection(app.machine!.id, app.machine!.ed25519Pub);
+  const conn = new RelayConnection(app.machine!.id, app.machine!.ed25519Pub, app.machine!.certificate ?? null);
   app.conn = conn;
   conn.onFingerprint = (fp, ok) => { app.fp = fp; app.fpVerified = ok; };
   conn.onState = (s: ConnState, detail?: string) => onConnState(s, detail);
@@ -167,7 +399,37 @@ const reconnector = createReconnectScheduler({
   reconnect: () => { app.conn?.close(); connect(); },
 });
 
+/**
+ * Why access ended, in the guest's words.
+ *
+ * Distinct per reason on purpose: telling someone "Will revoked your access"
+ * when Will merely closed a terminal is a false and socially loaded story, and
+ * the agent already knows which one it was.
+ */
+const ENDED_COPY: Record<string, { icon: string; title: string; body: string }> = {
+  revoked: { icon: '🔒', title: 'Your access was ended', body: 'The person who shared this session stopped sharing it.' },
+  expired: { icon: '⌛', title: 'Your access expired', body: 'Shared access runs out on a timer. Ask for a new link if you still need it.' },
+  session_ended: { icon: '⏹', title: 'That session ended', body: 'The terminal you were watching was closed. Nothing was taken away from you.' },
+  machine_unlinked: { icon: '🔌', title: 'That machine was unlinked', body: 'It is no longer reachable through Bodhilander.' },
+  not_authorized: { icon: '🚫', title: "You're not in yet", body: 'This machine did not accept the invitation. Ask for a new link.' },
+};
+
+function renderEnded(reason: string): void {
+  const copy = ENDED_COPY[reason] ?? ENDED_COPY.revoked!;
+  stopPolling();
+  reconnector.cancel();
+  app.conn?.close();
+  app.conn = null;
+  rootEl.innerHTML = `<div class="screen-center"><div class="card-center">
+    <div class="logo">${copy.icon}</div>
+    <h1>${esc(copy.title)}</h1>
+    <p>${esc(copy.body)}</p>
+    <a class="btn ghost" href="/">Go to my machines</a>
+  </div></div>`;
+}
+
 function onConnState(s: ConnState, detail?: string) {
+  if (s === 'denied') return renderEnded(detail ?? 'revoked');
   const dot = $('#mdot'); const list = $('#sessions');
   if (s === 'ready') {
     reconnector.cancel();
@@ -282,6 +544,10 @@ const isMobileView = () => matchMedia('(max-width:859px)').matches;
 // (the size comes back authoritatively via terminal:size). Only assert on real
 // changes to avoid reflow churn.
 function assertMobileSize() {
+  // A guest NEVER resizes the owner's PTY. Their phone must not reflow
+  // somebody else's terminal — the owner would watch their session jump
+  // around with no idea why. Guests read at true cell size and pan instead.
+  if (isGuest()) return;
   if (!term || !fitAddon || !isMobileView() || !app.activeId) return;
   const dims = fitAddon.proposeDimensions();
   if (!dims || !dims.cols || !dims.rows || !isFinite(dims.cols) || !isFinite(dims.rows)) return;
@@ -300,6 +566,22 @@ function scaleTerm() {
   const xtermEl = term?.element as HTMLElement | undefined;
   const screenEl = $<HTMLElement>('#screen');
   if (!xtermEl || !screenEl) return;
+
+  // Guests are never scaled. scaleTerm() CSS-downscales rather than reflows,
+  // so a 164-column desktop session shrinks to unreadable on a phone — and a
+  // guest cannot fix it, because they must not resize the owner's PTY. Render
+  // at true cell size and let them pan, with a banner that says why it's wide
+  // rather than leaving them to conclude the page is broken.
+  if (isGuest()) {
+    xtermEl.style.transform = '';
+    xtermEl.style.transformOrigin = '';
+    termScale = 1;
+    screenEl.classList.add('pan');
+    updateWideBanner(screenEl);
+    return;
+  }
+
+  screenEl.classList.remove('pan');
   if (!isMobileView()) { xtermEl.style.transform = ''; xtermEl.style.transformOrigin = ''; termScale = 1; return; }
   xtermEl.style.transformOrigin = 'top left';
   xtermEl.style.transform = 'none';

--- a/relay/web/src/styles.css
+++ b/relay/web/src/styles.css
@@ -214,3 +214,51 @@ input, textarea { font-family: inherit; }
 .sw { width: 30px; height: 30px; border-radius: 9px; border: 2px solid transparent; box-shadow: inset 0 0 0 1px rgba(0,0,0,.15); }
 .sw[aria-pressed="true"] { border-color: var(--ink); }
 .foot { position: absolute; left: 0; right: 0; bottom: 0; padding: 12px 18px calc(14px + var(--safe-b)); border-top: 1px solid var(--hair); background: var(--surface); color: var(--faint); font-size: 11.5px; display: flex; align-items: center; gap: 8px; font-family: var(--mono); }
+
+/* --------------------------------------------------------------------------
+   Guest (watch-only) surfaces — session sharing §7
+   -------------------------------------------------------------------------- */
+
+/* Occupies the compose bar's place so an upgrade to typing swaps in without
+   the layout jumping. Watch-only is never expressed by absence alone. */
+.compose.watch-only {
+  padding: 10px 12px;
+}
+
+.watch-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 9px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--muted);
+  background: var(--panel-2, rgba(127, 127, 127, 0.08));
+  border: 1px solid var(--border);
+}
+
+/* The screen is focusable for guests, so it must show focus. */
+.screen[tabindex]:focus-visible {
+  outline: 2px solid var(--accent, #69adff);
+  outline-offset: -2px;
+}
+
+/* True cell size with two-axis panning, rather than a CSS downscale that
+   would render a wide desktop session illegible on a phone. */
+.screen.pan {
+  overflow-x: auto;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+}
+
+.wide-banner {
+  padding: 7px 12px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--muted);
+  background: var(--panel-2, rgba(127, 127, 127, 0.08));
+  border-bottom: 1px solid var(--border);
+}

--- a/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
+++ b/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
@@ -679,8 +679,15 @@ describe('a lapsed grant stops the stream, not just the commands', () => {
     h.tunnel.revokeGrant('grant-1');
     emit('AFTER REVOKE');
 
-    expect(h.opened('c1', key).some((m) => m.data === 'AFTER REVOKE')).toBe(false);
+    const seen = h.opened('c1', key);
+    expect(seen.some((m) => m.data === 'AFTER REVOKE')).toBe(false);
+    // The REASON matters, not just the silence: DENY_ALL carries expiresAt 0,
+    // so a naive timestamp check would tell a revoked guest their access
+    // "expired" — a different and misleading story.
+    expect(seen.some((m) => m.type === 'denied' && m.reason === 'revoked')).toBe(true);
+    expect(seen.some((m) => m.type === 'denied' && m.reason === 'expired')).toBe(false);
   });
+
 
   test('the owner keeps receiving output regardless of grant clocks', () => {
     // ownerGrant() never expires; a bug that expired owners would take the

--- a/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
+++ b/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
@@ -625,3 +625,89 @@ describe('revokeGrant', () => {
     expect(h.opened('c1', key).some((m) => m.type === 'sessions')).toBe(true);
   });
 });
+
+describe('a lapsed grant stops the stream, not just the commands', () => {
+  /** Drive the PTY data listener the tunnel registered. */
+  function harnessWithPty() {
+    let emit: ((e: { id: string; data: string }) => void) | null = null;
+    const h = harness({
+      grantRow: storedGrant(),
+      pty: {
+        subscribe: (handlers) => {
+          emit = handlers.data;
+          return () => { emit = null; };
+        },
+        write: () => {},
+        resize: () => {},
+        getSize: () => ({ cols: 80, rows: 24 }),
+        isLive: () => true,
+        ptyEpoch: () => 111,
+        getSerializedBuffer: async () => '',
+      },
+    });
+    return { h, emit: (data: string) => emit?.({ id: 's1', data }) };
+  }
+
+  test('output stops once the grant has expired', () => {
+    // permits() gates INBOUND commands. Without a check at fan-out, an expired
+    // guest keeps RECEIVING live terminal output for as long as their socket
+    // stays open — and the stream is the thing being protected.
+    let now = NOW;
+    const { h, emit } = harnessWithPty();
+    h.deps.now = () => now;
+
+    const key = h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+
+    emit('BEFORE');
+    expect(h.opened('c1', key).some((m) => m.data === 'BEFORE')).toBe(true);
+
+    now = NOW + 4_000_000; // past the certificate's expiry
+    emit('AFTER');
+
+    const seen = h.opened('c1', key);
+    expect(seen.some((m) => m.data === 'AFTER')).toBe(false);
+    // And they are told, rather than left watching a frozen screen.
+    expect(seen.some((m) => m.type === 'denied' && m.reason === 'expired')).toBe(true);
+  });
+
+  test('a revoked guest stops receiving output immediately', () => {
+    const { h, emit } = harnessWithPty();
+    const key = h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+
+    h.tunnel.revokeGrant('grant-1');
+    emit('AFTER REVOKE');
+
+    expect(h.opened('c1', key).some((m) => m.data === 'AFTER REVOKE')).toBe(false);
+  });
+
+  test('the owner keeps receiving output regardless of grant clocks', () => {
+    // ownerGrant() never expires; a bug that expired owners would take the
+    // machine away from its own user.
+    let now = NOW;
+    const { h, emit } = harnessWithPty();
+    h.deps.now = () => now;
+
+    const key = h.openChannel('c1', { principal: { userId: OWNER_ID } })!;
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+
+    now = NOW + 10_000_000_000;
+    emit('STILL MINE');
+    expect(h.opened('c1', key).some((m) => m.data === 'STILL MINE')).toBe(true);
+  });
+
+  test('an expired guest disappears from presence', () => {
+    let now = NOW;
+    const { h, emit } = harnessWithPty();
+    h.deps.now = () => now;
+
+    const key = h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    expect(h.tunnel.attachedGuests()[0]!.sessionIds).toEqual(['s1']);
+
+    now = NOW + 4_000_000;
+    emit('tick');
+    expect(h.tunnel.attachedGuests()[0]!.sessionIds).toEqual([]);
+  });
+});

--- a/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
+++ b/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
@@ -688,7 +688,6 @@ describe('a lapsed grant stops the stream, not just the commands', () => {
     expect(seen.some((m) => m.type === 'denied' && m.reason === 'expired')).toBe(false);
   });
 
-
   test('the owner keeps receiving output regardless of grant clocks', () => {
     // ownerGrant() never expires; a bug that expired owners would take the
     // machine away from its own user.

--- a/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
+++ b/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
@@ -17,7 +17,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import crypto from 'crypto';
 import { SessionTunnel } from '../session-tunnel';
-import type { TunnelDeps, TunnelSessionRow, TunnelGroupRow, TunnelStoredGrant } from '../session-tunnel';
+import type { Principal, TunnelDeps, TunnelSessionRow, TunnelGroupRow, TunnelStoredGrant } from '../session-tunnel';
 import { deriveSessionKey, sealJson, openJson, buildHandshakeProof } from '../e2e';
 import { COMMAND_CAPS } from '../grants';
 
@@ -43,7 +43,7 @@ interface Harness {
   /** The client public key most recently offered, for proof assertions. */
   lastClientPub: string | null;
   /** Client-side key material, so tests can read what the tunnel sealed. */
-  openChannel(clientId: string, opts?: { principal?: { userId: string }; certificate?: string }): Buffer | null;
+  openChannel(clientId: string, opts?: { principal?: Principal; certificate?: string }): Buffer | null;
   send(clientId: string, key: Buffer, n: number, obj: unknown): void;
   opened(clientId: string, key: Buffer): { type?: string; [k: string]: unknown }[];
 }
@@ -502,5 +502,126 @@ describe('the handshake proof still binds the ephemeral key to this machine', ()
       .map((m) => (m.payload as { agentX25519Pub: string }).agentX25519Pub);
     expect(agentKeys).toHaveLength(2);
     expect(agentKeys[0]).not.toBe(agentKeys[1]);
+  });
+});
+
+describe('presence', () => {
+  test('a guest appears only once they are actually watching something', () => {
+    // "dana-k is here" and "dana-k is looking at this terminal right now" are
+    // different claims. Only the second is useful to an owner deciding
+    // whether to keep typing.
+    const h = harness({ grantRow: storedGrant() });
+    const key = h.openChannel('c1', {
+      principal: { userId: GUEST_ID, githubLogin: 'dana-k', displayName: 'Dana' },
+      certificate: mintCertificate(),
+    })!;
+
+    expect(h.tunnel.attachedGuests()).toHaveLength(1);
+    expect(h.tunnel.attachedGuests()[0]!.sessionIds).toEqual([]);
+
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    expect(h.tunnel.attachedGuests()[0]!.sessionIds).toEqual(['s1']);
+  });
+
+  test('presence carries the handle, which is what the owner is shown', () => {
+    const h = harness({ grantRow: storedGrant() });
+    h.openChannel('c1', {
+      principal: { userId: GUEST_ID, githubLogin: 'dana-k', displayName: 'Dana' },
+      certificate: mintCertificate(),
+    });
+    expect(h.tunnel.attachedGuests()[0]).toMatchObject({ login: 'dana-k', displayName: 'Dana', role: 'viewer' });
+  });
+
+  test('the owner is never listed as a guest', () => {
+    // Otherwise every owner would appear to be watching themselves.
+    const h = harness();
+    h.openChannel('c1', { principal: { userId: OWNER_ID } });
+    expect(h.tunnel.attachedGuests()).toEqual([]);
+  });
+
+  test('unsubscribing removes the session from presence', () => {
+    const h = harness({ grantRow: storedGrant() });
+    const key = h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    h.send('c1', key, 1, { type: 'terminal:unsubscribe', sessionId: 's1' });
+    expect(h.tunnel.attachedGuests()[0]!.sessionIds).toEqual([]);
+  });
+
+  test('disconnecting removes the guest entirely', () => {
+    // Detach is as load-bearing as attach: an owner who never sees someone
+    // leave cannot tell watching from watched-once.
+    const h = harness({ grantRow: storedGrant() });
+    h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() });
+    h.tunnel.closeClient('c1');
+    expect(h.tunnel.attachedGuests()).toEqual([]);
+  });
+
+  test('every presence transition notifies the owner surfaces', () => {
+    // Attach, subscribe, unsubscribe and detach must each push, or the badge
+    // goes stale and quietly lies about who is watching.
+    let notifications = 0;
+    const h = harness({ grantRow: storedGrant(), onPresenceChange: () => { notifications += 1; } });
+    const key = h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+    const afterAttach = notifications;
+    expect(afterAttach).toBeGreaterThan(0);
+
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    expect(notifications).toBeGreaterThan(afterAttach);
+    const afterSub = notifications;
+
+    h.send('c1', key, 1, { type: 'terminal:unsubscribe', sessionId: 's1' });
+    expect(notifications).toBeGreaterThan(afterSub);
+    const afterUnsub = notifications;
+
+    h.tunnel.closeClient('c1');
+    expect(notifications).toBeGreaterThan(afterUnsub);
+  });
+
+  test('an owner attaching does not notify the presence surfaces', () => {
+    let notifications = 0;
+    const h = harness({ onPresenceChange: () => { notifications += 1; } });
+    h.openChannel('c1', { principal: { userId: OWNER_ID } });
+    expect(notifications).toBe(0);
+  });
+});
+
+describe('revokeGrant', () => {
+  test('cuts every client holding that grant, not just one', () => {
+    // One person may have several browsers open under one grant. Missing one
+    // would leave a guest still watching a terminal the owner believes they
+    // have been removed from.
+    const h = harness({ grantRow: storedGrant() });
+    const k1 = h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+    const k2 = h.openChannel('c2', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+    h.send('c1', k1, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    h.send('c2', k2, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    expect(h.tunnel.attachedGuests()).toHaveLength(2);
+
+    h.tunnel.revokeGrant('grant-1');
+
+    expect(h.tunnel.attachedGuests().every((g) => g.sessionIds.length === 0)).toBe(true);
+    for (const [id, key] of [['c1', k1], ['c2', k2]] as const) {
+      const opened = h.opened(id, key);
+      expect(opened.some((m) => m.type === 'denied' && m.reason === 'revoked')).toBe(true);
+    }
+  });
+
+  test('leaves clients holding a different grant alone', () => {
+    const h = harness({ grantRow: storedGrant() });
+    const key = h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+
+    h.tunnel.revokeGrant('some-other-grant');
+
+    expect(h.tunnel.attachedGuests()[0]!.sessionIds).toEqual(['s1']);
+    expect(h.opened('c1', key).some((m) => m.type === 'denied')).toBe(false);
+  });
+
+  test('the owner is unaffected by a grant revocation', () => {
+    const h = harness();
+    const key = h.openChannel('c1', { principal: { userId: OWNER_ID } })!;
+    h.tunnel.revokeGrant('grant-1');
+    h.send('c1', key, 0, { type: 'sessions:list' });
+    expect(h.opened('c1', key).some((m) => m.type === 'sessions')).toBe(true);
   });
 });

--- a/src/main/api/relay/grant-sql.ts
+++ b/src/main/api/relay/grant-sql.ts
@@ -61,6 +61,21 @@ export const RELAY_SHARING_SCHEMA = `
     PRIMARY KEY(grant_id, session_id)
   );
 
+  -- Which session an invite was offered for.
+  --
+  -- The relay deliberately never learns this: no session id reaches it, which
+  -- is what keeps guests structurally invisible to it. So the mapping has to
+  -- live here, and the approval prompt reads it to pre-fill what the owner
+  -- already chose when they created the link.
+  CREATE TABLE IF NOT EXISTS relay_share_invites (
+    invite_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    -- The PTY instance the owner was looking at when they offered the share.
+    pty_epoch INTEGER NOT NULL,
+    role TEXT NOT NULL CHECK(role IN ('viewer','operator')),
+    created_at INTEGER NOT NULL
+  );
+
   CREATE INDEX IF NOT EXISTS idx_relay_grants_status ON relay_grants(status);
   CREATE INDEX IF NOT EXISTS idx_relay_grants_grantee ON relay_grants(grantee_user_id, status);
 `;
@@ -195,4 +210,26 @@ export function clearPendingRevocation(db: Db, grantId: string): void {
  */
 export function clearAllGrants(db: Db): void {
   db.prepare('DELETE FROM relay_grants').run();
+  db.prepare('DELETE FROM relay_share_invites').run();
+}
+
+export interface InviteScope {
+  sessionId: string;
+  ptyEpoch: number;
+  role: GrantRole;
+}
+
+/** Remember what an invite was offered for, so approval can pre-fill it. */
+export function recordInviteScope(db: Db, inviteId: string, scope: InviteScope, now: number): void {
+  db.prepare(
+    `INSERT OR REPLACE INTO relay_share_invites (invite_id, session_id, pty_epoch, role, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(inviteId, scope.sessionId, scope.ptyEpoch, scope.role, now);
+}
+
+export function getInviteScope(db: Db, inviteId: string): InviteScope | null {
+  const row = db
+    .prepare('SELECT session_id, pty_epoch, role FROM relay_share_invites WHERE invite_id = ?')
+    .get(inviteId) as { session_id: string; pty_epoch: number; role: GrantRole } | undefined;
+  return row ? { sessionId: row.session_id, ptyEpoch: row.pty_epoch, role: row.role } : null;
 }

--- a/src/main/api/relay/grants.ts
+++ b/src/main/api/relay/grants.ts
@@ -73,6 +73,35 @@ export const COMMAND_CAPS: Readonly<Record<string, Cap>> = Object.freeze({
   'dirs:list': 'browse',
 });
 
+/**
+ * Canonical message the agent signs to create a share invite. Mirrors
+ * `relay/src/protocol.ts`; both sides must produce identical bytes.
+ */
+export const SHARE_CREATE_VERSION = 'share-create:v1';
+
+export interface ShareCreateParts {
+  machineId: string;
+  /** Empty string for an open link. */
+  expectedGithubLogin: string;
+  role: string;
+  grantTtlSeconds: number;
+  inviteTtlSeconds: number;
+  issuedAt: number;
+}
+
+export function buildShareCreateMessage(p: ShareCreateParts): Uint8Array {
+  const line = [
+    SHARE_CREATE_VERSION,
+    p.machineId,
+    p.expectedGithubLogin,
+    p.role,
+    String(p.grantTtlSeconds),
+    String(p.inviteTtlSeconds),
+    String(p.issuedAt),
+  ].join('\n');
+  return new TextEncoder().encode(line);
+}
+
 export interface GrantParts {
   grantId: string;
   machineId: string;

--- a/src/main/api/relay/relay-client.ts
+++ b/src/main/api/relay/relay-client.ts
@@ -17,12 +17,13 @@ import { powerSaveBlocker } from 'electron';
 import { WebSocket } from 'ws';
 import log from 'electron-log';
 import { getPreference, setPreference, deletePreference } from '../../repositories/preferences';
-import type { RelayStatus } from '../../../shared/types';
+import type { RelayShare, RelayStatus } from '../../../shared/types';
 import { ensureIdentity, identityFingerprint, signWithIdentity } from './relay-identity';
 import { SessionTunnel, type Principal } from './session-tunnel';
 import { defaultDeps } from './session-tunnel-deps';
-import { CAP_GRANTS_V1 } from './grants';
+import { CAP_GRANTS_V1, buildShareCreateMessage } from './grants';
 import { ptyManager } from '../../pty-manager';
+import { getDatabase } from '../../database';
 import {
   clearAllGrants,
   clearPendingRevocation,
@@ -35,6 +36,13 @@ import {
   setOwnerUserId,
   GRANT_PREF,
 } from './grant-store';
+import { getInviteScope, recordInviteScope } from './grant-sql';
+import { getAllSessions } from '../../repositories/sessions';
+
+/** Session name for the approval prompt, or null if it has since gone. */
+function getSessionName(sessionId: string): string | null {
+  return getAllSessions().find((s) => s.id === sessionId)?.name ?? null;
+}
 import type { GrantRole } from './grants';
 
 /** A grant as the relay describes it. Never authorization on its own. */
@@ -46,6 +54,8 @@ export interface PendingGrant {
   granteeUserId: string;
   granteeLogin: string | null;
   granteeName: string | null;
+  /** The invite it came from, so we can recover the session it was offered for. */
+  inviteId: string | null;
   createdAt: number;
   expiresAt: number | null;
   /**
@@ -126,10 +136,15 @@ export class RelayClient extends EventEmitter {
   /** Routes E2E terminal frames to/from web clients (M3). */
   private readonly tunnel = new SessionTunnel(
     (clientId, payload) => this.send({ type: 'to-client', clientId, payload }),
-    defaultDeps(
-      () => stripTrailingSlashes(this.relayUrl),
-      () => getPreference(PREF.machineId),
-    ),
+    {
+      ...defaultDeps(
+        () => stripTrailingSlashes(this.relayUrl),
+        () => getPreference(PREF.machineId),
+      ),
+      // Presence changes are status changes: the owner's surfaces are driven
+      // off the same push everything else uses.
+      onPresenceChange: () => this.emitStatus(),
+    },
   );
 
   /** Origin of the relay, e.g. `https://relay.example.com`. */
@@ -167,6 +182,19 @@ export class RelayClient extends EventEmitter {
       pendingOwner: this.pendingOwner
         ? { ...this.pendingOwner, isChange: !!getOwnerUserId() }
         : null,
+      attachedGuests: this.tunnel.attachedGuests(),
+      pendingShares: this.getPendingGrants().map((g) => {
+        const scope = g.inviteId ? getInviteScope(getDatabase(), g.inviteId) : null;
+        return {
+          grantId: g.grantId,
+          role: g.role,
+          granteeLogin: g.granteeLogin,
+          granteeName: g.granteeName,
+          createdAt: g.createdAt,
+          sessionId: scope?.sessionId ?? null,
+          sessionName: scope ? (getSessionName(scope.sessionId) ?? null) : null,
+        };
+      }),
     };
   }
 
@@ -469,6 +497,91 @@ export class RelayClient extends EventEmitter {
 
   // --- sharing (M5.2) ---
 
+  /**
+   * Offer a share of one session, returning the link to send.
+   *
+   * **The URL is composed here, never by the relay.** If the relay authored it,
+   * it could put its own fingerprint in the `#fp=` fragment and serve the
+   * matching public key, so the guest's three-way check would agree perfectly
+   * and manufacture a false "verified". The relay only ever returns the code.
+   */
+  async createShareInvite(input: {
+    sessionId: string;
+    expectedGithubLogin: string | null;
+    role: GrantRole;
+    grantTtlSeconds: number;
+    inviteTtlSeconds: number;
+  }): Promise<{ code: string; url: string; expiresAt: number }> {
+    const machineId = getPreference(PREF.machineId);
+    if (!machineId) throw new Error('this machine is not linked');
+
+    // Capture the PTY instance now, so the approval prompt later refers to the
+    // terminal the owner actually meant rather than whatever the row became.
+    const ptyEpoch = ptyManager.getSession(input.sessionId)?.spawnedAt;
+    if (ptyEpoch === undefined) throw new Error('that session is not running');
+
+    const issuedAt = Date.now();
+    const origin = stripTrailingSlashes(this.relayUrl);
+    const signature = signWithIdentity(
+      buildShareCreateMessage({
+        machineId,
+        expectedGithubLogin: input.expectedGithubLogin ?? '',
+        role: input.role,
+        grantTtlSeconds: input.grantTtlSeconds,
+        inviteTtlSeconds: input.inviteTtlSeconds,
+        issuedAt,
+      }),
+    ).toString('base64');
+
+    const res = await fetch(`${origin}/api/machines/${machineId}/shares`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        expectedGithubLogin: input.expectedGithubLogin,
+        role: input.role,
+        grantTtlSeconds: input.grantTtlSeconds,
+        inviteTtlSeconds: input.inviteTtlSeconds,
+        issuedAt,
+        signature,
+      }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      throw new Error(`relay rejected the share request (${res.status})${detail ? `: ${detail}` : ''}`);
+    }
+    const body = (await res.json()) as { inviteId: string; code: string; expiresAt: number };
+
+    recordInviteScope(
+      getDatabase(),
+      body.inviteId,
+      { sessionId: input.sessionId, ptyEpoch, role: input.role },
+      issuedAt,
+    );
+
+    const fingerprint = identityFingerprint();
+    // The fragment never reaches the relay — that is what makes it usable as
+    // out-of-band provenance for the machine the guest is about to trust.
+    const url = `${origin}/i/${body.code}${fingerprint ? `#fp=${encodeURIComponent(fingerprint)}` : ''}`;
+    log.info('[Relay] share invite created', { addressed: !!input.expectedGithubLogin });
+    return { code: body.code, url, expiresAt: body.expiresAt };
+  }
+
+  /** Every grant this machine has issued, for the owner's settings list. */
+  listShares(): RelayShare[] {
+    return listGrants().map((g) => ({
+      grantId: g.id,
+      role: g.role,
+      status: g.status,
+      granteeLogin: g.granteeLogin,
+      createdAt: g.createdAt,
+      expiresAt: g.expiresAt,
+      // Surfaced so the UI can say "Revoked — takes effect when this machine
+      // reconnects" rather than implying it already has.
+      revokePending: g.revokePending,
+      sessionIds: g.sessions.map((x) => x.sessionId),
+    }));
+  }
+
   /** Grants the relay says exist that this machine has not answered yet. */
   getPendingGrants(): PendingGrant[] {
     return [...this.pendingGrants.values()];
@@ -525,15 +638,19 @@ export class RelayClient extends EventEmitter {
    * time — the grant is for the terminal the owner was looking at, and
    * `sessions.id` survives a restart into something else entirely.
    */
-  approveGrant(grantId: string, sessionIds: string[]): void {
+  approveGrant(grantId: string, sessionIds?: string[]): void {
     const pending = this.pendingGrants.get(grantId);
     if (!pending) throw new Error('no such pending share request');
-    if (sessionIds.length === 0) throw new Error('a share must name at least one session');
+    // Default to the session the invite was offered for. The relay never knew
+    // it — no session id ever reaches it — so this comes from our own table.
+    const scope = pending.inviteId ? getInviteScope(getDatabase(), pending.inviteId) : null;
+    const chosen = sessionIds?.length ? sessionIds : scope ? [scope.sessionId] : [];
+    if (chosen.length === 0) throw new Error('a share must name at least one session');
 
     const machineId = getPreference(PREF.machineId);
     if (!machineId) throw new Error('this machine is not linked');
 
-    const sessions = sessionIds.map((sessionId) => {
+    const sessions = chosen.map((sessionId) => {
       const ptyEpoch = ptyManager.getSession(sessionId)?.spawnedAt;
       if (ptyEpoch === undefined) throw new Error(`session ${sessionId} is not running`);
       return { sessionId, ptyEpoch };

--- a/src/main/api/relay/relay-client.ts
+++ b/src/main/api/relay/relay-client.ts
@@ -407,26 +407,7 @@ export class RelayClient extends EventEmitter {
       return;
     }
 
-    // A guest redeemed an invite, or we just reconnected and the relay is
-    // telling us everything it holds.
-    if (msg.type === 'share:pending' && msg.grants) {
-      this.notePendingGrants(msg.grants);
-      return;
-    }
-    if (msg.type === 'share:sync' && msg.grants) {
-      this.reconcileGrants(msg.grants);
-      return;
-    }
-    // Revoked elsewhere — by the owner on another device, or by the guest
-    // handing access back.
-    if (msg.type === 'grant:revoked' && msg.grantId) {
-      revokeGrantLocally(msg.grantId);
-      clearPendingRevocation(msg.grantId);
-      this.pendingGrants.delete(msg.grantId);
-      this.tunnel.revokeGrant(msg.grantId, 'revoked');
-      this.emit('grants-changed');
-      return;
-    }
+    if (this.handleShareMessage(msg)) return;
 
     if (msg.type === 'agent:ready') {
       this.connecting = false;
@@ -498,6 +479,36 @@ export class RelayClient extends EventEmitter {
   // --- sharing (M5.2) ---
 
   /**
+   * The relay's sharing messages. Split out of `handleMessage` so that method
+   * stays one dispatch rather than a growing pile of branches.
+   *
+   * Returns whether the message was one of ours.
+   */
+  private handleShareMessage(msg: { type?: string; grants?: PendingGrant[]; grantId?: string }): boolean {
+    // A guest redeemed an invite, or we just reconnected and the relay is
+    // telling us everything it holds.
+    if (msg.type === 'share:pending' && msg.grants) {
+      this.notePendingGrants(msg.grants);
+      return true;
+    }
+    if (msg.type === 'share:sync' && msg.grants) {
+      this.reconcileGrants(msg.grants);
+      return true;
+    }
+    // Revoked elsewhere — by the owner on another device, or by the guest
+    // handing access back.
+    if (msg.type === 'grant:revoked' && msg.grantId) {
+      revokeGrantLocally(msg.grantId);
+      clearPendingRevocation(msg.grantId);
+      this.pendingGrants.delete(msg.grantId);
+      this.tunnel.revokeGrant(msg.grantId, 'revoked');
+      this.emit('grants-changed');
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * Offer a share of one session, returning the link to send.
    *
    * **The URL is composed here, never by the relay.** If the relay authored it,
@@ -547,7 +558,8 @@ export class RelayClient extends EventEmitter {
     });
     if (!res.ok) {
       const detail = await res.text().catch(() => '');
-      throw new Error(`relay rejected the share request (${res.status})${detail ? `: ${detail}` : ''}`);
+      const suffix = detail ? `: ${detail}` : '';
+      throw new Error(`relay rejected the share request (${res.status})${suffix}`);
     }
     const body = (await res.json()) as { inviteId: string; code: string; expiresAt: number };
 
@@ -561,7 +573,8 @@ export class RelayClient extends EventEmitter {
     const fingerprint = identityFingerprint();
     // The fragment never reaches the relay — that is what makes it usable as
     // out-of-band provenance for the machine the guest is about to trust.
-    const url = `${origin}/i/${body.code}${fingerprint ? `#fp=${encodeURIComponent(fingerprint)}` : ''}`;
+    const fragment = fingerprint ? `#fp=${encodeURIComponent(fingerprint)}` : '';
+    const url = `${origin}/i/${body.code}${fragment}`;
     log.info('[Relay] share invite created', { addressed: !!input.expectedGithubLogin });
     return { code: body.code, url, expiresAt: body.expiresAt };
   }
@@ -644,7 +657,8 @@ export class RelayClient extends EventEmitter {
     // Default to the session the invite was offered for. The relay never knew
     // it — no session id ever reaches it — so this comes from our own table.
     const scope = pending.inviteId ? getInviteScope(getDatabase(), pending.inviteId) : null;
-    const chosen = sessionIds?.length ? sessionIds : scope ? [scope.sessionId] : [];
+    const fromInvite = scope ? [scope.sessionId] : [];
+    const chosen = sessionIds?.length ? sessionIds : fromInvite;
     if (chosen.length === 0) throw new Error('a share must name at least one session');
 
     const machineId = getPreference(PREF.machineId);

--- a/src/main/api/relay/relay-client.ts
+++ b/src/main/api/relay/relay-client.ts
@@ -22,7 +22,42 @@ import { ensureIdentity, identityFingerprint, signWithIdentity } from './relay-i
 import { SessionTunnel, type Principal } from './session-tunnel';
 import { defaultDeps } from './session-tunnel-deps';
 import { CAP_GRANTS_V1 } from './grants';
-import { clearAllGrants, getOwnerUserId, setOwnerUserId, GRANT_PREF } from './grant-store';
+import { ptyManager } from '../../pty-manager';
+import {
+  clearAllGrants,
+  clearPendingRevocation,
+  getGrant,
+  getOwnerUserId,
+  listGrants,
+  mintGrant,
+  pendingRevocations,
+  revokeGrant as revokeGrantLocally,
+  setOwnerUserId,
+  GRANT_PREF,
+} from './grant-store';
+import type { GrantRole } from './grants';
+
+/** A grant as the relay describes it. Never authorization on its own. */
+export interface PendingGrant {
+  grantId: string;
+  status: 'pending' | 'active' | 'revoked';
+  role: GrantRole;
+  label: string | null;
+  granteeUserId: string;
+  granteeLogin: string | null;
+  granteeName: string | null;
+  createdAt: number;
+  expiresAt: number | null;
+  /**
+   * The lifetime the invite promised. `expiresAt` is NULL until we
+   * countersign, so this is the only thing available at the moment of
+   * approval — which is the moment it is needed.
+   */
+  grantTtlSeconds: number | null;
+}
+
+/** Fallback when the relay did not state one. Deliberately short. */
+const DEFAULT_GRANT_TTL_SECONDS = 4 * 60 * 60;
 
 const PREF_OWNER_USER_ID = GRANT_PREF.ownerUserId;
 
@@ -86,6 +121,8 @@ export class RelayClient extends EventEmitter {
   private powerSaveBlockerId: number | null = null;
   /** An owner id the relay asserted that no human has confirmed yet. */
   private pendingOwner: AssertedOwner | null = null;
+  /** Share requests waiting on the owner, keyed by grant id. */
+  private readonly pendingGrants = new Map<string, PendingGrant>();
   /** Routes E2E terminal frames to/from web clients (M3). */
   private readonly tunnel = new SessionTunnel(
     (clientId, payload) => this.send({ type: 'to-client', clientId, payload }),
@@ -309,6 +346,8 @@ export class RelayClient extends EventEmitter {
       payload?: unknown;
       principal?: Principal;
       owner?: AssertedOwner | null;
+      grants?: PendingGrant[];
+      grantId?: string;
     };
     try {
       msg = JSON.parse(raw);
@@ -337,6 +376,27 @@ export class RelayClient extends EventEmitter {
         log.error('[Relay] failed to answer challenge:', err instanceof Error ? err.message : err);
         this.ws?.close();
       }
+      return;
+    }
+
+    // A guest redeemed an invite, or we just reconnected and the relay is
+    // telling us everything it holds.
+    if (msg.type === 'share:pending' && msg.grants) {
+      this.notePendingGrants(msg.grants);
+      return;
+    }
+    if (msg.type === 'share:sync' && msg.grants) {
+      this.reconcileGrants(msg.grants);
+      return;
+    }
+    // Revoked elsewhere — by the owner on another device, or by the guest
+    // handing access back.
+    if (msg.type === 'grant:revoked' && msg.grantId) {
+      revokeGrantLocally(msg.grantId);
+      clearPendingRevocation(msg.grantId);
+      this.pendingGrants.delete(msg.grantId);
+      this.tunnel.revokeGrant(msg.grantId, 'revoked');
+      this.emit('grants-changed');
       return;
     }
 
@@ -405,6 +465,122 @@ export class RelayClient extends EventEmitter {
       }
       this.ws = null;
     }
+  }
+
+  // --- sharing (M5.2) ---
+
+  /** Grants the relay says exist that this machine has not answered yet. */
+  getPendingGrants(): PendingGrant[] {
+    return [...this.pendingGrants.values()];
+  }
+
+  private notePendingGrants(grants: PendingGrant[]): void {
+    let added = false;
+    for (const g of grants) {
+      if (g.status !== 'pending') continue;
+      // Already answered on this machine — a duplicate share:pending after a
+      // reconnect must not re-prompt the owner for something they decided.
+      if (getGrant(g.grantId)) continue;
+      if (this.pendingGrants.has(g.grantId)) continue;
+      this.pendingGrants.set(g.grantId, g);
+      added = true;
+      this.emit('join-request', g);
+    }
+    if (added) this.emit('grants-changed');
+  }
+
+  /**
+   * Reconcile against what the relay says it holds, then assert our own view.
+   *
+   * Local status is the authority on revocation, so this is not a merge: we
+   * take the relay's list of *pending* requests (which only it can know about),
+   * flush anything we revoked while offline, and then tell it the set of
+   * grants we still consider live. Anything else it holds for this machine is
+   * a ghost — from a relay restore, or from a revocation it never heard.
+   */
+  private reconcileGrants(relayGrants: PendingGrant[]): void {
+    this.pendingGrants.clear();
+    this.notePendingGrants(relayGrants);
+
+    // Revocations queued while we were offline. Sending share:reconcile below
+    // would already drop them, but an explicit revoke is clearer in the
+    // relay's logs and does not depend on the reconcile arriving.
+    for (const grantId of pendingRevocations()) {
+      this.send({ type: 'share:deny', grantId, reason: 'revoked' });
+      clearPendingRevocation(grantId);
+    }
+
+    const active = listGrants()
+      .filter((g) => g.status === 'active')
+      .map((g) => g.id);
+    this.send({ type: 'share:reconcile', activeGrantIds: active });
+    this.emit('grants-changed');
+  }
+
+  /**
+   * The owner approved a request. Mint a certificate over the sessions they
+   * chose and hand it to the relay.
+   *
+   * `ptyEpoch` is captured HERE, at the moment of consent, not at connection
+   * time — the grant is for the terminal the owner was looking at, and
+   * `sessions.id` survives a restart into something else entirely.
+   */
+  approveGrant(grantId: string, sessionIds: string[]): void {
+    const pending = this.pendingGrants.get(grantId);
+    if (!pending) throw new Error('no such pending share request');
+    if (sessionIds.length === 0) throw new Error('a share must name at least one session');
+
+    const machineId = getPreference(PREF.machineId);
+    if (!machineId) throw new Error('this machine is not linked');
+
+    const sessions = sessionIds.map((sessionId) => {
+      const ptyEpoch = ptyManager.getSession(sessionId)?.spawnedAt;
+      if (ptyEpoch === undefined) throw new Error(`session ${sessionId} is not running`);
+      return { sessionId, ptyEpoch };
+    });
+
+    // From the invite the owner created, not from `expiresAt` — that is NULL
+    // until we countersign, which is exactly the moment we are in now.
+    const ttlSeconds = pending.grantTtlSeconds ?? DEFAULT_GRANT_TTL_SECONDS;
+    const { certificate, grant } = mintGrant({
+      grantId,
+      machineId,
+      relayOrigin: stripTrailingSlashes(this.relayUrl),
+      granteeUserId: pending.granteeUserId,
+      granteeLogin: pending.granteeLogin,
+      role: pending.role,
+      sessions,
+      ttlSeconds,
+    });
+
+    this.send({ type: 'share:bind', grantId, certificate, expiresAt: grant.expiresAt });
+    this.pendingGrants.delete(grantId);
+    log.info('[Relay] share approved', { grantId, sessions: sessions.length });
+    this.emit('grants-changed');
+  }
+
+  /** The owner said no. Nothing is minted, so there is nothing to revoke. */
+  denyGrant(grantId: string, reason = 'declined'): void {
+    this.pendingGrants.delete(grantId);
+    this.send({ type: 'share:deny', grantId, reason });
+    log.info('[Relay] share denied', { grantId });
+    this.emit('grants-changed');
+  }
+
+  /**
+   * End an active grant. Local status is the authority, so this takes effect
+   * at the guest's next `client:open` whether or not the relay ever hears —
+   * and the queue makes revoking while disconnected honest rather than a lie.
+   */
+  revokeGrant(grantId: string): void {
+    revokeGrantLocally(grantId);
+    this.tunnel.revokeGrant(grantId, 'revoked');
+    if (this.connected) {
+      this.send({ type: 'share:deny', grantId, reason: 'revoked' });
+      clearPendingRevocation(grantId);
+    }
+    log.info('[Relay] grant revoked', { grantId, queued: !this.connected });
+    this.emit('grants-changed');
   }
 
   // --- owner confirmation (design §3) ---

--- a/src/main/api/relay/relay-client.ts
+++ b/src/main/api/relay/relay-client.ts
@@ -37,13 +37,13 @@ import {
   GRANT_PREF,
 } from './grant-store';
 import { getInviteScope, recordInviteScope } from './grant-sql';
+import type { GrantRole } from './grants';
 import { getAllSessions } from '../../repositories/sessions';
 
 /** Session name for the approval prompt, or null if it has since gone. */
 function getSessionName(sessionId: string): string | null {
   return getAllSessions().find((s) => s.id === sessionId)?.name ?? null;
 }
-import type { GrantRole } from './grants';
 
 /** A grant as the relay describes it. Never authorization on its own. */
 export interface PendingGrant {

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -135,6 +135,14 @@ export interface TunnelDeps {
     warn(msg: string, meta?: unknown): void;
     error(msg: string, meta?: unknown): void;
   };
+  /**
+   * Called whenever the set of attached guests changes.
+   *
+   * Presence is a hard requirement, not a nicety: silent read access to a live
+   * terminal is the same class of harm as silent write access, so the owner
+   * must be able to see who is watching without going looking.
+   */
+  onPresenceChange?: () => void;
   /** The relay origin this agent is connected to, for certificate binding. */
   relayOrigin(): string;
   /** This machine's id as the relay knows it, or null before linking. */
@@ -145,6 +153,19 @@ export interface TunnelDeps {
 /** The relay-asserted identity of a connecting socket. Never authorization. */
 export interface Principal {
   userId: string;
+  githubLogin?: string | null;
+  displayName?: string | null;
+}
+
+/** One guest currently attached, as the owner's UI needs to see them. */
+export interface AttachedGuest {
+  clientId: string;
+  grantId: string | null;
+  role: string;
+  login: string | null;
+  displayName: string | null;
+  /** The sessions they are watching right now, not merely entitled to. */
+  sessionIds: string[];
 }
 
 interface ClientSession {
@@ -155,6 +176,8 @@ interface ClientSession {
   subs: Set<string>;
   /** What this client may do. Starts at DENY_ALL and is never widened later. */
   grant: Grant;
+  /** Who the relay says this is, for presence. Never authorization. */
+  principal: Principal | null;
 }
 
 /** Decrypted command from a web client (union of every message's fields). */
@@ -191,7 +214,9 @@ export class SessionTunnel {
     'groups:list': (clientId, s) => this.sendGroups(clientId, s),
     'terminal:subscribe': (clientId, s, inner) => void this.handleSubscribe(clientId, s, inner),
     'terminal:unsubscribe': (_clientId, s, inner) => {
-      if (typeof inner.sessionId === 'string') s.subs.delete(inner.sessionId);
+      if (typeof inner.sessionId === 'string' && s.subs.delete(inner.sessionId) && s.grant.role !== 'owner') {
+        this.deps.onPresenceChange?.();
+      }
     },
     'terminal:input': (_clientId, s, inner) => {
       if (typeof inner.sessionId === 'string' && typeof inner.data === 'string' && s.subs.has(inner.sessionId)) {
@@ -301,7 +326,14 @@ export class SessionTunnel {
       const key = deriveSessionKey(sharedSecret);
       const signature = this.deps.identity.sign(buildHandshakeProof(clientX25519Pub, ephemeralPubB64)).toString('base64');
 
-      const session: ClientSession = { key, sendCounter: 0, recvCounter: -1, subs: new Set(), grant };
+      const session: ClientSession = {
+        key,
+        sendCounter: 0,
+        recvCounter: -1,
+        subs: new Set(),
+        grant,
+        principal: principal ?? null,
+      };
       this.sessions.set(clientId, session);
       this.startListening();
 
@@ -318,6 +350,7 @@ export class SessionTunnel {
       // its own scope back.
       if (grant.role === 'owner') this.sendSessions(clientId, session);
       this.deps.log.info('[Relay] client channel opened', { clientId, role: grant.role });
+      if (grant.role !== 'owner') this.deps.onPresenceChange?.();
     } catch (err) {
       this.deps.log.error('[Relay] tunnel open failed:', err instanceof Error ? err.message : err);
     }
@@ -468,6 +501,7 @@ export class SessionTunnel {
     if (typeof inner.sessionId !== 'string') return;
     const sessionId = inner.sessionId;
     s.subs.add(sessionId);
+    if (s.grant.role !== 'owner') this.deps.onPresenceChange?.();
     // Tell the viewer the PTY's current size so it renders TUIs correctly.
     const size = this.deps.pty.getSize(sessionId);
     this.sealTo(clientId, { type: 'terminal:size', sessionId, cols: size.cols, rows: size.rows });
@@ -528,8 +562,12 @@ export class SessionTunnel {
 
   /** A web client disconnected — drop its state. */
   closeClient(clientId: string): void {
+    const was = this.sessions.get(clientId);
     if (!this.sessions.delete(clientId)) return;
     this.stopListeningIfIdle();
+    // Detach is as load-bearing as attach: an owner who never sees someone
+    // leave cannot tell watching from watched-once.
+    if (was && was.grant.role !== 'owner') this.deps.onPresenceChange?.();
   }
 
   /** Tear down every client (agent WebSocket dropped). */
@@ -567,6 +605,7 @@ export class SessionTunnel {
     if (!s) return;
     s.grant = DENY_ALL;
     s.subs.clear();
+    this.deps.onPresenceChange?.();
     // Sealed: an unsealed "your access ended" is forgeable by the relay, which
     // turns a revocation notice into a clean phishing lever.
     this.sealTo(clientId, { type: 'denied', reason });
@@ -613,6 +652,30 @@ export class SessionTunnel {
         parentId: g.parentId,
       }));
     this.sealTo(clientId, { type: 'groups', groups });
+  }
+
+  /**
+   * Guests currently attached, for the owner's presence surfaces.
+   *
+   * Reports what each guest is actually WATCHING (`subs`), not merely what
+   * they could watch — "dana-k is here" and "dana-k is looking at this
+   * terminal right now" are different claims and the second is the one that
+   * matters.
+   */
+  attachedGuests(): AttachedGuest[] {
+    const out: AttachedGuest[] = [];
+    for (const [clientId, s] of this.sessions) {
+      if (s.grant.role === 'owner') continue;
+      out.push({
+        clientId,
+        grantId: s.grant.grantId,
+        role: s.grant.role,
+        login: s.principal?.githubLogin ?? null,
+        displayName: s.principal?.displayName ?? null,
+        sessionIds: [...s.subs],
+      });
+    }
+    return out;
   }
 
   private sealTo(clientId: string, obj: unknown): void {

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -278,7 +278,7 @@ export class SessionTunnel {
       // stayed open — the stream is the thing being protected, so the check
       // belongs where the data leaves.
       if (!permits(s.grant, 'terminal:subscribe', sessionId, now)) {
-        this.expireClient(clientId, s);
+        this.expireClient(clientId, s, now);
         continue;
       }
       send(clientId);
@@ -286,9 +286,15 @@ export class SessionTunnel {
   }
 
   /** Stop streaming to a client whose grant has lapsed, and tell it why. */
-  private expireClient(clientId: string, s: ClientSession): void {
+  private expireClient(clientId: string, s: ClientSession, now: number): void {
     if (s.grant.role === 'owner') return;
-    const reason = s.grant.expiresAt <= this.deps.now() ? 'expired' : 'revoked';
+    // Do NOT infer the reason from the timestamp alone: DENY_ALL carries
+    // `expiresAt: 0`, so a revoked client would be told its access "expired" —
+    // a different and misleading story. A grant that still holds capabilities
+    // and has run out of clock genuinely expired; one stripped of them was
+    // taken away.
+    const ranOut = s.grant.caps.length > 0 && s.grant.expiresAt <= now;
+    const reason = ranOut ? 'expired' : 'revoked';
     s.subs.clear();
     s.grant = DENY_ALL;
     this.sealTo(clientId, { type: 'denied', reason });

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -269,9 +269,31 @@ export class SessionTunnel {
 
   /** Run `send` for every client subscribed to `sessionId`. */
   private fanOut(sessionId: string, send: (clientId: string) => void): void {
+    const now = this.deps.now();
     for (const [clientId, s] of this.sessions) {
-      if (s.subs.has(sessionId)) send(clientId);
+      if (!s.subs.has(sessionId)) continue;
+      // Re-check the grant on every frame, not just at subscribe time.
+      // `permits()` gates INBOUND commands; without this an expired or revoked
+      // guest would keep RECEIVING live output for as long as their socket
+      // stayed open — the stream is the thing being protected, so the check
+      // belongs where the data leaves.
+      if (!permits(s.grant, 'terminal:subscribe', sessionId, now)) {
+        this.expireClient(clientId, s);
+        continue;
+      }
+      send(clientId);
     }
+  }
+
+  /** Stop streaming to a client whose grant has lapsed, and tell it why. */
+  private expireClient(clientId: string, s: ClientSession): void {
+    if (s.grant.role === 'owner') return;
+    const reason = s.grant.expiresAt <= this.deps.now() ? 'expired' : 'revoked';
+    s.subs.clear();
+    s.grant = DENY_ALL;
+    this.sealTo(clientId, { type: 'denied', reason });
+    this.deps.onPresenceChange?.();
+    this.deps.log.info('[Relay] stopped streaming to a lapsed guest', { clientId, reason });
   }
 
   private startListening(): void {

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -548,6 +548,20 @@ export class SessionTunnel {
    * It keeps the shared PTY listener attached until the client actually
    * disconnects; `subs` is cleared, so `fanOut` never calls back for it.
    */
+  /**
+   * Revoke every live client holding `grantId`.
+   *
+   * Keyed by grant rather than by client because one person may have several
+   * browsers open under one grant, and revoking has to reach all of them —
+   * missing one would leave a guest still watching a terminal the owner
+   * believes they have been removed from.
+   */
+  revokeGrant(grantId: string, reason = 'revoked'): void {
+    for (const [clientId, s] of this.sessions) {
+      if (s.grant.grantId === grantId) this.revokeClient(clientId, reason);
+    }
+  }
+
   revokeClient(clientId: string, reason = 'revoked'): void {
     const s = this.sessions.get(clientId);
     if (!s) return;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, shell, crashReporter } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog, shell, crashReporter, Notification } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ptyManager } from './pty-manager';
@@ -483,6 +483,38 @@ function createWindow(): void {
   }, 1500); // Defer 1.5s to prioritize UI rendering
 
   // Relay status forwarding
+  // A guest is asking to join. This deliberately bypasses shouldNotify(),
+  // which suppresses notifications precisely when the owner is at their desk —
+  // the opposite of what a consent prompt needs. It also fires an OS
+  // notification, because a renderer modal in a minimised window is invisible
+  // and the request would simply expire unanswered.
+  getRelayClient().on('join-request', (grant: { granteeLogin: string | null; granteeName: string | null }) => {
+    const who = grant.granteeLogin ? `@${grant.granteeLogin}` : (grant.granteeName ?? 'Someone');
+    try {
+      const notification = new Notification({
+        title: 'Someone wants to watch a session',
+        body: `${who} is asking to join. Open Bodhilander to decide.`,
+        silent: false,
+      });
+      // The codebase has no notification action buttons, so the click restores
+      // and focuses instead — otherwise the prompt stays unreachable.
+      notification.on('click', () => {
+        if (mainWindow) {
+          if (mainWindow.isMinimized()) mainWindow.restore();
+          mainWindow.show();
+          mainWindow.focus();
+        }
+      });
+      notification.show();
+    } catch (e) {
+      log.warn('[Relay] could not raise a join-request notification:', (e as Error).message);
+    }
+  });
+
+  getRelayClient().on('grants-changed', () => {
+    mainWindow?.webContents.send('relay:status', getRelayClient().getStatus());
+  });
+
   getRelayClient().on('status', (status) => {
     mainWindow?.webContents.send('relay:status', status);
   });
@@ -1136,6 +1168,36 @@ safeHandle('relay:rejectOwner', () => {
   getRelayClient().rejectOwner();
   return getRelayClient().getStatus();
 });
+
+// --- session sharing (M5.2) ---
+
+safeHandle(
+  'relay:createShare',
+  async (input: {
+    sessionId: string;
+    expectedGithubLogin: string | null;
+    role: 'viewer' | 'operator';
+    grantTtlSeconds: number;
+    inviteTtlSeconds: number;
+  }) => getRelayClient().createShareInvite(input),
+);
+
+safeHandle('relay:approveShare', (grantId: string, sessionIds?: string[]) => {
+  getRelayClient().approveGrant(grantId, sessionIds);
+  return getRelayClient().getStatus();
+});
+
+safeHandle('relay:denyShare', (grantId: string) => {
+  getRelayClient().denyGrant(grantId);
+  return getRelayClient().getStatus();
+});
+
+safeHandle('relay:revokeShare', (grantId: string) => {
+  getRelayClient().revokeGrant(grantId);
+  return getRelayClient().getStatus();
+});
+
+safeHandle('relay:listShares', () => getRelayClient().listShares());
 
 // ============================================================================
 // Editor Integration IPC Handlers

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus } from '../shared/types';
+import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -262,6 +262,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
   relayGetPendingOwner: (): Promise<RelayStatus['pendingOwner']> => ipcRenderer.invoke('relay:getPendingOwner'),
   relayConfirmOwner: (userId: string): Promise<RelayStatus> => ipcRenderer.invoke('relay:confirmOwner', userId),
   relayRejectOwner: (): Promise<RelayStatus> => ipcRenderer.invoke('relay:rejectOwner'),
+  relayCreateShare: (input: {
+    sessionId: string;
+    expectedGithubLogin: string | null;
+    role: 'viewer' | 'operator';
+    grantTtlSeconds: number;
+    inviteTtlSeconds: number;
+  }): Promise<{ code: string; url: string; expiresAt: number }> => ipcRenderer.invoke('relay:createShare', input),
+  relayApproveShare: (grantId: string, sessionIds?: string[]): Promise<RelayStatus> =>
+    ipcRenderer.invoke('relay:approveShare', grantId, sessionIds),
+  relayDenyShare: (grantId: string): Promise<RelayStatus> => ipcRenderer.invoke('relay:denyShare', grantId),
+  relayRevokeShare: (grantId: string): Promise<RelayStatus> => ipcRenderer.invoke('relay:revokeShare', grantId),
+  relayListShares: (): Promise<RelayShare[]> => ipcRenderer.invoke('relay:listShares'),
   onRelayStatus: (callback: (status: RelayStatus) => void) => {
     const listener = (_: Electron.IpcRendererEvent, status: RelayStatus) => callback(status);
     ipcRenderer.on('relay:status', listener);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -908,7 +908,7 @@ const App: React.FC = () => {
     isSearching, effectiveAccountForSession, editingSessionId, editingSessionName,
     handleStartEditSession, handleFinishEditSession, handleSessionClick, handleSessionContextMenu,
     handleSessionDragStart, handleDragEnd, handleSessionDragOver, handleSessionDrop,
-    handleRemoveSession,, guestsBySession]);
+    handleRemoveSession, guestsBySession]);
 
   const getContextShortcuts = useCallback(() => {
     if (sidebarFocused) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,6 +4,8 @@ import TerminalHeader from './components/TerminalHeader';
 import ContextMenu, { MenuItem } from './components/ContextMenu';
 import { NamePromptModal } from './components/NamePromptModal';
 import { OwnerConfirmModal, type PendingOwner } from './components/OwnerConfirmModal';
+import { ShareSessionModal } from './components/ShareSessionModal';
+import { GuestJoinRequestModal } from './components/GuestJoinRequestModal';
 import { SettingsModal, SettingsTab } from './components/SettingsModal';
 import { NewItemChoice } from './components/NewItemChoice';
 import { SidebarFilter } from './components/SidebarFilter';
@@ -13,6 +15,7 @@ import AnalyticsPanel from './components/panels/AnalyticsPanel';
 import { ArenaPanel } from './components/ArenaPanel';
 import { ViewSwitcher, type ContentView } from './components/ViewSwitcher';
 import { ClaudeAccount, Session } from '../shared/types';
+import type { RelayAttachedGuest, RelayPendingShare, RelayStatus } from '../shared/types';
 import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
 import { computeGroupFilter, buildNavItems } from './store/groupFilter';
@@ -854,6 +857,27 @@ const App: React.FC = () => {
 
   // Wiring for one session row. Hoisted out of the JSX so the per-row callbacks
   // are not nested five closures deep inside the group/sub-group maps.
+  const [pendingOwner, setPendingOwner] = useState<PendingOwner | null>(null);
+  /** Guests attached right now — the presence surfaces read this. */
+  const [attachedGuests, setAttachedGuests] = useState<RelayAttachedGuest[]>([]);
+  /** Share requests waiting on an answer. */
+  const [pendingShares, setPendingShares] = useState<RelayPendingShare[]>([]);
+  /** The session the share modal is open for, if any. */
+  const [sharingSession, setSharingSession] = useState<{ id: string; name: string } | null>(null);
+
+  /** Guests watching a given session right now. */
+  const guestsBySession = useMemo(() => {
+    const map = new Map<string, RelayAttachedGuest[]>();
+    for (const guest of attachedGuests) {
+      for (const sessionId of guest.sessionIds) {
+        const list = map.get(sessionId);
+        if (list) list.push(guest);
+        else map.set(sessionId, [guest]);
+      }
+    }
+    return map;
+  }, [attachedGuests]);
+
   const sessionRowProps = useCallback((session: Session, groupId: string) => ({
     session,
     isActive: session.id === activeSessionId,
@@ -864,6 +888,8 @@ const App: React.FC = () => {
       : null,
     draggable: !isSearching,
     account: effectiveAccountForSession(session.id),
+    watchingCount: guestsBySession.get(session.id)?.length ?? 0,
+    watchingNames: guestsBySession.get(session.id)?.map((g) => (g.login ? `@${g.login}` : (g.displayName ?? 'someone'))),
     isEditing: editingSessionId === session.id,
     editingName: editingSessionName,
     onEditingNameChange: setEditingSessionName,
@@ -882,8 +908,7 @@ const App: React.FC = () => {
     isSearching, effectiveAccountForSession, editingSessionId, editingSessionName,
     handleStartEditSession, handleFinishEditSession, handleSessionClick, handleSessionContextMenu,
     handleSessionDragStart, handleDragEnd, handleSessionDragOver, handleSessionDrop,
-    handleRemoveSession,
-  ]);
+    handleRemoveSession,, guestsBySession]);
 
   const getContextShortcuts = useCallback(() => {
     if (sidebarFocused) {
@@ -994,23 +1019,47 @@ const App: React.FC = () => {
   // RemoteHostingSettings because it fires when the agent connects, which is
   // usually nowhere near the Settings modal — and it must be answered before
   // the machine can be shared from.
-  const [pendingOwner, setPendingOwner] = useState<PendingOwner | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    const apply = (s: RelayStatus) => {
+      setPendingOwner(s.pendingOwner);
+      setAttachedGuests(s.attachedGuests ?? []);
+      setPendingShares(s.pendingShares ?? []);
+    };
     window.electronAPI
       .relayGetStatus()
       .then((s) => {
-        if (!cancelled) setPendingOwner(s.pendingOwner);
+        if (!cancelled) apply(s);
       })
       .catch(() => {
-        /* relay off or unavailable — nothing to confirm */
+        /* relay off or unavailable — nothing to show */
       });
-    const off = window.electronAPI.onRelayStatus((s) => setPendingOwner(s.pendingOwner));
+    const off = window.electronAPI.onRelayStatus(apply);
     return () => {
       cancelled = true;
       off();
     };
+  }, []);
+
+  const handleApproveShare = useCallback(async (grantId: string) => {
+    try {
+      const status = await window.electronAPI.relayApproveShare(grantId);
+      setPendingShares(status.pendingShares ?? []);
+    } catch {
+      // The request went away underneath us (expired, or revoked elsewhere).
+      // Drop it rather than leaving a prompt that can no longer be answered.
+      setPendingShares((prev) => prev.filter((p) => p.grantId !== grantId));
+    }
+  }, []);
+
+  const handleDenyShare = useCallback(async (grantId: string) => {
+    try {
+      const status = await window.electronAPI.relayDenyShare(grantId);
+      setPendingShares(status.pendingShares ?? []);
+    } catch {
+      setPendingShares((prev) => prev.filter((p) => p.grantId !== grantId));
+    }
   }, []);
 
   const handleConfirmOwner = useCallback(async (userId: string) => {
@@ -1466,6 +1515,20 @@ const App: React.FC = () => {
         pending={pendingOwner}
         onConfirm={handleConfirmOwner}
         onReject={handleRejectOwner}
+      />
+
+      {/* One at a time: two people asking at once is rare, and stacking
+          consent prompts invites answering the wrong one. */}
+      <GuestJoinRequestModal
+        request={pendingShares[0] ?? null}
+        onApprove={handleApproveShare}
+        onDeny={handleDenyShare}
+      />
+
+      <ShareSessionModal
+        sessionId={sharingSession?.id ?? null}
+        sessionName={sharingSession?.name ?? ''}
+        onClose={() => setSharingSession(null)}
       />
 
       {/* Name prompt modals */}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -442,6 +442,18 @@ const App: React.FC = () => {
       { label: 'Rename', onClick: () => handleStartEditSession(sessionId, sessionName) },
     ];
 
+    // Sharing is entered PER SESSION, which is the whole shape of the feature —
+    // there is no "share my machine" anywhere. Only offered while remote
+    // hosting is actually connected: an invite minted against a relay we
+    // cannot reach would fail at the point the owner is trying to be helpful.
+    if (relayReady) {
+      items.push({ label: 'separator', onClick: () => {}, separator: true });
+      items.push({
+        label: 'Share…',
+        onClick: () => setSharingSession({ id: sessionId, name: sessionName }),
+      });
+    }
+
     // Account-assignment items (BDHLNDR-31) — only shown when accounts are registered.
     if (claudeAccounts.length > 0) {
       items.push({ label: 'separator', onClick: () => {}, separator: true });
@@ -864,6 +876,8 @@ const App: React.FC = () => {
   const [pendingShares, setPendingShares] = useState<RelayPendingShare[]>([]);
   /** The session the share modal is open for, if any. */
   const [sharingSession, setSharingSession] = useState<{ id: string; name: string } | null>(null);
+  /** Whether sharing can be offered at all — linked, enabled and connected. */
+  const [relayReady, setRelayReady] = useState(false);
 
   /** Guests watching a given session right now. */
   const guestsBySession = useMemo(() => {
@@ -1026,6 +1040,7 @@ const App: React.FC = () => {
       setPendingOwner(s.pendingOwner);
       setAttachedGuests(s.attachedGuests ?? []);
       setPendingShares(s.pendingShares ?? []);
+      setRelayReady(s.enabled && s.linked && s.connected);
     };
     window.electronAPI
       .relayGetStatus()

--- a/src/renderer/components/GuestJoinRequestModal.css
+++ b/src/renderer/components/GuestJoinRequestModal.css
@@ -1,0 +1,61 @@
+/* Layered on ShareSessionModal.css, which supplies the shell and buttons. */
+
+.guest-join-modal {
+  max-width: 440px;
+}
+
+.guest-join-identity {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 14px;
+  margin-bottom: 12px;
+  background: #1e1e1e;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+}
+
+/* The handle carries the weight, because it is the part that cannot be
+   chosen to impersonate someone. */
+.guest-join-login {
+  font-family: monospace;
+  font-size: 15px;
+  font-weight: 600;
+  color: #e0e0e0;
+  overflow-wrap: anywhere;
+}
+
+.guest-join-name {
+  font-size: 12px;
+  color: #9a9a9a;
+  overflow-wrap: anywhere;
+}
+
+.guest-join-unknown {
+  font-size: 13px;
+  color: #e8c48a;
+}
+
+.guest-join-what {
+  margin: 0 0 12px 0;
+  font-size: 13px;
+  color: #d4d4d4;
+}
+
+.guest-join-note {
+  margin: 0 0 12px 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #9a9a9a;
+}
+
+.guest-join-warning {
+  margin: 0 0 12px 0;
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #e8c48a;
+  background: rgba(232, 196, 138, 0.08);
+  border-left: 2px solid #e8c48a;
+  border-radius: 2px;
+}

--- a/src/renderer/components/GuestJoinRequestModal.tsx
+++ b/src/renderer/components/GuestJoinRequestModal.tsx
@@ -1,0 +1,106 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import type { RelayPendingShare } from '../../shared/types';
+import './ShareSessionModal.css';
+import './GuestJoinRequestModal.css';
+
+/**
+ * "Let them in?" — the consent step (docs/designs/session-sharing.md §7).
+ *
+ * Shows the **immutable GitHub login**, not a display name or an avatar. A
+ * display name is free text the account holder chooses, so showing it here
+ * would let someone set it to a name the owner trusts and borrow that trust at
+ * exactly the moment it matters. The handle cannot be chosen that way.
+ *
+ * The refusing button is focused and the buttons say what they do. Not
+ * "Not now" — that reads as a snooze, and this is not one: declining ends the
+ * request, and the person has to be invited again.
+ */
+
+interface GuestJoinRequestModalProps {
+  request: RelayPendingShare | null;
+  onApprove: (grantId: string) => void;
+  onDeny: (grantId: string) => void;
+}
+
+export const GuestJoinRequestModal: React.FC<GuestJoinRequestModalProps> = ({ request, onApprove, onDeny }) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const denyRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog || !request) return;
+    if (!dialog.open) dialog.showModal();
+    denyRef.current?.focus();
+  }, [request]);
+
+  const handleCancel = useCallback(
+    (e: React.SyntheticEvent<HTMLDialogElement>) => {
+      // Escape declines rather than dismissing. Leaving the request open with
+      // the prompt gone would mean the guest waits on an answer nobody can see.
+      e.preventDefault();
+      if (request) onDeny(request.grantId);
+    },
+    [request, onDeny],
+  );
+
+  if (!request) return null;
+
+  const who = request.granteeLogin ? `@${request.granteeLogin}` : null;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="share-session-modal guest-join-modal"
+      aria-labelledby="guest-join-title"
+      aria-describedby="guest-join-body"
+      onCancel={handleCancel}
+    >
+      <h3 id="guest-join-title">Let them watch?</h3>
+
+      <div id="guest-join-body">
+        <div className="guest-join-identity">
+          {who ? (
+            <span className="guest-join-login">{who}</span>
+          ) : (
+            // No handle means the account predates login capture. Say that,
+            // rather than falling back to a name that proves nothing.
+            <span className="guest-join-unknown">an account with no GitHub handle on record</span>
+          )}
+          {request.granteeName && who && <span className="guest-join-name">{request.granteeName}</span>}
+        </div>
+
+        <p className="guest-join-what">
+          wants to watch{' '}
+          <strong>{request.sessionName ? `“${request.sessionName}”` : 'a session you shared'}</strong>.
+        </p>
+
+        <p className="guest-join-note">
+          They&apos;ll see this session&apos;s live output from the moment you let them in — not what came
+          before. They can&apos;t type, create sessions, or browse your files. You can end it at any time.
+        </p>
+
+        {!request.sessionName && (
+          <p className="guest-join-warning">
+            This machine no longer has a record of which session the invite was for. Letting them in now
+            would not know what to share — decline and send a fresh link.
+          </p>
+        )}
+      </div>
+
+      <div className="share-buttons">
+        {/* Focused: the safe answer to an unexpected request is no. */}
+        <button ref={denyRef} type="button" className="share-secondary" onClick={() => onDeny(request.grantId)}>
+          Don&apos;t let them in
+        </button>
+        <button
+          type="button"
+          className="share-primary"
+          disabled={!request.sessionName}
+          onClick={() => onApprove(request.grantId)}
+        >
+          Let them watch
+        </button>
+      </div>
+    </dialog>
+  );
+};

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -11,6 +11,17 @@ interface SessionRowProps {
   dropPosition: string | null;
   draggable: boolean;
   account: ClaudeAccount | null;
+  /**
+   * Guests watching this session right now.
+   *
+   * Presence at a glance answers "is anyone looking at this?" without the
+   * owner having to go and check — which is the whole point: silent read
+   * access to a live terminal is the same class of harm as silent write
+   * access.
+   */
+  watchingCount?: number;
+  /** Handles for the tooltip, so the badge names people rather than a number. */
+  watchingNames?: string[];
 
   isEditing: boolean;
   editingName: string;
@@ -46,6 +57,7 @@ function accountTitle(account: ClaudeAccount, session: Session): string {
  */
 export const SessionRow: React.FC<SessionRowProps> = ({
   session, isActive, isFocused, isDragging, dropPosition, draggable, account,
+  watchingCount, watchingNames,
   isEditing, editingName, onEditingNameChange, onStartEdit, onFinishEdit, onCancelEdit,
   onSelect, onContextMenu, onDragStart, onDragEnd, onDragOver, onDrop, onClose,
 }) => {
@@ -109,6 +121,21 @@ export const SessionRow: React.FC<SessionRowProps> = ({
           )}
           <span className="session-info">
             <span className="session-name">{session.name}</span>
+            {!!watchingCount && watchingCount > 0 && (
+              // A glyph AND a count: an eye alone does not say how many, and a
+              // number alone does not say what it counts.
+              <span
+                className="session-watching"
+                title={
+                  watchingNames?.length
+                    ? `Watching now: ${watchingNames.join(', ')}`
+                    : `${watchingCount} watching now`
+                }
+                aria-label={`${watchingCount} watching now`}
+              >
+                👁 {watchingCount}
+              </span>
+            )}
             <SessionStatsBadge sessionId={session.id} />
           </span>
           {showProvider && (

--- a/src/renderer/components/ShareSessionModal.css
+++ b/src/renderer/components/ShareSessionModal.css
@@ -1,0 +1,237 @@
+/* Native <dialog> + showModal(): the browser owns modality and focus trapping. */
+
+.share-session-modal {
+  max-width: 480px;
+  padding: 20px 24px;
+  background: #252526;
+  border: 1px solid #3c3c3c;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  color: #d4d4d4;
+}
+
+.share-session-modal::backdrop {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.share-session-modal h3 {
+  margin: 0 0 16px 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: #e0e0e0;
+}
+
+.share-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0 0 18px 0;
+}
+
+.share-field-label {
+  display: block;
+  padding: 0;
+  margin-bottom: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #b8b8b8;
+}
+
+.share-login-row {
+  display: flex;
+  align-items: center;
+  background: #1e1e1e;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+}
+
+.share-at {
+  padding: 0 4px 0 10px;
+  color: #777;
+  font-size: 14px;
+}
+
+.share-login {
+  flex: 1;
+  padding: 9px 10px 9px 2px;
+  background: transparent;
+  border: none;
+  color: #d4d4d4;
+  font-size: 14px;
+  outline: none;
+}
+
+.share-login:disabled {
+  color: #666;
+}
+
+.share-hint {
+  margin: 6px 0 0 0;
+  font-size: 11px;
+  color: #8a8a8a;
+}
+
+.share-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  font-size: 12px;
+  color: #b8b8b8;
+  cursor: pointer;
+}
+
+.share-radio {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 10px;
+  margin-bottom: 6px;
+  background: #1e1e1e;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+}
+
+.share-radio span {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.share-radio strong {
+  font-size: 13px;
+  color: #e0e0e0;
+  font-weight: 600;
+}
+
+.share-radio em {
+  font-style: normal;
+  font-size: 11px;
+  line-height: 1.45;
+  color: #9a9a9a;
+}
+
+.share-radio-disabled {
+  opacity: 0.55;
+}
+
+.share-ttl-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+  font-size: 12px;
+  color: #b8b8b8;
+}
+
+.share-ttl-row select {
+  padding: 5px 8px;
+  background: #1e1e1e;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+  color: #d4d4d4;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.share-ttl-row .share-hint {
+  margin: 0;
+}
+
+.share-url {
+  width: 100%;
+  padding: 9px 10px;
+  background: #1e1e1e;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+  color: #d4d4d4;
+  font-family: monospace;
+  font-size: 12px;
+  outline: none;
+}
+
+.share-code {
+  margin: 10px 0 0 0;
+  font-size: 12px;
+  color: #9a9a9a;
+}
+
+.share-code strong {
+  font-family: monospace;
+  font-size: 14px;
+  letter-spacing: 1px;
+  color: #e0e0e0;
+}
+
+/* The link is the credential. This is not decoration. */
+.share-warning {
+  margin: 14px 0 0 0;
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #e8c48a;
+  background: rgba(232, 196, 138, 0.08);
+  border-left: 2px solid #e8c48a;
+  border-radius: 2px;
+}
+
+.share-note {
+  margin: 10px 0 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #9a9a9a;
+}
+
+.share-error {
+  margin: 0 0 12px 0;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: #f48771;
+  background: rgba(244, 135, 113, 0.08);
+  border-left: 2px solid #f48771;
+  border-radius: 2px;
+}
+
+.share-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.share-buttons button {
+  padding: 7px 14px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.share-secondary {
+  background: #3a3a3a;
+  border-color: #4a4a4a !important;
+  color: #d4d4d4;
+}
+
+.share-secondary:hover {
+  background: #454545;
+}
+
+.share-primary {
+  background: #0e639c;
+  color: #ffffff;
+}
+
+.share-primary:hover:not(:disabled) {
+  background: #1177bb;
+}
+
+.share-buttons button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.share-buttons button:focus-visible {
+  outline: 2px solid #69adff;
+  outline-offset: 2px;
+}

--- a/src/renderer/components/ShareSessionModal.css
+++ b/src/renderer/components/ShareSessionModal.css
@@ -80,10 +80,14 @@
   cursor: pointer;
 }
 
+/* Grid rather than nested wrappers: the label's text has to sit shallow
+   enough for accessibility tooling to find it (S6853). */
 .share-radio {
-  display: flex;
-  gap: 10px;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 10px;
+  row-gap: 3px;
+  align-items: start;
   padding: 10px;
   margin-bottom: 6px;
   background: #1e1e1e;
@@ -91,10 +95,9 @@
   border-radius: 4px;
 }
 
-.share-radio span {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
+.share-radio input {
+  grid-row: 1 / span 2;
+  margin-top: 2px;
 }
 
 .share-radio strong {

--- a/src/renderer/components/ShareSessionModal.tsx
+++ b/src/renderer/components/ShareSessionModal.tsx
@@ -1,0 +1,243 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import './ShareSessionModal.css';
+
+/**
+ * Offer one session to one person (docs/designs/session-sharing.md §7).
+ *
+ * Entry is deliberately **per-session**, not per-machine: there is no "share
+ * my machine" anywhere in this feature, and the modal is shaped so the thing
+ * being shared is never ambiguous.
+ *
+ * Only "Watch" exists in this milestone. "Watch and type" is M5.3 and is shown
+ * as a disabled option rather than hidden, because the absence of a control is
+ * not an explanation — and someone who wants it should learn now that it is a
+ * different, heavier decision rather than discovering later that it silently
+ * appeared.
+ */
+
+const HOUR = 3600;
+
+/** Invite lifetime — how long the link works if nobody uses it. */
+const INVITE_TTL_OPTIONS = [
+  { label: '15 minutes', seconds: 15 * 60 },
+  { label: '1 hour', seconds: HOUR },
+  { label: '1 day', seconds: 24 * HOUR },
+];
+
+/** Grant lifetime — how long access lasts once they join. */
+const GRANT_TTL_OPTIONS = [
+  { label: '1 hour', seconds: HOUR },
+  { label: '4 hours', seconds: 4 * HOUR },
+  { label: '8 hours', seconds: 8 * HOUR },
+];
+
+interface ShareSessionModalProps {
+  sessionId: string | null;
+  sessionName: string;
+  onClose: () => void;
+}
+
+type Created = { code: string; url: string; expiresAt: number };
+
+export const ShareSessionModal: React.FC<ShareSessionModalProps> = ({ sessionId, sessionName, onClose }) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const loginRef = useRef<HTMLInputElement>(null);
+  const [login, setLogin] = useState('');
+  const [openLink, setOpenLink] = useState(false);
+  const [inviteTtl, setInviteTtl] = useState(HOUR);
+  const [grantTtl, setGrantTtl] = useState(4 * HOUR);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [created, setCreated] = useState<Created | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (sessionId) {
+      if (!dialog.open) dialog.showModal();
+      setLogin('');
+      setOpenLink(false);
+      setCreated(null);
+      setError(null);
+      setCopied(false);
+      setTimeout(() => loginRef.current?.focus(), 50);
+    }
+  }, [sessionId]);
+
+  const handleCancel = useCallback(
+    (e: React.SyntheticEvent<HTMLDialogElement>) => {
+      e.preventDefault();
+      onClose();
+    },
+    [onClose],
+  );
+
+  const submit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!sessionId || busy) return;
+      setBusy(true);
+      setError(null);
+      try {
+        const result = await window.electronAPI.relayCreateShare({
+          sessionId,
+          expectedGithubLogin: openLink ? null : login.trim(),
+          role: 'viewer',
+          grantTtlSeconds: grantTtl,
+          inviteTtlSeconds: inviteTtl,
+        });
+        setCreated(result);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Could not create the invite.');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [sessionId, busy, openLink, login, grantTtl, inviteTtl],
+  );
+
+  const copy = useCallback(async () => {
+    if (!created) return;
+    await navigator.clipboard.writeText(created.url);
+    setCopied(true);
+  }, [created]);
+
+  if (!sessionId) return null;
+
+  const canSubmit = openLink || login.trim().length > 0;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="share-session-modal"
+      aria-labelledby="share-session-title"
+      onCancel={handleCancel}
+    >
+      <h3 id="share-session-title">{created ? 'Send this link' : `Share “${sessionName}”`}</h3>
+
+      {created ? (
+        <div className="share-created">
+          <label className="share-field-label" htmlFor="share-url">
+            Link
+          </label>
+          <input id="share-url" className="share-url" readOnly value={created.url} onFocus={(e) => e.target.select()} />
+
+          <p className="share-code">
+            or read out the code: <strong>{created.code}</strong>
+          </p>
+
+          {/* The link IS the credential — anyone holding it who also satisfies
+              the addressing can ask to join. Say so plainly rather than
+              trusting people to infer it. */}
+          <p className="share-warning">
+            🔑 This link is the key. Send it over something private.
+          </p>
+
+          <p className="share-note">
+            {openLink
+              ? 'Anyone with this link can ask to join. You still have to let them in.'
+              : `Only @${login.trim()} can use this link. You still have to let them in.`}
+          </p>
+
+          <div className="share-buttons">
+            <button type="button" className="share-secondary" onClick={onClose}>
+              Done
+            </button>
+            <button type="button" className="share-primary" onClick={copy}>
+              {copied ? 'Copied' : 'Copy link'}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={submit}>
+          <fieldset className="share-fieldset">
+            <legend className="share-field-label">Who&apos;s it for?</legend>
+            <div className="share-login-row">
+              <span className="share-at">@</span>
+              <input
+                ref={loginRef}
+                className="share-login"
+                value={login}
+                onChange={(e) => setLogin(e.target.value)}
+                placeholder="github-username"
+                disabled={openLink}
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </div>
+            <p className="share-hint">Only this GitHub account can use the link.</p>
+            <label className="share-checkbox">
+              <input type="checkbox" checked={openLink} onChange={(e) => setOpenLink(e.target.checked)} />
+              <span>Or make an open link (anyone with it can ask)</span>
+            </label>
+          </fieldset>
+
+          <fieldset className="share-fieldset">
+            <legend className="share-field-label">What can they do?</legend>
+            <label className="share-radio">
+              <input type="radio" checked readOnly />
+              <span>
+                <strong>Watch</strong>
+                <em>They see this session&apos;s live output. They can&apos;t type.</em>
+              </span>
+            </label>
+            {/* Shown disabled rather than hidden: the absence of a control is
+                not an explanation, and this is a materially heavier decision
+                than the one above. */}
+            <label className="share-radio share-radio-disabled">
+              <input type="radio" disabled />
+              <span>
+                <strong>Watch and type</strong>
+                <em>Not available yet — it hands over your whole environment, so it needs its own consent step.</em>
+              </span>
+            </label>
+          </fieldset>
+
+          <fieldset className="share-fieldset">
+            <legend className="share-field-label">How long?</legend>
+            {/* Two clocks, stated separately, because they mean different
+                things and collapsing them into one number would be a lie. */}
+            <div className="share-ttl-row">
+              <label htmlFor="share-invite-ttl">The link works for</label>
+              <select id="share-invite-ttl" value={inviteTtl} onChange={(e) => setInviteTtl(Number(e.target.value))}>
+                {INVITE_TTL_OPTIONS.map((o) => (
+                  <option key={o.seconds} value={o.seconds}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+              <span className="share-hint">if nobody uses it</span>
+            </div>
+            <div className="share-ttl-row">
+              <label htmlFor="share-grant-ttl">Once they join, access lasts</label>
+              <select id="share-grant-ttl" value={grantTtl} onChange={(e) => setGrantTtl(Number(e.target.value))}>
+                {GRANT_TTL_OPTIONS.map((o) => (
+                  <option key={o.seconds} value={o.seconds}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+              <span className="share-hint">you can end it sooner</span>
+            </div>
+          </fieldset>
+
+          {error && (
+            <p className="share-error" role="alert">
+              {error}
+            </p>
+          )}
+
+          <div className="share-buttons">
+            <button type="button" className="share-secondary" onClick={onClose}>
+              Cancel
+            </button>
+            <button type="submit" className="share-primary" disabled={!canSubmit || busy}>
+              {busy ? 'Creating…' : 'Create link'}
+            </button>
+          </div>
+        </form>
+      )}
+    </dialog>
+  );
+};

--- a/src/renderer/components/ShareSessionModal.tsx
+++ b/src/renderer/components/ShareSessionModal.tsx
@@ -105,7 +105,11 @@ export const ShareSessionModal: React.FC<ShareSessionModalProps> = ({ sessionId,
 
   if (!sessionId) return null;
 
-  const canSubmit = openLink || login.trim().length > 0;
+  // Not `??`: these are booleans, and `??` would short-circuit on `false`
+  // rather than falling through to the handle check. Written as a branch so
+  // the intent is explicit either way.
+  const hasLogin = login.trim().length > 0;
+  const canSubmit = openLink ? true : hasLogin;
 
   return (
     <dialog
@@ -177,20 +181,16 @@ export const ShareSessionModal: React.FC<ShareSessionModalProps> = ({ sessionId,
             <legend className="share-field-label">What can they do?</legend>
             <label className="share-radio">
               <input type="radio" checked readOnly />
-              <span>
-                <strong>Watch</strong>
-                <em>They see this session&apos;s live output. They can&apos;t type.</em>
-              </span>
+              <strong>Watch</strong>
+              <em>They see this session&apos;s live output. They can&apos;t type.</em>
             </label>
             {/* Shown disabled rather than hidden: the absence of a control is
                 not an explanation, and this is a materially heavier decision
                 than the one above. */}
             <label className="share-radio share-radio-disabled">
               <input type="radio" disabled />
-              <span>
-                <strong>Watch and type</strong>
-                <em>Not available yet — it hands over your whole environment, so it needs its own consent step.</em>
-              </span>
+              <strong>Watch and type</strong>
+              <em>Not available yet — it hands over your whole environment, so it needs its own consent step.</em>
             </label>
           </fieldset>
 

--- a/src/renderer/components/__tests__/GuestJoinRequestModal.test.tsx
+++ b/src/renderer/components/__tests__/GuestJoinRequestModal.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * The consent step for letting a guest watch (session sharing §7).
+ *
+ * The tests that matter are about what the owner is shown and how easy the
+ * refusing answer is — this is the moment trust is handed over, and the
+ * failure mode is someone approving a request they misread.
+ *
+ * Run with: bun test src/renderer/components/__tests__/GuestJoinRequestModal.test.tsx
+ */
+import React from 'react';
+import { describe, expect, test, afterEach } from 'bun:test';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { GuestJoinRequestModal } from '../GuestJoinRequestModal';
+import type { RelayPendingShare } from '../../../shared/types';
+
+afterEach(cleanup);
+
+const request = (over: Partial<RelayPendingShare> = {}): RelayPendingShare => ({
+  grantId: 'grant-1',
+  role: 'viewer',
+  granteeLogin: 'dana-k',
+  granteeName: 'Dana K',
+  createdAt: Date.now(),
+  sessionId: 's1',
+  sessionName: 'Auth refactor',
+  ...over,
+});
+
+function renderModal(over: { request?: RelayPendingShare | null } = {}) {
+  const approved: string[] = [];
+  const denied: string[] = [];
+  render(
+    <GuestJoinRequestModal
+      request={over.request === undefined ? request() : over.request}
+      onApprove={(id) => approved.push(id)}
+      onDeny={(id) => denied.push(id)}
+    />,
+  );
+  return { approved, denied };
+}
+
+const dialogEl = () => document.querySelector('dialog')!;
+
+describe('what the owner is shown', () => {
+  test('renders nothing when there is no request', () => {
+    renderModal({ request: null });
+    expect(document.querySelector('dialog')).toBeNull();
+  });
+
+  test('leads with the immutable GitHub handle', () => {
+    // A display name is free text the account holder picks; showing it as the
+    // identity would let someone set it to a name the owner trusts.
+    renderModal();
+    expect(screen.getByText('@dana-k')).toBeTruthy();
+  });
+
+  test('names the session being asked for', () => {
+    renderModal();
+    expect(screen.getByText(/Auth refactor/)).toBeTruthy();
+  });
+
+  test('says plainly what the guest will and will not be able to do', () => {
+    renderModal();
+    expect(screen.getByText(/can't type/i)).toBeTruthy();
+    expect(screen.getByText(/not what came before/i)).toBeTruthy();
+  });
+
+  test('an account with no handle on record says so rather than substituting a name', () => {
+    // Falling back to a display name here would present something that proves
+    // nothing as though it were the identity.
+    renderModal({ request: request({ granteeLogin: null, granteeName: 'Totally Will' }) });
+    expect(screen.getByText(/no GitHub handle on record/i)).toBeTruthy();
+    expect(screen.queryByText('Totally Will')).toBeNull();
+  });
+});
+
+describe('answering', () => {
+  test('approving reports the grant id', () => {
+    const h = renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /let them watch/i }));
+    expect(h.approved).toEqual(['grant-1']);
+  });
+
+  test('declining reports the grant id', () => {
+    const h = renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /don't let them in/i }));
+    expect(h.denied).toEqual(['grant-1']);
+  });
+
+  test('nothing is approved merely by rendering', () => {
+    const h = renderModal();
+    expect(h.approved).toEqual([]);
+    expect(h.denied).toEqual([]);
+  });
+
+  test('Escape declines rather than dismissing', () => {
+    // Dismissing would leave the guest waiting on an answer nobody can see.
+    const h = renderModal();
+    fireEvent(dialogEl(), new Event('cancel', { bubbles: false, cancelable: true }));
+    expect(h.denied).toEqual(['grant-1']);
+    expect(h.approved).toEqual([]);
+  });
+
+  test('there are exactly two ways out, and neither is a snooze', () => {
+    // Not "Not now" — that reads as deferral, and declining is not one.
+    renderModal();
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(2);
+    expect(screen.queryByRole('button', { name: /not now|later|remind/i })).toBeNull();
+  });
+});
+
+describe('a request this machine can no longer honour', () => {
+  test('approving is disabled when the session is unknown', () => {
+    // The invite's session mapping lives only on this desktop. Without it,
+    // approving would not know what to share.
+    renderModal({ request: request({ sessionName: null, sessionId: null }) });
+    expect(screen.getByRole('button', { name: /let them watch/i }).hasAttribute('disabled')).toBe(true);
+    expect(screen.getByText(/no longer has a record/i)).toBeTruthy();
+  });
+
+  test('declining still works in that state', () => {
+    const h = renderModal({ request: request({ sessionName: null, sessionId: null }) });
+    fireEvent.click(screen.getByRole('button', { name: /don't let them in/i }));
+    expect(h.denied).toEqual(['grant-1']);
+  });
+});

--- a/src/renderer/components/__tests__/ShareSessionModal.test.tsx
+++ b/src/renderer/components/__tests__/ShareSessionModal.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * The owner's "offer a share" flow (session sharing §7).
+ *
+ * Raised in review on #161: this is the primary entry point for minting a
+ * share, so the branch that decides whether an invite is ADDRESSED or OPEN is
+ * the one that most needs pinning — getting it backwards would turn a link
+ * meant for one person into one anybody can use.
+ *
+ * Run with: bun test src/renderer/components/__tests__/ShareSessionModal.test.tsx
+ */
+import React from 'react';
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { ShareSessionModal } from '../ShareSessionModal';
+
+type CreateInput = {
+  sessionId: string;
+  expectedGithubLogin: string | null;
+  role: string;
+  grantTtlSeconds: number;
+  inviteTtlSeconds: number;
+};
+
+let calls: CreateInput[] = [];
+let nextResult: { code: string; url: string; expiresAt: number } | Error = {
+  code: 'K7Q2-9F3D',
+  url: 'https://relay.example.com/i/K7Q2-9F3D#fp=SHA256%3Aabc',
+  expiresAt: Date.now() + 3_600_000,
+};
+
+beforeEach(() => {
+  calls = [];
+  nextResult = {
+    code: 'K7Q2-9F3D',
+    url: 'https://relay.example.com/i/K7Q2-9F3D#fp=SHA256%3Aabc',
+    expiresAt: Date.now() + 3_600_000,
+  };
+  (globalThis as unknown as { window: Record<string, unknown> }).window ??= {};
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    relayCreateShare: (input: CreateInput) => {
+      calls.push(input);
+      return nextResult instanceof Error ? Promise.reject(nextResult) : Promise.resolve(nextResult);
+    },
+  };
+});
+
+afterEach(cleanup);
+
+function renderModal(sessionId: string | null = 's1') {
+  let closed = 0;
+  render(<ShareSessionModal sessionId={sessionId} sessionName="Auth refactor" onClose={() => (closed += 1)} />);
+  return { closes: () => closed };
+}
+
+const loginInput = () => screen.getByPlaceholderText('github-username') as HTMLInputElement;
+const createBtn = () => screen.getByRole('button', { name: /create link/i });
+
+describe('rendering', () => {
+  test('renders nothing without a session', () => {
+    renderModal(null);
+    expect(document.querySelector('dialog')).toBeNull();
+  });
+
+  test('names the session being shared, so what is on offer is never ambiguous', () => {
+    renderModal();
+    expect(screen.getByText(/Auth refactor/)).toBeTruthy();
+  });
+
+  test('states both clocks separately', () => {
+    // They mean different things — link lifetime vs access lifetime — and
+    // collapsing them into one number would be a lie.
+    renderModal();
+    expect(screen.getByText(/The link works for/i)).toBeTruthy();
+    expect(screen.getByText(/Once they join, access lasts/i)).toBeTruthy();
+  });
+
+  test('offers watch-and-type as disabled rather than hiding it', () => {
+    // The absence of a control is not an explanation.
+    renderModal();
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios).toHaveLength(2);
+    expect(radios[1]!.disabled).toBe(true);
+    expect(screen.getByText(/Not available yet/i)).toBeTruthy();
+  });
+
+  test('both role options carry accessible text', () => {
+    // They were once nested too deeply for a11y tooling to find, which meant
+    // the options had no accessible name at all on a consent screen.
+    expect(screen.queryByText('Watch')).toBeNull();
+    renderModal();
+    expect(screen.getByText('Watch')).toBeTruthy();
+    expect(screen.getByText('Watch and type')).toBeTruthy();
+  });
+});
+
+describe('addressed vs open — the branch that matters', () => {
+  test('cannot submit an addressed invite with no handle', () => {
+    // Submitting blank would silently create an open link.
+    renderModal();
+    expect((createBtn() as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('a typed handle is sent as the addressing', async () => {
+    renderModal();
+    fireEvent.change(loginInput(), { target: { value: '  Dana-K  ' } });
+    fireEvent.click(createBtn());
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0]!.expectedGithubLogin).toBe('Dana-K');
+    expect(calls[0]!.role).toBe('viewer');
+  });
+
+  test('the open-link toggle sends null, not an empty string', () => {
+    // An empty string is not "no addressing" — it must be an explicit null or
+    // the relay would try to match a handle nobody has.
+    renderModal();
+    fireEvent.change(loginInput(), { target: { value: 'dana-k' } });
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect((createBtn() as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(createBtn());
+    return waitFor(() => {
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.expectedGithubLogin).toBeNull();
+    });
+  });
+
+  test('the open-link toggle disables the handle field', () => {
+    renderModal();
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(loginInput().disabled).toBe(true);
+  });
+
+  test('only viewer is ever requested in this milestone', async () => {
+    renderModal();
+    fireEvent.change(loginInput(), { target: { value: 'dana-k' } });
+    fireEvent.click(createBtn());
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0]!.role).toBe('viewer');
+  });
+});
+
+describe('the created state', () => {
+  async function create(open = false) {
+    renderModal();
+    if (open) fireEvent.click(screen.getByRole('checkbox'));
+    else fireEvent.change(loginInput(), { target: { value: 'dana-k' } });
+    fireEvent.click(createBtn());
+    await waitFor(() => expect(screen.queryByText(/Send this link/i)).not.toBeNull());
+  }
+
+  test('shows the link and says it is the credential', async () => {
+    // Anyone holding it who also satisfies the addressing can ask to join.
+    await create();
+    expect(screen.getByText(/This link is the key/i)).toBeTruthy();
+    expect((screen.getByLabelText('Link') as HTMLInputElement).value).toContain('/i/K7Q2-9F3D');
+  });
+
+  test('shows the readable code for reading aloud', async () => {
+    await create();
+    expect(screen.getByText('K7Q2-9F3D')).toBeTruthy();
+  });
+
+  test('an addressed link says who it is for, and that approval is still needed', async () => {
+    await create();
+    expect(screen.getByText(/Only @dana-k can use this link/i)).toBeTruthy();
+    expect(screen.getByText(/still have to let them in/i)).toBeTruthy();
+  });
+
+  test('an open link says anyone can ask, and that approval is still needed', async () => {
+    await create(true);
+    expect(screen.getByText(/Anyone with this link can ask/i)).toBeTruthy();
+    expect(screen.getByText(/still have to let them in/i)).toBeTruthy();
+  });
+});
+
+describe('failure', () => {
+  test('surfaces the error and does not pretend a link was created', async () => {
+    nextResult = new Error('relay rejected the share request (401)');
+    renderModal();
+    fireEvent.change(loginInput(), { target: { value: 'dana-k' } });
+    fireEvent.click(createBtn());
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeNull());
+    expect(screen.getByRole('alert').textContent).toContain('401');
+    expect(screen.queryByText(/Send this link/i)).toBeNull();
+  });
+
+  test('stays submittable after a failure so it can be retried', async () => {
+    nextResult = new Error('nope');
+    renderModal();
+    fireEvent.change(loginInput(), { target: { value: 'dana-k' } });
+    fireEvent.click(createBtn());
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeNull());
+    expect((createBtn() as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus } from '../shared/types';
+import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -106,6 +106,17 @@ interface ElectronAPI {
   relayGetPendingOwner: () => Promise<RelayStatus['pendingOwner']>;
   relayConfirmOwner: (userId: string) => Promise<RelayStatus>;
   relayRejectOwner: () => Promise<RelayStatus>;
+  relayCreateShare: (input: {
+    sessionId: string;
+    expectedGithubLogin: string | null;
+    role: 'viewer' | 'operator';
+    grantTtlSeconds: number;
+    inviteTtlSeconds: number;
+  }) => Promise<{ code: string; url: string; expiresAt: number }>;
+  relayApproveShare: (grantId: string, sessionIds?: string[]) => Promise<RelayStatus>;
+  relayDenyShare: (grantId: string) => Promise<RelayStatus>;
+  relayRevokeShare: (grantId: string) => Promise<RelayStatus>;
+  relayListShares: () => Promise<RelayShare[]>;
   onRelayStatus: (callback: (status: RelayStatus) => void) => () => void;
 
   // Sound notifications

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -2035,3 +2035,19 @@ body {
   font-size: 11px;
   color: #9fc3f0;
 }
+
+/* Presence: someone is watching this session right now (session sharing §7).
+   Glyph AND count — an eye alone doesn't say how many, a number alone doesn't
+   say what it counts. */
+.session-watching {
+  flex-shrink: 0;
+  margin-left: 6px;
+  padding: 1px 5px;
+  border-radius: 8px;
+  font-size: 10px;
+  line-height: 1.5;
+  color: #9fd0ff;
+  background: rgba(105, 173, 255, 0.14);
+  border: 1px solid rgba(105, 173, 255, 0.3);
+  white-space: nowrap;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -137,6 +137,50 @@ export interface RelayStatus {
   ownerUserId: string | null;
   /** An owner the relay asserted that is still waiting on a human decision. */
   pendingOwner: { userId: string; displayName: string | null; email: string | null; isChange: boolean } | null;
+  /**
+   * Guests attached right now, and what each is watching.
+   *
+   * Presence is a hard requirement of session sharing: silent read access to a
+   * live terminal is the same class of harm as silent write access.
+   */
+  attachedGuests: RelayAttachedGuest[];
+  /** Share requests waiting on this machine's owner to answer. */
+  pendingShares: RelayPendingShare[];
+}
+
+export interface RelayAttachedGuest {
+  clientId: string;
+  grantId: string | null;
+  role: string;
+  login: string | null;
+  displayName: string | null;
+  /** Sessions they are watching right now, not merely entitled to. */
+  sessionIds: string[];
+}
+
+/** An active or revoked share, as the owner's settings list shows it. */
+export interface RelayShare {
+  grantId: string;
+  role: string;
+  status: 'pending' | 'active' | 'revoked';
+  granteeLogin: string | null;
+  createdAt: number;
+  expiresAt: number | null;
+  /** True while a revocation is queued for a relay we could not reach. */
+  revokePending: boolean;
+  sessionIds: string[];
+}
+
+export interface RelayPendingShare {
+  grantId: string;
+  role: string;
+  /** The immutable handle. Shown instead of a display name, which is free text. */
+  granteeLogin: string | null;
+  granteeName: string | null;
+  createdAt: number;
+  /** The session the invite was offered for, if this machine still knows it. */
+  sessionId: string | null;
+  sessionName: string | null;
 }
 
 /** Result of probing one provider CLI's availability (#97). */


### PR DESCRIPTION
Closes #160

M5.2 of `docs/designs/session-sharing.md` — the first milestone where a guest can actually connect. Everything before this was machinery with no reachable guest; this makes one real.

Seven commits, each a reviewable slice in dependency order: invite lifecycle → HTTP → WebSocket → minting → owner UI → presence → guest surfaces.

Both hard gates are satisfied. **M5.2 must not ship without M5.0 and M5.1** — both merged and deployed to bodhi-dev (`user_version` 2). **M5.2 must not ship without attach/detach presence** — built in from the start rather than bolted on, see below.

## The shape of it

A guest redeems into a **pending** grant with no certificate. Redeeming is *asking*, not entering: `getMachineAccess` ignores it until the owner's agent countersigns, and a test asserts a freshly-redeemed guest still gets `relation: 'none'`. The owner gets an OS notification, approves, the desktop mints a certificate over the sessions it chose, the relay binds it, and only then is the guest reachable.

## Things worth reviewing closely

**`003_github_login.sql` is a new migration, not an edit to 002.** `runMigrations` skips any file whose version isn't greater than the current `user_version`, so now that bodhi-dev is at 2, editing 002 would have been a silent no-op on every existing database — working perfectly in tests and doing nothing in production. The column is nullable with no backfill, which makes "NULL login" a real state, and `redeemShareInvite` explicitly refuses to let a NULL satisfy an addressed invite. A NULL must never read as "matches anything".

**Invite creation is Ed25519-signed, not cookie-authenticated.** Only the machine can countersign a grant, so only the machine may offer one — a stolen relay session cookie cannot mint invites. The addressed login is inside the signed bytes, so the relay cannot downgrade an addressed invite into an open link in transit.

**The relay never authors the invite URL.** It returns the code and nothing else; the desktop composes `origin + code + #fp`. If the relay authored it, it could put its own fingerprint in the fragment and serve the matching key, so the guest's three-way check would agree perfectly and manufacture a false "verified". A test greps the whole create response for `http` and `#fp`.

**Which session an invite was for lives only on the desktop.** No session id ever reaches the relay — that's what keeps guests structurally invisible to it. `pty_epoch` is captured at invite time *and* re-captured at approval, so the grant is for the terminal the owner actually meant; `sessions.id` survives stop/restart into something else entirely.

**Reconciliation is not a merge.** Local status is the authority on revocation. On every connect the desktop takes the relay's pending list (only it can know those), flushes revocations queued while offline, then asserts its own live set — anything else the relay holds for that machine is a ghost from a restore or a revocation it never heard. `share:sync` deliberately does **not** echo the certificate back: the agent signed it, and sending it back would put a credential on a wire with no need to carry one.

**Presence reports what guests are *watching*, not what they're entitled to watch.** "dana-k is here" and "dana-k is looking at this terminal right now" are different claims and only the second is useful. Attach, detach, subscribe, unsubscribe and revoke all push an update — detach is as load-bearing as attach, since an owner who never sees someone leave can't tell watching from watched-once.

## UX decisions that are security decisions

**The approval prompt leads with the immutable GitHub handle**, never a display name. A display name is free text the account holder chooses, so showing it *as the identity* would let someone set it to a name the owner trusts and borrow that trust at exactly the moment it matters. An account with no handle on record says so rather than substituting a name that proves nothing — there's a test asserting the display name isn't rendered in that case.

**"Watch and type" is shown disabled, not hidden.** The absence of a control is not an explanation, and someone who wants it should learn now that it's a heavier decision rather than discover later that it silently appeared.

**Approving is disabled when this machine no longer knows which session an invite was for**, because approving blind wouldn't know what to share.

**Both modals focus the refusing button and route Escape to refusal**, not dismissal. Exactly two ways out, and neither is "Not now" — that reads as a snooze, and declining isn't one.

**An unsealed denial is only ever trusted to mean "you didn't get in"**, never to explain why; nothing has authenticated it at that point. Only a sealed one drives the reason-specific ending copy (`revoked` / `expired` / `session_ended` / `machine_unlinked`). Telling a guest "Will revoked your access" when Will merely closed a terminal is false and socially loaded.

**Guests never send `terminal:resize`** — a phone must not reflow somebody else's terminal, and the owner would watch their session jump with no idea why. `scaleTerm()` is also skipped for them: it CSS-downscales rather than reflows, so a 164-column session would shrink to unreadable with no way for the guest to fix it. They get true cell size, two-axis panning, and a banner naming whose screen it's sized for. **The design's escape hatch — cutting phone guests from M5.2 — was not needed.**

**The `#fp` fragment does not survive OAuth**, so the full location is stashed in `sessionStorage` before the redirect. Otherwise the guest returns unable to check provenance, and we'd be left either lying about verification or nagging.

**The empty state is split in two.** Telling someone who was invited to a session to go generate a link code in a desktop app they don't have is advice for a different person. Their invite action posts to `/api/shares/redeem`, never `/link/claim` — which would attempt an ownership transfer.

## A bug I introduced and caught

My first cut of `approveGrant` read `pending.expiresAt` for the TTL. That's NULL until the agent countersigns — the exact moment `approveGrant` runs — so every approved grant would have lasted the 60-second floor. The invite's TTL now travels with the grant.

## Testing

- Desktop: **693 pass, 0 fail** (3504 assertions, 49 files)
- Relay: **150 pass, 0 fail** (2381 assertions, 7 files)
- Four typechecks clean; `bun run build:web` bundles

New coverage: the full invite lifecycle including every refusal reason, the `share:*` verbs each scoped to the sender's own machine (three separate tests, because they're three code paths and a shared assumption is what rots), the HTTP authorization boundaries, and the approval modal.

**Where coverage is thin, stated plainly:** the guest web surfaces have no automated tests. `relay/web` has only `reconnect.test.ts` and the new code is DOM-heavy render functions; the logic that matters — certificate handling and the sealed/unsealed denial trust boundary — lives in `connection.ts`, but the render paths would need a harness that doesn't exist. I'd rather say so than imply the coverage is uniform.

## For the reviewer

**`relay/` is still not Sonar-scanned** (`sonar.sources=src`), so the migration, the six new routes and the `share:*` handlers get no automated gate at all. Human review is the only one.

**Deploying carries a migration** — `user_version` 2 → 3 — so the relay needs a rebuild-and-recreate with a volume snapshot first, not a restart.

**This is the first milestone a human can exercise end to end.** Suggested order once merged: cut a beta, redeploy the relay, then try it with a real second GitHub account before anything goes near production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
