### PR TITLE
184 — Owners can see and revoke shares from the browser

### DIFF
--- a/relay/src/repositories.ts
+++ b/relay/src/repositories.ts
@@ -108,6 +108,13 @@ export interface Repositories {
    */
   getMachineAccess(machineId: string, userId: string): MachineAccess;
 
+  /**
+   * Why a former guest no longer gets in: the ending their most recent grant
+   * met. Null for someone who never held one — a stranger must stay
+   * indistinguishable from one asking about a machine that does not exist.
+   */
+  endedGrantReason(machineId: string, userId: string): 'revoked' | 'expired' | null;
+
   // --- sharing (M5.2) ---
 
   createShareInvite(input: CreateShareInviteInput): { invite: ShareInvite; code: string };
@@ -354,6 +361,23 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
 
       if (!grant) return { relation: 'none' };
       return { relation: 'grantee', machine, grant };
+    },
+
+    endedGrantReason(machineId, userId) {
+      // The most recent grant tells the story; the reaper purging dead rows
+      // bounds how long it can be told, which is acceptable — after that the
+      // caller falls back to the stranger answer.
+      const grant = db
+        .query(
+          `SELECT * FROM machine_grants
+            WHERE machine_id = ? AND grantee_user_id = ?
+            ORDER BY created_at DESC LIMIT 1`,
+        )
+        .get(machineId, userId) as MachineGrant | null;
+      if (!grant) return null;
+      if (grant.status === 'revoked') return 'revoked';
+      if (grant.expires_at !== null && grant.expires_at <= now()) return 'expired';
+      return null;
     },
 
     createShareInvite(input) {

--- a/relay/src/ws.test.ts
+++ b/relay/src/ws.test.ts
@@ -48,8 +48,8 @@ function connect(url: string, headers?: Record<string, string>) {
     ws.onopen = () => res();
     ws.onerror = () => rej(new Error('ws error'));
   });
