### PR TITLE
fix(sharing): a refused command is not a revoked session

### DIFF
--- a/relay/web/src/connection.test.ts
+++ b/relay/web/src/connection.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Frame routing in `RelayConnection` — the logic that caused a production
+ * incident on beta.4.
+ *
+ * A guest sent one command their role does not allow, the agent replied with a
+ * `denied` frame, and this class reported it as the session ending — so the
+ * UI told them the owner had revoked their access. Nothing here was tested,
+ * which is why it took a human hitting it to find.
+ *
+ * These drive the REAL `handle()` through a real handshake and real sealed
+ * frames rather than testing an extracted helper: the bug was not in a
+ * predicate, it was in which branch the frame reached.
+ *
+ * Run with: bun test relay/web/src/connection.test.ts
+ */
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { RelayConnection, isEndingReason, ENDING_REASONS, type ConnState } from './connection';
+
+const subtle = crypto.subtle;
+const enc = (s: string) => new TextEncoder().encode(s);
+const algo = (a: Record<string, unknown>) => a as unknown as AlgorithmIdentifier;
+
+function toB64(u: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < u.length; i++) s += String.fromCharCode(u[i]!);
+  return btoa(s);
+}
+function fromB64(s: string): Uint8Array {
+  const bin = atob(s);
+  const u = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) u[i] = bin.charCodeAt(i);
+  return u;
+}
+function ab(u: Uint8Array): ArrayBuffer {
+  const b = new ArrayBuffer(u.byteLength);
+  new Uint8Array(b).set(u);
+  return b;
+}
+
+/** A stand-in for the browser WebSocket the connection opens. */
+class FakeSocket {
+  static last: FakeSocket | null = null;
+  // `send()` guards on `readyState === WebSocket.OPEN`, so a fake without this
+  // constant silently drops every outbound frame — the fake has to match the
+  // real API surface the code under test actually reads.
+  static readonly OPEN = 1;
+  readonly sent: unknown[] = [];
+  readyState = 1;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor() {
+    FakeSocket.last = this;
+  }
+  send(raw: string) {
+    this.sent.push(JSON.parse(raw));
+  }
+  close() {
+    this.readyState = 3;
+  }
+  /** Deliver a frame from the "agent", via the relay's envelope. */
+  deliver(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify({ type: 'from-agent', payload }) });
+  }
+}
+
+const g = globalThis as unknown as { WebSocket: unknown; location?: unknown };
+const OriginalWebSocket = g.WebSocket;
+const hadLocation = 'location' in g;
+
+beforeEach(() => {
+  FakeSocket.last = null;
+  g.WebSocket = FakeSocket;
+  // The relay tree has no DOM globals; `connect()` builds its URL from
+  // `location`, so supply just the two fields it reads.
+  if (!hadLocation) g.location = { protocol: 'https:', host: 'relay.test' };
+});
+afterEach(() => {
+  g.WebSocket = OriginalWebSocket;
+  if (!hadLocation) delete g.location;
+});
+
+interface Session {
+  socket: FakeSocket;
+  states: { state: ConnState; detail?: string }[];
+  messages: { type: string }[];
+  refusals: string[];
+  /** Seal a frame the way the agent would, on the shared session key. */
+  seal(counter: number, value: unknown): Promise<{ n: number; ct: string }>;
+}
+
+/**
+ * Open a connection and complete a genuine handshake, so everything after it
+ * runs through the real decrypt path rather than a stub.
+ */
+async function connected(): Promise<Session> {
+  // The "machine" identity, and the per-channel key it would mint.
+  const ed = (await subtle.generateKey(algo({ name: 'Ed25519' }), true, ['sign', 'verify'])) as CryptoKeyPair;
+  const edPubB64 = toB64(new Uint8Array(await subtle.exportKey('raw', ed.publicKey)));
+  const agentX = (await subtle.generateKey(algo({ name: 'X25519' }), true, ['deriveBits'])) as CryptoKeyPair;
+  const agentXPubB64 = toB64(new Uint8Array(await subtle.exportKey('raw', agentX.publicKey)));
+
+  const states: { state: ConnState; detail?: string }[] = [];
+  const messages: { type: string }[] = [];
+  const refusals: string[] = [];
+
+  const conn = new RelayConnection('machine-1', edPubB64, 'grant:v1.aa.bb');
+  conn.onState = (state, detail) => states.push({ state, detail });
+  conn.onMessage = (m) => messages.push(m as { type: string });
+  conn.onCommandDenied = (command) => refusals.push(command);
+  conn.connect();
+
+  const socket = FakeSocket.last!;
+  await socket.onopen!();
+
+  const open = socket.sent.find((m) => (m as { type: string }).type === 'client:open') as {
+    payload: { clientX25519Pub: string; certificate?: string };
+  };
+  const clientPubB64 = open.payload.clientX25519Pub;
+
+  // Sign the proof exactly as the agent does.
+  const msg = enc(`e2e-handshake:v1\n${clientPubB64}\n${agentXPubB64}`);
+  const sig = new Uint8Array(await subtle.sign(algo({ name: 'Ed25519' }), ed.privateKey, ab(msg)));
+
+  socket.deliver({
+    type: 'handshake',
+    ed25519Pub: edPubB64,
+    agentX25519Pub: agentXPubB64,
+    signature: toB64(sig),
+  });
+  // Let the async handshake settle.
+  await Bun.sleep(20);
+
+  // Mirror the client's key derivation from the agent side.
+  const clientPub = await subtle.importKey('raw', ab(fromB64(clientPubB64)), algo({ name: 'X25519' }), false, []);
+  const shared = new Uint8Array(
+    await subtle.deriveBits(algo({ name: 'X25519', public: clientPub }), agentX.privateKey, 256),
+  );
+  const hk = await subtle.importKey('raw', ab(shared), 'HKDF', false, ['deriveBits']);
+  const bits = await subtle.deriveBits(
+    algo({
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: ab(enc('bodhilander-relay-salt:v1')),
+      info: ab(enc('bodhilander-relay-e2e:v1')),
+    }),
+    hk,
+    256,
+  );
+  const key = await subtle.importKey('raw', bits, 'AES-GCM', false, ['encrypt', 'decrypt']);
+
+  const nonce = (counter: number) => {
+    const n = new Uint8Array(12);
+    new DataView(n.buffer).setBigUint64(4, BigInt(counter));
+    return n;
+  };
+  const seal = async (counter: number, value: unknown) => ({
+    n: counter,
+    ct: toB64(
+      new Uint8Array(
+        await subtle.encrypt({ name: 'AES-GCM', iv: ab(nonce(counter)) }, key, ab(enc(JSON.stringify(value)))),
+      ),
+    ),
+  });
+
+  return { socket, states, messages, refusals, seal };
+}
+
+describe('the handshake still works', () => {
+  test('a verified proof reaches ready and carries the certificate', async () => {
+    const s = await connected();
+    expect(s.states.map((x) => x.state)).toContain('ready');
+    const open = s.socket.sent.find((m) => (m as { type: string }).type === 'client:open') as {
+      payload: { certificate?: string };
+    };
+    expect(open.payload.certificate).toBe('grant:v1.aa.bb');
+  });
+});
+
+describe('a refused command must not end the session', () => {
+  test('command:denied routes to onCommandDenied, never to a state change', async () => {
+    const s = await connected();
+    const before = s.states.length;
+
+    s.socket.deliver(await s.seal(0, { type: 'command:denied', reason: 'not_permitted', command: 'terminal:input' }));
+    await Bun.sleep(20);
+
+    expect(s.refusals).toEqual(['terminal:input']);
+    // No new state at all — the session is untouched.
+    expect(s.states.length).toBe(before);
+  });
+
+  test('a LEGACY denied/not_permitted is treated as a refusal, not an ending', async () => {
+    // This is the exact frame that caused the incident. Agents update on their
+    // own schedule, so the client has to keep handling it correctly long after
+    // the agent stopped sending it.
+    const s = await connected();
+    const before = s.states.length;
+
+    s.socket.deliver(await s.seal(0, { type: 'denied', reason: 'not_permitted', command: 'terminal:resize' }));
+    await Bun.sleep(20);
+
+    expect(s.refusals).toEqual(['terminal:resize']);
+    expect(s.states.length).toBe(before);
+    expect(s.states.some((x) => x.state === 'denied')).toBe(false);
+  });
+
+  test('the connection keeps delivering messages after a refusal', async () => {
+    const s = await connected();
+    s.socket.deliver(await s.seal(0, { type: 'command:denied', command: 'terminal:input' }));
+    s.socket.deliver(await s.seal(1, { type: 'sessions', sessions: [] }));
+    await Bun.sleep(20);
+
+    expect(s.messages.map((m) => m.type)).toEqual(['sessions']);
+  });
+});
+
+describe('losing access still ends the session', () => {
+  test.each([...ENDING_REASONS])('reason %s ends it, with that reason preserved', async (reason) => {
+    const s = await connected();
+    s.socket.deliver(await s.seal(0, { type: 'denied', reason }));
+    await Bun.sleep(20);
+
+    const denied = s.states.filter((x) => x.state === 'denied');
+    expect(denied).toHaveLength(1);
+    // The reason must survive: it is what selects the copy the guest reads.
+    expect(denied[0]!.detail).toBe(reason);
+    expect(s.refusals).toEqual([]);
+  });
+
+  test('a denied with NO reason ends the session rather than being swallowed', async () => {
+    // Failing the other way would leave a guest watching a channel that is
+    // already closed — silence is the worse error.
+    const s = await connected();
+    s.socket.deliver(await s.seal(0, { type: 'denied' }));
+    await Bun.sleep(20);
+
+    expect(s.states.some((x) => x.state === 'denied')).toBe(true);
+    expect(s.refusals).toEqual([]);
+  });
+
+  test('an UNSEALED denied before any key means only "not authorized"', async () => {
+    // Nothing has authenticated it at that point, so it may say you did not
+    // get in — never why.
+    const states: { state: ConnState; detail?: string }[] = [];
+    const conn = new RelayConnection('machine-1', 'AAAA', null);
+    conn.onState = (state, detail) => states.push({ state, detail });
+    conn.connect();
+    const socket = FakeSocket.last!;
+    await socket.onopen!();
+
+    socket.deliver({ type: 'denied', reason: 'revoked' });
+    await Bun.sleep(20);
+
+    const denied = states.find((x) => x.state === 'denied');
+    expect(denied?.detail).toBe('not_authorized');
+  });
+});
+
+describe('isEndingReason', () => {
+  test('accepts every reason that ends access', () => {
+    for (const r of ENDING_REASONS) expect(isEndingReason(r)).toBe(true);
+  });
+
+  test('rejects a command refusal and anything unknown', () => {
+    expect(isEndingReason('not_permitted')).toBe(false);
+    expect(isEndingReason('')).toBe(false);
+    expect(isEndingReason('something_new')).toBe(false);
+  });
+});

