### PR TITLE
168 — setDefaultAccount with a stale id no longer demotes the incumbent to zero defaults

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -838,7 +838,7 @@ safeHandle('accounts:update', (
 });
 
 safeHandle('accounts:setDefault', (id: string) => {
-  accountsRepo.setDefaultAccount(id);
+  return accountsRepo.setDefaultAccount(id);
 });
 
 // Assigning an account is routed through account-switch (not db:sessions:update)

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -342,7 +342,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('accounts:delete', id),
   updateAccount: (id: string, updates: { label?: string; color?: string; email?: string | null }): Promise<void> =>
     ipcRenderer.invoke('accounts:update', id, updates),
-  setDefaultAccount: (id: string): Promise<void> =>
+  setDefaultAccount: (id: string): Promise<boolean> =>
     ipcRenderer.invoke('accounts:setDefault', id),
   assignAccountToSession: (sessionId: string, accountId: string | null): Promise<AccountSwitchResult> =>
     ipcRenderer.invoke('accounts:assignToSession', sessionId, accountId),

--- a/src/main/repositories/__tests__/accounts.test.ts
+++ b/src/main/repositories/__tests__/accounts.test.ts
@@ -217,32 +217,37 @@ describe('setDefaultAccount', () => {
     seedAccount('a', '2026-01-01T00:00:00.000Z', { isDefault: true });
     seedAccount('b', '2026-02-01T00:00:00.000Z');
 
-    accountsRepo.setDefaultAccount('b');
+    expect(accountsRepo.setDefaultAccount('b')).toBe(true);
 
     expect(defaultIds()).toEqual(['b']);
     expect(accountsRepo.getDefaultAccount()?.id).toBe('b');
   });
 
