### PR TITLE
[192] CI test gate — run the suite on every PR, coverage to Sonar, relay in scope

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -31,6 +31,25 @@ jobs:
           # Disabling shallow clone is recommended for improving relevancy of reporting.
           fetch-depth: 0
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      # --ignore-scripts skips postinstall's electron-rebuild, which needs an
+      # Electron download and a native toolchain. The suites never load a
+      # native module: they use bun:sqlite and mock node-pty.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Install relay dependencies
+        run: bun install --frozen-lockfile
+        working-directory: relay
+
+      # One root run discovers relay's tests too, producing a single
+      # coverage/lcov.info whose paths are all repo-root-relative — the shape
+      # sonar.javascript.lcov.reportPaths expects.
+      - name: Generate test coverage
+        run: bun test --coverage --coverage-reporter=lcov
+
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -33,6 +33,11 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          # Exact pin: bun:test module-mock semantics changed between minors
+          # (1.4.0 shares one mock registry across files unless --isolate), so
+          # a floating runtime can flip this gate without any code change.
+          bun-version: 1.4.0
 
       # --ignore-scripts skips postinstall's electron-rebuild, which needs an
       # Electron download and a native toolchain. The suites never load a
@@ -46,9 +51,10 @@ jobs:
 
       # One root run discovers relay's tests too, producing a single
       # coverage/lcov.info whose paths are all repo-root-relative — the shape
-      # sonar.javascript.lcov.reportPaths expects.
+      # sonar.javascript.lcov.reportPaths expects. --isolate keeps each file's
+      # module mocks to itself, same as the Tests workflow.
       - name: Generate test coverage
-        run: bun test --coverage --coverage-reporter=lcov
+        run: bun test --coverage --coverage-reporter=lcov --isolate
 
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,8 @@ jobs:
         run: bun test --isolate
 
       # The relay deploys against its own lockfile (relay/bun.lock), so its
-      # suite must also pass standalone from relay/.
+      # suite must also pass standalone from relay/. --isolate for the same
+      # reason as above — the first relay mock.module must not change this.
       - name: Run relay suite
-        run: bun test
+        run: bun test --isolate
         working-directory: relay

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,11 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          # Exact pin: bun:test module-mock semantics changed between minors
+          # (1.4.0 shares one mock registry across files unless --isolate), so
+          # a floating runtime can flip this gate without any code change.
+          bun-version: 1.4.0
 
       # --ignore-scripts skips postinstall's electron-rebuild, which needs an
       # Electron download and a native toolchain. The suites never load a
@@ -37,8 +42,10 @@ jobs:
         working-directory: relay
 
       # Discovers every *.test.ts(x) under the repo, relay/ included.
+      # --isolate gives each file its own module registry, so one file's
+      # mock.module can never become another file's subject.
       - name: Run app suite
-        run: bun test
+        run: bun test --isolate
 
       # The relay deploys against its own lockfile (relay/bun.lock), so its
       # suite must also pass standalone from relay/.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+# Cancel superseded runs only on pull requests; pushes to development run to
+# completion so the branch's check history stays gap-free.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      # --ignore-scripts skips postinstall's electron-rebuild, which needs an
+      # Electron download and a native toolchain. The suites never load a
+      # native module: they use bun:sqlite and mock node-pty.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Install relay dependencies
+        run: bun install --frozen-lockfile
+        working-directory: relay
+
+      # Discovers every *.test.ts(x) under the repo, relay/ included.
+      - name: Run app suite
+        run: bun test
+
+      # The relay deploys against its own lockfile (relay/bun.lock), so its
+      # suite must also pass standalone from relay/.
+      - name: Run relay suite
+        run: bun test
+        working-directory: relay

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ node_modules/
 dist/
 out/
 
