### PR TITLE
Web client has no way to sign out — or to see who you are signed in as

### DIFF
--- a/docs/designs/session-sharing.md
+++ b/docs/designs/session-sharing.md
@@ -413,6 +413,12 @@ roll-up, not the only route.
   gets its own reason, `login_unknown`, and copy that offers the one action that fixes it:
   sign in again, which is what puts the handle on file. Telling the person the link *was*
   addressed to that it "isn't for this account" is both wrong and a dead end.
+
+  A genuine `wrong_account` needs an escape too (#175). Re-running OAuth would hand back the
+  same session, so that refusal offers **sign out, then sign in** — and the invite is
+  re-stashed *after* the sign-out wipe so the pending link outlives the session it was
+  refused by. Without it the copy asks the guest to switch accounts in an app that, until
+  #175, had no sign-out control anywhere.
 - **What they can do?**
   - **Watch** — *"They see this session's live output. They can't type."*
   - **Watch and type** — *"They can run any command you can, read any file you can, and spend

--- a/relay/src/http.ts
+++ b/relay/src/http.ts
@@ -578,6 +578,11 @@ function publicUser(user: User) {
     displayName: user.display_name,
     email: user.primary_email,
     avatarUrl: user.avatar_url,
+    // Null is a real, reachable state: a row created before we recorded logins
+    // has none until the next sign-in backfills it. The client surfaces that
+    // rather than hiding it — it is the whole reason an addressed invite can
+    // refuse someone who IS the right person (#170).
+    githubLogin: user.github_login,
   };
 }
 

