### PR TITLE
167 — PtyManager.kill rejections no longer escape its fire-and-forget callers

### DIFF
--- a/src/main/__tests__/account-auth.test.ts
+++ b/src/main/__tests__/account-auth.test.ts
@@ -111,7 +111,7 @@ function fakePtyManager(): PtyManager & { loginSessions: string[] } {
     },
     on() {},
     off() {},
-    kill() {},
+    kill: () => Promise.resolve(),
   };
   return stub as unknown as PtyManager & { loginSessions: string[] };
 }
@@ -193,5 +193,36 @@ describe('startLoginFlow legacy seeding', () => {
 
     accountAuth.cancelLoginFlow(pty, a.ptyId, false);
     accountAuth.cancelLoginFlow(pty, b.ptyId, false);
+  });
+});
+
+describe('cancelLoginFlow', () => {
+  test('a rejecting kill is swallowed and cleanup still runs to completion', async () => {
+    const pty = fakePtyManager();
+    let kills = 0;
+    pty.kill = () => {
+      kills++;
+      return Promise.reject(new Error('teardown glitched'));
+    };
+    const { ptyId } = await accountAuth.startLoginFlow(pty, null, 'Doomed');
+
+    const escaped: unknown[] = [];
+    const onUnhandled = (err: unknown) => { escaped.push(err); };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      accountAuth.cancelLoginFlow(pty, ptyId, true);
+      // Give a floating rejection an event-loop turn to surface.
+      await new Promise((r) => setTimeout(r, 10));
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+
+    expect(escaped).toEqual([]);
+    expect(kills).toBe(1);
+    // The abort rollback ran past the failed kill: the account row is gone.
+    expect(storedAccounts()).toEqual([]);
+    // And so is the flow itself — a second cancel is a no-op, not a re-kill.
+    accountAuth.cancelLoginFlow(pty, ptyId, true);
+    expect(kills).toBe(1);
   });
 });

--- a/src/main/__tests__/pty-manager.test.ts
+++ b/src/main/__tests__/pty-manager.test.ts
@@ -12,6 +12,9 @@
  *   the replacement bound to its id, kill() settles off the real exit and
  *   coalesces per id, and the silent resume-failure respawn inherits the last
  *   known size instead of dropping back to 80x24,
+ * - the kill force path, on an injectable grace: a pty trapping the graceful
+ *   signal is reaped by SIGKILL, and a graceful kill that throws rejects the
+ *   caller while the armed reaper still escalates,
  * - live-account publication (#165) for a provider without account support.
  *
  * Run with: bun test src/main/__tests__
@@ -28,11 +31,13 @@ interface FakePty {
   spawnOpts: { cols: number; rows: number };
   dataCb: ((data: string) => void) | null;
   exitCb: ((event: { exitCode: number }) => void) | null;
+  /** Signals delivered through the handle; undefined is the default kill(). */
+  killSignals: (string | undefined)[];
   onData(cb: (data: string) => void): void;
   onExit(cb: (event: { exitCode: number }) => void): void;
   write(data: string): void;
   resize(cols: number, rows: number): void;
-  kill(): void;
+  kill(signal?: string): void;
 }
 
 const spawned: FakePty[] = [];
@@ -45,11 +50,15 @@ function fakeSpawn(file: string, args: string[], opts: { cols: number; rows: num
     spawnOpts: opts,
     dataCb: null,
     exitCb: null,
+    killSignals: [],
     onData(cb) { p.dataCb = cb; },
     onExit(cb) { p.exitCb = cb; },
     write() {},
     resize() {},
-    kill() { p.exitCb?.({ exitCode: 0 }); },
+    kill(signal?: string) {
+      p.killSignals.push(signal);
+      p.exitCb?.({ exitCode: 0 });
+    },
   };
   spawned.push(p);
   return p;
@@ -439,6 +448,45 @@ describe('pty identity (#164)', () => {
     expect(spawned[0].spawnOpts.cols).toBe(100);
     expect(spawned[0].spawnOpts.rows).toBe(30);
     expect(manager.getSize('s2')).toEqual({ cols: 100, rows: 30 });
+  });
+});
+
+describe('kill() force path (injectable grace)', () => {
+  // The escalation branch is POSIX (win32 shells out to taskkill instead).
+  const posixTest = process.platform === 'win32' ? test.skip : test;
+
+  posixTest('a pty that traps the graceful signal is SIGKILLed and the waiter still resolves', async () => {
+    const manager = new PtyManager({ killGraceMs: 5 });
+    createAgentSession(manager);
+    const proc = spawned[0];
+    // Records the signals but never exits — the timer is the only way out.
+    proc.kill = (signal?: string) => { proc.killSignals.push(signal); };
+
+    await manager.kill('session-1');
+
+    expect(proc.killSignals).toEqual([undefined, 'SIGKILL']);
+  });
+
+  posixTest('a graceful kill that throws rejects the caller but leaves the reaper armed', async () => {
+    const manager = new PtyManager({ killGraceMs: 5 });
+    createAgentSession(manager);
+    const proc = spawned[0];
+    proc.kill = (signal?: string) => {
+      if (signal === undefined) throw new Error('native handle already gone');
+      proc.killSignals.push(signal);
+    };
+
+    await expect(manager.kill('session-1')).rejects.toThrow('native handle already gone');
+    // The map slot emptied before the throw, so a caller that catches can
+    // retry its own work without tripping over a phantom live session.
+    expect(manager.getSession('session-1')).toBeUndefined();
+
+    // The force timer armed ahead of the signal still escalates and reaps.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(proc.killSignals).toEqual(['SIGKILL']);
+    // The drained teardown released its pending entry: a follow-up kill
+    // resolves immediately instead of joining a settled waiter.
+    await manager.kill('session-1');
   });
 });
 

