### PR TITLE
Bug: an addressed share link rejects the correct GitHub account when the relay has no handle on file

### DIFF
--- a/docs/designs/session-sharing.md
+++ b/docs/designs/session-sharing.md
@@ -373,6 +373,12 @@ roll-up, not the only route.
   `expected_github_login` so redemption by anyone else fails closed. A secondary *"Or make an
   open link"* covers the case where the owner doesn't know the handle. An addressed invite
   turns the approval modal into a confirmation instead of a stranger-check.
+
+  A NULL `users.github_login` — every account that has not signed in since migration 003 —
+  fails closed, and must, but it is **not** the same refusal as a wrong account (#170). It
+  gets its own reason, `login_unknown`, and copy that offers the one action that fixes it:
+  sign in again, which is what puts the handle on file. Telling the person the link *was*
+  addressed to that it "isn't for this account" is both wrong and a dead end.
 - **What they can do?**
   - **Watch** — *"They see this session's live output. They can't type."*
   - **Watch and type** — *"They can run any command you can, read any file you can, and spend

--- a/relay/src/http.ts
+++ b/relay/src/http.ts
@@ -484,6 +484,10 @@ export function createRouter(ctx: RelayContext) {
     const result = repos.redeemShareInvite(code, user, crypto.randomUUID());
     if (!result.ok) {
       const status = result.reason === 'not_found' ? 404 : 409;
+      // Logged because a refusal is the one outcome the guest cannot explain
+      // and the owner cannot see. `login_unknown` in particular looked exactly
+      // like a wrong account from the outside.
+      logger.info('share invite refused', { reason: result.reason });
       return json({ error: `invite_${result.reason}` }, status);
     }
 

--- a/relay/src/repositories.ts
+++ b/relay/src/repositories.ts
@@ -164,7 +164,18 @@ export interface CreateShareInviteInput {
 
 export type RedeemResult =
   | { ok: true; grant: MachineGrant; invite: ShareInvite }
-  | { ok: false; reason: 'not_found' | 'expired' | 'already_used' | 'revoked' | 'wrong_account' | 'own_machine' };
+  | {
+      ok: false;
+      reason:
+        | 'not_found'
+        | 'expired'
+        | 'already_used'
+        | 'revoked'
+        | 'wrong_account'
+        | 'own_machine'
+        /** Addressed invite, and this user's GitHub handle is not on file yet. */
+        | 'login_unknown';
+    };
 
 /** Thrown inside the redemption transaction to roll it back on a lost race. */
 class RedeemRaceError extends Error {
@@ -420,10 +431,15 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
       if (machine.user_id === user.id) return { ok: false, reason: 'own_machine' };
 
       if (row.expected_github_login) {
-        // A NULL login can never match: a user who has not signed in since
-        // migration 003 must not silently satisfy an addressed invite.
         const login = user.github_login?.trim().toLowerCase();
-        if (!login || login !== row.expected_github_login) return { ok: false, reason: 'wrong_account' };
+        // A NULL login can never match: a user who has not signed in since
+        // migration 003 must not silently satisfy an addressed invite. But it
+        // is not evidence that this is the wrong person either, and answering
+        // as though it were told the RIGHT person the link was not for them,
+        // with no hint that signing in again is all it takes. Fail closed on
+        // both, distinguish the cause.
+        if (!login) return { ok: false, reason: 'login_unknown' };
+        if (login !== row.expected_github_login) return { ok: false, reason: 'wrong_account' };
       }
 
       const ts = now();

--- a/relay/src/shares-http.test.ts
+++ b/relay/src/shares-http.test.ts
@@ -313,6 +313,35 @@ describe('POST /api/shares/redeem', () => {
     }
   });
 
+  test('an account whose GitHub handle is not on file gets its own answer', async () => {
+    // Same refusal, different cause: this one the person reading it can fix,
+    // and the wrong_account copy tells them not to bother trying.
+    const f = await fixture();
+    try {
+      const code = await codeFor(f);
+      const stale = f.repos.upsertGithubUser({
+        providerUserId: '4',
+        displayName: 'Signed in before migration 003',
+        login: '',
+        email: null,
+        avatarUrl: null,
+      });
+      f.db.query('UPDATE users SET github_login = NULL WHERE id = ?').run(stale.id);
+      const res = await f.route(
+        new Request('http://relay.test/api/shares/redeem', {
+          method: 'POST',
+          headers: { cookie: `bdl_session=${f.repos.createSession(stale.id, 3600).token}` },
+          body: JSON.stringify({ code }),
+        }),
+      );
+      expect(res.status).toBe(409);
+      expect((await res.json()) as unknown).toEqual({ error: 'invite_login_unknown' });
+      expect(f.redeemed).toHaveLength(0);
+    } finally {
+      f.db.close();
+    }
+  });
+
   test('requires a session', async () => {
     const f = await fixture();
     try {

--- a/relay/src/sharing.test.ts
+++ b/relay/src/sharing.test.ts
@@ -408,7 +408,38 @@ describe('redeemShareInvite', () => {
     try {
       const { code } = f.repos.createShareInvite(inviteInput(f));
       const result = f.repos.redeemShareInvite(code, guestUser(f, null), crypto.randomUUID());
-      expect(result).toEqual({ ok: false, reason: 'wrong_account' });
+      expect(result.ok).toBe(false);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('a missing login is reported as its own cause, not as the wrong account', () => {
+    // The refusal is the same; the explanation is not. Told "this link isn't
+    // for this account", the person it WAS for has no reason to think signing
+    // in again would change anything — and it is the only thing that does.
+    const f = freshFixture();
+    try {
+      const { code } = f.repos.createShareInvite(inviteInput(f, { expectedGithubLogin: 'dana-k' }));
+      const result = f.repos.redeemShareInvite(code, guestUser(f, null), crypto.randomUUID());
+      expect(result).toEqual({ ok: false, reason: 'login_unknown' });
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('the invite survives a login_unknown refusal, so the retry works', () => {
+    // A refusal that consumed the code would make the fix unreachable: the
+    // guest signs in again and finds a link that now says "already used".
+    const f = freshFixture();
+    try {
+      const { code } = f.repos.createShareInvite(inviteInput(f, { expectedGithubLogin: 'dana-k' }));
+      expect(f.repos.redeemShareInvite(code, guestUser(f, null), crypto.randomUUID())).toEqual({
+        ok: false,
+        reason: 'login_unknown',
+      });
+      // Same person, back from OAuth with their handle on file.
+      expect(f.repos.redeemShareInvite(code, guestUser(f, 'dana-k'), crypto.randomUUID()).ok).toBe(true);
     } finally {
       f.db.close();
     }

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -117,8 +117,13 @@ function invitedFingerprint(): string | null {
   return m ? decodeURIComponent(m[1]!) : null;
 }
 
-/** Copy for each way an invite can fail. Never guesses. */
-const REDEEM_COPY: Record<string, { title: string; body: string }> = {
+/**
+ * Copy for each way an invite can fail. Never guesses.
+ *
+ * `reauth` marks the one failure the person reading it can actually fix, and
+ * gets a button rather than a sentence telling them to go and do it.
+ */
+const REDEEM_COPY: Record<string, { title: string; body: string; reauth?: boolean }> = {
   invite_not_found: { title: "That link doesn't work", body: 'Check you copied all of it, or ask for a new one.' },
   invite_expired: { title: 'That link has expired', body: 'Ask for a new one — links stop working after a while on purpose.' },
   invite_already_used: { title: 'That link has been used', body: 'Invite links work once. Ask for a new one.' },
@@ -128,6 +133,13 @@ const REDEEM_COPY: Record<string, { title: string; body: string }> = {
     body: 'It was addressed to a specific GitHub account. Sign in as that account, or ask for a link addressed to you.',
   },
   invite_own_machine: { title: "That's your own machine", body: 'You already have full access to it — no invite needed.' },
+  invite_login_unknown: {
+    title: "One more sign-in and you're in",
+    body:
+      "This link is addressed to a GitHub account, and we don't have your handle on file yet — signing in again " +
+      'fetches it and brings you straight back here.',
+    reauth: true,
+  },
 };
 
 async function renderRedeem(code: string): Promise<void> {
@@ -162,10 +174,25 @@ async function renderRedeem(code: string): Promise<void> {
       body: 'Ask whoever sent it for a new one.',
     };
     rootEl.innerHTML = `<div class="screen-center"><div class="card-center">
-      <div class="logo">🚫</div><h1>${esc(copy.title)}</h1>
+      <div class="logo">${copy.reauth ? '🔑' : '🚫'}</div><h1>${esc(copy.title)}</h1>
       <p>${esc(copy.body)}</p>
+      ${copy.reauth ? '<button class="btn gh" id="reauth">Sign in with GitHub</button>' : ''}
       <a class="btn ghost" href="/">Go to my machines</a>
     </div></div>`;
+    // Stash the invite the same way the signed-out path does, so OAuth returns
+    // to this link — with its fingerprint fragment — instead of the home page.
+    const reauth = $('#reauth');
+    if (reauth) {
+      reauth.onclick = () => {
+        // From the path, keep the fragment: it carries the machine fingerprint
+        // and does not survive the OAuth round trip on its own. From a typed
+        // code there is no fragment, so rebuild the link from the code itself
+        // rather than stashing whatever page they happened to be on.
+        const here = inviteCodeFromPath() === code ? location.pathname + location.hash : `/i/${encodeURIComponent(code)}`;
+        sessionStorage.setItem(INVITE_STASH, here);
+        location.href = '/auth/github/login';
+      };
+    }
     return;
   }
 


### PR DESCRIPTION
## What this fixes

An addressed share link (`Who's it for? → @william-long-ii`) refused the person it was addressed to, while they were signed in to the relay as exactly that GitHub account: *"This link isn't for this account — sign in as that account, or ask for a link addressed to you."*

## Why it happened

`003_github_login.sql` added `users.github_login` **nullable with no backfill** — "existing users acquire it on their next sign-in" — and relay sessions live 30 days (`http.ts:63`). So any account whose cookie predates that deploy has a NULL handle, and `redeemShareInvite` fails closed on NULL.

Failing closed is correct. Reporting it as `wrong_account` is not: it names the wrong cause, tells the right person the link isn't theirs, and points at the one recovery that doesn't work (signing in *as that account* — they already are) while hiding the one that does (signing in *again*).

## The change

- **Relay** — NULL handle on an addressed invite returns a new `login_unknown` reason. A genuine mismatch still returns `wrong_account`. Neither can be satisfied by a NULL.
- **Web** — `invite_login_unknown` copy explains the real cause and renders a *Sign in with GitHub* button, which stashes the invite through `INVITE_STASH` before redirecting so OAuth returns to the link with its `#fp=` fingerprint fragment intact, rather than to the home page. Re-auth upserts the profile, which is what puts the handle on file.
- **Observability** — refused redemptions are now logged with their reason. Previously a refusal was invisible from both ends: misleading copy for the guest, nothing at all for the owner.

A failed redemption leaves the invite `pending`, so the retry after signing in lands on a code that still works — covered by a test, because the alternative (a refusal that consumed the code) would make the fix unreachable.

## Tests

- `sharing.test.ts` — NULL handle reports `login_unknown`; the invite survives the refusal and the same user's retry succeeds after their handle is on file.
- `shares-http.test.ts` — the endpoint returns `409 invite_login_unknown` and fires no redemption callback.
- Relay suite (166) green; `tsc --noEmit` clean for both relay and web trees.

## Still worth confirming on the live relay

`redeemShareInvite` checks `own_machine` **before** the handle, so clicking your own machine's link as its owner shows "That's your own machine", not the addressing error. Seeing the addressing error means the browser's relay user row was not the row the machine is linked to. `SELECT id, display_name, github_login FROM users;` plus the machine's `user_id` would confirm whether this PR is the whole story or only part of it — and the new refusal log will say so directly on the next attempt.

Closes #170