-  const closed = new Promise<{ code: number }>((res) => {
-    ws.addEventListener('close', (e) => res({ code: (e as CloseEvent).code }));
+  const closed = new Promise<{ code: number; reason: string }>((res) => {
+    ws.addEventListener('close', (e) => res({ code: (e as CloseEvent).code, reason: (e as CloseEvent).reason }));
   });
   const next = () =>
     new Promise<any>((res) => {
@@ -286,7 +286,11 @@ describe('client ↔ agent brokering (M3)', () => {
       const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
       await client.opened;
       client.ws.send(JSON.stringify({ type: 'client:open', machineId }));
-      expect((await client.closed).code).toBe(4403);
+      const closed = await client.closed;
+      expect(closed.code).toBe(4403);
+      // A stranger gets the unrevealing answer — never a grant's ending,
+      // which would confirm a share existed on a machine that is not theirs.
+      expect(closed.reason).toBe('not your machine');
     } finally {
       server.stop(true);
     }
@@ -766,7 +770,59 @@ describe('share:* messages (M5.2)', () => {
       await client.nextOfType('channel:open');
 
       gateway.notifyGrantRevoked(repos.getGrant(grantId)!);
-      expect((await client.closed).code).toBe(4403);
+      const closed = await client.closed;
+      expect(closed.code).toBe(4403);
+      // The literal is load-bearing: the web client maps exactly this reason
+      // to a terminal ending, so a rename here would silently regress every
+      // revoked guest back into a reconnect loop.
+      expect(closed.reason).toBe('revoked');
+    } finally {
+      db.close();
+      server.stop(true);
+    }
+  });
+
+  test('a revoked guest who reconnects is told the ending, not the stranger answer', async () => {
+    // A browser revoke lands while the guest's phone is asleep; on wake the
+    // client reopens the channel. 'not your machine' is not an ending reason,
+    // so it would leave them silently retrying against a dead grant.
+    const { db, repos } = freshReposWithDb();
+    const m = await registerMachine(repos);
+    const server = startServer(repos);
+    try {
+      const { grantId, guest } = await shared(server.port!, db, repos, m);
+      repos.bindGrantCertificate(grantId, 'grant:v1.a.b', Date.now() + 3_600_000);
+      repos.revokeGrant(grantId);
+
+      const { token } = repos.createSession(guest.id, 3600);
+      const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
+      await client.opened;
+      client.ws.send(JSON.stringify({ type: 'client:open', machineId: m.machineId }));
+      const closed = await client.closed;
+      expect(closed.code).toBe(4403);
+      expect(closed.reason).toBe('revoked');
+    } finally {
+      db.close();
+      server.stop(true);
+    }
+  });
+
+  test('a guest whose grant ran out is told "expired"', async () => {
+    const { db, repos } = freshReposWithDb();
+    const m = await registerMachine(repos);
+    const server = startServer(repos);
+    try {
+      const { grantId, guest } = await shared(server.port!, db, repos, m);
+      // Bound with a lifetime that has already run out.
+      repos.bindGrantCertificate(grantId, 'grant:v1.a.b', Date.now() - 1);
+
+      const { token } = repos.createSession(guest.id, 3600);
+      const client = connect(`ws://127.0.0.1:${server.port}/ws/client`, { cookie: `bdl_session=${token}` });
+      await client.opened;
+      client.ws.send(JSON.stringify({ type: 'client:open', machineId: m.machineId }));
+      const closed = await client.closed;
+      expect(closed.code).toBe(4403);
+      expect(closed.reason).toBe('expired');
     } finally {
       db.close();
       server.stop(true);

--- a/relay/src/ws.ts
+++ b/relay/src/ws.ts
@@ -360,7 +360,10 @@ export function createGateway(ctx: WsGatewayContext) {
       }
       const access = repos.getMachineAccess(msg.machineId, data.userId);
       if (access.relation === 'none') {
-        ws.close(4403, 'not your machine');
+        // A former guest is told which ending their access met — anything
+        // else sends their client into a silent reconnect loop against a
+        // dead grant. A stranger still gets the unrevealing answer.
+        ws.close(4403, repos.endedGrantReason(msg.machineId, data.userId) ?? 'not your machine');
         return;
       }
       const machine = access.machine;

--- a/relay/web/src/connection.test.ts
+++ b/relay/web/src/connection.test.ts
@@ -14,7 +14,7 @@
  * Run with: bun test relay/web/src/connection.test.ts
  */
 import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
-import { RelayConnection, isEndingReason, ENDING_REASONS, type ConnState } from './connection';
+import { RelayConnection, isEndingReason, CONNECTION_ENDED, ENDING_REASONS, type ConnState } from './connection';
 
 const subtle = crypto.subtle;
 const enc = (s: string) => new TextEncoder().encode(s);
@@ -262,13 +262,16 @@ describe('the relay cutting the socket', () => {
   // An HTTP revoke reaches a live guest as a close from the relay itself —
   // the agent never gets a sealed word in first. Without this mapping the
   // guest would sit on a frozen terminal, silently reconnecting forever.
-  test('a 4403 close with a known ending reason ends the session with it', async () => {
+  test('a 4403 close with a known ending reason is terminal — without its story', async () => {
     const s = await connected();
     s.socket.onclose!({ code: 4403, reason: 'revoked' });
 
     const denied = s.states.filter((x) => x.state === 'denied');
     expect(denied).toHaveLength(1);
-    expect(denied[0]!.detail).toBe('revoked');
+    // The unsealed reason must not travel: forwarding it would select the
+    // person-attributed "they stopped sharing" copy the sealed path renders.
+    expect(denied[0]!.detail).toBe(CONNECTION_ENDED);
+    expect(denied[0]!.detail).not.toBe('revoked');
     expect(s.states.some((x) => x.state === 'closed')).toBe(false);
   });
 

--- a/relay/web/src/connection.test.ts
+++ b/relay/web/src/connection.test.ts
@@ -48,7 +48,7 @@ class FakeSocket {
   readyState = 1;
   onopen: (() => void) | null = null;
   onmessage: ((e: { data: string }) => void) | null = null;
-  onclose: (() => void) | null = null;
+  onclose: ((e: { code: number; reason: string }) => void) | null = null;
   onerror: (() => void) | null = null;
   constructor() {
     FakeSocket.last = this;
@@ -255,6 +255,37 @@ describe('losing access still ends the session', () => {
 
     const denied = states.find((x) => x.state === 'denied');
     expect(denied?.detail).toBe('not_authorized');
+  });
+});
+
+describe('the relay cutting the socket', () => {
+  // An HTTP revoke reaches a live guest as a close from the relay itself —
+  // the agent never gets a sealed word in first. Without this mapping the
+  // guest would sit on a frozen terminal, silently reconnecting forever.
+  test('a 4403 close with a known ending reason ends the session with it', async () => {
+    const s = await connected();
+    s.socket.onclose!({ code: 4403, reason: 'revoked' });
+
+    const denied = s.states.filter((x) => x.state === 'denied');
+    expect(denied).toHaveLength(1);
+    expect(denied[0]!.detail).toBe('revoked');
+    expect(s.states.some((x) => x.state === 'closed')).toBe(false);
+  });
+
+  test('a 4403 with an unknown reason stays a plain close, so it reconnects', async () => {
+    const s = await connected();
+    s.socket.onclose!({ code: 4403, reason: 'paused' });
+
+    expect(s.states.some((x) => x.state === 'denied')).toBe(false);
+    expect(s.states.some((x) => x.state === 'closed')).toBe(true);
+  });
+
+  test('an ordinary network drop is still a plain close', async () => {
+    const s = await connected();
+    s.socket.onclose!({ code: 1006, reason: '' });
+
+    expect(s.states.some((x) => x.state === 'closed')).toBe(true);
+    expect(s.states.some((x) => x.state === 'denied')).toBe(false);
   });
 });
 

--- a/relay/web/src/connection.ts
+++ b/relay/web/src/connection.ts
@@ -37,6 +37,13 @@ export type DeniedReason = (typeof ENDING_REASONS)[number];
 export function isEndingReason(reason: string): reason is DeniedReason {
   return (ENDING_REASONS as readonly string[]).includes(reason);
 }
+
+/**
+ * The detail reported for a close-derived ending. Close reasons select
+ * termination, never attribution: a person-attributed story ("they stopped
+ * sharing") is reserved for reasons that arrive SEALED from the machine.
+ */
+export const CONNECTION_ENDED = 'connection_ended';
 export interface Inner {
   type: string;
   [k: string]: unknown;
@@ -102,11 +109,10 @@ export class RelayConnection {
     ws.onmessage = (e) => void this.handle(JSON.parse(String(e.data)));
     ws.onclose = (e) => {
       this.stopPing();
-      // 4403 is the relay itself cutting access — an HTTP revoke kicks the
-      // live socket before the agent can say anything sealed. A known ending
-      // reason is trusted from it; anything else stays a plain close, so the
-      // reconnect behaviour is untouched.
-      if (e.code === 4403 && isEndingReason(e.reason)) return this.onState('denied', e.reason);
+      // A 4403 with a known ending reason is terminal — reconnecting would
+      // loop forever against a dead grant. The reason itself is not forwarded:
+      // it came unsealed, so it may end the session but never tell its story.
+      if (e.code === 4403 && isEndingReason(e.reason)) return this.onState('denied', CONNECTION_ENDED);
       this.onState('closed');
     };
     ws.onerror = () => this.onState('error');

--- a/relay/web/src/connection.ts
+++ b/relay/web/src/connection.ts
@@ -100,8 +100,13 @@ export class RelayConnection {
       this.onState('handshaking');
     };
     ws.onmessage = (e) => void this.handle(JSON.parse(String(e.data)));
-    ws.onclose = () => {
+    ws.onclose = (e) => {
       this.stopPing();
+      // 4403 is the relay itself cutting access — an HTTP revoke kicks the
+      // live socket before the agent can say anything sealed. A known ending
+      // reason is trusted from it; anything else stays a plain close, so the
+      // reconnect behaviour is untouched.
+      if (e.code === 4403 && isEndingReason(e.reason)) return this.onState('denied', e.reason);
       this.onState('closed');
     };
     ws.onerror = () => this.onState('error');

--- a/relay/web/src/ended.test.ts
+++ b/relay/web/src/ended.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Which story an ended session tells. The rule under test: person-attributed
+ * copy is reserved for reasons that arrived SEALED — anything derived from a
+ * socket close lands on the neutral fallback, whatever the wire said.
+ */
+import { describe, expect, test } from 'bun:test';
+import { CONNECTION_ENDED, ENDING_REASONS } from './connection';
+import { endedCopy } from './ended';
+
+describe('endedCopy', () => {
+  test('a close-derived ending renders the neutral copy, not the attributed story', () => {
+    const copy = endedCopy(CONNECTION_ENDED);
+    expect(copy.title).toBe('This session ended');
+    expect(copy.body).toBe('The connection to that machine closed. Ask whoever shared it if you still need access.');
+    expect(copy.body).not.toContain('stopped sharing');
+  });
+
+  test('only the sealed revoked reason reaches the attributed story', () => {
+    expect(endedCopy('revoked').body).toBe('The person who shared this session stopped sharing it.');
+  });
+
+  test('every sealed ending reason has its own words, none of them the fallback', () => {
+    const titles = ENDING_REASONS.map((r) => endedCopy(r).title);
+    expect(new Set(titles).size).toBe(ENDING_REASONS.length);
+    for (const r of ENDING_REASONS) expect(endedCopy(r).title).not.toBe('This session ended');
+  });
+
+  test('an unknown reason is a statement of fact, never a guessed story', () => {
+    expect(endedCopy('something_new')).toEqual(endedCopy(CONNECTION_ENDED));
+    expect(endedCopy('')).toEqual(endedCopy(CONNECTION_ENDED));
+  });
+});

--- a/relay/web/src/ended.ts
+++ b/relay/web/src/ended.ts
@@ -1,0 +1,44 @@
+/**
+ * Why access ended, in the guest's words. Apart from main.ts so the choice
+ * of story can be tested: main.ts pulls in xterm and runs boot() at import
+ * time, so nothing in it is reachable from a unit test.
+ */
+
+export interface EndedCopy {
+  icon: string;
+  title: string;
+  body: string;
+}
+
+/**
+ * Distinct per reason on purpose: telling someone "Will revoked your access"
+ * when Will merely closed a terminal is a false and socially loaded story,
+ * and the agent already knows which one it was.
+ */
+const ENDED_COPY: Record<string, EndedCopy> = {
+  revoked: { icon: '🔒', title: 'Your access was ended', body: 'The person who shared this session stopped sharing it.' },
+  expired: { icon: '⌛', title: 'Your access expired', body: 'Shared access runs out on a timer. Ask for a new link if you still need it.' },
+  session_ended: { icon: '⏹', title: 'That session ended', body: 'The terminal you were watching was closed. Nothing was taken away from you.' },
+  machine_unlinked: { icon: '🔌', title: 'That machine was unlinked', body: 'It is no longer reachable through Bodhilander.' },
+  not_authorized: { icon: '🚫', title: "You're not in yet", body: 'This machine did not accept the invitation. Ask for a new link.' },
+};
+
+/**
+ * The story-free ending, for any reason the table does not name. Guessing a
+ * cause we do not know puts a false and socially loaded story in front of
+ * someone — the exact failure the table above exists to prevent.
+ */
+const ENDED_FALLBACK: EndedCopy = {
+  icon: '🔌',
+  title: 'This session ended',
+  body: 'The connection to that machine closed. Ask whoever shared it if you still need access.',
+};
+
+/**
+ * Person-attributed stories come only from keys in the table, which only
+ * SEALED frames select — a close-derived ending arrives as CONNECTION_ENDED
+ * and lands on the fallback. Never interpolate a name or login into these.
+ */
+export function endedCopy(reason: string): EndedCopy {
+  return ENDED_COPY[reason] ?? ENDED_FALLBACK;
+}

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -6,6 +6,17 @@ import { FitAddon } from '@xterm/addon-fit';
 import { RelayConnection, type ConnState, type Inner } from './connection';
 import { createReconnectScheduler } from './reconnect';
 import { clearAccountState, INVITE_STASH } from './account';
+import {
+  confirmCopy,
+  guestShareRows,
+  ownerShareRows,
+  revokeDoneCopy,
+  revokeFailedCopy,
+  type ShareRow,
+  type WireMyShare,
+  type WireShareGrant,
+  type WireShareInvite,
+} from './shares';
 
 // ---------------------------------------------------------------------------
 // Types (mirror the agent's sealed payloads)
@@ -325,11 +336,11 @@ function renderApp(machines: Machine[]) {
         <button class="iconbtn" id="theme" aria-label="Toggle light/dark theme">◐</button>
         ${accountButton()}
       </header>
-      <div style="padding:12px 16px 0"><button class="machine-pill" id="machineBtn"><span class="dot off" id="mdot"></span> <span>${esc(
+      <div class="pill-row"><button class="machine-pill" id="machineBtn"><span class="dot off" id="mdot"></span> <span>${esc(
         app.machine.relation === 'grantee' && app.machine.ownerName
           ? `${app.machine.ownerName}'s ${app.machine.name}`
           : app.machine.name,
-      )}</span></button></div>
+      )}</span></button><button class="sharebtn" id="shareBtn"><span aria-hidden="true">🤝</span> ${isGuest() ? 'Your access' : 'Sharing'}</button></div>
       <div class="list-head"><h2>Sessions</h2><span class="attn-count hidden" id="attn"></span></div>
       <ul class="sessions" id="sessions"><li class="empty-note"><div class="spinner"></div><p style="margin-top:14px">Connecting securely…</p></li></ul>
       <button class="fab" id="fab" aria-label="New session">＋</button>
@@ -361,6 +372,7 @@ function renderApp(machines: Machine[]) {
   $('#fab')!.onclick = openCreate;
   $('#fpBtn')!.onclick = openFp; $('#fpBtn2')!.onclick = openFp;
   $('#machineBtn')!.onclick = openMachineMenu;
+  $('#shareBtn')!.onclick = () => (isGuest() ? openMyShares() : openSharing());
   $('#back')!.onclick = () => history.back();
   if (isGuest()) applyWatchOnly();
   else { buildKeys(); setupCompose(); }
@@ -454,6 +466,10 @@ function connect() {
 
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 let lastSessionsJson = '';
+// Whether the relay last said this machine's agent is connected. The sharing
+// sheet's after-revoke copy hangs on it: "disconnected now" and "lands when it
+// reconnects" are different claims, and only one of them is true at a time.
+let machineOffline = false;
 function startPolling() { stopPolling(); pollTimer = setInterval(() => app.conn?.command({ type: 'sessions:list' }), 2500); }
 function stopPolling() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
 
@@ -508,12 +524,14 @@ function onConnState(s: ConnState, detail?: string) {
   if (s === 'denied') return renderEnded(detail ?? 'revoked');
   const dot = $('#mdot'); const list = $('#sessions');
   if (s === 'ready') {
+    machineOffline = false;
     reconnector.cancel();
     dot?.classList.remove('off');
     app.conn!.command({ type: 'groups:list' });
     app.conn!.command({ type: 'sessions:list' });
     startPolling(); // keep the list live (new/removed sessions + state changes)
   } else if (s === 'offline') {
+    machineOffline = true;
     stopPolling(); dot?.classList.add('off');
     if (list) list.innerHTML = `<li class="empty-note"><div style="font-size:28px">🌙</div><p>This machine is offline. It'll appear here when it reconnects.</p></li>`;
     reconnector.schedule(3000); // agent not connected yet — keep polling until it appears
@@ -1058,6 +1076,167 @@ async function signOut(opts: { to?: string; stashInvite?: string; btn?: HTMLButt
   }
   clearAccountState({ local: localStorage, session: sessionStorage }, stashInvite);
   location.href = to;
+}
+
+// ---------------------------------------------------------------------------
+// Sharing: the owner's list of who can reach this machine, and the guest's
+// mirror of what is shared with them
+// ---------------------------------------------------------------------------
+
+function openSharing(): void {
+  const scrim = document.createElement('div');
+  scrim.className = 'sheet-scrim open';
+  scrim.innerHTML = `<div class="sheet" role="dialog" aria-modal="true" aria-labelledby="shh">
+    <div class="sheet-head"><h3 id="shh">Sharing</h3><button class="iconbtn" id="shx" aria-label="Close">✕</button></div>
+    <p>Who can reach <b>${esc(app.machine!.name)}</b> right now, and who has been invited.</p>
+    <div class="banner hidden" id="shNote" role="status"></div>
+    <ul class="share-list" id="shList"><li class="empty-note"><div class="spinner"></div></li></ul>
+  </div>`;
+  document.body.appendChild(scrim);
+  pushLayer(() => scrim.remove());
+  scrim.onclick = (e) => { if (e.target === scrim) history.back(); };
+  $('#shx')!.onclick = () => history.back();
+  void loadOwnerShares();
+}
+
+async function loadOwnerShares(): Promise<void> {
+  let rows: ShareRow[];
+  try {
+    const res = await api(`/api/machines/${app.machine!.id}/shares`);
+    if (!res.ok) throw new Error();
+    const body = (await res.json()) as { invites: WireShareInvite[]; grants: WireShareGrant[] };
+    rows = ownerShareRows(body.invites, body.grants, Date.now());
+  } catch {
+    return renderShareLoadError('#shList', loadOwnerShares);
+  }
+  renderShareRows(
+    '#shList',
+    rows,
+    `<div style="font-size:28px">🤝</div><p>Nothing is shared right now. Share a session from the desktop app to invite someone.</p>`,
+    (r, b) => void revokeOwnerRow(r, b),
+  );
+}
+
+async function revokeOwnerRow(row: ShareRow, btn: HTMLButtonElement): Promise<void> {
+  if (!confirm(confirmCopy(row))) return;
+  btn.disabled = true;
+  // Invites are cancelled on the machine-scoped route; grants on their own.
+  const path = row.kind === 'invite'
+    ? `/api/machines/${app.machine!.id}/shares/${row.id}`
+    : `/api/shares/${row.id}`;
+  const status = await del(path);
+  const note = $('#shNote');
+  if (status === 204 || status === 404) {
+    if (note) {
+      note.className = `banner ${status === 204 ? 'ok' : 'warn'}`;
+      note.textContent = status === 204 ? revokeDoneCopy(row, machineOffline) : revokeFailedCopy(404);
+    }
+    void loadOwnerShares();
+    return;
+  }
+  if (note) { note.className = 'banner err'; note.textContent = revokeFailedCopy(status); }
+  btn.disabled = false;
+}
+
+function openMyShares(): void {
+  const scrim = document.createElement('div');
+  scrim.className = 'sheet-scrim open';
+  scrim.innerHTML = `<div class="sheet" role="dialog" aria-modal="true" aria-labelledby="msh">
+    <div class="sheet-head"><h3 id="msh">Your access</h3><button class="iconbtn" id="msx" aria-label="Close">✕</button></div>
+    <p>What people are sharing with you. Leaving hands access back — nobody has to approve it.</p>
+    <div class="banner hidden" id="msNote" role="status"></div>
+    <ul class="share-list" id="msList"><li class="empty-note"><div class="spinner"></div></li></ul>
+  </div>`;
+  document.body.appendChild(scrim);
+  pushLayer(() => scrim.remove());
+  scrim.onclick = (e) => { if (e.target === scrim) history.back(); };
+  $('#msx')!.onclick = () => history.back();
+  void loadMyShares();
+}
+
+async function loadMyShares(): Promise<void> {
+  let rows: ShareRow[];
+  try {
+    const res = await api('/api/shares');
+    if (!res.ok) throw new Error();
+    const body = (await res.json()) as { grants: WireMyShare[] };
+    rows = guestShareRows(body.grants, Date.now());
+  } catch {
+    return renderShareLoadError('#msList', loadMyShares);
+  }
+  renderShareRows(
+    '#msList',
+    rows,
+    `<div style="font-size:28px">🤝</div><p>Nothing is shared with you right now. If someone sends you a link, it starts here.</p>`,
+    (r, b) => void leaveShareRow(r, b),
+  );
+}
+
+async function leaveShareRow(row: ShareRow, btn: HTMLButtonElement): Promise<void> {
+  if (!confirm(confirmCopy(row))) return;
+  btn.disabled = true;
+  // Leaving the share we are connected THROUGH: tear the channel down first,
+  // deliberately, so the relay cutting it doesn't render as "your access was
+  // ended" — a false story about a choice this person just made.
+  const current = app.machine?.grantId === row.id;
+  if (current) { stopPolling(); reconnector.cancel(); app.conn?.close(); app.conn = null; }
+  const status = await del(`/api/shares/${row.id}`);
+  if (status === 204 || status === 404) {
+    if (current) { localStorage.removeItem('bodhi.machineId'); location.href = '/'; return; }
+    const note = $('#msNote');
+    if (note) { note.className = 'banner ok'; note.textContent = revokeDoneCopy(row, false); }
+    void loadMyShares();
+    return;
+  }
+  const note = $('#msNote');
+  if (note) { note.className = 'banner err'; note.textContent = revokeFailedCopy(status); }
+  if (current) connect();
+  btn.disabled = false;
+}
+
+function renderShareRows(
+  listSel: string,
+  rows: ShareRow[],
+  emptyHtml: string,
+  act: (row: ShareRow, btn: HTMLButtonElement) => void,
+): void {
+  const list = $(listSel);
+  if (!list) return; // the sheet was closed while the fetch was in flight
+  if (!rows.length) { list.innerHTML = `<li class="empty-note">${emptyHtml}</li>`; return; }
+  list.innerHTML = '';
+  for (const r of rows) {
+    const li = document.createElement('li');
+    li.className = 'share-row';
+    li.innerHTML = `<div class="share-main">
+      <div class="share-who">${esc(r.person)}</div>
+      <div class="share-meta"><span class="share-role">${esc(r.roleWord)}</span>${r.pending ? '<span class="share-pend">Pending</span>' : ''}</div>
+      <div class="share-detail">${esc(r.detail)}</div></div>
+      <button class="share-x" aria-label="${escAttr(`${r.action} — ${r.person}`)}">${esc(r.action)}</button>`;
+    const btn = li.querySelector<HTMLButtonElement>('button')!;
+    btn.onclick = () => act(r, btn);
+    list.appendChild(li);
+  }
+}
+
+function renderShareLoadError(listSel: string, retry: () => Promise<void>): void {
+  const list = $(listSel);
+  if (!list) return;
+  list.innerHTML = `<li class="empty-note"><div style="font-size:28px">📡</div>
+    <p>Couldn't load this. Check your connection.</p>
+    <button class="btn ghost" style="margin-top:6px">Try again</button></li>`;
+  list.querySelector('button')!.addEventListener('click', () => {
+    list.innerHTML = `<li class="empty-note"><div class="spinner"></div></li>`;
+    void retry();
+  });
+}
+
+/** DELETE, returning the status — null when the request never got through. */
+async function del(path: string): Promise<number | null> {
+  try {
+    return (await api(path, { method: 'DELETE' })).status;
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -6,6 +6,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { RelayConnection, type ConnState, type Inner } from './connection';
 import { createReconnectScheduler } from './reconnect';
 import { clearAccountState, INVITE_STASH } from './account';
+import { endedCopy } from './ended';
 import {
   confirmCopy,
   guestShareRows,
@@ -483,31 +484,10 @@ const reconnector = createReconnectScheduler({
   reconnect: () => { app.conn?.close(); connect(); },
 });
 
-/**
- * Why access ended, in the guest's words.
- *
- * Distinct per reason on purpose: telling someone "Will revoked your access"
- * when Will merely closed a terminal is a false and socially loaded story, and
- * the agent already knows which one it was.
- */
-const ENDED_COPY: Record<string, { icon: string; title: string; body: string }> = {
-  revoked: { icon: '🔒', title: 'Your access was ended', body: 'The person who shared this session stopped sharing it.' },
-  expired: { icon: '⌛', title: 'Your access expired', body: 'Shared access runs out on a timer. Ask for a new link if you still need it.' },
-  session_ended: { icon: '⏹', title: 'That session ended', body: 'The terminal you were watching was closed. Nothing was taken away from you.' },
-  machine_unlinked: { icon: '🔌', title: 'That machine was unlinked', body: 'It is no longer reachable through Bodhilander.' },
-  not_authorized: { icon: '🚫', title: "You're not in yet", body: 'This machine did not accept the invitation. Ask for a new link.' },
-};
-
 function renderEnded(reason: string): void {
-  // Fall back to a statement of fact, NOT to "they revoked you". Guessing a
-  // cause we do not know puts a false and socially loaded story in front of
-  // someone — the exact failure this enum exists to prevent.
-  const copy =
-    ENDED_COPY[reason] ?? {
-      icon: '🔌',
-      title: 'This session ended',
-      body: "The connection to that machine closed. Ask whoever shared it if you still need access.",
-    };
+  // The words live in ended.ts, where the sealed-only attribution rule is
+  // pinned by tests; a close-derived ending can only reach the neutral copy.
+  const copy = endedCopy(reason);
   stopPolling();
   reconnector.cancel();
   app.conn?.close();

--- a/relay/web/src/shares.test.ts
+++ b/relay/web/src/shares.test.ts
@@ -1,0 +1,239 @@
+/**
+ * The sharing sheets' data and copy. What matters here is honesty: the two
+ * role words are the ONLY capability vocabulary that may reach a person, the
+ * "until you revoke it" sentinel must not render as a date, and the
+ * after-revoke copy must not claim more than the relay actually did.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  confirmCopy,
+  guestShareRows,
+  ownerShareRows,
+  revokeDoneCopy,
+  revokeFailedCopy,
+  roleWord,
+  timeLeft,
+  type ShareRow,
+  type WireMyShare,
+  type WireShareGrant,
+  type WireShareInvite,
+} from './shares';
+
+const NOW = 1_700_000_000_000;
+const HOUR = 3_600_000;
+// What the desktop binds for a share that lasts until revoked: the largest
+// timestamp Date can represent.
+const NEVER = 8_640_000_000_000_000;
+
+function grant(over: Partial<WireShareGrant> = {}): WireShareGrant {
+  return {
+    id: 'g1',
+    role: 'viewer',
+    status: 'active',
+    granteeName: 'Dana',
+    granteeLogin: 'dana-k',
+    expiresAt: NOW + 4 * HOUR,
+    ...over,
+  };
+}
+
+function invite(over: Partial<WireShareInvite> = {}): WireShareInvite {
+  return { id: 'i1', expectedGithubLogin: 'dana-k', role: 'viewer', status: 'pending', expiresAt: NOW + 24 * HOUR, ...over };
+}
+
+function myShare(over: Partial<WireMyShare> = {}): WireMyShare {
+  return { ...grant(), machineName: 'laptop', ownerName: 'Will', ...over };
+}
+
+describe('roleWord', () => {
+  test('maps the two server roles to the two words', () => {
+    expect(roleWord('viewer')).toBe('Watching');
+    expect(roleWord('operator')).toBe('Watching and typing');
+  });
+
+  test('an unknown role reads as the smaller capability', () => {
+    expect(roleWord('admin')).toBe('Watching');
+    expect(roleWord('')).toBe('Watching');
+  });
+});
+
+describe('timeLeft', () => {
+  test('scales through minutes, hours and days', () => {
+    expect(timeLeft(20_000)).toBe('under a minute');
+    expect(timeLeft(60_000)).toBe('1 minute');
+    expect(timeLeft(5 * 60_000)).toBe('5 minutes');
+    expect(timeLeft(HOUR)).toBe('1 hour');
+    expect(timeLeft(4 * HOUR)).toBe('4 hours');
+    expect(timeLeft(26 * HOUR)).toBe('1 day');
+    expect(timeLeft(3 * 24 * HOUR)).toBe('3 days');
+  });
+});
+
+describe('ownerShareRows', () => {
+  test('an active timed grant renders the person, the role word and the end', () => {
+    const rows = ownerShareRows([], [grant()], NOW);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      kind: 'grant',
+      id: 'g1',
+      person: '@dana-k',
+      roleWord: 'Watching',
+      pending: false,
+      detail: 'Ends in 4 hours',
+      action: 'Revoke',
+    });
+  });
+
+  test('the until-revoked sentinel renders as words, never as a date', () => {
+    const rows = ownerShareRows([], [grant({ expiresAt: NEVER })], NOW);
+    expect(rows[0]!.detail).toBe('Until you revoke it');
+  });
+
+  test('an operator grant says "Watching and typing"', () => {
+    expect(ownerShareRows([], [grant({ role: 'operator' })], NOW)[0]!.roleWord).toBe('Watching and typing');
+  });
+
+  test('a person with no handle on file still gets a name', () => {
+    expect(ownerShareRows([], [grant({ granteeLogin: null })], NOW)[0]!.person).toBe('Dana');
+  });
+
+  test('a pending grant is marked pending, with a Refuse action', () => {
+    const rows = ownerShareRows([], [grant({ status: 'pending', expiresAt: null })], NOW);
+    expect(rows[0]).toMatchObject({
+      pending: true,
+      detail: 'Waiting for your approval in the desktop app',
+      action: 'Refuse',
+    });
+  });
+
+  test('an expired grant is dropped — it no longer lets anyone in', () => {
+    expect(ownerShareRows([], [grant({ expiresAt: NOW - 1 })], NOW)).toHaveLength(0);
+  });
+
+  test('an addressed invite is a pending row for that handle', () => {
+    const rows = ownerShareRows([invite()], [], NOW);
+    expect(rows[0]).toMatchObject({
+      kind: 'invite',
+      person: '@dana-k',
+      pending: true,
+      detail: 'Invite link not used yet — it expires in 1 day',
+      action: 'Cancel',
+    });
+  });
+
+  test('an open invite says who it admits: anyone holding it', () => {
+    expect(ownerShareRows([invite({ expectedGithubLogin: null })], [], NOW)[0]!.person).toBe('Anyone with the link');
+  });
+
+  test('redeemed, revoked and expired invites are not rows', () => {
+    const gone = [
+      invite({ status: 'redeemed' }),
+      invite({ status: 'revoked' }),
+      invite({ expiresAt: NOW - 1 }),
+    ];
+    expect(ownerShareRows(gone, [], NOW)).toHaveLength(0);
+  });
+
+  test('who has access now comes first, then the waiting, then the links', () => {
+    const rows = ownerShareRows(
+      [invite({ id: 'i1' })],
+      [grant({ id: 'pend', status: 'pending', expiresAt: null }), grant({ id: 'act' })],
+      NOW,
+    );
+    expect(rows.map((r) => r.id)).toEqual(['act', 'pend', 'i1']);
+  });
+
+  test('no server vocabulary reaches any rendered string', () => {
+    const rows = ownerShareRows(
+      [invite(), invite({ expectedGithubLogin: null, role: 'operator' })],
+      [grant(), grant({ id: 'g2', role: 'operator', expiresAt: NEVER }), grant({ id: 'g3', status: 'pending', expiresAt: null })],
+      NOW,
+    );
+    expectHumanWordsOnly(rows);
+  });
+});
+
+describe('guestShareRows', () => {
+  test('a share is labelled by person, the way a guest was invited', () => {
+    const rows = guestShareRows([myShare()], NOW);
+    expect(rows[0]).toMatchObject({
+      person: "Will's laptop",
+      roleWord: 'Watching',
+      pending: false,
+      detail: 'Ends in 4 hours',
+      action: 'Leave',
+    });
+  });
+
+  test('falls back through the labels it has', () => {
+    expect(guestShareRows([myShare({ ownerName: null })], NOW)[0]!.person).toBe('laptop');
+    expect(guestShareRows([myShare({ ownerName: null, machineName: null })], NOW)[0]!.person).toBe('A shared session');
+  });
+
+  test('a pending share reads as waiting, in the guest voice', () => {
+    const rows = guestShareRows([myShare({ status: 'pending', expiresAt: null })], NOW);
+    expect(rows[0]!.pending).toBe(true);
+    expect(rows[0]!.detail).toBe("Waiting to be let in — they'll get a prompt on their machine");
+  });
+
+  test('the sentinel reads in the guest voice, not the owner one', () => {
+    expect(guestShareRows([myShare({ expiresAt: NEVER })], NOW)[0]!.detail).toBe('Until you leave, or they stop sharing');
+  });
+
+  test('an expired share is dropped', () => {
+    expect(guestShareRows([myShare({ expiresAt: NOW - 1 })], NOW)).toHaveLength(0);
+  });
+
+  test('no server vocabulary reaches the guest either', () => {
+    expectHumanWordsOnly(guestShareRows([myShare(), myShare({ role: 'operator', status: 'pending', expiresAt: null })], NOW));
+  });
+});
+
+describe('the copy around a revoke', () => {
+  const activeRow = ownerShareRows([], [grant()], NOW)[0]!;
+  const pendingRow = ownerShareRows([], [grant({ status: 'pending', expiresAt: null })], NOW)[0]!;
+  const inviteRow = ownerShareRows([invite()], [], NOW)[0]!;
+  const leaveRow = guestShareRows([myShare()], NOW)[0]!;
+
+  test('each action asks a question about what it actually does', () => {
+    expect(confirmCopy(activeRow)).toContain('Revoke access for @dana-k');
+    expect(confirmCopy(pendingRow)).toContain('Refuse @dana-k');
+    expect(confirmCopy(inviteRow)).toContain('Cancel this invite');
+    expect(confirmCopy(leaveRow)).toContain("Leave Will's laptop");
+  });
+
+  test('revoking with the machine connected says the guest was cut off', () => {
+    expect(revokeDoneCopy(activeRow, false)).toBe("Access ended. If they were connected, they've been disconnected.");
+  });
+
+  test('revoking with the machine offline is honest about when it lands there', () => {
+    const copy = revokeDoneCopy(activeRow, true);
+    expect(copy).toContain('offline');
+    expect(copy).toContain('reconnects');
+    expect(copy).toContain("can't get back in");
+  });
+
+  test('cancelling an invite and refusing a request each say what happened', () => {
+    expect(revokeDoneCopy(inviteRow, false)).toContain("That link doesn't work any more");
+    expect(revokeDoneCopy(pendingRow, true)).toContain("They haven't been let in");
+  });
+
+  test('leaving reads the same whatever the machine is doing', () => {
+    expect(revokeDoneCopy(leaveRow, true)).toBe(revokeDoneCopy(leaveRow, false));
+    expect(revokeDoneCopy(leaveRow, false)).toContain("You've left");
+  });
+
+  test('failure copy distinguishes gone, unreachable and refused', () => {
+    expect(revokeFailedCopy(404)).toBe('That share was already gone.');
+    expect(revokeFailedCopy(null)).toContain("Couldn't reach the server");
+    expect(revokeFailedCopy(500)).toContain('Try again');
+  });
+});
+
+/** Every string a person could read, checked against the words that must not appear. */
+function expectHumanWordsOnly(rows: ShareRow[]): void {
+  for (const row of rows) {
+    const visible = [row.person, row.roleWord, row.detail, row.action, confirmCopy(row), revokeDoneCopy(row, false), revokeDoneCopy(row, true)].join(' ');
+    expect(visible).not.toMatch(/viewer|operator|grantee|scope|\bgrants?\b/i);
+  }
+}

--- a/relay/web/src/shares.test.ts
+++ b/relay/web/src/shares.test.ts
@@ -1,8 +1,7 @@
 /**
  * The sharing sheets' data and copy. What matters here is honesty: the two
- * role words are the ONLY capability vocabulary that may reach a person, the
- * "until you revoke it" sentinel must not render as a date, and the
- * after-revoke copy must not claim more than the relay actually did.
+ * role words are the only capability vocabulary that may reach a person, and
+ * the copy must not claim more than the relay actually did.
  */
 import { describe, expect, test } from 'bun:test';
 import {

--- a/relay/web/src/shares.ts
+++ b/relay/web/src/shares.ts
@@ -1,0 +1,173 @@
+/**
+ * Data and copy for the sharing sheets. Apart from main.ts so it can be
+ * tested: main.ts pulls in xterm and runs boot() at import time, so nothing
+ * in it is reachable from a unit test.
+ */
+
+/** An invite as `GET /api/machines/:id/shares` returns it (the fields read here). */
+export interface WireShareInvite {
+  id: string;
+  expectedGithubLogin: string | null;
+  role: string;
+  status: string;
+  expiresAt: number;
+}
+
+/** A grant from the same listing. `expiresAt` is null until the machine countersigns. */
+export interface WireShareGrant {
+  id: string;
+  role: string;
+  status: string;
+  granteeName: string | null;
+  granteeLogin: string | null;
+  expiresAt: number | null;
+}
+
+/** The guest's own holdings, from `GET /api/shares`. */
+export interface WireMyShare extends WireShareGrant {
+  machineName: string | null;
+  ownerName: string | null;
+}
+
+/** One row of a sharing sheet, ready to render. */
+export interface ShareRow {
+  kind: 'grant' | 'invite';
+  id: string;
+  person: string;
+  roleWord: string;
+  pending: boolean;
+  detail: string;
+  action: string;
+}
+
+/**
+ * The only vocabulary for what shared access allows. Server role names never
+ * reach the UI, and an unknown role reads as the smaller capability rather
+ * than promising typing it may not include.
+ */
+export function roleWord(role: string): string {
+  return role === 'operator' ? 'Watching and typing' : 'Watching';
+}
+
+// Timed certificates are capped at a day; "until revoked" is bound with the
+// largest timestamp Date can represent. An expiry even a year out can only be
+// that sentinel, so the horizon reads it without hard-coding the exact value.
+const UNTIL_REVOKED_HORIZON_MS = 365 * 24 * 60 * 60 * 1000;
+
+const expired = (g: WireShareGrant, now: number) => g.expiresAt !== null && g.expiresAt <= now;
+const untilRevoked = (g: WireShareGrant, now: number) =>
+  g.expiresAt === null || g.expiresAt - now >= UNTIL_REVOKED_HORIZON_MS;
+const personOf = (g: WireShareGrant) => (g.granteeLogin ? `@${g.granteeLogin}` : (g.granteeName ?? 'Someone'));
+
+/** "under a minute", "5 minutes", "3 hours", "2 days" — for expiry copy. */
+export function timeLeft(ms: number): string {
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 1) return 'under a minute';
+  if (minutes < 60) return minutes === 1 ? '1 minute' : `${minutes} minutes`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return hours === 1 ? '1 hour' : `${hours} hours`;
+  const days = Math.round(hours / 24);
+  return days === 1 ? '1 day' : `${days} days`;
+}
+
+/**
+ * The owner's rows: who has access now, who is waiting to be let in, and
+ * which invite links are still out. Expired entries are dropped — they no
+ * longer let anyone in, and the reaper sweeps them.
+ */
+export function ownerShareRows(invites: WireShareInvite[], grants: WireShareGrant[], now: number): ShareRow[] {
+  const active = grants
+    .filter((g) => g.status === 'active' && !expired(g, now))
+    .map(
+      (g): ShareRow => ({
+        kind: 'grant',
+        id: g.id,
+        person: personOf(g),
+        roleWord: roleWord(g.role),
+        pending: false,
+        detail: untilRevoked(g, now) ? 'Until you revoke it' : `Ends in ${timeLeft(g.expiresAt! - now)}`,
+        action: 'Revoke',
+      }),
+    );
+  const waiting = grants
+    .filter((g) => g.status === 'pending')
+    .map(
+      (g): ShareRow => ({
+        kind: 'grant',
+        id: g.id,
+        person: personOf(g),
+        roleWord: roleWord(g.role),
+        pending: true,
+        detail: 'Waiting for your approval in the desktop app',
+        action: 'Refuse',
+      }),
+    );
+  const links = invites
+    .filter((i) => i.status === 'pending' && i.expiresAt > now)
+    .map(
+      (i): ShareRow => ({
+        kind: 'invite',
+        id: i.id,
+        person: i.expectedGithubLogin ? `@${i.expectedGithubLogin}` : 'Anyone with the link',
+        roleWord: roleWord(i.role),
+        pending: true,
+        detail: `Invite link not used yet — it expires in ${timeLeft(i.expiresAt - now)}`,
+        action: 'Cancel',
+      }),
+    );
+  return [...active, ...waiting, ...links];
+}
+
+/** The guest's mirror: each share they hold, labelled by person, with a way out. */
+export function guestShareRows(shares: WireMyShare[], now: number): ShareRow[] {
+  return shares
+    .filter((g) => !(g.status === 'active' && expired(g, now)))
+    .map(
+      (g): ShareRow => ({
+        kind: 'grant',
+        id: g.id,
+        person:
+          g.ownerName && g.machineName
+            ? `${g.ownerName}'s ${g.machineName}`
+            : (g.machineName ?? g.ownerName ?? 'A shared session'),
+        roleWord: roleWord(g.role),
+        pending: g.status === 'pending',
+        detail:
+          g.status === 'pending'
+            ? "Waiting to be let in — they'll get a prompt on their machine"
+            : untilRevoked(g, now)
+              ? 'Until you leave, or they stop sharing'
+              : `Ends in ${timeLeft(g.expiresAt! - now)}`,
+        action: 'Leave',
+      }),
+    );
+}
+
+/** The question a revoke action asks, honest about what saying yes does. */
+export function confirmCopy(row: ShareRow): string {
+  if (row.action === 'Leave') return `Leave ${row.person}? You'll need a new link to come back.`;
+  if (row.kind === 'invite') return 'Cancel this invite? The link will stop working.';
+  if (row.pending) return `Refuse ${row.person}? They won't be let in.`;
+  return `Revoke access for ${row.person}? If they're connected, they'll be cut off.`;
+}
+
+/**
+ * What a 204 actually did, without overclaiming: the relay bars the door
+ * immediately, but an offline machine only applies the change to its own
+ * records when it next connects.
+ */
+export function revokeDoneCopy(row: ShareRow, machineOffline: boolean): string {
+  if (row.action === 'Leave') return "You've left. Ask for a new link if you need access again.";
+  if (row.kind === 'invite') return "Cancelled. That link doesn't work any more.";
+  if (row.pending) return "Refused. They haven't been let in.";
+  return machineOffline
+    ? "Access ended. They can't get back in — this machine is offline, so it finishes applying the change when it reconnects."
+    : "Access ended. If they were connected, they've been disconnected.";
+}
+
+/** `status` is the HTTP status, or null when the request never got through. */
+export function revokeFailedCopy(status: number | null): string {
+  if (status === 404) return 'That share was already gone.';
+  if (status === null) return "Couldn't reach the server. Check your connection and try again.";
+  return "The server couldn't do that just now. Try again.";
+}

--- a/relay/web/src/styles.css
+++ b/relay/web/src/styles.css
@@ -275,3 +275,23 @@ input, textarea { font-family: inherit; }
   background: var(--panel-2, rgba(127, 127, 127, 0.08));
   border-bottom: 1px solid var(--border);
 }
+
+/* --------------------------------------------------------------------------
+   Sharing sheet — who can reach a machine, and the guest's mirror of it
+   -------------------------------------------------------------------------- */
+
+.pill-row { display: flex; align-items: center; gap: 8px; padding: 12px 16px 0; }
+.pill-row .machine-pill { min-width: 0; }
+.sharebtn { flex: none; display: inline-flex; align-items: center; gap: 6px; min-height: 44px; min-width: 44px; padding: 8px 14px; border-radius: 12px; font-size: 13px; font-weight: 600; color: var(--accent); background: var(--accent-dim); }
+.sharebtn:active { background: color-mix(in srgb, var(--accent) 22%, transparent); }
+.share-list { list-style: none; margin: 0; padding: 0; }
+.share-row { display: flex; align-items: center; gap: 12px; padding: 12px 2px; border-bottom: 1px solid var(--hair); }
+.share-row:last-child { border-bottom: 0; }
+.share-main { flex: 1; min-width: 0; }
+.share-who { font-weight: 600; font-size: 14.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.share-meta { display: flex; align-items: center; gap: 6px; margin-top: 4px; }
+.share-role { font-family: var(--mono); font-size: 11px; color: var(--accent); background: var(--accent-dim); padding: 2px 8px; border-radius: 20px; white-space: nowrap; }
+.share-pend { font-family: var(--mono); font-size: 11px; color: var(--wait); background: var(--wait-dim); padding: 2px 8px; border-radius: 20px; white-space: nowrap; }
+.share-detail { color: var(--muted); font-size: 12.5px; margin-top: 4px; }
+.share-x { flex: none; min-height: 44px; min-width: 44px; padding: 0 14px; border-radius: 12px; color: var(--err); background: var(--err-dim); font-weight: 600; font-size: 13px; }
+.share-x:disabled { opacity: .5; }


### PR DESCRIPTION
## Description

Owners of the machine they are viewing get a **"Sharing" sheet** (button beside the machine pill) listing everything granted on that machine:

- rows for **active grants**, **pending requests**, and **invite links** — the person, a role word ("Watching" / "Watching and typing"), pending vs active, and expiry ("Until you revoke it" for the never-expires sentinel);
- actions per kind: **Revoke** (`DELETE /api/shares/:grantId`), **Refuse** for a pending request, **Cancel invite** (`DELETE /api/machines/:id/shares/:inviteId`);
- after-revoke copy distinguishes a connected machine from an offline one, driven by the `agent:offline` / `agent:ready` signals.

Guests get a **"Your access"** sheet (`GET /api/shares`) with a **Leave** action. Leaving the share you are connected through tears down the channel first, so the resulting kick cannot render a false "your access was ended" story.

**Fix commit `2cb6d24`** (landed after gate 3's first pass, in response to its one must-fix):

- Close-derived endings now emit a `CONNECTION_ENDED` sentinel rendered as **neutral, non-attributed copy** — the client never names a person for an ending it learned from an unsealed relay-authored close. `ENDED_COPY` is extracted to `relay/web/src/ended.ts` and pinned in both directions by `ended.test.ts`.
- Relay-side, a reconnecting revoked/expired guest is now closed with **their own grant's ending reason** instead of `'not your machine'`, ending the silent reconnect loop (`endedGrantReason` in `repositories.ts`, two new `ws.test.ts` tests). The reason literals are pinned in `ws.test.ts`.

Files:

- `relay/web/src/shares.ts` — new pure module: types, `roleWord`, `timeLeft`, row builders, copy — with `shares.test.ts` (26 tests, including a forbidden-vocabulary sweep over the user-facing copy)
- `relay/web/src/ended.ts` — new: `ENDED_COPY`, neutral close-derived ending copy — with `ended.test.ts` (4 tests)
- `relay/web/src/main.ts` — both sheets, the existing dialog/aria/`pushLayer` pattern, `machineOffline` tracking
- `relay/web/src/connection.ts` — a 4403 close carrying a known ending reason maps to the denied path (`connection.test.ts`: 16 tests)
- `relay/src/ws.ts`, `relay/src/repositories.ts` — reconnect close reasons for ended grants (`ws.test.ts`: 31 tests)
- `relay/web/src/styles.css` — token-only additions, 44px touch targets

**Merge note:** PR #188 (approved, unmerged) touches neighboring files in `relay/web`, and this branch was cut from `development` before it. A trivial merge-forward may be needed at merge time. Merges here are true merge commits — do not squash.

### For review attention

1. **The 4403 relay-authored close → ending-state mapping** in `connection.ts`. Rationale: an HTTP revoke makes the relay kick the socket before the agent can send the sealed denied frame; the mapping is scoped to known ending reasons, and other 4403 codes keep the reconnect behavior. Reviewed against the sealed-denied rationale in `docs/designs/session-sharing.md` §5 — see Gate results below.
2. **Revoking while the agent is offline leaves a desktop ghost** until reconnect reconciliation; the after-revoke copy says so explicitly.
3. `confirm()` is used for the destructive step, matching the existing client precedent.
4. Refusing a pending request leaves the waiting guest polling. That behavior exists on `development` today and this change does not alter it.
5. The sheet shows **no presence** (who is connected right now): the relay has no existing data path for it — the `ws.ts` clients map has no HTTP accessor — and this change does not invent a relay seam to add one. That decision is recorded on issue #184.

## Related issue
Closes #184

Initiative: 184 (single-repo; merge position 1 of 1).

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Hotfix
- [ ] Refactor / chore
- [ ] Docs

## How was this tested?

Verified (commands run in `relay/` at head `2cb6d24`):

- `bun test` — **211 pass / 0 fail (2512 expects, 11 files)**: `shares.test.ts` 26, `connection.test.ts` 16, `ended.test.ts` 4, `ws.test.ts` 31, plus the pre-existing suites
- typecheck — clean. Web test files are executed by bun but excluded from the web typecheck (pre-existing convention), so "typechecks clean" covers sources, not tests.
- `build:web` — bundles successfully
- harness `verify.sh Bodhilander=feat/184-Bodhilander` — **GREEN**. The registry test/lint rows are registry SKIPs for this repo, so the direct runs above are the test evidence, not the harness rows.

Not verified:

- No live end-to-end pass against a running relay + agent; the offline-agent, kick, and reconnect-close behaviors are covered at the unit level via the `agent:offline` / `agent:ready` and close-code paths, not against a live machine.

## Checklist
- [x] Tests pass locally
- [x] Self-reviewed the changes
- [x] Docs updated where needed (no doc changes required)
- [x] Linked the related issue above

## Gate results

**Gate 3 — reviewer: GREEN** (first pass RED, re-check of `2cb6d24` GREEN). The one must-fix: person-attributed copy was reachable from an unsealed relay-authored close — including an honest-path case where a guest's own Leave on one device was misattributed to the owner on their other device. The fix is complete and mutation-proven (reverting the `ws.ts` change fails exactly the two new tests), with no assertions weakened.

**Security review: no blocking findings.** The 4403 mapping is acceptable as scoped, with two standing conditions now encoded in the code itself: ending copy never interpolates a name, and the trusted-close set is pinned to `ENDING_REASONS`. Authorization, IDOR, CSRF, and escaping all clean. No existence oracle in `endedGrantReason`: it reads only the caller's own grant history, and a stranger's answer is byte-identical to a nonexistent machine's.

**Gate 4 — verifier: VERIFIED.** Receipts reproduced; wire/route shapes and reason literals hand-traced to server code. Non-blocking items recorded on issue #187 (sheet inventory, `confirm()` calls, 40×40 close buttons), plus one test gap noted there: a stranger-beside-a-revoked-guest fixture would pin the `grantee_user_id` filter in `endedGrantReason`.

CI: GitGuardian, SonarQube, and quality-gate all pass at `2cb6d24`. `verify-merge-order.sh` released the draft itself.

<!-- bodhi:merge-order -->
**Merge position 1 of 1.** Nothing merges before this one.
Order: Bodhilander
<!-- bodhi:merge-order -->