--- a/src/main/account-auth.ts
+++ b/src/main/account-auth.ts
@@ -237,11 +237,12 @@ export function cancelLoginFlow(
 
   flow.watcher?.close();
   ptyManager.off('exit', flow.exitListener);
-  try {
-    ptyManager.kill(ptyId);
-  } catch (err) {
-    // Pty may have already exited.
-  }
+  // Best-effort: a pty that already exited resolves cleanly, so a rejection
+  // means teardown itself glitched — and with the flow being discarded either
+  // way, that is worth a log line, not a failed cancel.
+  ptyManager.kill(ptyId).catch((err) => {
+    log.warn(`[Accounts] Failed to kill login pty ${ptyId}:`, err);
+  });
 
   if (deleteAccount) {
     try {

--- a/src/main/api/routes/__tests__/sessions.test.ts
+++ b/src/main/api/routes/__tests__/sessions.test.ts
@@ -1,0 +1,226 @@
+/**
+ * The PTY teardown routes await kill() and answer from its outcome — a
+ * rejection becomes the route's 500, never an unhandled one. Real router,
+ * in-memory bun:sqlite; the singleton's getSession/kill shadowed per test.
+ */
+
+// Run with: bun test src/main/api
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { randomUUID } from 'node:crypto';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import express from 'express';
+import type { PairedDevice } from '../../pairing/pairing-manager';
+
+let db: Database;
+mock.module('../../../database', () => ({
+  getDatabase: () => db,
+}));
+mock.module('electron-log', () => ({
+  default: { info() {}, warn() {}, error() {} },
+}));
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
+  safeStorage: { isEncryptionAvailable: () => false },
+}));
+mock.module('../../../repositories/preferences', () => ({
+  getPreference: () => null,
+  setPreference: () => {},
+  deletePreference: () => {},
+}));
+// Keeps node-pty's native binding out of the test process; nothing here spawns.
+mock.module('node-pty', () => ({
+  spawn: () => { throw new Error('no pty spawns in these tests'); },
+}));
+
+const { createSessionsRouter } = await import('../sessions');
+const { ptyManager } = await import('../../../pty-manager');
+
+/**
+ * Per-test shadows over the singleton's prototype methods. getSession only
+ * feeds truthiness checks in the routes, so a bare object stands in for a
+ * live session.
+ */
+const patchable = ptyManager as unknown as {
+  getSession?: (id: string) => unknown;
+  kill?: (id: string) => Promise<void>;
+};
+
+function freshDb(): Database {
+  const d = new Database(':memory:');
+  d.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      group_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      working_dir TEXT,
+      state TEXT,
+      shell_type TEXT DEFAULT 'bash',
+      "order" INTEGER DEFAULT 0,
+      created_at TEXT,
+      last_activity_at TEXT,
+      claude_session_id TEXT DEFAULT NULL,
+      ended_at TEXT DEFAULT NULL,
+      duration_seconds REAL DEFAULT 0,
+      claude_account_id TEXT DEFAULT NULL,
+      provider TEXT NOT NULL DEFAULT 'claude'
+    )
+  `);
+  return d;
+}
+
+function insertSession(id: string): void {
+  db.prepare(`
+    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at)
+    VALUES (?, 'g1', 'test', '/tmp', 'idle', 'claude', 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  `).run(id);
+}
+
+function sessionRowCount(id: string): number {
+  return (db.prepare('SELECT COUNT(*) AS c FROM sessions WHERE id = ?').get(id) as { c: number }).c;
+}
+
+const device: PairedDevice = {
+  id: 'device-1',
+  name: 'test-phone',
+  platform: 'ios',
+  canControl: true,
+  canModify: true,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  lastUsedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+let server: Server;
+let baseUrl = '';
+
+beforeAll(() => new Promise<void>((resolve) => {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.device = device;
+    next();
+  });
+  app.use('/sessions', createSessionsRouter());
+  server = app.listen(0, '127.0.0.1', () => {
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    resolve();
+  });
+}));
+
+afterAll(() => {
+  server?.close();
+});
+
+beforeEach(() => {
+  db = freshDb();
+});
+
+afterEach(() => {
+  delete patchable.getSession;
+  delete patchable.kill;
+});
+
+describe('POST /sessions/:id/stop', () => {
+  test('the response waits on kill() and reports success only once it settles', async () => {
+    const id = randomUUID();
+    patchable.getSession = () => ({});
+    let resolveKill: () => void = () => {};
+    const killCalls: string[] = [];
+    patchable.kill = (killedId: string) => {
+      killCalls.push(killedId);
+      return new Promise<void>((resolve) => { resolveKill = resolve; });
+    };
+
+    const pending = fetch(`${baseUrl}/sessions/${id}/stop`, { method: 'POST' });
+    let settled = false;
+    const tracked = pending.then((r) => { settled = true; return r; });
+    await new Promise((r) => setTimeout(r, 25));
+    // The kill has been asked for but has not settled: no response yet, so
+    // success can only ever mean the process is really gone.
+    expect(killCalls).toEqual([id]);
+    expect(settled).toBe(false);
+
+    resolveKill();
+    const res = await tracked;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+  });
+
+  test('a kill rejection surfaces as the route 500, not an unhandled rejection', async () => {
+    const id = randomUUID();
+    patchable.getSession = () => ({});
+    patchable.kill = () => Promise.reject(new Error('teardown exploded'));
+
+    const escaped: unknown[] = [];
+    const onUnhandled = (err: unknown) => { escaped.push(err); };
+    process.on('unhandledRejection', onUnhandled);
+    let status = 0;
+    let body: unknown = null;
+    try {
+      const res = await fetch(`${baseUrl}/sessions/${id}/stop`, { method: 'POST' });
+      status = res.status;
+      body = await res.json();
+      await new Promise((r) => setTimeout(r, 10));
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+
+    expect(status).toBe(500);
+    expect(body).toEqual({ error: 'Failed to stop session' });
+    expect(escaped).toEqual([]);
+  });
+});
+
+describe('DELETE /sessions/:id', () => {
+  test('with no running pty, deletes the record without touching kill()', async () => {
+    const id = randomUUID();
+    insertSession(id);
+    const killCalls: string[] = [];
+    patchable.kill = (killedId: string) => {
+      killCalls.push(killedId);
+      return Promise.resolve();
+    };
+
+    const res = await fetch(`${baseUrl}/sessions/${id}`, { method: 'DELETE' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(killCalls).toEqual([]);
+    expect(sessionRowCount(id)).toBe(0);
+  });
+
+  test('a kill rejection aborts the delete with a 500, and a retry completes it', async () => {
+    const id = randomUUID();
+    insertSession(id);
+    patchable.getSession = () => ({});
+    patchable.kill = () => Promise.reject(new Error('teardown exploded'));
+
+    const escaped: unknown[] = [];
+    const onUnhandled = (err: unknown) => { escaped.push(err); };
+    process.on('unhandledRejection', onUnhandled);
+    let status = 0;
+    let body: unknown = null;
+    try {
+      const res = await fetch(`${baseUrl}/sessions/${id}`, { method: 'DELETE' });
+      status = res.status;
+      body = await res.json();
+      await new Promise((r) => setTimeout(r, 10));
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+
+    expect(status).toBe(500);
+    expect(body).toEqual({ error: 'Failed to delete session' });
+    expect(escaped).toEqual([]);
+    // The record survives the failed attempt rather than half-vanishing.
+    expect(sessionRowCount(id)).toBe(1);
+
+    // kill() empties its session slot before anything can throw, so the retry
+    // finds no live pty and goes straight to removing the record.
+    delete patchable.getSession;
+    const retry = await fetch(`${baseUrl}/sessions/${id}`, { method: 'DELETE' });
+    expect(retry.status).toBe(200);
+    expect(sessionRowCount(id)).toBe(0);
+  });
+});

--- a/src/main/api/routes/sessions.ts
+++ b/src/main/api/routes/sessions.ts
@@ -261,13 +261,15 @@ export function createSessionsRouter(): Router {
     '/:id',
     requireModifyPermission,
     validateIdParam,
-    (req: Request, res: Response) => {
+    async (req: Request, res: Response) => {
       try {
         const id = getStringParam(req.params.id);
 
-        // Stop PTY if running
+        // Stop PTY if running. A kill failure aborts the delete and surfaces
+        // as the 500 below; kill() already emptied its session slot, so a
+        // retry skips straight to removing the record.
         if (ptyManager.getSession(id)) {
-          ptyManager.kill(id);
+          await ptyManager.kill(id);
         }
 
         sessionsRepo.deleteSession(id);
@@ -324,7 +326,7 @@ export function createSessionsRouter(): Router {
     '/:id/stop',
     requireControlPermission,
     validateIdParam,
-    (req: Request, res: Response) => {
+    async (req: Request, res: Response) => {
       try {
         const id = getStringParam(req.params.id);
 
@@ -333,7 +335,9 @@ export function createSessionsRouter(): Router {
           return;
         }
 
-        ptyManager.kill(id);
+        // Settles on the real exit (force path bounds it), so success means
+        // the process is gone — a client may start again on this response.
+        await ptyManager.kill(id);
 
         log.info(`[SessionsAPI] Stopped session: ${id}`);
         res.json({ success: true });

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -223,10 +223,13 @@ export class PtyManager extends EventEmitter {
   private sessions: Map<string, PtySession> = new Map();
   private readonly pendingKills: Map<string, PendingKill> = new Map();
   private socketPath: string;
+  /** How long a signalled pty gets to exit before kill() escalates by force. */
+  private readonly killGraceMs: number;
 
-  constructor() {
+  constructor(opts?: { killGraceMs?: number }) {
     super();
     this.socketPath = getSocketPath();
+    this.killGraceMs = opts?.killGraceMs ?? 3000;
   }
 
   private getShellInfo(): ShellInfo {
@@ -1060,7 +1063,7 @@ export class PtyManager extends EventEmitter {
     // its caller, not the mechanism that normally settles.
     if (process.platform === 'win32' && pid) {
       entry.timer = setTimeout(() => {
-        log.warn(`[PTY] Force-killing session ${id} (pid ${pid}) after 3s timeout`);
+        log.warn(`[PTY] Force-killing session ${id} (pid ${pid}) after ${this.killGraceMs}ms timeout`);
         try {
           execFile('taskkill', ['/F', '/T', '/PID', String(pid)], (err) => {
             if (err) {
@@ -1072,7 +1075,7 @@ export class PtyManager extends EventEmitter {
           log.error(`[PTY] Failed to spawn taskkill for pid ${pid}:`, err);
           entry.settle();
         }
-      }, 3000);
+      }, this.killGraceMs);
     } else {
       entry.timer = setTimeout(() => {
         // node-pty's UnixTerminal.kill() sends SIGHUP and swallows the result,
@@ -1081,7 +1084,7 @@ export class PtyManager extends EventEmitter {
         // `await kill()` on a live process and hand the restart the same
         // guess-based ordering #164 removed, except now the survivor is muted
         // by the identity guard and there is no exit to notice it by.
-        log.warn(`[PTY] Session ${id} (pid ${pid}) ignored SIGHUP for 3s; escalating to SIGKILL`);
+        log.warn(`[PTY] Session ${id} (pid ${pid}) ignored SIGHUP for ${this.killGraceMs}ms; escalating to SIGKILL`);
         // Through the pty handle rather than process.kill, so the signal can
         // only ever reach a process this manager spawned.
         try {
@@ -1090,7 +1093,7 @@ export class PtyManager extends EventEmitter {
           log.error(`[PTY] SIGKILL failed for session ${id} (pid ${pid}):`, err);
         }
         entry.settle();
-      }, 3000);
+      }, this.killGraceMs);
     }
 
     // Send the graceful kill signal. The onExit handler registered at spawn


### PR DESCRIPTION
## Description
`PtyManager.kill()` returns a promise that three callers ignored, so a rejection escaped as an unhandled rejection. Rather than a blanket `await`, each call site got the handling its semantics call for:

- **`account-auth.ts` `cancelLoginFlow`** — handled with `.catch()` and a `log.warn`. This is the sync-IPC modal-close path; `kill()` on an absent session resolves cleanly, so a rejection here is a teardown glitch worth a log line, never a failed cancel.
- **`api/routes/sessions.ts` `POST /:id/stop`** — now awaited (handler made async). A rejection surfaces as the route's 500, and `success: true` now truthfully means the process is dead. The force path bounds the wait at ~3s.
- **`api/routes/sessions.ts` `DELETE /:id`** — awaited inside the existing `try`. A rejection aborts with the 500 envelope instead of half-succeeding, and retry is clean because `kill()` empties its session slot before anything can throw (pinned by a test).

Alongside: `pty-manager.ts` gained an injectable `killGraceMs` (constructor option, default 3000), which makes the force-timer paths testable.

**For review attention:**
1. `DELETE /:id` now blocks up to ~3s on a hung pty — truthful surfacing was chosen over the old instant-but-lying response.
2. `cancelLoginFlow` still `rmSync`s the account dir while the login pty may take up to 3s to die. That race predates this change and this PR does not alter it — flagged so the reviewer weighs it deliberately.
3. These routes belong to the legacy LAN API (epic #179). This fix keeps them honest for as long as they exist.

## Related issue
Closes #167

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Hotfix
- [ ] Refactor / chore
- [ ] Docs

## How was this tested?
Direct runs on the branch (`feat/167-Bodhilander`, worktree at `_wt-167-Bodhilander`):

- `pty-manager.test.ts` — **30 pass** (2 new: SIGKILL escalation resolves the waiter; a throwing graceful kill rejects the caller while the armed reaper still escalates and drains).
- `account-auth.test.ts` — **4 pass** (1 new: a rejecting `kill` is swallowed, rollback completes, no `unhandledRejection`).
- NEW `src/main/api/routes/__tests__/sessions.test.ts` — **4 pass** (stop gated on `kill` settling; stop/delete rejections → 500 with zero unhandled rejections; retry-after-failure completes the delete).
- Full suite: **878 pass / 0 fail** across 61 files.
- `tsc` (main) clean.
- Harness `verify.sh`: **GREEN**. Note: the registry's `test`/`lint` entries reported SKIP for this repo, so the evidence above is the direct runs, not the registry wrappers.

**Not verified:** no manual end-to-end run against a live hung pty; the ~3s force-timer behavior is exercised via the injectable `killGraceMs` in tests, not wall-clock. The `cancelLoginFlow` `rmSync`-vs-dying-pty race (item 2 above) has no test coverage in this PR.

## Checklist
- [x] Tests pass locally
- [x] Self-reviewed the changes
- [x] Docs updated where needed
- [x] Linked the related issue above

## Gate results

**Gate 3 — reviewer: GREEN.** Completeness swept: six external `ptyManager.kill` call sites — the three fixed here, and three already handled (safeHandle-returned IPC, provider-install awaits, `killAll` in try/catch). Operator paths improved, not regressed: the PWA stop button now renders teardown failures in its existing error banner instead of a lying 200, and no consumer depends on the old instant response (the PWA's `apiFetch` has no timeout and shows a busy state). The benign already-exited path never rejects, so the cancel-login `log.warn` stays quiet. Mutation check: reverting the DELETE await kills its test. Discipline clean.

**Gate 4 — verifier: VERIFIED.** Every count reproduced first-try: scoped 38/0; full 878/0 vs 871/0 at base — exactly +7 tests / +1 file, purely additive. The new tests were also run against the OLD production code and fail there (the `unhandledRejection` listener captures the old escape at account-auth.ts:241; 3 of 4 route tests fail pre-fix), so their green is evidence, not decoration. Anchored claims re-grepped: `killGraceMs` defaults to 3000, the sole production constructor call stays bare, and the slot-emptied-before-throw retry safety is pinned. Stated not-verified: the win32 taskkill branch ran under no test (constant-for-constant change, tsc-covered, equally untested before this PR).

CI at `735e7de`: GitGuardian passes. SonarQube quality gate is red on a single condition — **0% Security Hotspots Reviewed on New Code** (needs 100%); no other condition failed and no new issues were reported. The likely subject is the pre-existing win32 `execFile('taskkill', ...)` block, whose surrounding lines changed in this PR. Hotspot review is a SonarQube-UI action; the `quality-gate` job re-runs green once it is done.

<!-- bodhi:merge-order -->
**Merge position 1 of 1.** Nothing merges before this one.
Order: Bodhilander
<!-- bodhi:merge-order -->