--- a/relay/src/m2.test.ts
+++ b/relay/src/m2.test.ts
@@ -295,6 +295,17 @@ describe('router: GitHub OAuth', () => {
   }
   const mockFetch = makeMockFetch();
 
+  /** Run the OAuth callback and return the issued session token. */
+  async function signIn(route: (req: Request) => Promise<Response> | Response): Promise<string> {
+    const res = await route(
+      new Request('http://relay.test/auth/github/callback?code=abc&state=xyz', {
+        headers: { cookie: 'bdl_oauth_state=xyz' },
+      }),
+    );
+    const session = res.headers.getSetCookie().find((c) => c.startsWith('bdl_session='))!;
+    return session.slice('bdl_session='.length).split(';')[0]!;
+  }
+
   test('login without OAuth config returns 503', async () => {
     const { config } = loadConfig({});
     const route = createRouter({ config, logger, repos: freshRepos() });
@@ -332,6 +343,42 @@ describe('router: GitHub OAuth', () => {
     const { user } = (await meRes.json()) as { user: { displayName: string; email: string } };
     expect(user.displayName).toBe('The Octocat');
     expect(user.email).toBe('octo@gh.com');
+  });
+
+  // The client shows this handle, and shows a warning when it is missing —
+  // an addressed invite matches on it, so an absent one is the difference
+  // between a link working and being refused (#170).
+  test('/api/me reports the GitHub handle the relay holds', async () => {
+    const { config } = loadConfig({ GITHUB_CLIENT_ID: 'id', GITHUB_CLIENT_SECRET: 'secret' });
+    const route = createRouter({ config, logger, repos: freshRepos(), fetchImpl: mockFetch });
+    const token = await signIn(route);
+
+    const meRes = await route(new Request('http://relay.test/api/me', { headers: { cookie: `bdl_session=${token}` } }));
+    const { user } = (await meRes.json()) as { user: { githubLogin: string | null } };
+    expect(user.githubLogin).toBe('octocat');
+  });
+
+  test('logout destroys the session, so the same cookie stops working', async () => {
+    const { config } = loadConfig({ GITHUB_CLIENT_ID: 'id', GITHUB_CLIENT_SECRET: 'secret' });
+    const route = createRouter({ config, logger, repos: freshRepos(), fetchImpl: mockFetch });
+    const token = await signIn(route);
+    const cookie = `bdl_session=${token}`;
+
+    const outRes = await route(new Request('http://relay.test/auth/logout', { method: 'POST', headers: { cookie } }));
+    expect(outRes.status).toBe(204);
+    expect(outRes.headers.get('set-cookie')).toContain('bdl_session=;');
+
+    // Clearing the cookie is only half of it. A cookie that was copied off the
+    // machine has to die server-side too, or "sign out" is decoration.
+    const after = await route(new Request('http://relay.test/api/me', { headers: { cookie } }));
+    expect(after.status).toBe(401);
+  });
+
+  test('logout without a session is not an error', async () => {
+    const { config } = loadConfig({ GITHUB_CLIENT_ID: 'id', GITHUB_CLIENT_SECRET: 'secret' });
+    const route = createRouter({ config, logger, repos: freshRepos() });
+    const res = await route(new Request('http://relay.test/auth/logout', { method: 'POST' }));
+    expect(res.status).toBe(204);
   });
 
   test('callback with mismatched state is rejected', async () => {

--- a/relay/web/src/account.test.ts
+++ b/relay/web/src/account.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { clearAccountState, INVITE_STASH, MACHINE_PREF_KEY } from './account';
+
+function fakeStores() {
+  const local = new Map<string, string>();
+  const session = new Map<string, string>();
+  return {
+    local,
+    session,
+    stores: {
+      local: { removeItem: (k: string) => void local.delete(k) },
+      session: {
+        removeItem: (k: string) => void session.delete(k),
+        setItem: (k: string, v: string) => void session.set(k, v),
+      },
+    },
+  };
+}
+
+describe('clearAccountState', () => {
+  test('drops the machine preference — it belongs to the account, not the browser', () => {
+    const { local, stores } = fakeStores();
+    local.set(MACHINE_PREF_KEY, 'machine-a');
+    clearAccountState(stores);
+    expect(local.has(MACHINE_PREF_KEY)).toBe(false);
+  });
+
+  test('drops a stale invite when none is being carried across', () => {
+    const { session, stores } = fakeStores();
+    session.set(INVITE_STASH, '/i/old-code');
+    clearAccountState(stores);
+    expect(session.has(INVITE_STASH)).toBe(false);
+  });
+
+  // The invariant the ordering exists for: written back AFTER the wipe, not
+  // protected from it. Stash-then-wipe passes every other test in this file
+  // and drops the invite exactly when it matters.
+  test('a carried invite survives the wipe it is performed alongside', () => {
+    const { session, stores } = fakeStores();
+    session.set(INVITE_STASH, '/i/old-code');
+    clearAccountState(stores, '/i/new-code#fp');
+    expect(session.get(INVITE_STASH)).toBe('/i/new-code#fp');
+  });
+
+  test('a carried invite replaces whatever was stashed before', () => {
+    const { session, stores } = fakeStores();
+    clearAccountState(stores, '/i/new-code#fp');
+    expect(session.get(INVITE_STASH)).toBe('/i/new-code#fp');
+  });
+
+  test('carrying an invite does not spare the machine preference', () => {
+    const { local, stores } = fakeStores();
+    local.set(MACHINE_PREF_KEY, 'machine-a');
+    clearAccountState(stores, '/i/new-code');
+    expect(local.has(MACHINE_PREF_KEY)).toBe(false);
+  });
+});

--- a/relay/web/src/account.ts
+++ b/relay/web/src/account.ts
@@ -1,0 +1,36 @@
+/**
+ * Per-account local state, and the rules for clearing it at sign-out.
+ *
+ * This lives apart from main.ts so it can be tested: main.ts pulls in xterm and
+ * runs boot() at import time, so nothing in it is reachable from a unit test.
+ * The sequencing below is the kind of thing that is silently wrong if you get
+ * it backwards, which is exactly what wants a test rather than a comment.
+ */
+
+/** Which machine this browser last looked at. Belongs to the ACCOUNT: leaving
+ *  it behind greets the next person to sign in with the last one's context. */
+export const MACHINE_PREF_KEY = 'bodhi.machineId';
+
+/** A share link caught mid-redemption, held across an OAuth round trip. */
+export const INVITE_STASH = 'bodhi.invite';
+
+export interface AccountStores {
+  local: Pick<Storage, 'removeItem'>;
+  session: Pick<Storage, 'removeItem' | 'setItem'>;
+}
+
+/**
+ * Wipe the signed-out account's traces.
+ *
+ * `keepInvite` is the one exception, and the order matters: the invite is
+ * written back AFTER the wipe, never protected from it. Someone switching
+ * accounts to accept a link that refused them is the only case where a pending
+ * invite must outlive the session it was refused by — and stashing it first
+ * would simply be erased a line later, sending them to an empty home page with
+ * no sign of the link they were trying to open.
+ */
+export function clearAccountState(stores: AccountStores, keepInvite?: string): void {
+  stores.local.removeItem(MACHINE_PREF_KEY);
+  stores.session.removeItem(INVITE_STASH);
+  if (keepInvite) stores.session.setItem(INVITE_STASH, keepInvite);
+}

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -123,7 +123,6 @@ async function boot() {
 // Invite redemption (/i/:code)
 // ---------------------------------------------------------------------------
 
-
 function inviteCodeFromPath(): string | null {
   const m = /^\/i\/([^/]+)\/?$/.exec(location.pathname);
   return m ? decodeURIComponent(m[1]!) : null;

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -5,6 +5,7 @@ import { WebglAddon } from '@xterm/addon-webgl';
 import { FitAddon } from '@xterm/addon-fit';
 import { RelayConnection, type ConnState, type Inner } from './connection';
 import { createReconnectScheduler } from './reconnect';
+import { clearAccountState, INVITE_STASH } from './account';
 
 // ---------------------------------------------------------------------------
 // Types (mirror the agent's sealed payloads)
@@ -49,6 +50,14 @@ function h(tag: string, attrs: Record<string, string> = {}, html?: string): HTML
   return el;
 }
 const esc = (s: string) => { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; };
+/**
+ * `esc()` serializes a TEXT node, and the HTML spec does not escape quotes
+ * there — only `&`, `<`, `>` and nbsp. That is safe between tags and unsafe
+ * inside a quoted attribute, where a `"` in the value ends the attribute and
+ * everything after it is parsed as markup. Display names and avatar URLs both
+ * arrive from GitHub, so attribute interpolation uses this instead.
+ */
+const escAttr = (s: string) => esc(s).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 const api = (path: string, init?: RequestInit) => fetch(path, { credentials: 'same-origin', ...init });
 
 // ---------------------------------------------------------------------------
@@ -114,7 +123,6 @@ async function boot() {
 // Invite redemption (/i/:code)
 // ---------------------------------------------------------------------------
 
-const INVITE_STASH = 'bodhi.invite';
 
 function inviteCodeFromPath(): string | null {
   const m = /^\/i\/([^/]+)\/?$/.exec(location.pathname);
@@ -587,7 +595,7 @@ function renderSessions() {
   for (const s of sorted) {
     const b = BADGE[s.state]; const gp = groupPath(s.groupId);
     const li = document.createElement('li');
-    li.innerHTML = `<button class="session s-${s.state === 'working' ? 'work' : s.state === 'waiting' ? 'wait' : s.state === 'error' ? 'err' : s.state === 'idle' ? 'idle' : 'stop'} ${s.state === 'waiting' ? 'attn' : ''}" aria-label="${esc(s.name)}, ${b.label}">
+    li.innerHTML = `<button class="session s-${s.state === 'working' ? 'work' : s.state === 'waiting' ? 'wait' : s.state === 'error' ? 'err' : s.state === 'idle' ? 'idle' : 'stop'} ${s.state === 'waiting' ? 'attn' : ''}" aria-label="${escAttr(s.name)}, ${b.label}">
       <span class="state-rail" aria-hidden="true"></span>
       <span class="s-main"><span class="s-title"><span class="s-name">${esc(s.name)}</span><span class="provider">${esc(s.shellType === 'bash' ? 'shell' : s.provider)}</span></span>
       <span class="s-sub"><span class="gd" style="background:${gp.color}"></span>${esc(gp.label)}</span></span>
@@ -987,9 +995,9 @@ function accountButton(): string {
   const name = u?.displayName ?? 'your account';
   const avatar = safeAvatar(u?.avatarUrl);
   const face = avatar
-    ? `<img class="avatar" src="${esc(avatar)}" alt="" />`
+    ? `<img class="avatar" src="${escAttr(avatar)}" alt="" />`
     : `<span class="avatar init">${esc(initialOf(name))}</span>`;
-  return `<button class="acctbtn" id="acct" aria-label="Account — signed in as ${esc(name)}">${face}</button>`;
+  return `<button class="acctbtn" id="acct" aria-label="Account — signed in as ${escAttr(name)}">${face}</button>`;
 }
 
 function openAccount() {
@@ -1008,7 +1016,7 @@ function openAccount() {
   scrim.innerHTML = `<div class="sheet" role="dialog" aria-modal="true" aria-labelledby="acch">
     <div class="sheet-head"><h3 id="acch">Account</h3><button class="iconbtn" id="accx" aria-label="Close">✕</button></div>
     <div class="acct-id">
-      ${avatar ? `<img class="avatar lg" src="${esc(avatar)}" alt="" />` : `<span class="avatar init lg">${esc(initialOf(name))}</span>`}
+      ${avatar ? `<img class="avatar lg" src="${escAttr(avatar)}" alt="" />` : `<span class="avatar init lg">${esc(initialOf(name))}</span>`}
       <div class="acct-who">
         <div class="acct-name">${esc(name)}</div>
         ${u?.email ? `<div class="acct-mail">${esc(u.email)}</div>` : ''}
@@ -1037,17 +1045,19 @@ async function signOut(opts: { to?: string; stashInvite?: string; btn?: HTMLButt
   if (btn) { btn.disabled = true; btn.textContent = 'Signing out…'; }
   app.conn?.close();
   try {
-    await api('/auth/logout', { method: 'POST' });
+    // Bounded, because the alternative to a slow relay answering is not
+    // "wait longer" — it is a disabled button that never comes back. The
+    // cookie may then outlive the click, so we cannot claim success; the
+    // local wipe and the reload still land them on the sign-in screen,
+    // which is where a retry starts from anyway.
+    await Promise.race([
+      api('/auth/logout', { method: 'POST' }),
+      new Promise((resolve) => setTimeout(resolve, 5000)),
+    ]);
   } catch {
-    // The cookie may survive a network failure, so we cannot claim success —
-    // but the local wipe below and the reload still put them on the sign-in
-    // screen, which is where a retry starts from anyway.
+    // Same reasoning: a network failure changes nothing about where we go.
   }
-  localStorage.removeItem('bodhi.machineId');
-  sessionStorage.removeItem(INVITE_STASH);
-  // Re-stash AFTER the wipe: switching accounts to accept an invite is the one
-  // case where the pending link must outlive the session it was refused by.
-  if (stashInvite) sessionStorage.setItem(INVITE_STASH, stashInvite);
+  clearAccountState({ local: localStorage, session: sessionStorage }, stashInvite);
   location.href = to;
 }
 

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -26,6 +26,15 @@ interface Machine {
   certificate?: string | null;
 }
 
+interface Me {
+  id: string;
+  displayName: string;
+  email: string | null;
+  avatarUrl: string | null;
+  /** The handle the RELAY holds, which may be null — see the account sheet. */
+  githubLogin: string | null;
+}
+
 /** True when the signed-in user is a guest on the machine they are viewing. */
 const isGuest = () => app.machine?.relation === 'grantee';
 
@@ -54,7 +63,7 @@ function toggleTheme() { const d = !isDark(); root.setAttribute('data-theme', d 
 // ---------------------------------------------------------------------------
 // App state
 // ---------------------------------------------------------------------------
-const app = { conn: null as RelayConnection | null, machine: null as Machine | null, machines: [] as Machine[], sessions: [] as RSession[], groups: [] as RGroup[], activeId: null as string | null, fp: '', fpVerified: false, devLogin: false };
+const app = { conn: null as RelayConnection | null, user: null as Me | null, machine: null as Machine | null, machines: [] as Machine[], sessions: [] as RSession[], groups: [] as RGroup[], activeId: null as string | null, fp: '', fpVerified: false, devLogin: false };
 const rootEl = document.getElementById('root')!;
 
 // history-layer nav so Back works within the app
@@ -80,6 +89,7 @@ async function boot() {
       if (invite) sessionStorage.setItem(INVITE_STASH, location.pathname + location.hash);
       return renderSignIn(!!invite);
     }
+    app.user = ((await me.json().catch(() => ({}))) as { user?: Me }).user ?? null;
 
     // Back from OAuth on an invite link.
     const stashed = sessionStorage.getItem(INVITE_STASH);
@@ -123,7 +133,7 @@ function invitedFingerprint(): string | null {
  * `reauth` marks the one failure the person reading it can actually fix, and
  * gets a button rather than a sentence telling them to go and do it.
  */
-const REDEEM_COPY: Record<string, { title: string; body: string; reauth?: boolean }> = {
+const REDEEM_COPY: Record<string, { title: string; body: string; reauth?: boolean; switchAccount?: boolean }> = {
   invite_not_found: { title: "That link doesn't work", body: 'Check you copied all of it, or ask for a new one.' },
   invite_expired: { title: 'That link has expired', body: 'Ask for a new one — links stop working after a while on purpose.' },
   invite_already_used: { title: 'That link has been used', body: 'Invite links work once. Ask for a new one.' },
@@ -131,6 +141,7 @@ const REDEEM_COPY: Record<string, { title: string; body: string; reauth?: boolea
   invite_wrong_account: {
     title: "This link isn't for this account",
     body: 'It was addressed to a specific GitHub account. Sign in as that account, or ask for a link addressed to you.',
+    switchAccount: true,
   },
   invite_own_machine: { title: "That's your own machine", body: 'You already have full access to it — no invite needed.' },
   invite_login_unknown: {
@@ -177,21 +188,32 @@ async function renderRedeem(code: string): Promise<void> {
       <div class="logo">${copy.reauth ? '🔑' : '🚫'}</div><h1>${esc(copy.title)}</h1>
       <p>${esc(copy.body)}</p>
       ${copy.reauth ? '<button class="btn gh" id="reauth">Sign in with GitHub</button>' : ''}
+      ${copy.switchAccount ? '<button class="btn gh" id="switchAcct">Sign in as another account</button>' : ''}
       <a class="btn ghost" href="/">Go to my machines</a>
     </div></div>`;
     // Stash the invite the same way the signed-out path does, so OAuth returns
     // to this link — with its fingerprint fragment — instead of the home page.
+    // From the path that means keeping the fragment: it carries the machine fingerprint and
+    // does not survive the OAuth round trip on its own. From a typed code there
+    // is no fragment, so rebuild the link from the code itself rather than
+    // stashing whatever page they happened to be on.
+    const returnTo = () =>
+      inviteCodeFromPath() === code ? location.pathname + location.hash : `/i/${encodeURIComponent(code)}`;
+
     const reauth = $('#reauth');
     if (reauth) {
       reauth.onclick = () => {
-        // From the path, keep the fragment: it carries the machine fingerprint
-        // and does not survive the OAuth round trip on its own. From a typed
-        // code there is no fragment, so rebuild the link from the code itself
-        // rather than stashing whatever page they happened to be on.
-        const here = inviteCodeFromPath() === code ? location.pathname + location.hash : `/i/${encodeURIComponent(code)}`;
-        sessionStorage.setItem(INVITE_STASH, here);
+        sessionStorage.setItem(INVITE_STASH, returnTo());
         location.href = '/auth/github/login';
       };
+    }
+    // Addressed to someone else. Re-running OAuth would silently hand back the
+    // same account, so this one has to end the session first — otherwise the
+    // copy above tells them to do something the app gives them no way to do.
+    const switchAcct = $<HTMLButtonElement>('#switchAcct');
+    if (switchAcct) {
+      switchAcct.onclick = () =>
+        void signOut({ to: '/auth/github/login', stashInvite: returnTo(), btn: switchAcct });
     }
     return;
   }
@@ -264,8 +286,13 @@ function renderApp(machines: Machine[]) {
       <button class="btn" id="inviteBtn">Enter an invite code</button>
       <button class="btn ghost" style="margin-top:10px" id="linkBtn">Link my own machine</button>
       <button class="btn ghost" style="margin-top:10px" onclick="location.reload()">Refresh</button>
+      ${accountFooter()}
     </div></div>`;
     $('#linkBtn')!.onclick = openLinkMachine;
+    // "Nothing here yet" is exactly what the wrong account looks like, so this
+    // screen of all of them must offer a way out of the identity you're in.
+    const out = $<HTMLButtonElement>('#emptyOut');
+    if (out) out.onclick = () => void signOut({ btn: out });
     // Posts to /api/shares/redeem, never /link/claim — the latter would
     // attempt an ownership transfer, which is a completely different act.
     $('#inviteBtn')!.onclick = () => {
@@ -289,6 +316,7 @@ function renderApp(machines: Machine[]) {
       <header class="bar">
         <div class="brand grow"><span class="logo">🛰️</span> <span>Bodhilander</span></div>
         <button class="iconbtn" id="theme" aria-label="Toggle light/dark theme">◐</button>
+        ${accountButton()}
       </header>
       <div style="padding:12px 16px 0"><button class="machine-pill" id="machineBtn"><span class="dot off" id="mdot"></span> <span>${esc(
         app.machine.relation === 'grantee' && app.machine.ownerName
@@ -322,6 +350,7 @@ function renderApp(machines: Machine[]) {
   </div>`;
 
   $('#theme')!.onclick = toggleTheme;
+  $('#acct')!.onclick = openAccount;
   $('#fab')!.onclick = openCreate;
   $('#fpBtn')!.onclick = openFp; $('#fpBtn2')!.onclick = openFp;
   $('#machineBtn')!.onclick = openMachineMenu;
@@ -930,6 +959,96 @@ function renderDirs(d: { path: string; entries: string[] }) {
   list.innerHTML = '';
   if (!d.entries.length) list.appendChild(h('li', {}, '<div class="dir empty">No subfolders — use this folder</div>'));
   for (const name of d.entries) { const b = h('button', { class: 'dir' }, `<span class="f-ico">📁</span><span class="f-name">${esc(name)}</span><span class="f-chev">›</span>`); b.onclick = () => browseDir(d.path.replace(/\/$/, '') + '/' + name); const li = document.createElement('li'); li.appendChild(b); list.appendChild(li); }
+}
+
+// ---------------------------------------------------------------------------
+// Account
+// ---------------------------------------------------------------------------
+
+/** Avatars come from GitHub via our own DB, but src is attacker-adjacent
+ *  enough to be worth a scheme check rather than a trusting interpolation. */
+const safeAvatar = (url: string | null | undefined) => (url?.startsWith('https://') ? url : null);
+
+const initialOf = (name: string) => [...name.trim()][0]?.toUpperCase() ?? '?';
+
+/**
+ * A signed-in line for screens that have no header bar to hang the avatar on.
+ * Only the empty state needs it today, but that is the screen a wrong-account
+ * sign-in lands on, so it is not an optional flourish there.
+ */
+function accountFooter(): string {
+  const name = app.user?.githubLogin ? `@${app.user.githubLogin}` : app.user?.displayName;
+  if (!name) return '';
+  return `<p class="acct-foot">Signed in as ${esc(name)} · <button id="emptyOut">Sign out</button></p>`;
+}
+
+function accountButton(): string {
+  const u = app.user;
+  const name = u?.displayName ?? 'your account';
+  const avatar = safeAvatar(u?.avatarUrl);
+  const face = avatar
+    ? `<img class="avatar" src="${esc(avatar)}" alt="" />`
+    : `<span class="avatar init">${esc(initialOf(name))}</span>`;
+  return `<button class="acctbtn" id="acct" aria-label="Account — signed in as ${esc(name)}">${face}</button>`;
+}
+
+function openAccount() {
+  const u = app.user;
+  const name = u?.displayName ?? 'Signed in';
+  const avatar = safeAvatar(u?.avatarUrl);
+  // The handle is the point of this sheet, not decoration: an addressed invite
+  // matches on it, and until now nothing in the UI revealed what we hold.
+  const handle = u?.githubLogin
+    ? `<div class="acct-handle">@${esc(u.githubLogin)}</div>`
+    : `<div class="banner warn" role="status">We don't have your GitHub handle on file. Invites addressed to a
+       specific account can't reach you until you sign in again — that fetches it.</div>`;
+
+  const scrim = document.createElement('div');
+  scrim.className = 'sheet-scrim open';
+  scrim.innerHTML = `<div class="sheet" role="dialog" aria-modal="true" aria-labelledby="acch">
+    <div class="sheet-head"><h3 id="acch">Account</h3><button class="iconbtn" id="accx" aria-label="Close">✕</button></div>
+    <div class="acct-id">
+      ${avatar ? `<img class="avatar lg" src="${esc(avatar)}" alt="" />` : `<span class="avatar init lg">${esc(initialOf(name))}</span>`}
+      <div class="acct-who">
+        <div class="acct-name">${esc(name)}</div>
+        ${u?.email ? `<div class="acct-mail">${esc(u.email)}</div>` : ''}
+      </div>
+    </div>
+    ${handle}
+    <button class="btn ghost" id="accOut" style="margin-top:18px">Sign out</button>
+  </div>`;
+  document.body.appendChild(scrim);
+  pushLayer(() => scrim.remove());
+  scrim.onclick = (e) => { if (e.target === scrim) history.back(); };
+  $('#accx')!.onclick = () => history.back();
+  $('#accOut')!.onclick = (e) => void signOut({ btn: e.currentTarget as HTMLButtonElement });
+}
+
+/**
+ * End the session on the server, then reload signed-out.
+ *
+ * Local state is cleared because it is per-ACCOUNT, not per-browser: leaving a
+ * machine preference or a half-finished invite behind would greet whoever signs
+ * in next with the last person's context. The reload (rather than a re-render)
+ * is deliberate — it drops the decrypted terminal buffers held in memory.
+ */
+async function signOut(opts: { to?: string; stashInvite?: string; btn?: HTMLButtonElement | null } = {}): Promise<void> {
+  const { to = '/', stashInvite, btn } = opts;
+  if (btn) { btn.disabled = true; btn.textContent = 'Signing out…'; }
+  app.conn?.close();
+  try {
+    await api('/auth/logout', { method: 'POST' });
+  } catch {
+    // The cookie may survive a network failure, so we cannot claim success —
+    // but the local wipe below and the reload still put them on the sign-in
+    // screen, which is where a retry starts from anyway.
+  }
+  localStorage.removeItem('bodhi.machineId');
+  sessionStorage.removeItem(INVITE_STASH);
+  // Re-stash AFTER the wipe: switching accounts to accept an invite is the one
+  // case where the pending link must outlive the session it was refused by.
+  if (stashInvite) sessionStorage.setItem(INVITE_STASH, stashInvite);
+  location.href = to;
 }
 
 // ---------------------------------------------------------------------------

--- a/relay/web/src/styles.css
+++ b/relay/web/src/styles.css
@@ -70,6 +70,18 @@ input, textarea { font-family: inherit; }
 .machine-pill { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono); font-size: 12.5px; color: var(--muted); background: var(--surface-2); border: 1px solid var(--hair); padding: 4px 10px; border-radius: 20px; max-width: 100%; }
 .machine-pill .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--idle); box-shadow: 0 0 0 3px var(--idle-dim); flex: none; }
 .machine-pill .dot.off { background: var(--stop); box-shadow: 0 0 0 3px transparent; }
+.acctbtn { width: 40px; height: 40px; border-radius: 50%; display: grid; place-items: center; flex: none; padding: 0; }
+.acctbtn:hover .avatar, .acctbtn:focus-visible .avatar { box-shadow: 0 0 0 2px var(--accent); }
+.avatar { width: 30px; height: 30px; border-radius: 50%; object-fit: cover; background: var(--surface-2); border: 1px solid var(--hair); transition: box-shadow .15s ease; }
+.avatar.init { display: grid; place-items: center; font-size: 13px; font-weight: 700; color: var(--muted); }
+.avatar.lg { width: 48px; height: 48px; font-size: 19px; }
+.acct-id { display: flex; align-items: center; gap: 13px; margin-bottom: 14px; }
+.acct-who { min-width: 0; }
+.acct-name { font-weight: 640; font-size: 16px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.acct-mail { color: var(--muted); font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.acct-foot { margin: 18px 0 0 !important; font-size: 12.5px; color: var(--faint) !important; }
+.acct-foot button { color: var(--accent); font-size: 12.5px; text-decoration: underline; }
+.acct-handle { font-family: var(--mono); font-size: 13px; color: var(--accent); background: var(--accent-dim); border-radius: 9px; padding: 9px 12px; }
 .lock { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; color: var(--accent); font-family: var(--mono); }
 .iconbtn { width: 40px; height: 40px; border-radius: 10px; display: grid; place-items: center; color: var(--muted); font-size: 17px; flex: none; }
 .iconbtn:hover { background: var(--surface-2); color: var(--ink); }
@@ -155,6 +167,7 @@ input, textarea { font-family: inherit; }
 .banner { padding: 11px 14px; border-radius: 8px; margin: 10px 0 0; font-size: 13px; }
 .banner.err { background: var(--err-dim); color: var(--err); }
 .banner.ok { background: var(--idle-dim); color: var(--idle); }
+.banner.warn { background: var(--wait-dim); color: var(--wait); }
 .attn-banner { display: flex; align-items: center; gap: 10px; margin: 8px 10px 0; padding: 10px 12px; border-radius: 10px; background: var(--wait-dim); border: 1px solid color-mix(in srgb, var(--wait) 40%, transparent); color: var(--wait); font-size: 12.5px; }
 
 /* sheets */


### PR DESCRIPTION
Found while testing the #170 fix live: the instruction "sign out and back in" turned out to be unfollowable, because the web client has no sign-out.

`POST /auth/logout` has always worked server-side (`relay/src/http.ts:157`) — it deletes the session row and clears the cookie. Nothing in the client ever called it, and nothing rendered your identity either.

## What that broke

- **`invite_wrong_account` is a dead end.** The screen tells the guest to "sign in as that account" and then offers only "Go to my machines". No control in the app could carry out its own instruction.
- **A borrowed browser can't be released.** Sessions run for `SESSION_TTL_SECONDS`; the only exit was clearing site cookies by hand.
- **The handle on file was invisible.** A user row with a NULL `github_login` looks identical to a correct one from the client. That is what made #170 hard to diagnose against a live relay — the account *was* right, the stored handle was missing, and nothing could show that.

## What's here

- **Account control** in the session-list header — avatar (initial as fallback) opening a sheet, following the existing `openMachineMenu` pattern: name, email, the handle the relay holds, and Sign out.
- **An explicit warning when there is no handle on file**, since that state silently breaks addressed invites and previously had no symptom the user could see.
- **Sign-out on the empty state too.** "Nothing here yet" is exactly what the wrong account looks like, so that screen needs its own way out — it has no header bar to hang the avatar on.
- **`invite_wrong_account` gets a working action** — sign out, then a fresh GitHub sign-in. Re-running OAuth alone would silently hand back the same account, so the session has to end first. The invite is re-stashed *after* the sign-out wipe so the pending link outlives the session that refused it.
- **`publicUser` returns `githubLogin`.**

Sign-out also clears `bodhi.machineId` and the invite stash — per-account state, not per-browser — and reloads rather than re-rendering, which drops the decrypted terminal buffers held in memory.

## Verification

`tsc` clean on both trees; 171 relay tests pass (168 + 3 new).

Exercised end-to-end against a local relay rather than only asserting in tests:

```
/api/me  → {"displayName":"Dev User", …, "githubLogin":"devuser"}
logout   → 204
/api/me with the same cookie → 401
```

That last line is the one that matters: the session dies server-side, so a cookie copied off the machine stops working too. Sign-out that only cleared the cookie would be decoration. I also nulled `github_login` in the local DB to confirm `/api/me` reports `githubLogin: null` — reproducing the exact state that caused #170 — so the new warning has something real to key off.

**Not visually verified.** The browser extension wasn't connected in this session, so the sheet's layout is typechecked and built but not rendered. Worth a look on the deployed relay.

## Scope

Relay + web client only. No desktop changes, so this ships on a relay redeploy — no new beta build needed.

Closes #175
