### PR TITLE
Bug: a guest re-opening a shared session loses everything they had watched

### DIFF
--- a/docs/designs/session-sharing.md
+++ b/docs/designs/session-sharing.md
@@ -38,7 +38,8 @@ the split §4 of the relay design already pre-committed to — "enforced by the 
 
 ## Non-goals (v1)
 
-Machine-wide grants · guest-initiated sharing · sharing scrollback history · guest-driven
+Machine-wide grants · guest-initiated sharing · sharing scrollback history *from before the
+share* (see §6.1) · guest-driven
 `terminal:resize` · `session:create` / `group:create` / `dirs:list` for any guest, ever ·
 browser-held guest device keys · session recording · federation of grants between relays.
 
@@ -339,8 +340,9 @@ Concretely in `session-tunnel.ts`:
   per repeat, and `PtyManager` never raises its default max of 10);
 - replace the three per-client listeners with **one tunnel-level set** fanning out over the
   client map;
-- gate `terminal:subscribe` on scope *before* `getSerializedBuffer`, and skip history entirely
-  for guests — seal `\x1b[2J\x1b[3J\x1b[H` plus `── shared from here ──`;
+- gate `terminal:subscribe` on scope *before* `getSerializedBuffer`, and skip pre-share
+  history for guests — seal `\x1b[2J\x1b[3J\x1b[H` plus `── shared from here ──`, then the
+  share window (§6.1);
 - filter `sendSessions`/`sendGroups` to scope and strip `workingDir`;
 - `revokeGrant()` → `DENY_ALL`, clear subs, detach, sealed `denied`, `client:kick`;
 - cache decrypted key material in memory — `deriveSharedSecret` and `signWithIdentity` each
@@ -355,6 +357,32 @@ in bun and will break `pty-manager.test.ts` in a load-order-dependent way. Refac
 defaulting to the singletons, matching the repo's existing injectable-database convention.
 Testing an extracted pure policy module proves the table is right but not that `dispatch()`
 consults it — which is the bug class this feature must not ship.
+
+### 6.1 The share window (#169)
+
+"No scrollback" was implemented as "nothing, on every attach", and those are not the same
+rule. A guest who left the shared session to look at one of their own and came back found it
+wiped, with no way to recover what they had already been shown — which makes watching a
+session useless to anyone who is also doing their own work, the exact person sharing is for.
+
+The line is drawn at the moment of consent, not at each attach:
+
+- `approveGrant` captures a **mark** per session alongside `ptyEpoch` — a count of characters
+  the PTY has ever produced, not an index into the scrollback buffer, so it stays resolvable
+  after the 2 MB cap trims.
+- Every guest `terminal:subscribe` replays `getSerializedBufferSince(sessionId, mark)` after
+  the `── shared from here ──` marker. Re-attaching, refreshing, reconnecting and joining
+  from a second device all become continuous.
+- A grant with **no** mark starts its window at first attach. A missing mark is never treated
+  as position zero: zero means "replay everything", which is precisely what a guest is not
+  entitled to.
+- Marks live in memory on the tunnel, keyed by `grantId`, and are dropped on revocation. They
+  index into a PTY instance's output and the grant is bound to that instance by `ptyEpoch`, so
+  neither outlives the process; persisting one would create a number that survives the buffer
+  it points into.
+
+What a guest can see is therefore unchanged in extent — everything from the moment they were
+let in, nothing before it — and changed only in that it survives them looking away.
 
 ## 7. UX
 

--- a/docs/designs/session-sharing.md
+++ b/docs/designs/session-sharing.md
@@ -376,10 +376,16 @@ The line is drawn at the moment of consent, not at each attach:
 - A grant with **no** mark starts its window at first attach. A missing mark is never treated
   as position zero: zero means "replay everything", which is precisely what a guest is not
   entitled to.
-- Marks live in memory on the tunnel, keyed by `grantId`, and are dropped on revocation. They
-  index into a PTY instance's output and the grant is bound to that instance by `ptyEpoch`, so
-  neither outlives the process; persisting one would create a number that survives the buffer
-  it points into.
+- Marks live in memory on the tunnel, keyed by `grantId`. They index into a PTY instance's
+  output and the grant is bound to that instance by `ptyEpoch`, so neither outlives the
+  process; persisting one would create a number that survives the buffer it points into.
+- A window is dropped on revocation, and **swept on expiry** — on every write and every
+  `client:open`. Revocation reaches the map through `revokeGrant`, but a grant that is
+  approved, never connected to, and simply times out leaves no client behind to carry its
+  window out any other way.
+- A mark, once recorded for a session, is never overwritten. Recomputing it would move a
+  window **forward**, hiding output the guest was entitled to — the same failure as sending
+  nothing, arriving by a different route.
 
 What a guest can see is therefore unchanged in extent — everything from the moment they were
 let in, nothing before it — and changed only in that it survives them looking away.

--- a/src/main/__tests__/pty-manager.test.ts
+++ b/src/main/__tests__/pty-manager.test.ts
@@ -477,3 +477,56 @@ describe('getSerializedBuffer (rendered-text history)', () => {
     expect(await manager.getSerializedBuffer('nope')).toBe('');
   });
 });