-  test('re-defaulting the current default is idempotent', () => {
+  test('re-defaulting the current default is idempotent, and still reports true', () => {
     seedAccount('a', '2026-01-01T00:00:00.000Z', { isDefault: true });
 
-    accountsRepo.setDefaultAccount('a');
+    expect(accountsRepo.setDefaultAccount('a')).toBe(true);
 
     expect(defaultIds()).toEqual(['a']);
   });
 
-  test('pointing at an unknown id leaves the app with no default', () => {
-    // Pinning current behaviour, not endorsing it: the demote runs
-    // unconditionally, so a stale id demotes the incumbent and promotes
-    // nobody. That is the same accountless state #165 just closed on the
-    // delete path. The window is narrow — the renderer only offers ids it read
-    // out of this table moments earlier — so this test exists to make the
-    // behaviour visible and to fail loudly if someone tightens it.
+  test('pointing at an unknown id leaves the incumbent default and reports false', () => {
+    // The renderer offers ids from a cached list, so it can ask for an account
+    // another window already deleted. The demote must not land without a
+    // matching promote — otherwise this is the same accountless state #165
+    // closed on the delete path — and `false` is how a caller can tell the
+    // switch it asked for never happened.
     seedAccount('a', '2026-01-01T00:00:00.000Z', { isDefault: true });
 
-    accountsRepo.setDefaultAccount('ghost');
+    expect(accountsRepo.setDefaultAccount('ghost')).toBe(false);
 
-    expect(defaultIds()).toEqual([]);
+    expect(defaultIds()).toEqual(['a']);
+    expect(accountsRepo.getDefaultAccount()?.id).toBe('a');
+  });
+
+  test('an unknown id against an empty table reports false without throwing', () => {
+    expect(accountsRepo.setDefaultAccount('ghost')).toBe(false);
+    expect(accountsRepo.getDefaultAccount()).toBeNull();
   });
 });
 
@@ -313,8 +318,8 @@ describe('deleteAccount promotes a survivor (#165)', () => {
     seedAccount('a', '2026-01-01T00:00:00.000Z');
     seedAccount('b', '2026-02-01T00:00:00.000Z');
 
-    // Neither row is default (a state the app can reach by deleting the
-    // default before #165, or by setDefaultAccount on a stale id).
+    // Neither row is default (a state databases that predate the #165
+    // promotion can still carry).
     accountsRepo.deleteAccount('b');
 
     expect(defaultIds()).toEqual([]);

--- a/src/main/repositories/accounts.ts
+++ b/src/main/repositories/accounts.ts
@@ -93,13 +93,21 @@ export function updateAccount(id: string, updates: UpdateAccountInput): void {
   db.prepare(`UPDATE claude_accounts SET ${fields.join(', ')} WHERE id = ?`).run(...values);
 }
 
-export function setDefaultAccount(id: string): void {
+/**
+ * Make the account the default, demoting the incumbent in one transaction.
+ * A missing id — the renderer can offer one another window already deleted —
+ * returns false and touches nothing: demoting anyway would leave no default.
+ */
+export function setDefaultAccount(id: string): boolean {
   const db = getDatabase();
   const tx = db.transaction(() => {
+    const target = db.prepare('SELECT 1 FROM claude_accounts WHERE id = ?').get(id);
+    if (!target) return false;
     db.prepare('UPDATE claude_accounts SET is_default = 0 WHERE is_default = 1').run();
     db.prepare('UPDATE claude_accounts SET is_default = 1 WHERE id = ?').run(id);
+    return true;
   });
-  tx();
+  return tx();
 }
 
 export function touchAccount(id: string): void {

--- a/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
+++ b/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
@@ -110,7 +110,7 @@ describe('ClaudeAccountsPanel delete confirmation', () => {
       onPtyLiveAccount: () => () => {},
       onAccountLoginCompleted: () => () => {},
       deleteAccount: async (id: string) => { deleted.push(id); },
-      setDefaultAccount: async () => {},
+      setDefaultAccount: async () => true,
       startAccountLogin: async () => ({ account: listed[0], ptyId: 'p' }),
       cancelAccountLogin: async () => {},
       platform: 'darwin',

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -174,7 +174,7 @@ interface ElectronAPI {
   confirmAccountLoginMacOS: (ptyId: string) => Promise<void>;
   deleteAccount: (id: string) => Promise<void>;
   updateAccount: (id: string, updates: { label?: string; color?: string; email?: string | null }) => Promise<void>;
-  setDefaultAccount: (id: string) => Promise<void>;
+  setDefaultAccount: (id: string) => Promise<boolean>;
   assignAccountToSession: (sessionId: string, accountId: string | null) => Promise<AccountSwitchResult>;
   assignAccountToGroup: (groupId: string, accountId: string | null) => Promise<AccountSwitchResult>;
   onAccountLoginCompleted: (callback: (data: { accountId: string; email: string | null }) => void) => () => void;


### PR DESCRIPTION
## Description
`setDefaultAccount` demoted the incumbent default unconditionally before promoting by id. When the id was stale — e.g. a renderer's cached list offering an account another window had already deleted — the transaction committed with **zero** defaults.

The transaction is now guarded on the target row existing, and the contract is `setDefaultAccount(id): boolean`:

- `true` — the row exists and is the default (idempotent re-default included)
- `false` — no row matched; nothing changed

No-op-with-signal was chosen over a throw to match this repository's pinned voice — `updateAccount`, `touchAccount` and `deleteAccount` all no-op on unknown ids — and because the modal's unconditional `refresh()` already reconciles the ghost row out of the list.

The full caller chain carries the new contract: the IPC handler returns the boolean (`src/main/index.ts`), and the preload + `electron.d.ts` signatures are now `Promise<boolean>`. The boolean is **available to** the renderer through the full IPC chain — its one caller (`ClaudeAccountsModal`) deliberately discards it and relies on `refresh()`; the renderer does not consume the value today.

Commit d209938 (a verifier finding): the panel test stub now answers `async () => true` to match the `Promise<boolean>` contract; a sweep confirmed no other stub anywhere misstates it.

Initiative 168.

### For review attention
1. The modal discarding the returned boolean is deliberate (see above), not an oversight.
2. One comment in a pinned `deleteAccount` test was reworded — it cited the now-fixed behavior as a route to the no-default state. Assertions are unchanged.

## Related issue
Closes #168

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Hotfix
- [ ] Refactor / chore
- [ ] Docs

## How was this tested?
Evidence at head d209938:
- `bun test` (full) — 872 pass / 0 fail, 60 files (3902 expects)
- `bun test src/renderer` — 287 pass / 0 fail
- `bun test src/main/repositories` — 33 pass / 0 fail
- `tsc` — main and renderer both clean
- Harness `verify.sh` — GREEN (the registry test/lint rows are SKIPs for this repo; the evidence is the direct runs above)

**Not verified:** no manual multi-window run reproducing the original race (stale renderer cache offering a deleted account); the stale-id path is covered by the repository unit tests, not an end-to-end exercise.

## Checklist
- [x] Tests pass locally
- [x] Self-reviewed the changes
- [x] Docs updated where needed
- [x] Linked the related issue above

## Gate results

**Gate 3 — reviewer: GREEN.** The only operator surface (the panel's "Make default") can no longer produce a click that appears to succeed while leaving zero defaults. Transaction guard confirmed atomic-in-effect (synchronous better-sqlite3, single-instance lock = one writer); mutation test: deleting the guard fails exactly the stale-id and empty-table tests. All other zero-default paths walked — creation, `deleteAccount` promotion, account-switch, resolver legacy fallback — none needed this guard. Non-blocking note: the ghost-click gives no message by design (`refresh()` removes the row); the boolean makes a toast a one-line change if ever wanted.

**Gate 4 — verifier: VERIFIED.** All counts reproduced exactly against a real in-memory DB with the single-default partial unique index; no global mocks in play; no pre-existing assertion weakened (the one changed assertion was the bug's own pin, replaced by the fix's pin). Commit d209938 closed the verifier's type-stale-mock finding.

CI: GitGuardian, SonarQube, and quality-gate all pass on d209938.

<!-- bodhi:merge-order -->
**Merge position 1 of 1.** Nothing merges before this one.
Order: Bodhilander
<!-- bodhi:merge-order -->