+# Test coverage
+coverage/
+
 # Electron
 release/
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "main": "dist/main/index.js",
   "scripts": {
     "postinstall": "electron-rebuild -o better-sqlite3,node-pty && node node_modules/node-pty/scripts/post-install.js",
+    "test": "bun test",
     "build:main": "tsc -p tsconfig.main.json",
     "build:hooks": "esbuild src/hooks/bodhilander-hook.ts --bundle --platform=node --target=node18 --outfile=dist/hooks/bodhilander-hook.js --sourcemap --format=cjs",
     "build:renderer": "webpack --mode production",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "main": "dist/main/index.js",
   "scripts": {
     "postinstall": "electron-rebuild -o better-sqlite3,node-pty && node node_modules/node-pty/scripts/post-install.js",
-    "test": "bun test",
+    "test": "bun test --isolate",
     "build:main": "tsc -p tsconfig.main.json",
     "build:hooks": "esbuild src/hooks/bodhilander-hook.ts --bundle --platform=node --target=node18 --outfile=dist/hooks/bodhilander-hook.js --sourcemap --format=cjs",
     "build:renderer": "webpack --mode production",

--- a/relay/package.json
+++ b/relay/package.json
@@ -12,7 +12,7 @@
     "start": "bun run src/index.ts",
     "dev": "bun run build:web && bun --watch src/index.ts",
     "build:web": "bun build web/src/main.ts --outdir web/dist --target browser --minify",
-    "test": "bun test",
+    "test": "bun test --isolate",
     "typecheck": "tsc --noEmit",
     "typecheck:web": "tsc -p web/tsconfig.json"
   },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,13 @@
 sonar.projectKey=Software-Development-LLC_Bodhilander_2d637ced-8612-41e6-a7d6-d6127023db10
 
-# Only application code is analyzed. Everything outside src/ is either
+# Only application code is analyzed: the app plus both sides of the relay
+# (server and browser client). Everything outside these dirs is either
 # packaging assets (build/, resources/), docs, or repo tooling (scripts/).
-sonar.sources=src
+sonar.sources=src,relay/src,relay/web/src
 
-# Generated / vendored artifacts inside src that are not authored code.
-sonar.exclusions=src/pwa/public/**,**/*.d.ts
+# Generated / vendored artifacts that are not authored code, plus test files
+# and their fixtures.
+sonar.exclusions=src/pwa/public/**,**/*.d.ts,**/*.test.ts,**/*.test.tsx,**/__tests__/**
+
+# Produced by `bun test --coverage --coverage-reporter=lcov` in sonarqube.yml.
+sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/src/main/__tests__/account-auth.test.ts
+++ b/src/main/__tests__/account-auth.test.ts
@@ -4,9 +4,9 @@
  * creation (no await between check and insert), so overlapping calls can't
  * both become the default.
  *
- * electron, mcp-config, pty-manager (node-pty), and the seed helper are all
- * stubbed; the flow's own fs usage (mkdir, watch) runs against a temp userData
- * dir. The accounts repository runs REAL against an in-memory bun:sqlite
+ * electron, mcp-config, and the seed helper are stubbed (pty-manager is only
+ * a type import); the flow's own fs usage (mkdir, watch) runs against a temp
+ * userData dir. The accounts repository runs REAL against an in-memory bun:sqlite
  * standing in for '../database' — the same shape account-switch.test.ts uses.
  * It used to be a hand-rolled array fake, but bun's mock.module patches a
  * specifier for the whole test process, so that fake silently became the
@@ -16,7 +16,7 @@
  *
  * Run with: bun test src/main/__tests__
  */
-import { describe, expect, test, mock, beforeEach, afterEach } from 'bun:test';
+import { describe, expect, test, mock, beforeEach, afterEach, afterAll } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -26,8 +26,6 @@ import type { PtyManager } from '../pty-manager';
 let userDataDir = '';
 mock.module('electron', () => ({
   app: { getPath: () => userDataDir },
-  // Only referenced in type positions by account-auth; never constructed.
-  BrowserWindow: Object,
 }));
 
 let db: Database;
@@ -74,8 +72,9 @@ function freshDb(): Database {
 // Stubbed so the flow never writes into a real ~/.claude. registerHooks is the
 // only registration left now that the memory MCP server is gone; the calls are
 // recorded so the tests can assert it targets the new account's isolated
-// config dir. cleanupLegacyMcpServer is included because bun's mock.module
-// patches globally and index.ts imports it from here.
+// config dir. The stub covers the module's FULL export shape — a registered
+// mock namespace can never gain names it was created without.
+const realMcpConfig = { ...(await import('../mcp-config')) };
 const hookRegistrations: Array<string | undefined> = [];
 mock.module('../mcp-config', () => ({
   registerHooks: (configDir?: string) => {
@@ -83,10 +82,13 @@ mock.module('../mcp-config', () => ({
     return { success: true, action: 'added' as const };
   },
   cleanupLegacyMcpServer: () => undefined,
+  unregisterMcpServer: () => false,
+  getHooksStatus: () => ({ configured: false }),
 }));
 
 // Seed spy with a controllable delay — a slow copy is exactly what widened
 // the old check-then-act window across an await boundary.
+const realLegacySeed = { ...(await import('../legacy-claude-seed')) };
 const seedCalls: string[] = [];
 let seedDelayMs = 0;
 mock.module('../legacy-claude-seed', () => ({
@@ -97,9 +99,13 @@ mock.module('../legacy-claude-seed', () => ({
   },
 }));
 
-// Keep node-pty out of the test process; the flow only calls methods on the
-// instance we pass in (PtyManager is only referenced in type positions).
-mock.module('../pty-manager', () => ({ PtyManager: Object }));
+// Hand the REAL modules back when this file finishes — mcp-config.test.ts and
+// legacy-claude-seed.test.ts drive them for real, and in a shared-registry run
+// a stub left registered here would silently become their subject.
+afterAll(() => {
+  mock.module('../mcp-config', () => realMcpConfig);
+  mock.module('../legacy-claude-seed', () => realLegacySeed);
+});
 
 const accountAuth = await import('../account-auth');
 

--- a/src/main/__tests__/canary.test.ts
+++ b/src/main/__tests__/canary.test.ts
@@ -1,0 +1,6 @@
+/** Deliberately failing test proving the CI gate turns red. Reverted next commit. */
+import { expect, test } from 'bun:test';
+
+test('canary: the test gate must fail on a failing test', () => {
+  expect('gate').toBe('red');
+});

--- a/src/main/__tests__/canary.test.ts
+++ b/src/main/__tests__/canary.test.ts
@@ -1,6 +1,0 @@
-/** Deliberately failing test proving the CI gate turns red. Reverted next commit. */
-import { expect, test } from 'bun:test';
-
-test('canary: the test gate must fail on a failing test', () => {
-  expect('gate').toBe('red');
-});

--- a/src/main/account-auth.ts
+++ b/src/main/account-auth.ts
@@ -18,9 +18,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
-import { app, BrowserWindow } from 'electron';
+import { app } from 'electron';
+import type { BrowserWindow } from 'electron';
 import log from 'electron-log';
-import { PtyManager } from './pty-manager';
+// Type-only: a value import would drag node-pty (a native module) into every
+// process that loads this file, including the test runner.
+import type { PtyManager } from './pty-manager';
 import * as accountsRepo from './repositories/accounts';
 import { registerHooks } from './mcp-config';
 import { seedLegacyConversations } from './legacy-claude-seed';

--- a/src/main/arena/__tests__/engine-ollama.test.ts
+++ b/src/main/arena/__tests__/engine-ollama.test.ts
@@ -17,7 +17,9 @@ mock.module('../../repositories/preferences', () => ({
 }));
 
 // In-memory stand-in mirroring the repo's semantics so prepareFollowUp's
-// history replay can be exercised (it reads prior rounds via getRun).
+// history replay can be exercised (it reads prior rounds via getRun). It
+// mirrors the repo's FULL export shape: in a shared-registry run a partial
+// mock namespace reads as "Export named '…' not found" to any later importer.
 const finalized: any[] = [];
 const store = { runs: new Map<string, any>(), responses: [] as any[] };
 mock.module('../../repositories/arena', () => ({
@@ -38,6 +40,17 @@ mock.module('../../repositories/arena', () => ({
       Object.assign(row, { status: final.status, text: final.text, sessionRef: final.sessionRef, error: final.error });
     }
   },
+  settleInterruptedResponses: () => {
+    let settled = 0;
+    for (const row of store.responses) {
+      if (row.status === 'running') {
+        row.status = 'error';
+        row.error = 'Interrupted by app restart';
+        settled += 1;
+      }
+    }
+    return settled;
+  },
   getRun: (id: string) => {
     const run = store.runs.get(id);
     if (!run) return null;
@@ -53,6 +66,10 @@ mock.module('../../providers', () => ({
     throw new Error('CLI providers not used in these tests');
   },
 }));
+// The engine imports the key vault, whose real module links electron's
+// safeStorage — an export this file's electron stub does not provide. Without
+// this stub the whole file dies at import in an isolated (per-file) registry.
+mock.module('../../key-vault', () => ({ vaultEnvFor: () => ({}) }));
 
 const { ArenaEngine } = await import('../engine');
 

--- a/src/main/arena/__tests__/engine.test.ts
+++ b/src/main/arena/__tests__/engine.test.ts
@@ -19,7 +19,9 @@ mock.module('../../repositories/preferences', () => ({
 }));
 
 // In-memory stand-in mirroring the repo's semantics (round ordering,
-// session_ref persistence) so prepareFollowUp can be exercised for real.
+// session_ref persistence) so prepareFollowUp can be exercised for real. It
+// mirrors the repo's FULL export shape: in a shared-registry run a partial
+// mock namespace reads as "Export named '…' not found" to any later importer.
 const finalized: any[] = [];
 const store = {
   runs: new Map<string, any>(),
@@ -47,6 +49,17 @@ mock.module('../../repositories/arena', () => ({
         error: final.error,
       });
     }
+  },
+  settleInterruptedResponses: () => {
+    let settled = 0;
+    for (const row of store.responses) {
+      if (row.status === 'running') {
+        row.status = 'error';
+        row.error = 'Interrupted by app restart';
+        settled += 1;
+      }
+    }
+    return settled;
   },
   getRun: (id: string) => {
     const run = store.runs.get(id);


### PR DESCRIPTION
## Description
Initiative 192. Adds a CI test gate and wires coverage and the relay into Sonar:

- **New `.github/workflows/test.yml`** — runs on `pull_request` and on push to `development`. Pinned `checkout`/`setup-bun` action SHAs (matching the `release.yml` convention) and **`bun-version: 1.4.0` pinned** in both test.yml and sonarqube.yml (`release.yml` keeps floating per its own convention). Root install is `bun install --frozen-lockfile --ignore-scripts`, which skips the electron-rebuild postinstall — no Electron download or native toolchain on CI; the suites use `bun:sqlite` and mock `node-pty`. Plain frozen install in `relay/`, then both suites run with `--isolate`. PR-only concurrency cancellation, `contents: read`, 15-minute timeout.
- **Coverage to Sonar** — `bun test --coverage --coverage-reporter=lcov` produces `coverage/lcov.info` with repo-root-relative `SF` paths; a relay-cwd lcov would collide on `src/...` paths and was deliberately avoided. Generation steps added to `sonarqube.yml`'s workspace before the scan; `sonar.javascript.lcov.reportPaths=coverage/lcov.info`; `coverage/` gitignored.
- **Sonar scope** — sources are now `src,relay/src,relay/web/src`; exclusions add `**/*.test.ts,**/*.test.tsx,**/__tests__/**`. There were no test exclusions before, so test files were being scanned as main code.

### What the gate's own first run exposed
The first ubuntu run of the new workflow went red on **pre-existing order-dependent mock poisonings** (817 pass / 16 fail / 2 errors). Root cause, refined during the fix: **bun 1.4.0** — which the floating `setup-bun` resolved on CI — changed `bun:test` semantics: module mocks leak across files through one shared registry keyed by resolved path (1.3.x restored them between files), and the victim set varies with the repo's absolute path (38 failures in a Linux container at the CI path vs 16 + 2 on CI itself). Fixes on this branch:

- `bun test --isolate` everywhere a suite runs — the package.json script and both workflow steps, including the relay step (6ca167f).
- `bun-version: 1.4.0` pinned in test.yml and sonarqube.yml, so the semantics CI runs under are the semantics that were tested.
- Mock repairs (b9cd55f): `account-auth.test.ts` restores the real mcp-config/legacy-claude-seed modules in `afterAll` and its stub covers the full four-export shape; its pty-manager mock is deleted (`account-auth.ts` imports `PtyManager`/`BrowserWindow` as type-only); the engine/engine-ollama arena stubs gained a faithful `settleInterruptedResponses`; engine-ollama stubs key-vault itself instead of borrowing another file's mock.

## Related issue
Closes #192

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Hotfix
- [x] Refactor / chore
- [ ] Docs

## How was this tested?
**Local receipts (draft stage, b4cd2a7):** in a clean worktree with no `node_modules`, `bun install --frozen-lockfile --ignore-scripts` followed by the suites gave root **871 pass / 0 fail** (60 files, includes the relay's 9) and relay standalone **176 pass / 0 fail**. `coverage/lcov.info` confirmed with repo-root-relative `SF` paths. `actionlint` clean on both touched workflows. Harness `verify.sh` GREEN (registry test/lint entries SKIP for this repo — the direct runs are the receipts).

**CI proof chain (everything the draft listed as CI-only-provable is now proven):**

- **Canary red at ce54311** — [test run 32783011981](https://github.com/Software-Development-LLC/Bodhilander/actions/runs/32783011981) failed with exactly the one deliberately failing canary test, 871 passing beside it. The gate goes red on a failing test.
- **Byte-exact revert at bbbcd3e** — [test run 32783136578](https://github.com/Software-Development-LLC/Bodhilander/actions/runs/32783136578) green (871/0 app + 176/0 relay); [quality-gate run 32783136397](https://github.com/Software-Development-LLC/Bodhilander/actions/runs/32783136397) green with the scanner logging `Analysing [.../coverage/lcov.info]` — coverage ingested by Sonar.
- **Final head 6ca167f** — all four checks green: test, quality-gate, SonarQube, GitGuardian.

**Not verified / outstanding:** nothing in the code path. The one remaining step is manual and human-only (below).

## Checklist
- [x] Tests pass locally
- [x] Self-reviewed the changes
- [x] Docs updated where needed
- [x] Linked the related issue above

## Gate results

**Gate 4 — verifier: VERIFIED at b4cd2a7.** Receipts reproduced; lcov shape confirmed; action pins byte-matched against the release.yml convention; exclusion patterns swept.

**Gate 3 — reviewer: first pass RED** — the CI-red finding (the order-dependent mock poisonings surfaced by the gate's own first ubuntu run). **Delta re-check at bbbcd3e GREEN:** mocks are faithful supersets and properly restored; the type-only import claim confirmed via clean `tsc`; `--isolate` proven non-masking on three configurations; zero changed `expect` lines; canary pair byte-exact. The isolate sweep at 6ca167f closes the reviewer's last carry-forward (the relay step now runs isolated too).

## Two warnings the team needs

1. The first post-merge `development` analysis pulls 17 relay files (both `crypto.ts`, `auth/github.ts`, `auth/cookies.ts`) into the Sonar new-code period and will likely raise Security Hotspots needing UI review plus a re-run — the PR #191 pattern.
2. 51 test files leave `sonar.sources`, so LOC drops and existing test-code issues auto-close on the next analysis. Deliberate, and stated here so nobody reads it as an accident.

## Manual repo-settings step (human)
Mark job `test` in workflow **"Tests"** as a required status check.

<!-- bodhi:merge-order -->
**Merge position 1 of 1.** Nothing merges before this one.
Order: Bodhilander
<!-- bodhi:merge-order -->