+
+/**
+ * #169. A shared session replays the window since someone was let in — not the
+ * whole scrollback, which would hand over what was on screen before the
+ * decision to share, and not nothing, which wipes the guest's view every time
+ * they come back to it.
+ */
+describe('getSerializedBufferSince (the window a guest is entitled to)', () => {
+  test('replays from the mark onward and nothing before it', async () => {
+    const manager = new PtyManager();
+    const { ptyProc } = createAgentSession(manager);
+    ptyProc.dataCb!('SECRET BEFORE THE SHARE\r\n');
+
+    const mark = manager.scrollbackMark('session-1')!;
+    ptyProc.dataCb!('watched output\r\n');
+
+    const text = await manager.getSerializedBufferSince('session-1', mark);
+    expect(text).toContain('watched output');
+    expect(text).not.toContain('SECRET BEFORE THE SHARE');
+  });
+
+  test('a mark taken at the current position replays nothing', async () => {
+    const manager = new PtyManager();
+    const { ptyProc } = createAgentSession(manager);
+    ptyProc.dataCb!('already on screen\r\n');
+
+    const text = await manager.getSerializedBufferSince('session-1', manager.scrollbackMark('session-1')!);
+    expect(text).toBe('');
+  });
+
+  test('a mark the scrollback cap has evicted yields what survives, never more', async () => {
+    // The mark counts characters ever produced, so it stays resolvable after a
+    // trim; an index into the buffer would silently point somewhere else and
+    // replay content from before the share.
+    const manager = new PtyManager();
+    const { ptyProc } = createAgentSession(manager);
+    ptyProc.dataCb!('EVICTED FIRST LINE\r\n');
+    const mark = manager.scrollbackMark('session-1')!;
+    // Push past the 2MB cap plus its 25% slack so the trim actually runs.
+    for (let i = 0; i < 40; i++) ptyProc.dataCb!('x'.repeat(100 * 1024));
+    ptyProc.dataCb!('\r\nlast line\r\n');
+
+    const text = await manager.getSerializedBufferSince('session-1', mark);
+    expect(text).toContain('last line');
+    expect(text).not.toContain('EVICTED FIRST LINE');
+  });
+
+  test('returns empty string for an unknown session, and no mark for one', async () => {
+    const manager = new PtyManager();
+    expect(manager.scrollbackMark('nope')).toBeNull();
+    expect(await manager.getSerializedBufferSince('nope', 0)).toBe('');
+  });
+});

--- a/src/main/__tests__/pty-manager.test.ts
+++ b/src/main/__tests__/pty-manager.test.ts
@@ -524,6 +524,19 @@ describe('getSerializedBufferSince (the window a guest is entitled to)', () => {
     expect(text).not.toContain('EVICTED FIRST LINE');
   });
 
