### PR TITLE
Feature: an "until I revoke it" duration for shared session access

### DIFF
--- a/docs/designs/session-sharing.md
+++ b/docs/designs/session-sharing.md
@@ -382,6 +382,14 @@ roll-up, not the only route.
   *"This link works for 1 hour if nobody uses it. Once dana-k joins, they have access for 4
   hours."*
 
+  Access may also last **until the owner revokes it** (#171), carried as
+  `grantTtlSeconds: 0` — a different answer to the question, not a longer one. The clock was
+  never what bounded a share: the desktop's own table decides whether a grant is live and is
+  consulted at every `client:open`, the scope is bound to a PTY instance so a restart of the
+  shared session ends it regardless, and revocation reaches live sockets immediately. An
+  unexpiring certificate is not an unrevocable one, and a four-hour ceiling only meant
+  re-inviting the same colleague every afternoon.
+
 The created state shows the URL, a QR, the readable code, and `🔑 This link is the key. Send
 it over something private.`
 

--- a/fixtures/sharing-v1.json
+++ b/fixtures/sharing-v1.json
@@ -33,6 +33,25 @@
     "certificate": "grant:v1.Z3JhbnQ6djEKN2YzYTFjOTItNWI0ZS00ZDE4LTlhMjAtNmMxZThmMGIzZDQ3CmMyYjhhNGUwLTFkNzYtNGYzOS04ZTU1LTlhM2I3YzBkMmY2MQpodHRwczovL3JlbGF5LmV4YW1wbGUuY29tCmQ5MWU2YjczLTJhMDgtNGM1Zi1iMTM0LTdlNTBmOWE2Yzg4Mgp2aWV3ZXIKMTc2MDAwMDAwMDAwMAoxNzYwMDE0NDAwMDAw.xINoFOrJmE64iKEUDCsYEGL6JSpBOPOLl8KucZy8RFktvWqwxgcOmcn5IBXLgd-ejm6Aj44cMzuGkvNHiHZYAw"
   },
 