--- a/relay/web/src/connection.ts
+++ b/relay/web/src/connection.ts
@@ -22,16 +22,20 @@ export type ConnState = 'connecting' | 'handshaking' | 'ready' | 'offline' | 'cl
  * tells people false stories — "Will revoked your access" when Will merely
  * closed a terminal is socially loaded and untrue.
  */
-export type DeniedReason = 'not_authorized' | 'revoked' | 'expired' | 'session_ended' | 'machine_unlinked';
-
 /**
  * The reasons that actually END access. Anything else on a `denied` frame is a
  * refusal of one command, which must not be presented as losing access.
+ *
+ * The union is derived from this array rather than written twice, so the two
+ * cannot drift — a reason added to one and not the other is the shape of the
+ * bug this whole file is fixing.
  */
-const ENDING_REASONS: readonly string[] = ['not_authorized', 'revoked', 'expired', 'session_ended', 'machine_unlinked'];
+export const ENDING_REASONS = ['not_authorized', 'revoked', 'expired', 'session_ended', 'machine_unlinked'] as const;
+
+export type DeniedReason = (typeof ENDING_REASONS)[number];
 
 export function isEndingReason(reason: string): reason is DeniedReason {
-  return ENDING_REASONS.includes(reason);
+  return (ENDING_REASONS as readonly string[]).includes(reason);
 }
 export interface Inner {
   type: string;
@@ -172,9 +176,15 @@ export class RelayConnection {
         return;
       }
       if (inner.type === 'denied') {
-        const reason = typeof inner.reason === 'string' ? inner.reason : '';
-        if (isEndingReason(reason)) {
-          this.onState('denied', reason);
+        // A `denied` with NO reason ends the session. Failing the other way
+        // would swallow a genuine access-ended notice from any sender that
+        // omits the field — silence is the worse error here, because the
+        // guest would sit watching a channel that is already closed.
+        // A reason that is present but not an ending one is a command
+        // refusal, which is the legacy frame this fix exists for.
+        const reason = typeof inner.reason === 'string' ? inner.reason : null;
+        if (reason === null || isEndingReason(reason)) {
+          this.onState('denied', reason ?? 'revoked');
         } else {
           this.onCommandDenied(typeof inner.command === 'string' ? inner.command : '');
         }

--- a/relay/web/src/connection.ts
+++ b/relay/web/src/connection.ts
@@ -23,6 +23,16 @@ export type ConnState = 'connecting' | 'handshaking' | 'ready' | 'offline' | 'cl
  * closed a terminal is socially loaded and untrue.
  */
 export type DeniedReason = 'not_authorized' | 'revoked' | 'expired' | 'session_ended' | 'machine_unlinked';
+
+/**
+ * The reasons that actually END access. Anything else on a `denied` frame is a
+ * refusal of one command, which must not be presented as losing access.
+ */
+const ENDING_REASONS: readonly string[] = ['not_authorized', 'revoked', 'expired', 'session_ended', 'machine_unlinked'];
+
+export function isEndingReason(reason: string): reason is DeniedReason {
+  return ENDING_REASONS.includes(reason);
+}
 export interface Inner {
   type: string;
   [k: string]: unknown;
@@ -50,6 +60,8 @@ export class RelayConnection {
   onState: (s: ConnState, detail?: string) => void = () => {};
   onMessage: (m: Inner) => void = () => {};
   onFingerprint: (fp: string, verified: boolean) => void = () => {};
+  /** One command was refused. Not an ended session — see `handle`. */
+  onCommandDenied: (command: string) => void = () => {};
 
   constructor(
     private readonly machineId: string,
@@ -148,8 +160,24 @@ export class RelayConnection {
       this.recvCounter = frame.n;
       // A SEALED refusal is trustworthy: only the machine could have written
       // it, so its reason can safely drive what the guest is told.
+      //
+      // But ONLY an access-ended reason ends the session. A refused single
+      // command is not an ended session, and treating every `denied` as
+      // terminal told people the owner had revoked them when they had merely
+      // sent one command their role does not allow. The reason is checked
+      // against the known ending set rather than trusted blindly, which also
+      // covers agents still sending the old shared frame type.
+      if (inner.type === 'command:denied') {
+        this.onCommandDenied(typeof inner.command === 'string' ? inner.command : '');
+        return;
+      }
       if (inner.type === 'denied') {
-        this.onState('denied', typeof inner.reason === 'string' ? inner.reason : 'revoked');
+        const reason = typeof inner.reason === 'string' ? inner.reason : '';
+        if (isEndingReason(reason)) {
+          this.onState('denied', reason);
+        } else {
+          this.onCommandDenied(typeof inner.command === 'string' ? inner.command : '');
+        }
         return;
       }
       this.onMessage(inner);

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -381,6 +381,11 @@ function connect() {
   conn.onFingerprint = (fp, ok) => { app.fp = fp; app.fpVerified = ok; };
   conn.onState = (s: ConnState, detail?: string) => onConnState(s, detail);
   conn.onMessage = (m) => onAgentMessage(m);
+  // A refused command is a fact about that command, not about your access.
+  conn.onCommandDenied = (command) => {
+    // eslint-disable-next-line no-console
+    console.warn('[relay] command refused by the machine:', command || '(unknown)');
+  };
   conn.connect();
 }
 
@@ -415,7 +420,15 @@ const ENDED_COPY: Record<string, { icon: string; title: string; body: string }> 
 };
 
 function renderEnded(reason: string): void {
-  const copy = ENDED_COPY[reason] ?? ENDED_COPY.revoked!;
+  // Fall back to a statement of fact, NOT to "they revoked you". Guessing a
+  // cause we do not know puts a false and socially loaded story in front of
+  // someone — the exact failure this enum exists to prevent.
+  const copy =
+    ENDED_COPY[reason] ?? {
+      icon: '🔌',
+      title: 'This session ended',
+      body: "The connection to that machine closed. Ask whoever shared it if you still need access.",
+    };
   stopPolling();
   reconnector.cancel();
   app.conn?.close();

--- a/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
+++ b/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
@@ -287,7 +287,7 @@ describe('the capability gate is consulted by dispatch', () => {
     const refused = ['terminal:input', 'terminal:resize', 'session:create', 'group:create', 'dirs:list'];
     refused.forEach((type, i) => h.send('c1', key, i, { type, sessionId: 's1', data: 'x', name: 'n', groupId: 'g1' }));
 
-    const denials = h.opened('c1', key).filter((m) => m.type === 'denied');
+    const denials = h.opened('c1', key).filter((m) => m.type === 'command:denied');
     expect(denials.map((d) => d.command).sort()).toEqual([...refused].sort());
   });
 
@@ -310,7 +310,7 @@ describe('the capability gate is consulted by dispatch', () => {
     Object.keys(COMMAND_CAPS).forEach((type, i) =>
       h.send('c1', key, i, { type, sessionId: 's1', data: 'x', name: 'n', groupId: 'g1', path: '/' }),
     );
-    expect(h.opened('c1', key).filter((m) => m.type === 'denied')).toEqual([]);
+    expect(h.opened('c1', key).filter((m) => m.type === 'command:denied')).toEqual([]);
   });
 
   test('an unknown command is ignored, not executed', () => {
@@ -325,7 +325,7 @@ describe('the capability gate is consulted by dispatch', () => {
     const h = harness({ grantRow: storedGrant() });
     const key = h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
     h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's2' });
-    expect(h.opened('c1', key).some((m) => m.type === 'denied' && m.command === 'terminal:subscribe')).toBe(true);
+    expect(h.opened('c1', key).some((m) => m.type === 'command:denied' && m.command === 'terminal:subscribe')).toBe(true);
   });
 });
 
@@ -715,5 +715,47 @@ describe('a lapsed grant stops the stream, not just the commands', () => {
     now = NOW + 4_000_000;
     emit('tick');
     expect(h.tunnel.attachedGuests()[0]!.sessionIds).toEqual([]);
+  });
+});
+
+describe('a refused command is not an ended session', () => {
+  // Found in production on beta.4: a guest sent one command their role does
+  // not allow, the tunnel replied `denied`, and the web client — which read
+  // every `denied` as terminal — told them the owner had revoked their access.
+  // One frame type was carrying two meanings.
+  test('refusing a command uses a distinct type from access-ended', () => {
+    const h = harness({ grantRow: storedGrant() });
+    const key = h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+
+    h.send('c1', key, 0, { type: 'terminal:input', sessionId: 's1', data: 'x' });
+
+    const seen = h.opened('c1', key);
+    expect(seen.some((m) => m.type === 'command:denied' && m.command === 'terminal:input')).toBe(true);
+    // The frame that means "you are out" must NOT be what a refusal produces.
+    expect(seen.some((m) => m.type === 'denied')).toBe(false);
+  });
+
+  test('the client keeps working after a refusal', () => {
+    // The guest stays connected and their grant is untouched — the refusal is
+    // about one command, not about them.
+    const h = harness({ grantRow: storedGrant() });
+    const key = h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+
+    h.send('c1', key, 0, { type: 'terminal:resize', sessionId: 's1', cols: 80, rows: 24 });
+    h.send('c1', key, 1, { type: 'sessions:list' });
+
+    expect(h.opened('c1', key).some((m) => m.type === 'sessions')).toBe(true);
+  });
+
+  test('losing access still uses the ended frame', () => {
+    // The two paths must stay distinguishable in the other direction too.
+    const h = harness({ grantRow: storedGrant() });
+    const key = h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+
+    h.tunnel.revokeGrant('grant-1');
+
+    const seen = h.opened('c1', key);
+    expect(seen.some((m) => m.type === 'denied' && m.reason === 'revoked')).toBe(true);
+    expect(seen.some((m) => m.type === 'command:denied')).toBe(false);
   });
 });

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -502,7 +502,12 @@ export class SessionTunnel {
 
     const sessionId = typeof inner.sessionId === 'string' ? inner.sessionId : null;
     if (!permits(s.grant, command, sessionId, this.deps.now())) {
-      this.sealTo(clientId, { type: 'denied', reason: 'not_permitted', command });
+      // A refused COMMAND is not an ended SESSION. These were one frame type
+      // once, and the guest client — reasonably — read every `denied` as "you
+      // are out", so a single unpermitted command told someone their access
+      // had been revoked. Separate types, separate meanings.
+      this.sealTo(clientId, { type: 'command:denied', reason: 'not_permitted', command });
+      this.deps.log.warn('[Relay] refused a command', { clientId, command, role: s.grant.role });
       return;
     }
     handler(clientId, s, inner);


### PR DESCRIPTION
Closes #162

First bug from real use of session sharing, found on **beta.4** against the dev relay. A guest connected fine, then was repeatedly told *"Your access was ended — the person who shared this session stopped sharing it"* and had to rejoin. Nobody had revoked anything.

## How it was diagnosed, since the logs were silent

Both obvious causes were ruled out by evidence:

- The relay logged **no** `grant revoked`, no `reconciled away stale grants`, no kick.
- The agent logged **no** expiry and **no** revocation — only three `client channel opened` lines, which are the guest's three manual rejoins.

Neither side had ended his access, so the client manufactured the message. That left exactly one unlogged producer.

## The cause

`dispatch()` replied `{ type: 'denied', reason: 'not_permitted', command }` when refusing a single command — a `viewer` sending `terminal:input`, `terminal:resize`, `session:create`, `group:create` or `dirs:list`. The web client treats **any** `denied` as terminal, looks up `ENDED_COPY['not_permitted']`, finds nothing, and falls through to the default entry, which is the revoked copy.

**One frame type carrying two meanings**: *"you may not do that"* and *"you are out"*. The client couldn't distinguish them and defaulted to the alarming one.

Worth naming plainly: this is exactly the failure the reason enum was introduced to prevent. I built the enum so the app would stop telling guests false stories about why their access ended — and then had the app tell one anyway, through a path the enum didn't cover.

## The fix, on three fronts

**1. The agent distinguishes them.** A refused command is now `command:denied`; `denied` is reserved for access actually ending. It also **logs** the refusal with the command and role — the total absence of a log line is why this needed elimination rather than reading, and I'd rather not repeat that.

**2. The client only ends on a known ending reason.** `not_authorized` / `revoked` / `expired` / `session_ended` / `machine_unlinked`; anything else is treated as a command refusal. This one matters independently of (1): agents auto-update on their own schedule, so this is what fixes guests talking to builds still sending the old shared frame. Fixing only the agent would leave the bug live for everyone who hasn't updated.

**3. The fallback copy no longer blames the owner.** An unrecognised reason now states what is actually known — the connection closed — rather than asserting a revocation nobody performed. A default that invents a cause is how a defensive branch becomes a lie.

## Testing

Three new tests pin the distinction in both directions: a refusal produces `command:denied` and **never** `denied`; the client keeps working afterwards and its grant is untouched; and losing access still produces `denied` with the right reason and never `command:denied`.

**Two existing tests had to change** — they asserted `type === 'denied'` for command refusals. That they passed happily is the tell: they were pinning the conflation rather than the intent.

- Desktop: **726 pass, 0 fail** (3579 assertions, 50 files)
- Relay: **150 pass, 0 fail**
- Four typechecks clean; `bun run build:web` bundles

## Still unknown

**Which command he actually sent.** Tapping into the terminal (`terminal:input`) is the most likely, but nothing recorded it — that's the diagnostic gap this PR closes. The new log line will name it if it recurs.

## Deploying

Both halves ship together for the full fix, but neither is blocked on the other: the relay serves the web client (fix 2, and it stands alone), and the desktop carries the agent change (fixes 1 and 3's producer side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