+  test('a mark from a previous PTY instance clamps to the end and replays nothing', async () => {
+    // A restarted session gets a fresh buffer, so an older instance's mark is
+    // larger than everything this one has produced. The grant's ptyEpoch check
+    // already refuses a certificate whose sessions have restarted, so such a
+    // mark should never reach here — and if one does it must fail closed and
+    // empty rather than replaying from a clamped-to-zero start.
+    const manager = new PtyManager();
+    const { ptyProc } = createAgentSession(manager);
+    ptyProc.dataCb!('output from the new instance\r\n');
+
+    expect(await manager.getSerializedBufferSince('session-1', 10_000_000)).toBe('');
+  });
+
   test('returns empty string for an unknown session, and no mark for one', async () => {
     const manager = new PtyManager();
     expect(manager.scrollbackMark('nope')).toBeNull();

--- a/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
+++ b/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
@@ -28,6 +28,7 @@ const RELAY_ORIGIN = 'https://relay.example.com';
 const OWNER_ID = 'owner-user';
 const GUEST_ID = 'guest-user';
 const NOW = 1_800_000_000_000;
+const HOUR = 3_600_000;
 
 // The machine identity the fake identity port serves.
 const machineKeys = crypto.generateKeyPairSync('ed25519');
@@ -428,7 +429,7 @@ describe('a guest coming back to a session they already watched', () => {
   test('is replayed what it has already seen, and nothing from before the share', async () => {
     const h = harness({ grantRow: storedGrant() });
     // What the approval flow records at the moment of consent.
-    h.tunnel.noteShareMarks('grant-1', [{ sessionId: 's1', mark: h.markNow('s1') }]);
+    h.tunnel.noteShareMarks('grant-1', [{ sessionId: 's1', mark: h.markNow('s1') }], NOW + HOUR);
     h.append('s1', 'AFTER ONE');
 
     const key = guest(h, 'c1');
@@ -475,7 +476,7 @@ describe('a guest coming back to a session they already watched', () => {
 
   test('every attach still says where the share starts', async () => {
     const h = harness({ grantRow: storedGrant() });
-    h.tunnel.noteShareMarks('grant-1', [{ sessionId: 's1', mark: h.markNow('s1') }]);
+    h.tunnel.noteShareMarks('grant-1', [{ sessionId: 's1', mark: h.markNow('s1') }], NOW + HOUR);
 
     const key = guest(h, 'c1');
     h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
@@ -485,11 +486,64 @@ describe('a guest coming back to a session they already watched', () => {
     expect(String(first[0]!.data)).toContain('shared from here');
   });
 
+  test('a second approval does not move an already-recorded window forward', async () => {
+    // Approval is one-shot per grantId today — `pendingGrants` is cleared and
+    // `insertGrant` would collide — but if it ever stops being, recomputing
+    // the marks would hide everything produced between the two calls from a
+    // guest already watching. First write wins.
+    const h = harness({ grantRow: storedGrant() });
+    h.tunnel.noteShareMarks('grant-1', [{ sessionId: 's1', mark: h.markNow('s1') }], NOW + HOUR);
+    h.append('s1', 'BETWEEN THE TWO APPROVALS');
+    h.tunnel.noteShareMarks('grant-1', [{ sessionId: 's1', mark: h.markNow('s1') }], NOW + HOUR);
+
+    const key = guest(h, 'c1');
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    await Bun.sleep(5);
+
+    const replayed = h
+      .opened('c1', key)
+      .filter((m) => m.type === 'terminal:output')
+      .map((m) => String(m.data))
+      .join('');
+    expect(replayed).toContain('BETWEEN THE TWO APPROVALS');
+  });
+
+  test('a window whose grant ran out is swept, not held for the life of the process', async () => {
+    // Revocation reaches the map through revokeGrant, but expiry does not: a
+    // grant approved, never connected to, and simply timed out leaves no
+    // client behind to carry its window out. So the map is swept on write and
+    // on open. Observed through behaviour — a swept window falls back to
+    // starting at the next attach — since the map itself is private.
+    const clock = { now: NOW };
+    const h = harness({ grantRow: storedGrant(), now: () => clock.now });
+    h.tunnel.noteShareMarks('grant-1', [{ sessionId: 's1', mark: h.markNow('s1') }], NOW + 1000);
+    h.append('s1', 'PRODUCED WHILE NOBODY WATCHED');
+
+    clock.now = NOW + 2000; // the grant's clock runs out with nobody attached
+
+    // A later channel sweeps it. In production the certificate would have
+    // expired with it; here it carries a fresh expiry so the sweep — not the
+    // certificate check — is what the assertion is about.
+    const key = h.openChannel('c1', {
+      principal: { userId: GUEST_ID },
+      certificate: mintCertificate({ expiresAt: NOW + HOUR }),
+    })!;
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    await Bun.sleep(5);
+
+    const replayed = h
+      .opened('c1', key)
+      .filter((m) => m.type === 'terminal:output')
+      .map((m) => String(m.data))
+      .join('');
+    expect(replayed).not.toContain('PRODUCED WHILE NOBODY WATCHED');
+  });
+
   test('revoking the grant forgets the window it opened', async () => {
     // Otherwise a re-approval would inherit a start point from access that was
     // taken away, and replay output produced while the guest had none.
     const h = harness({ grantRow: storedGrant() });
-    h.tunnel.noteShareMarks('grant-1', [{ sessionId: 's1', mark: h.markNow('s1') }]);
+    h.tunnel.noteShareMarks('grant-1', [{ sessionId: 's1', mark: h.markNow('s1') }], NOW + HOUR);
     h.append('s1', 'WHILE REVOKED');
     h.tunnel.revokeGrant('grant-1');
 

--- a/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
+++ b/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
@@ -40,6 +40,10 @@ interface Harness {
   tunnel: SessionTunnelType;
   sent: { clientId: string; payload: unknown }[];
   deps: TunnelDeps;
+  /** Represent output arriving on a session. */
+  append(sessionId: string, data: string): void;
+  /** The mark the approval flow would capture right now. */
+  markNow(sessionId: string): number;
   /** The client public key most recently offered, for proof assertions. */
   lastClientPub: string | null;
   /** Client-side key material, so tests can read what the tunnel sealed. */
@@ -59,6 +63,12 @@ const GROUPS: TunnelGroupRow[] = [
 
 function harness(over: Partial<TunnelDeps> & { grantRow?: TunnelStoredGrant | null } = {}): Harness {
   const sent: { clientId: string; payload: unknown }[] = [];
+  // What each session has produced so far. Tests append to it to represent
+  // output arriving while a guest is attached, or away.
+  const stream = new Map<string, string>([
+    ['s1', 'BEFORE THE SHARE'],
+    ['s2', ''],
+  ]);
   const epochs = new Map<string, number>([
     ['s1', 111],
     ['s2', 222],
@@ -74,6 +84,11 @@ function harness(over: Partial<TunnelDeps> & { grantRow?: TunnelStoredGrant | nu
       isLive: (id) => epochs.has(id),
       ptyEpoch: (id) => epochs.get(id) ?? null,
       getSerializedBuffer: async () => 'OWNER SCROLLBACK',
+      // A stand-in for the PTY's output stream: a mark is a length, and
+      // "since" is the tail past it — the same contract `PtyManager` honours
+      // through its evict-aware counter.
+      scrollbackMark: (id) => (epochs.has(id) ? (stream.get(id) ?? '').length : null),
+      getSerializedBufferSince: async (id, mark) => (stream.get(id) ?? '').slice(mark),
     },
     sessions: { getAll: () => SESSIONS },
     groups: { getAll: () => GROUPS },
@@ -104,6 +119,12 @@ function harness(over: Partial<TunnelDeps> & { grantRow?: TunnelStoredGrant | nu
     sent,
     deps,
     lastClientPub: null,
+    append(sessionId, data) {
+      stream.set(sessionId, (stream.get(sessionId) ?? '') + data);
+    },
+    markNow(sessionId) {
+      return (stream.get(sessionId) ?? '').length;
+    },
     openChannel(clientId, opts = {}) {
       const clientKeys = crypto.generateKeyPairSync('x25519');
       const pubB64 = Buffer.from(
@@ -394,6 +415,97 @@ describe('scoped disclosure', () => {
   });
 });
 
+/**
+ * #169. Sending a guest nothing on every attach is not the same rule as "no
+ * scrollback": it also throws away what they were already shown, so leaving a
+ * shared session to look at your own and coming back wiped it. The window
+ * since the share began is theirs; everything before it still is not.
+ */
+describe('a guest coming back to a session they already watched', () => {
+  const guest = (h: ReturnType<typeof harness>, clientId: string) =>
+    h.openChannel(clientId, { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+
+  test('is replayed what it has already seen, and nothing from before the share', async () => {
+    const h = harness({ grantRow: storedGrant() });
+    // What the approval flow records at the moment of consent.
+    h.tunnel.noteShareMarks('grant-1', [{ sessionId: 's1', mark: h.markNow('s1') }]);
+    h.append('s1', 'AFTER ONE');
+
+    const key = guest(h, 'c1');
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    await Bun.sleep(5);
+
+    // They step away to one of their own sessions; output keeps arriving.
+    h.send('c1', key, 1, { type: 'terminal:unsubscribe', sessionId: 's1' });
+    h.append('s1', ' AND TWO');
+
+    h.send('c1', key, 2, { type: 'terminal:subscribe', sessionId: 's1' });
+    await Bun.sleep(5);
+
+    const replayed = h
+      .opened('c1', key)
+      .filter((m) => m.type === 'terminal:output')
+      .map((m) => String(m.data))
+      .join('');
+    expect(replayed).toContain('AFTER ONE AND TWO');
+    expect(replayed).not.toContain('BEFORE THE SHARE');
+  });
+
+  test('with no recorded mark, starts its window at the first attach', async () => {
+    // A grant minted without a mark must not fall back to position zero —
+    // that would replay the entire scrollback to someone entitled to none.
+    const h = harness({ grantRow: storedGrant() });
+
+    const key = guest(h, 'c1');
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    await Bun.sleep(5);
+    h.send('c1', key, 1, { type: 'terminal:unsubscribe', sessionId: 's1' });
+    h.append('s1', 'ONLY THIS');
+    h.send('c1', key, 2, { type: 'terminal:subscribe', sessionId: 's1' });
+    await Bun.sleep(5);
+
+    const replayed = h
+      .opened('c1', key)
+      .filter((m) => m.type === 'terminal:output')
+      .map((m) => String(m.data))
+      .join('');
+    expect(replayed).toContain('ONLY THIS');
+    expect(replayed).not.toContain('BEFORE THE SHARE');
+  });
+
+  test('every attach still says where the share starts', async () => {
+    const h = harness({ grantRow: storedGrant() });
+    h.tunnel.noteShareMarks('grant-1', [{ sessionId: 's1', mark: h.markNow('s1') }]);
+
+    const key = guest(h, 'c1');
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    await Bun.sleep(5);
+
+    const first = h.opened('c1', key).filter((m) => m.type === 'terminal:output');
+    expect(String(first[0]!.data)).toContain('shared from here');
+  });
+
+  test('revoking the grant forgets the window it opened', async () => {
+    // Otherwise a re-approval would inherit a start point from access that was
+    // taken away, and replay output produced while the guest had none.
+    const h = harness({ grantRow: storedGrant() });
+    h.tunnel.noteShareMarks('grant-1', [{ sessionId: 's1', mark: h.markNow('s1') }]);
+    h.append('s1', 'WHILE REVOKED');
+    h.tunnel.revokeGrant('grant-1');
+
+    const key = guest(h, 'c2');
+    h.send('c2', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    await Bun.sleep(5);
+
+    const replayed = h
+      .opened('c2', key)
+      .filter((m) => m.type === 'terminal:output')
+      .map((m) => String(m.data))
+      .join('');
+    expect(replayed).not.toContain('WHILE REVOKED');
+  });
+});
+
 describe('revocation of a live client', () => {
   test('drops it to DENY_ALL and tells it, sealed', () => {
     const h = harness({ grantRow: storedGrant() });
@@ -437,6 +549,8 @@ describe('PTY listener lifecycle', () => {
         isLive: () => true,
         ptyEpoch: () => 111,
         getSerializedBuffer: async () => '',
+        scrollbackMark: () => 0,
+        getSerializedBufferSince: async () => '',
       },
     });
 
@@ -466,6 +580,8 @@ describe('PTY listener lifecycle', () => {
         isLive: () => true,
         ptyEpoch: () => 111,
         getSerializedBuffer: async () => '',
+        scrollbackMark: () => 0,
+        getSerializedBufferSince: async () => '',
       },
     });
 
@@ -643,6 +759,8 @@ describe('a lapsed grant stops the stream, not just the commands', () => {
         isLive: () => true,
         ptyEpoch: () => 111,
         getSerializedBuffer: async () => '',
+        scrollbackMark: () => 0,
+        getSerializedBufferSince: async () => '',
       },
     });
     return { h, emit: (data: string) => emit?.({ id: 's1', data }) };

--- a/src/main/api/relay/relay-client.ts
+++ b/src/main/api/relay/relay-client.ts
@@ -670,18 +670,18 @@ export class RelayClient extends EventEmitter {
       return { sessionId, ptyEpoch };
     });
 
-    // Where the guest's view of each session begins — captured HERE for the
-    // same reason `ptyEpoch` is: this is the moment of consent. Everything
-    // from here on is theirs to re-read when they come back to it (#169);
+    // Where the guest's view of each session begins — read HERE for the same
+    // reason `ptyEpoch` is: this is the moment of consent. Everything from
+    // here on is theirs to re-read when they come back to it (#169);
     // everything before it is not, and never becomes so.
-    this.tunnel.noteShareMarks(
-      grantId,
-      // A missing mark is dropped, never defaulted to 0: zero would replay the
-      // whole scrollback, which is the one thing a guest must never be sent.
-      sessions
-        .map(({ sessionId }) => ({ sessionId, mark: ptyManager.scrollbackMark(sessionId) }))
-        .filter((m): m is { sessionId: string; mark: number } => m.mark !== null),
-    );
+    //
+    // A missing mark is dropped, never defaulted to 0: zero would replay the
+    // whole scrollback, which is the one thing a guest must never be sent.
+    // Read before minting and handed over after, so the window cannot drift
+    // past the moment being consented to.
+    const marks = sessions
+      .map(({ sessionId }) => ({ sessionId, mark: ptyManager.scrollbackMark(sessionId) }))
+      .filter((m): m is { sessionId: string; mark: number } => m.mark !== null);
 
     // From the invite the owner created, not from `expiresAt` — that is NULL
     // until we countersign, which is exactly the moment we are in now.
@@ -696,6 +696,13 @@ export class RelayClient extends EventEmitter {
       sessions,
       ttlSeconds,
     });
+
+    // The certificate's own expiry, so an approved grant nobody ever connects
+    // to takes its window with it when it runs out. The fallback is
+    // unreachable — `insertGrant` always writes one — and exists only because
+    // the row type allows null between redemption and countersigning, and a
+    // window with no expiry would never be swept.
+    this.tunnel.noteShareMarks(grantId, marks, grant.expiresAt ?? Date.now());
 
     this.send({ type: 'share:bind', grantId, certificate, expiresAt: grant.expiresAt });
     this.pendingGrants.delete(grantId);

--- a/src/main/api/relay/relay-client.ts
+++ b/src/main/api/relay/relay-client.ts
@@ -670,6 +670,19 @@ export class RelayClient extends EventEmitter {
       return { sessionId, ptyEpoch };
     });
 
+    // Where the guest's view of each session begins — captured HERE for the
+    // same reason `ptyEpoch` is: this is the moment of consent. Everything
+    // from here on is theirs to re-read when they come back to it (#169);
+    // everything before it is not, and never becomes so.
+    this.tunnel.noteShareMarks(
+      grantId,
+      // A missing mark is dropped, never defaulted to 0: zero would replay the
+      // whole scrollback, which is the one thing a guest must never be sent.
+      sessions
+        .map(({ sessionId }) => ({ sessionId, mark: ptyManager.scrollbackMark(sessionId) }))
+        .filter((m): m is { sessionId: string; mark: number } => m.mark !== null),
+    );
+
     // From the invite the owner created, not from `expiresAt` — that is NULL
     // until we countersign, which is exactly the moment we are in now.
     const ttlSeconds = pending.grantTtlSeconds ?? DEFAULT_GRANT_TTL_SECONDS;

--- a/src/main/api/relay/session-tunnel-deps.ts
+++ b/src/main/api/relay/session-tunnel-deps.ts
@@ -41,6 +41,8 @@ export function defaultDeps(relayOrigin: () => string, machineId: () => string |
       // restart, which is exactly the staleness a session grant must notice.
       ptyEpoch: (id) => ptyManager.getSession(id)?.spawnedAt ?? null,
       getSerializedBuffer: (id) => ptyManager.getSerializedBuffer(id),
+      scrollbackMark: (id) => ptyManager.scrollbackMark(id),
+      getSerializedBufferSince: (id, mark) => ptyManager.getSerializedBufferSince(id, mark),
     },
     sessions: { getAll: () => getAllSessions() as unknown as TunnelSessionRow[] },
     groups: { getAll: () => getAllGroups() as unknown as TunnelGroupRow[] },

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -215,18 +215,30 @@ interface ResolvedGrant {
   marks: Map<string, number>;
 }
 
+/** One grant's share window: where each session's replay starts, and until when. */
+interface ShareWindow {
+  /**
+   * The grant's expiry, carried so the entry can be swept.
+   *
+   * Revocation reaches this map through `revokeGrant`, but expiry does not:
+   * a grant that is approved, never connected to, and simply runs out leaves
+   * no client behind to notice, so nothing would ever delete it.
+   */
+  expiresAt: number;
+  marks: Map<string, number>;
+}
+
 export class SessionTunnel {
   private readonly sessions = new Map<string, ClientSession>();
   /**
-   * grantId → sessionId → the point in that session's output the share began
-   * at (#169).
+   * grantId → where each of its sessions' output the share began at (#169).
    *
    * Deliberately in memory rather than in `relay_grants`: a mark indexes into
    * a PTY instance's live output, and a grant is bound to that instance by
    * `ptyEpoch`, so neither can outlive this process. Persisting it would
    * create a number that survives the buffer it points into.
    */
-  private readonly shareMarks = new Map<string, Map<string, number>>();
+  private readonly shareMarks = new Map<string, ShareWindow>();
   /** Detaches the shared PTY listeners; null when not attached. */
   private detach: (() => void) | null = null;
   private readonly deps: TunnelDeps;
@@ -368,6 +380,7 @@ export class SessionTunnel {
         this.deps.log.warn('[Relay] ignoring duplicate client:open', { clientId });
         return;
       }
+      this.sweepShareWindows();
 
       const resolved = this.resolveGrant(payload, principal);
       if (resolved === null) {
@@ -506,7 +519,7 @@ export class SessionTunnel {
     // The share window this grant was approved at, per session. Absent when
     // the grant was minted without one; `shareMark` then starts the window at
     // first attach rather than replaying anything the guest was not shown.
-    const recorded = this.shareMarks.get(checked.parts.grantId);
+    const recorded = this.shareMarks.get(checked.parts.grantId)?.marks;
     const marks = new Map<string, number>();
     for (const { sessionId } of live) {
       const mark = recorded?.get(sessionId);
@@ -583,10 +596,32 @@ export class SessionTunnel {
    * covers the whole window they were let into, not just whatever happened
    * after they got round to opening the link.
    */
-  noteShareMarks(grantId: string, marks: { sessionId: string; mark: number }[]): void {
-    const forGrant = this.shareMarks.get(grantId) ?? new Map<string, number>();
-    for (const { sessionId, mark } of marks) forGrant.set(sessionId, mark);
-    this.shareMarks.set(grantId, forGrant);
+  noteShareMarks(grantId: string, marks: { sessionId: string; mark: number }[], expiresAt: number): void {
+    this.sweepShareWindows();
+    const window = this.shareMarks.get(grantId) ?? { expiresAt, marks: new Map<string, number>() };
+    for (const { sessionId, mark } of marks) {
+      // First write wins. A second call for a session already recorded would
+      // move that window FORWARD, hiding everything produced between the two
+      // calls from a guest who is entitled to it — and a window that only ever
+      // moves forward is the bug this whole change exists to fix. New sessions
+      // are added; recorded ones are left where they are.
+      if (!window.marks.has(sessionId)) window.marks.set(sessionId, mark);
+    }
+    this.shareMarks.set(grantId, window);
+  }
+
+  /**
+   * Drop windows whose grants have run out.
+   *
+   * On write and on open rather than on a timer: both are the moments the map
+   * is about to be used, and a grant that expired with nobody attached has no
+   * client left to carry it out of here any other way.
+   */
+  private sweepShareWindows(): void {
+    const now = this.deps.now();
+    for (const [grantId, window] of this.shareMarks) {
+      if (window.expiresAt <= now) this.shareMarks.delete(grantId);
+    }
   }
 
   /**
@@ -605,7 +640,7 @@ export class SessionTunnel {
     const here = this.deps.pty.scrollbackMark(sessionId);
     if (here === null) return null;
     s.marks.set(sessionId, here);
-    if (s.grant.grantId) this.noteShareMarks(s.grant.grantId, [{ sessionId, mark: here }]);
+    if (s.grant.grantId) this.noteShareMarks(s.grant.grantId, [{ sessionId, mark: here }], s.grant.expiresAt);
     return here;
   }
 

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -72,6 +72,10 @@ export interface TunnelPty {
   /** Identifies the PTY *instance*; changes when a session is restarted. */
   ptyEpoch(id: string): number | null;
   getSerializedBuffer(id: string): Promise<string>;
+  /** A point in the output stream that survives the scrollback cap trimming. */
+  scrollbackMark(id: string): number | null;
+  /** Rendered history from `mark` onward — never the whole scrollback. */
+  getSerializedBufferSince(id: string, mark: number): Promise<string>;
 }
 
 export interface TunnelSessionRow {
@@ -178,6 +182,13 @@ interface ClientSession {
   grant: Grant;
   /** Who the relay says this is, for presence. Never authorization. */
   principal: Principal | null;
+  /**
+   * Per-session point in the output stream this client's share began at, so a
+   * guest re-attaching is replayed what it has already been shown rather than
+   * being wiped back to a blank screen (#169). Empty for the owner, who gets
+   * the whole scrollback instead.
+   */
+  marks: Map<string, number>;
 }
 
 /** Decrypted command from a web client (union of every message's fields). */
@@ -198,8 +209,24 @@ interface ClientFrame {
 
 type Handler = (clientId: string, s: ClientSession, inner: ClientFrame) => void;
 
+/** What a connecting client may do, and where its view of each session starts. */
+interface ResolvedGrant {
+  grant: Grant;
+  marks: Map<string, number>;
+}
+
 export class SessionTunnel {
   private readonly sessions = new Map<string, ClientSession>();
+  /**
+   * grantId → sessionId → the point in that session's output the share began
+   * at (#169).
+   *
+   * Deliberately in memory rather than in `relay_grants`: a mark indexes into
+   * a PTY instance's live output, and a grant is bound to that instance by
+   * `ptyEpoch`, so neither can outlive this process. Persisting it would
+   * create a number that survives the buffer it points into.
+   */
+  private readonly shareMarks = new Map<string, Map<string, number>>();
   /** Detaches the shared PTY listeners; null when not attached. */
   private detach: (() => void) | null = null;
   private readonly deps: TunnelDeps;
@@ -295,6 +322,10 @@ export class SessionTunnel {
     // taken away.
     const ranOut = s.grant.caps.length > 0 && s.grant.expiresAt <= now;
     const reason = ranOut ? 'expired' : 'revoked';
+    // Both endings are terminal for the grant — an expired certificate never
+    // verifies again — so its share window goes with it rather than sitting in
+    // the map for as long as the app runs.
+    if (s.grant.grantId) this.shareMarks.delete(s.grant.grantId);
     s.subs.clear();
     s.grant = DENY_ALL;
     this.sealTo(clientId, { type: 'denied', reason });
@@ -338,13 +369,15 @@ export class SessionTunnel {
         return;
       }
 
-      const grant = this.resolveGrant(payload, principal);
-      if (grant === null) {
+      const resolved = this.resolveGrant(payload, principal);
+      if (resolved === null) {
         this.deps.log.warn('[Relay] refusing a channel with no usable grant', { clientId });
         // Unsealed: no key exists yet, and there is nothing secret in it.
         this.route(clientId, { type: 'denied', reason: 'not_authorized' });
         return;
       }
+
+      const { grant, marks } = resolved;
 
       // A per-channel ephemeral keypair (see e2e.ts) — never the machine's
       // long-lived X25519 key, which would make this exchange replayable.
@@ -361,6 +394,7 @@ export class SessionTunnel {
         subs: new Set(),
         grant,
         principal: principal ?? null,
+        marks,
       };
       this.sessions.set(clientId, session);
       this.startListening();
@@ -393,11 +427,13 @@ export class SessionTunnel {
    *   - nothing, before the owner id has ever been confirmed — the pre-sharing
    *     behaviour, allowed only until the latch closes.
    */
-  private resolveGrant(payload: unknown, principal?: Principal): Grant | null {
+  private resolveGrant(payload: unknown, principal?: Principal): ResolvedGrant | null {
     const certificate = (payload as { certificate?: unknown })?.certificate;
     const ownerId = this.deps.grants.ownerUserId();
 
-    if (ownerId && principal?.userId === ownerId) return ownerGrant();
+    // The owner is replayed the whole scrollback, so there is no window to
+    // mark — hence an empty mark map on both owner branches.
+    if (ownerId && principal?.userId === ownerId) return { grant: ownerGrant(), marks: new Map() };
 
     if (certificate !== undefined && certificate !== null) {
       return this.grantFromCertificate(certificate, principal);
@@ -415,11 +451,11 @@ export class SessionTunnel {
       this.deps.log.warn('[Relay] refusing an unconfirmed-owner channel: grant enforcement is latched on');
       return null;
     }
-    return ownerGrant();
+    return { grant: ownerGrant(), marks: new Map() };
   }
 
   /** Verify a presented certificate and resolve it against our own table. */
-  private grantFromCertificate(certificate: unknown, principal?: Principal): Grant | null {
+  private grantFromCertificate(certificate: unknown, principal?: Principal): ResolvedGrant | null {
     const machineId = this.deps.machineId();
     if (!machineId || !principal?.userId) return null;
 
@@ -467,7 +503,16 @@ export class SessionTunnel {
     // From here on this machine has enforced a certificate, so it must never
     // fall back to "whoever connects is the owner" again.
     this.deps.grants.latch();
-    return grantFrom(checked.parts, live.map((s) => s.sessionId));
+    // The share window this grant was approved at, per session. Absent when
+    // the grant was minted without one; `shareMark` then starts the window at
+    // first attach rather than replaying anything the guest was not shown.
+    const recorded = this.shareMarks.get(checked.parts.grantId);
+    const marks = new Map<string, number>();
+    for (const { sessionId } of live) {
+      const mark = recorded?.get(sessionId);
+      if (mark !== undefined) marks.set(sessionId, mark);
+    }
+    return { grant: grantFrom(checked.parts, live.map((s) => s.sessionId)), marks };
   }
 
   /** A sealed frame arrived from a web client. */
@@ -530,6 +575,40 @@ export class SessionTunnel {
     }
   }
 
+  /**
+   * Record where a grant's view of each session starts — called at the moment
+   * of consent, from the same place that captures `ptyEpoch`.
+   *
+   * Taken at approval rather than at first attach so the guest's first view
+   * covers the whole window they were let into, not just whatever happened
+   * after they got round to opening the link.
+   */
+  noteShareMarks(grantId: string, marks: { sessionId: string; mark: number }[]): void {
+    const forGrant = this.shareMarks.get(grantId) ?? new Map<string, number>();
+    for (const { sessionId, mark } of marks) forGrant.set(sessionId, mark);
+    this.shareMarks.set(grantId, forGrant);
+  }
+
+  /**
+   * Where this client's view of `sessionId` starts, or null if there is
+   * nothing to replay from.
+   *
+   * A missing mark is not treated as position zero — that would replay the
+   * entire scrollback to a guest, which is the one thing this must never do.
+   * It starts the window here instead, so this attach shows nothing extra and
+   * every later one is continuous.
+   */
+  private shareMark(s: ClientSession, sessionId: string): number | null {
+    const known = s.marks.get(sessionId);
+    if (known !== undefined) return known;
+
+    const here = this.deps.pty.scrollbackMark(sessionId);
+    if (here === null) return null;
+    s.marks.set(sessionId, here);
+    if (s.grant.grantId) this.noteShareMarks(s.grant.grantId, [{ sessionId, mark: here }]);
+    return here;
+  }
+
   private async handleSubscribe(clientId: string, s: ClientSession, inner: ClientFrame): Promise<void> {
     if (typeof inner.sessionId !== 'string') return;
     const sessionId = inner.sessionId;
@@ -539,15 +618,28 @@ export class SessionTunnel {
     const size = this.deps.pty.getSize(sessionId);
     this.sealTo(clientId, { type: 'terminal:size', sessionId, cols: size.cols, rows: size.rows });
 
-    // Scrollback is not shared. A guest joins at the moment they were let in,
-    // not at whatever was on screen before — replaying history would hand over
+    // Scrollback from before the share is never sent: a guest joins at the
+    // moment they were let in, and replaying the buffer would hand over
     // everything typed before the decision to share was made.
+    //
+    // What IS replayed is the window since that moment. Sending nothing on
+    // every attach — which is what this did — meant a guest who stepped away
+    // to their own session and came back found the shared one wiped, and had
+    // no way to get back what they had already been shown (#169).
     if (s.grant.role !== 'owner') {
+      const mark = this.shareMark(s, sessionId);
       this.sealTo(clientId, {
         type: 'terminal:output',
         sessionId,
         data: '\x1b[2J\x1b[3J\x1b[H── shared from here ──\r\n',
       });
+      if (mark === null) return;
+      const since = await this.deps.pty.getSerializedBufferSince(sessionId, mark);
+      for (const data of chunkText(since)) {
+        // Re-check every chunk: the client may unsubscribe or drop mid-replay.
+        if (!s.subs.has(sessionId) || this.sessions.get(clientId) !== s) return;
+        this.sealTo(clientId, { type: 'terminal:output', sessionId, data });
+      }
       return;
     }
 
@@ -628,6 +720,10 @@ export class SessionTunnel {
    * believes they have been removed from.
    */
   revokeGrant(grantId: string, reason = 'revoked'): void {
+    // The share window dies with the grant. Keeping it would mean a later
+    // grant reusing this id — or a re-approval — inheriting a start point from
+    // access that was taken away.
+    this.shareMarks.delete(grantId);
     for (const [clientId, s] of this.sessions) {
       if (s.grant.grantId === grantId) this.revokeClient(clientId, reason);
     }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -47,6 +47,13 @@ interface PtySession {
   lastState: string;
   outputBuffer: string;
   scrollbackBuffer: string;  // Larger buffer for terminal history
+  /**
+   * Every character ever appended to `scrollbackBuffer`, including what the
+   * cap has since evicted. `scrollbackBuffer` is a sliding window, so an
+   * index into it stops meaning the same thing the moment it trims; this
+   * counter is what makes a mark taken now still resolvable later.
+   */
+  scrollbackTotal: number;
   idleTimeout: NodeJS.Timeout | null;
   workingDebounce: NodeJS.Timeout | null;
   recentOutputBytes: number;
@@ -137,6 +144,7 @@ const MAX_SCROLLBACK_SIZE = 2 * 1024 * 1024;
  */
 function appendScrollback(session: PtySession, data: string): void {
   session.scrollbackBuffer += data;
+  session.scrollbackTotal += data.length;
   if (session.scrollbackBuffer.length > MAX_SCROLLBACK_SIZE * 1.25) {
     session.scrollbackBuffer = session.scrollbackBuffer.slice(-MAX_SCROLLBACK_SIZE);
   }
@@ -454,6 +462,7 @@ export class PtyManager extends EventEmitter {
       lastState: 'idle',
       outputBuffer: '',
       scrollbackBuffer: '',
+      scrollbackTotal: 0,
       idleTimeout: null,
       workingDebounce: null,
       recentOutputBytes: 0,
@@ -792,6 +801,7 @@ export class PtyManager extends EventEmitter {
       lastState: 'idle',
       outputBuffer: '',
       scrollbackBuffer: '',
+      scrollbackTotal: 0,
       idleTimeout: null,
       workingDebounce: null,
       recentOutputBytes: 0,
@@ -904,6 +914,7 @@ export class PtyManager extends EventEmitter {
       lastState: 'idle',
       outputBuffer: '',
       scrollbackBuffer: '',
+      scrollbackTotal: 0,
       idleTimeout: null,
       workingDebounce: null,
       recentOutputBytes: 0,
@@ -1131,6 +1142,54 @@ export class PtyManager extends EventEmitter {
     const session = this.sessions.get(id);
     const raw = session?.scrollbackBuffer;
     if (!session || !raw) return '';
+    return this.serialize(session, raw);
+  }
+
+  /**
+   * A point in this session's output stream that stays meaningful later.
+   *
+   * Returned as a count of characters ever produced, not an index into the
+   * scrollback: the buffer is a sliding window, so an index into it means
+   * something different after every trim. Null when the session isn't running,
+   * which the caller must treat as "no mark" rather than as position zero —
+   * zero would replay the whole buffer.
+   */
+  scrollbackMark(id: string): number | null {
+    const session = this.sessions.get(id);
+    return session ? session.scrollbackTotal : null;
+  }
+
+  /**
+   * Rendered-text history from `mark` onward — what a shared session has
+   * produced since someone was let into it (#169).
+   *
+   * A guest is never sent the whole scrollback: replaying it would hand over
+   * everything typed before the decision to share was made. But sending them
+   * nothing on every attach means leaving the session and coming back wipes
+   * what they had already watched, so the window between the mark and now is
+   * exactly what they are entitled to and exactly what they lose otherwise.
+   *
+   * If the cap has already evicted the mark, this returns everything still
+   * held — which is a subset of what they were entitled to, never a superset.
+   */
+  async getSerializedBufferSince(id: string, mark: number): Promise<string> {
+    const session = this.sessions.get(id);
+    if (!session || !session.scrollbackBuffer) return '';
+    const evicted = session.scrollbackTotal - session.scrollbackBuffer.length;
+    const start = Math.min(Math.max(0, mark - evicted), session.scrollbackBuffer.length);
+    const raw = session.scrollbackBuffer.slice(start);
+    if (!raw) return '';
+    return this.serialize(session, raw);
+  }
+
+  /**
+   * Render raw PTY bytes to resolved text through a headless terminal at the
+   * session's CURRENT width. Unlike the raw bytes this can be reflowed to a
+   * different width (e.g. a phone) WITHOUT garbling — the absolute cursor
+   * moves have already been applied here. Falls back to the raw bytes if
+   * serialization isn't available.
+   */
+  private async serialize(session: PtySession, raw: string): Promise<string> {
     try {
       const term = new HeadlessTerminal({
         cols: session.lastCols || 80,
@@ -1145,7 +1204,7 @@ export class PtyManager extends EventEmitter {
       term.dispose();
       return text;
     } catch (err) {
-      console.warn('[PtyManager] getSerializedBuffer failed, falling back to raw:', err);
+      console.warn('[PtyManager] serialize failed, falling back to raw:', err);
       return raw;
     }
   }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1174,7 +1174,7 @@ export class PtyManager extends EventEmitter {
    */
   async getSerializedBufferSince(id: string, mark: number): Promise<string> {
     const session = this.sessions.get(id);
-    if (!session || !session.scrollbackBuffer) return '';
+    if (!session?.scrollbackBuffer) return '';
     const evicted = session.scrollbackTotal - session.scrollbackBuffer.length;
     const start = Math.min(Math.max(0, mark - evicted), session.scrollbackBuffer.length);
     const raw = session.scrollbackBuffer.slice(start);


### PR DESCRIPTION
## What this fixes

A guest watching a shared session lost everything they had seen the moment they navigated away and back. Reported from testing: *"me leaving the session after having joined to one of mine and then coming back resulted in again a wipe of all info from that point forward — this would be basically useless to anyone staying busy with their own work + monitoring a shared session."*

## Why it happened

`handleSubscribe` sent `\x1b[2J\x1b[3J\x1b[H── shared from here ──` and returned for **every** non-owner subscribe, not just the first. "No scrollback for guests" had been implemented as "nothing, on every attach", and those are not the same rule — the second one also throws away what the guest was already shown.

## The change

The line is drawn at the moment of consent instead of at each attach:

- `approveGrant` captures a **mark** per session alongside `ptyEpoch` — the same moment, for the same reason.
- Every guest subscribe replays `getSerializedBufferSince(sessionId, mark)` after the marker, chunked like the owner path.
- The mark counts characters the PTY has ever produced rather than indexing into the scrollback buffer, so it survives the 2 MB cap trimming. If the cap has already evicted it, the guest gets what survives — a subset of what they were entitled to, never a superset.
- A grant with no mark starts its window at first attach. A missing mark is never read as position zero; zero means "replay everything", which is the one thing a guest must never be sent.
- Marks live in memory on the tunnel keyed by `grantId`, dropped on revoke and on expiry. They index into a PTY instance's output and a grant is bound to that instance by `ptyEpoch`, so neither outlives the process — persisting one would create a number that survives the buffer it points into.

**What a guest can see is unchanged in extent**: everything from the moment they were let in, nothing from before it. It just survives them looking away — which also fixes a browser refresh, a reconnect, and joining from a second device, all of which started blank before.

## Tests

- `session-tunnel-policy.test.ts` — re-attach is replayed and pre-share output is not; a grant with no mark starts its window at first attach; the marker still leads every attach; revocation forgets the window.
- `pty-manager.test.ts` — replay from a mark, a mark at the current position replaying nothing, and a mark the cap has evicted yielding only what survives.
- Full desktop suite (848) and relay suite (163) green; `tsc -p tsconfig.main.json` clean.

## Manual verification wanted

Two testers, one shared session: watch, back out to your own session, produce output on the shared one, return — the intervening output should be there, and nothing from before the share.

Closes #169