+  "shareCreate": {
+    "_note": [
+      "The message a desktop signs to create a share invite. Hand-duplicated in",
+      "src/main/api/relay/grants.ts and relay/src/protocol.ts, and a drift between them is",
+      "invisible until it surfaces as 'relay rejected the share request (401)'.",
+      "grantTtlSeconds is 0 on purpose: 0 means UNTIL REVOKED, and it is the value most",
+      "likely to be 'helpfully' defaulted away by one side and not the other."
+    ],
+    "parts": {
+      "machineId": "c2b8a4e0-1d76-4f39-8e55-9a3b7c0d2f61",
+      "expectedGithubLogin": "dana-k",
+      "role": "viewer",
+      "grantTtlSeconds": 0,
+      "inviteTtlSeconds": 3600,
+      "issuedAt": 1760000000000
+    },
+    "message": "share-create:v1\nc2b8a4e0-1d76-4f39-8e55-9a3b7c0d2f61\ndana-k\nviewer\n0\n3600\n1760000000000"
+  },
+
   "policy": {
     "_note": [
       "The certificate format will not drift; this will, the moment 'operator' becomes",

--- a/relay/src/http.ts
+++ b/relay/src/http.ts
@@ -76,6 +76,7 @@ const SHARE_PER_IP = 20;
  * defaults; these exist so a malformed or hostile request cannot produce a
  * grant that outlives any reasonable session.
  */
+/** Upper bound for a grant that expires at all; 0 means "until revoked". */
 const MAX_GRANT_TTL_SECONDS = 24 * 60 * 60;
 const MAX_INVITE_TTL_SECONDS = 7 * 24 * 60 * 60;
 
@@ -394,7 +395,13 @@ export function createRouter(ctx: RelayContext) {
       return json({ error: 'invalid_request' }, 400);
     }
     if (!(MINTABLE_ROLES as readonly string[]).includes(role)) return json({ error: 'invalid_role' }, 400);
-    if (grantTtlSeconds <= 0 || grantTtlSeconds > MAX_GRANT_TTL_SECONDS) return json({ error: 'invalid_ttl' }, 400);
+    // 0 is "until the owner revokes it" — see GRANT_TTL_UNTIL_REVOKED. The
+    // relay stores it and nothing more: it is not the authority on how long a
+    // grant lives, the machine that signs the certificate is, and that machine
+    // ends the grant on revoke or on a restart of the shared session whatever
+    // the clock says. Every other value stays capped.
+    if (!Number.isInteger(grantTtlSeconds) || grantTtlSeconds < 0) return json({ error: 'invalid_ttl' }, 400);
+    if (grantTtlSeconds > MAX_GRANT_TTL_SECONDS) return json({ error: 'invalid_ttl' }, 400);
     if (inviteTtlSeconds <= 0 || inviteTtlSeconds > MAX_INVITE_TTL_SECONDS) return json({ error: 'invalid_ttl' }, 400);
     if (Math.abs(Date.now() - issuedAt) > LINK_MAX_SKEW_MS) return json({ error: 'stale_request' }, 400);
 

--- a/relay/src/protocol.ts
+++ b/relay/src/protocol.ts
@@ -66,6 +66,7 @@ export interface ShareCreateParts {
   /** Empty string for an open link. */
   expectedGithubLogin: string;
   role: string;
+  /** Seconds of access once the guest joins; 0 means until the owner revokes. */
   grantTtlSeconds: number;
   inviteTtlSeconds: number;
   issuedAt: number;

--- a/relay/src/shares-http.test.ts
+++ b/relay/src/shares-http.test.ts
@@ -205,12 +205,29 @@ describe('POST /api/machines/:id/shares', () => {
     }
   });
 
-  test('rejects a TTL beyond the ceiling', async () => {
+  test('rejects a TTL beyond the ceiling, or one that is not a whole count', async () => {
     const f = await fixture();
     try {
       expect((await createInvite(f, { grantTtlSeconds: 400 * 24 * 3600 })).status).toBe(400);
       expect((await createInvite(f, { inviteTtlSeconds: 400 * 24 * 3600 })).status).toBe(400);
-      expect((await createInvite(f, { grantTtlSeconds: 0 })).status).toBe(400);
+      expect((await createInvite(f, { grantTtlSeconds: -1 })).status).toBe(400);
+      expect((await createInvite(f, { grantTtlSeconds: 1.5 })).status).toBe(400);
+    } finally {
+      f.db.close();
+    }
+  });
+
+  test('accepts 0 — the owner asking for access that lasts until they revoke it', async () => {
+    // The relay is not the authority on how long a grant lives: the machine
+    // that signs the certificate is, and it ends the grant on revoke or on a
+    // restart of the shared session whatever the clock says. Storing 0 is
+    // storing the owner's answer, not granting anything.
+    const f = await fixture();
+    try {
+      const res = await createInvite(f, { grantTtlSeconds: 0 });
+      expect(res.status).toBe(200);
+      const { inviteId } = (await res.json()) as { inviteId: string };
+      expect(f.repos.listShareInvites(f.machineId).find((i) => i.id === inviteId)?.grant_ttl_seconds).toBe(0);
     } finally {
       f.db.close();
     }

--- a/relay/src/sharing.test.ts
+++ b/relay/src/sharing.test.ts
@@ -5,11 +5,13 @@ import { openDb, type RelayDb } from './db';
 import { createRepositories, type Repositories } from './repositories';
 import {
   buildGrantMessage,
+  buildShareCreateMessage,
   formatCertificate,
   GRANT_VERSION,
   MINTABLE_ROLES,
   parseCertificate,
   type GrantParts,
+  type ShareCreateParts,
 } from './protocol';
 import { verifyEd25519, fromBase64 } from './crypto';
 
@@ -34,6 +36,7 @@ const FIXTURE = JSON.parse(
     signatureB64url: string;
     certificate: string;
   };
+  shareCreate: { parts: ShareCreateParts; message: string };
   policy: { mintableRoles: string[] };
 };
 
@@ -59,6 +62,17 @@ describe('grant certificate wire format', () => {
 
   test('parsing yields exactly the fixture parts', () => {
     expect(parseCertificate(VEC.certificate)!.parts).toEqual(VEC.parts);
+  });
+
+  test('the share-create message matches the desktop byte for byte', () => {
+    // This one the relay DOES evaluate: it verifies the signature over these
+    // bytes before creating an invite, so a drift here rejects a share request
+    // from a machine that did everything right. `grantTtlSeconds: 0` — until
+    // revoked — is in the vector because it is the field most likely to be
+    // defaulted away by one tree and not the other.
+    expect(Buffer.from(buildShareCreateMessage(FIXTURE.shareCreate.parts)).toString('utf8')).toBe(
+      FIXTURE.shareCreate.message,
+    );
   });
 
   test('mintable roles match the fixture and exclude owner', () => {

--- a/src/main/api/relay/__tests__/grants.test.ts
+++ b/src/main/api/relay/__tests__/grants.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
   buildGrantMessage,
+  buildShareCreateMessage,
   checkCertificate,
   COMMAND_CAPS,
   DENY_ALL,
@@ -11,6 +12,9 @@ import {
   grantFrom,
   isSessionScoped,
   MINTABLE_ROLES,
+  GRANT_NEVER_EXPIRES,
+  GRANT_TTL_UNTIL_REVOKED,
+  grantExpiryAt,
   ownerGrant,
   parseCertificate,
   permits,
@@ -18,6 +22,7 @@ import {
   verifyCertificateSignature,
   type Cap,
   type GrantParts,
+  type ShareCreateParts,
 } from '../grants';
 
 const FIXTURE = JSON.parse(
@@ -32,6 +37,7 @@ const FIXTURE = JSON.parse(
     signatureB64url: string;
     certificate: string;
   };
+  shareCreate: { parts: ShareCreateParts; message: string };
   policy: {
     caps: Cap[];
     roleCaps: Record<string, Cap[]>;
@@ -96,6 +102,22 @@ describe('the checked-in certificate vector', () => {
 
   test('parsing the fixture yields exactly the fixture parts', () => {
     expect(parseCertificate(VEC.certificate)!.parts).toEqual(VEC.parts);
+  });
+});
+
+describe('the checked-in share-create vector', () => {
+  test('builds byte-for-byte what the relay expects to verify', () => {
+    // The two trees build this message independently. A drift is invisible
+    // until it lands as "relay rejected the share request (401)" for someone
+    // who did nothing wrong.
+    expect(new TextDecoder().decode(buildShareCreateMessage(FIXTURE.shareCreate.parts))).toBe(
+      FIXTURE.shareCreate.message,
+    );
+  });
+
+  test('an until-revoked TTL travels as 0, not as an omission or a large number', () => {
+    expect(FIXTURE.shareCreate.parts.grantTtlSeconds).toBe(0);
+    expect(FIXTURE.shareCreate.message.split('\n')[4]).toBe('0');
   });
 });
 
@@ -355,5 +377,41 @@ describe('policy immutability', () => {
     const g = grantFrom({ ...VEC.parts, role: 'viewer' }, scope);
     scope.push('s2');
     expect(permits(g, 'terminal:subscribe', 's2', VEC.parts.issuedAt + 1)).toBe(false);
+  });
+});
+
+/**
+ * "Until I revoke it" (#171). The clock is not what bounds a share — the
+ * desktop's own table is, and it is consulted on every open — so an expiry
+ * the owner never has to renew is a real option rather than a loophole.
+ */
+describe('grantExpiryAt', () => {
+  const now = 1_700_000_000_000;
+
+  test('a TTL of seconds is that many seconds from now', () => {
+    expect(grantExpiryAt(now, 4 * 3600)).toBe(now + 4 * 3600 * 1000);
+  });
+
+  test('the until-revoked sentinel expires at the end of representable time', () => {
+    expect(GRANT_TTL_UNTIL_REVOKED).toBe(0);
+    expect(grantExpiryAt(now, GRANT_TTL_UNTIL_REVOKED)).toBe(GRANT_NEVER_EXPIRES);
+  });
+
+  test('that expiry is a safe integer and a valid Date, so nothing has to special-case it', () => {
+    // Every expiry check in both trees is a plain comparison, and
+    // `assertGrantFieldsSafe` refuses anything that is not a safe integer.
+    expect(Number.isSafeInteger(GRANT_NEVER_EXPIRES)).toBe(true);
+    expect(Number.isNaN(new Date(GRANT_NEVER_EXPIRES).getTime())).toBe(false);
+  });
+
+  test('an unexpiring grant is still stopped by revocation', () => {
+    // Which is the whole reason it is safe to offer: what ends the share is
+    // the owner, not the clock.
+    const live = grantFrom(
+      { ...FIXTURE.certificate.parts, expiresAt: GRANT_NEVER_EXPIRES },
+      ['s1'],
+    );
+    expect(permits(live, 'terminal:subscribe', 's1', GRANT_NEVER_EXPIRES - 1)).toBe(true);
+    expect(permits(DENY_ALL, 'terminal:subscribe', 's1', now)).toBe(false);
   });
 });

--- a/src/main/api/relay/grant-store.ts
+++ b/src/main/api/relay/grant-store.ts
@@ -16,7 +16,14 @@ import { getDatabase } from '../../database';
 import { getPreference, setPreference } from '../../repositories/preferences';
 import { signWithIdentity, ensureIdentity } from './relay-identity';
 import * as sql from './grant-sql';
-import { buildGrantMessage, formatCertificate, MINTABLE_ROLES, type GrantRole, type GrantParts } from './grants';
+import {
+  buildGrantMessage,
+  formatCertificate,
+  grantExpiryAt,
+  MINTABLE_ROLES,
+  type GrantRole,
+  type GrantParts,
+} from './grants';
 
 export type { StoredGrant, StoredGrantSession } from './grant-sql';
 export { RELAY_SHARING_SCHEMA } from './grant-sql';
@@ -100,6 +107,7 @@ export interface MintRequest {
   role: GrantRole;
   /** Sessions the owner approved, with the PTY instance each was approved on. */
   sessions: sql.StoredGrantSession[];
+  /** Seconds of access, or `GRANT_TTL_UNTIL_REVOKED` (0) for no expiry. */
   ttlSeconds: number;
 }
 
@@ -127,7 +135,7 @@ export function mintGrant(req: MintRequest, now = Date.now()): { grant: sql.Stor
     throw new Error('refusing to mint a grant with no sessions');
   }
 
-  const expiresAt = now + req.ttlSeconds * 1000;
+  const expiresAt = grantExpiryAt(now, req.ttlSeconds);
   const parts: GrantParts = {
     grantId: req.grantId,
     machineId: req.machineId,

--- a/src/main/api/relay/grants.ts
+++ b/src/main/api/relay/grants.ts
@@ -102,6 +102,35 @@ export function buildShareCreateMessage(p: ShareCreateParts): Uint8Array {
   return new TextEncoder().encode(line);
 }
 
+/**
+ * `grantTtlSeconds: 0` means "until the owner revokes it".
+ *
+ * Zero rather than a magic large number because it is the value that travels:
+ * it sits inside the signed `share-create:v1` message and in the relay's
+ * `grant_ttl_seconds` column, and a sentinel that reads as "no duration" is
+ * harder to mistake for a duration than 3155760000 is.
+ *
+ * This is safe here because a certificate's lifetime is not what bounds a
+ * share. The desktop's own table decides whether a grant is still live and is
+ * consulted on every `client:open`, the scope is bound to a PTY instance so a
+ * session restart ends it regardless of clock, and revocation reaches live
+ * sockets immediately. An unexpiring certificate is not an unrevocable one.
+ */
+export const GRANT_TTL_UNTIL_REVOKED = 0;
+
+/**
+ * The expiry an "until revoked" certificate carries: the largest timestamp
+ * `Date` can represent. Every check on this value is a plain comparison, so
+ * nothing needs to special-case it — and it stays a safe integer, which
+ * `assertGrantFieldsSafe` requires and SQLite stores exactly.
+ */
+export const GRANT_NEVER_EXPIRES = 8_640_000_000_000_000;
+
+/** When a grant minted now with `ttlSeconds` should stop being honoured. */
+export function grantExpiryAt(now: number, ttlSeconds: number): number {
+  return ttlSeconds === GRANT_TTL_UNTIL_REVOKED ? GRANT_NEVER_EXPIRES : now + ttlSeconds * 1000;
+}
+
 export interface GrantParts {
   grantId: string;
   machineId: string;

--- a/src/main/api/relay/relay-client.ts
+++ b/src/main/api/relay/relay-client.ts
@@ -672,6 +672,9 @@ export class RelayClient extends EventEmitter {
 
     // From the invite the owner created, not from `expiresAt` — that is NULL
     // until we countersign, which is exactly the moment we are in now.
+    //
+    // `??`, not `||`: 0 is a value the owner chose (until revoked), and `||`
+    // would quietly turn it back into four hours.
     const ttlSeconds = pending.grantTtlSeconds ?? DEFAULT_GRANT_TTL_SECONDS;
     const { certificate, grant } = mintGrant({
       grantId,

--- a/src/renderer/components/ShareSessionModal.tsx
+++ b/src/renderer/components/ShareSessionModal.tsx
@@ -24,11 +24,20 @@ const INVITE_TTL_OPTIONS = [
   { label: '1 day', seconds: 24 * HOUR },
 ];
 
-/** Grant lifetime — how long access lasts once they join. */
+/**
+ * Grant lifetime — how long access lasts once they join.
+ *
+ * "Until I revoke it" is 0, not a very large number: it is a different answer
+ * to the question, not a longer one. Someone watching a session alongside
+ * their own work should not lose it mid-afternoon and have to be re-invited,
+ * and re-issuing a link every few hours buys nothing — revoking is instant,
+ * and restarting the shared session ends the share on its own.
+ */
 const GRANT_TTL_OPTIONS = [
   { label: '1 hour', seconds: HOUR },
   { label: '4 hours', seconds: 4 * HOUR },
   { label: '8 hours', seconds: 8 * HOUR },
+  { label: 'Until I revoke it', seconds: 0 },
 ];
 
 interface ShareSessionModalProps {
@@ -144,6 +153,14 @@ export const ShareSessionModal: React.FC<ShareSessionModalProps> = ({ sessionId,
               : `Only @${login.trim()} can use this link. You still have to let them in.`}
           </p>
 
+          {/* Stated on the confirmation too: this is the one choice that keeps
+              running after the owner has stopped thinking about it. */}
+          {grantTtl === 0 && (
+            <p className="share-note">
+              Access lasts until you revoke it — or until this session restarts.
+            </p>
+          )}
+
           <div className="share-buttons">
             <button type="button" className="share-secondary" onClick={onClose}>
               Done
@@ -218,7 +235,7 @@ export const ShareSessionModal: React.FC<ShareSessionModalProps> = ({ sessionId,
                   </option>
                 ))}
               </select>
-              <span className="share-hint">you can end it sooner</span>
+              <span className="share-hint">{grantTtl === 0 ? 'ends when you say so' : 'you can end it sooner'}</span>
             </div>
           </fieldset>
 

--- a/src/renderer/components/__tests__/ShareSessionModal.test.tsx
+++ b/src/renderer/components/__tests__/ShareSessionModal.test.tsx
@@ -74,6 +74,25 @@ describe('rendering', () => {
     expect(screen.getByText(/Once they join, access lasts/i)).toBeTruthy();
   });
 
+  test('offers access that lasts until the owner revokes it', async () => {
+    // A 4-hour ceiling means anyone monitoring a session alongside their own
+    // work loses it mid-afternoon and has to be re-invited. 0 is the sentinel
+    // for "no expiry" — the desktop still decides when the grant ends.
+    renderModal();
+    const grantSelect = document.getElementById('share-grant-ttl') as HTMLSelectElement;
+    expect([...grantSelect.options].map((o) => o.textContent)).toContain('Until I revoke it');
+
+    fireEvent.change(loginInput(), { target: { value: 'dana-k' } });
+    fireEvent.change(grantSelect, { target: { value: '0' } });
+    fireEvent.click(createBtn());
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0]!.grantTtlSeconds).toBe(0);
+    // And the confirmation says so, because this is the choice that keeps
+    // running after the owner has stopped thinking about it.
+    expect(screen.getByText(/until you revoke it/i)).toBeTruthy();
+  });
+
   test('offers watch-and-type as disabled rather than hiding it', () => {
     // The absence of a control is not an explanation.
     renderModal();


### PR DESCRIPTION
## What this adds

An **Until I revoke it** choice under "Once they join, access lasts". The options were 1, 4 and 8 hours, and the relay refused anything past 24 (`MAX_GRANT_TTL_SECONDS`). Anyone monitoring a shared session alongside their own work lost access mid-afternoon and had to be re-invited.

## Why it's safe to offer

The clock was never what bounded a share:

- the desktop's own table decides whether a grant is live, and `session-tunnel.ts:437` consults it on **every** `client:open`;
- scope is bound to the PTY **instance**, so restarting the shared session ends the grant whatever the certificate says;
- revocation reaches live sockets immediately (`revokeGrant` → `DENY_ALL` + sealed `denied`).

An unexpiring certificate is not an unrevocable one. The relay stores the owner's answer; it was never the authority on it.

## Shape

`grantTtlSeconds: 0` — a different answer to the question, not a longer one, which is why it isn't `3155760000`:

- **Modal** — new option, plus a line on the confirmation screen, because this is the one choice that keeps running after the owner has stopped thinking about it.
- **Certificate** — `grantExpiryAt(now, ttl)` maps 0 to `8_640_000_000_000_000`, the largest timestamp `Date` can represent. It's a safe integer (`assertGrantFieldsSafe` requires that) and every expiry check in both trees is a plain comparison, so nothing special-cases it.
- **Relay** — `grantTtlSeconds` must now be a whole number ≥ 0; 0 bypasses the cap, everything else is still capped at 24h. Negatives and fractions are newly rejected.
- **Approval** — `pending.grantTtlSeconds ?? DEFAULT` was already `??` rather than `||`, which is what keeps a chosen 0 from silently becoming four hours. Now commented as load-bearing.

## Correction to the issue

The issue said `fixtures/sharing-v1.json` covers the `share-create:v1` message and needed a case. It didn't cover it at all — the fixture only pinned the certificate and the policy table. That message is hand-duplicated in `relay/src/protocol.ts` and `src/main/api/relay/grants.ts`, is verified by signature, and a drift between the copies surfaces only as *"relay rejected the share request (401)"* for someone who did nothing wrong. So this PR **adds** a `shareCreate` vector, asserted independently by both trees, with `grantTtlSeconds: 0` in it — precisely the field one side might helpfully default away.

## Tests

- `ShareSessionModal.test.tsx` — the option exists, sends `0`, and the confirmation says so.
- `grants.test.ts` — `grantExpiryAt` for both branches; the never-expiry value is a safe integer and a valid `Date`; an unexpiring grant is still stopped by revocation. Plus the new cross-tree share-create assertions.
- `shares-http.test.ts` — 0 is accepted and stored as 0; negative and fractional TTLs are rejected; the ceiling still holds.
- Desktop suite (849) and relay suite (165) green; `tsc -p tsconfig.main.json` clean.

## Not included

Nothing renders a grant list in the desktop yet (`relayListShares` has no renderer consumer), so there is no "Until revoked" label to add to a settings screen. When that screen lands it must not format `8640000000000000` as a date.

Closes #171
