### PR TITLE
193 — README truth pass: docs match the code at HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Unified Session Management
 
-*A cross-platform Claude Code session manager*
+*A cross-platform session manager for AI coding CLIs — with Claude Code as the flagship*
 
 </div>
 
@@ -18,16 +18,33 @@
 
 ## Overview
 
-Managing multiple Claude Code terminal sessions across different projects can be challenging. **Bodhilander** provides a unified interface to organize, monitor, and manage all your Claude Code sessions in one place.
+Bodhilander is a desktop app for running, organizing, and monitoring AI coding-agent
+CLI sessions. It manages seven providers — **Claude Code**, **Codex (OpenAI)**,
+**Grok Build (xAI)**, **opencode**, **Kimi Code**, **Cursor Agent**, and
+**Antigravity** — with automatic detection of installed CLIs, one-click install for
+missing ones, and a vault for provider API keys. Claude Code gets the deepest
+integration: multiple accounts and CLI lifecycle hooks for precise session-state
+reporting.
+
+Your sessions are also reachable off the desktop: from a phone on the same LAN via
+a paired mobile web app, or from anywhere through an end-to-end-encrypted cloud
+relay — including sharing a live session with an invited guest.
 
 ## Features
 
-### Session Management
-All your Claude Code sessions in one application. No more hunting through terminal windows.
+### Multi-Provider Sessions
+Run sessions against any of the seven supported agent CLIs. **Settings → Providers**
+detects what's installed, offers "Install for me" for what isn't, and stores
+provider API keys in an encrypted key vault. Claude Code additionally supports
+multiple accounts (per-session or per-group) and state-reporting hooks.
+
+### Arena
+Run the same prompt against several provider CLIs side by side and compare the
+responses, with follow-up rounds that resume each provider's conversation.
 
 ### Real-Time Status Detection
 See at a glance which sessions are:
-- **Waiting** - Claude awaits your command
+- **Waiting** - The agent awaits your command
 - **Working** - Processing your request
 - **Idle** - Shell ready
 - **Error** - Something went wrong
@@ -51,13 +68,28 @@ Stay informed without watching the window:
 - Badge showing count of waiting sessions
 - Quick access to waiting sessions from the tray context menu
 
-### Mobile Companion
-Connect to your sessions from a mobile device:
-- **Local API server** on the same LAN — HTTPS/TLS, bound to all interfaces
-- **Pairing codes** with QR code generation
-- **Device management** with per-device permissions
-- **Network discovery** via mDNS/Bonjour
-- **Remote access** via [Tailscale Funnel](https://tailscale.com/kb/1223/funnel) — no Bodhilander-hosted infrastructure required. See **Settings → Mobile App → Remote Access** for the two-command setup.
+### Mobile Companion (same LAN)
+A mobile web app served by the desktop app itself:
+- **Pairing codes** with QR code generation — scan from your phone to connect
+- **Device management** with per-device permissions (view / control / modify) and unpairing
+- **Push notifications** to the paired device for session events
+- The local API server speaks **plain HTTP** (default port 8443, all interfaces)
+  with access restricted to private-network addresses. Traffic on the LAN is not
+  encrypted — for access from outside your network, use Remote Hosting below.
+
+### Remote Hosting & Session Sharing
+Reach your desktop from anywhere through a cloud relay ([self-hostable](relay/README.md)):
+- **End-to-end encrypted** — traffic between your browser and your desktop is
+  sealed with X25519 + HKDF + AES-256-GCM and a fingerprint you can verify; the
+  relay blindly routes ciphertext it cannot read
+- **GitHub sign-in** on the relay, with machine linking via short link codes
+  (**Settings → Remote Hosting**)
+- **Web client** — mobile-first: session list with live state, a full terminal,
+  and session/group creation from the browser
+- **Session sharing** — invite a guest to watch a live session: invites are
+  single-use, addressed to a GitHub account (or an open link), and every join
+  needs your explicit approval. Shared sessions show who's watching, and access
+  is time-boxed or lasts until you revoke it. Guests are watch-only.
 
 ### Microsoft Teams Integration
 Receive session event notifications in Microsoft Teams:
@@ -88,57 +120,68 @@ Grab the latest release for your platform from [Releases](https://github.com/Sof
 | macOS | `Bodhilander-x.x.x.dmg` |
 | Linux | `Bodhilander-x.x.x.AppImage` or `.deb` |
 
-> **macOS Note:** The app is currently unsigned. Run this before opening:
-> ```bash
-> xattr -cr /Applications/Bodhilander.app
-> ```
+> **macOS Note:** Releases are signed with a Developer ID certificate and
+> notarized by Apple, so the app opens like any other. If Gatekeeper complains,
+> you are running an old unsigned build — download the current DMG instead.
 
 ### Build from Source
+
+Building requires [Bun](https://bun.sh) — the npm scripts delegate to `bun run`.
 
 ```bash
 # Clone the repository
 git clone https://github.com/Software-Development-LLC/Bodhilander.git
-cd bodhilander
+cd Bodhilander
 
-# Install dependencies
-npm install
+# Install dependencies (rebuilds native modules for Electron)
+bun install
 
-# Run in development
-npm run start
+# Build and run
+bun run start
 
-# Build for your platform
-npm run dist:linux   # Linux
-npm run dist:mac     # macOS
-npm run dist:win     # Windows
+# Run the tests
+bun test
+
+# Build installers for your platform
+bun run dist:linux   # Linux
+bun run dist:mac     # macOS
+bun run dist:win     # Windows
 ```
 
 ---
 
 ## Keyboard Shortcuts
 
-| Action | Shortcut |
-|--------|----------|
-| New Session | `Ctrl/Cmd + N` |
-| Close Session | `Ctrl/Cmd + W` |
-| Next Session | `Ctrl/Cmd + Tab` |
-| Previous Session | `Ctrl/Cmd + Shift + Tab` |
-| Next Waiting | `Ctrl/Cmd + Shift + W` |
-| New Group | `Ctrl/Cmd + G` |
-| New Sub-group | `Ctrl/Cmd + Shift + G` |
-| Focus Sidebar | `Ctrl/Cmd + Q` |
-| Settings | `Ctrl/Cmd + ,` |
+Bare `Ctrl` chords always pass through to the terminal (SIGINT, readline, tmux),
+so app actions use `Cmd` on macOS and `Ctrl+Shift` on Windows/Linux.
+
+| Action | macOS | Windows / Linux |
+|--------|-------|-----------------|
+| New Session | `Cmd + N` | `Ctrl + Shift + N` |
+| Close Session | `Cmd + W` | `Ctrl + Shift + W` |
+| Next Session | `Ctrl + Tab` | `Ctrl + Tab` |
+| Previous Session | `Ctrl + Shift + Tab` | `Ctrl + Shift + Tab` |
+| Next Waiting | `Cmd + Shift + J` | `Ctrl + Shift + J` |
+| Terminal / Analytics / Arena view | `Cmd + 1 / 2 / 3` | `Ctrl + Shift + 1 / 2 / 3` |
+| Focus Sidebar | `Cmd + B` | `Ctrl + Shift + B` |
+| Copy / Paste | `Cmd + C` / `Cmd + V` | `Ctrl + Shift + C` / `Ctrl + Shift + V` |
+| Clear Terminal | `Cmd + K` | `Ctrl + Shift + K` |
+| Settings | `Cmd + ,` | `Ctrl + ,` |
 
 ---
 
 ## Settings
 
-Bodhilander offers extensive configuration across multiple tabs:
+Nine tabs of configuration:
 
-- **General** - Auto-launch Claude, custom shell path, preferred editor, close-to-tray
+- **General** - Auto-launch Claude, custom shell path, preferred editor, close-to-tray, data import/export, diagnostics
 - **Terminal** - Font size, WebGL renderer acceleration
+- **Mobile App** - Local API server, QR pairing, device management
+- **Remote Hosting** - Relay connection: machine name, link code, relay URL, machine fingerprint, keep-awake
 - **Sound** - Master toggle, per-event sounds, volume, debounce frequency, custom audio files
-- **Mobile** - API server, pairing, device management, Tailscale Funnel guidance for remote access
 - **Integrations** - Microsoft Teams notifications
+- **Providers** - Detect installed agent CLIs, one-click install, API key vault
+- **Claude Accounts** - Manage multiple Claude accounts
 - **Updates** - Release channel (Stable / Beta opt-in)
 
 ---
@@ -147,25 +190,22 @@ Bodhilander offers extensive configuration across multiple tabs:
 
 - **Electron** - Cross-platform desktop framework
 - **TypeScript** - Type-safe development
-- **React** - UI rendering
+- **React** - UI rendering (desktop renderer and the mobile PWA)
 - **xterm.js** - Terminal emulation
 - **node-pty** - Pseudo-terminal management
 - **better-sqlite3** - Persistent storage
-- **sqlite-vec** - Vector similarity search
-- **tree-sitter** - Code parsing and symbol extraction
-- **onnxruntime-node** - Local embedding inference
+- **Express** - Local API server for the mobile companion
 - **electron-updater** - Auto-updates
+- **Bun** - Build/test toolchain, and the runtime of the [cloud relay](relay/README.md)
 
 ---
 
-## Roadmap
+## Status & Direction
 
-| Phase | Status | Features |
-|-------|--------|----------|
-| **1 (MVP)** | Complete | Multi-session management, state detection, groups, persistence, auto-update |
-| **2** | Complete | Notifications & sound, settings |
-| **3** | Complete | Teams integration, mobile companion, editor integration |
-| **4** | Future | AI session summaries, advanced analytics |
+Recent releases shipped multi-provider sessions with arena mode, the LAN mobile
+companion, and relay-based remote hosting with end-to-end encryption and session
+sharing. Active work is tracked in the
+[GitHub issues](https://github.com/Software-Development-LLC/Bodhilander/issues).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ provider API keys in an encrypted key vault. Claude Code additionally supports
 multiple accounts (per-session or per-group) and state-reporting hooks.
 
 ### Arena
-Run the same prompt against several provider CLIs side by side and compare the
-responses, with follow-up rounds that resume each provider's conversation.
+Run the same prompt against several provider CLIs — plus a local
+[Ollama](https://ollama.com) model — side by side and compare the responses,
+with follow-up rounds that resume each contestant's conversation.
 
 ### Real-Time Status Detection
 See at a glance which sessions are:
@@ -89,7 +90,8 @@ Reach your desktop from anywhere through a cloud relay ([self-hostable](relay/RE
 - **Session sharing** — invite a guest to watch a live session: invites are
   single-use, addressed to a GitHub account (or an open link), and every join
   needs your explicit approval. Shared sessions show who's watching, and access
-  is time-boxed or lasts until you revoke it. Guests are watch-only.
+  is time-boxed or lasts until you revoke it — or until the shared session
+  restarts. Guests are watch-only.
 
 ### Microsoft Teams Integration
 Receive session event notifications in Microsoft Teams:
@@ -101,7 +103,7 @@ Receive session event notifications in Microsoft Teams:
 New versions download and install automatically via GitHub Releases. Two channels are available:
 
 - **Stable** (default) — tested releases only.
-- **Beta** (opt-in) — earlier access to new features while they're being validated. Enable from **Settings → Updates**. You'll see a small **BETA** pill in the sidebar while running a beta build. Switch back to Stable any time; the next stable release ≥ your current beta will auto-install.
+- **Beta** (opt-in) — earlier access to new features while they're being validated. Enable from **Settings → Updates**. You'll see a small **BETA** pill in the sidebar while running a beta build. Switch back to Stable any time; the app will move you back to the latest stable release (a downgrade if no stable ≥ your beta exists yet).
 
 ### Cross-Platform Support
 - Windows (native + WSL)
@@ -126,7 +128,11 @@ Grab the latest release for your platform from [Releases](https://github.com/Sof
 
 ### Build from Source
 
-Building requires [Bun](https://bun.sh) — the npm scripts delegate to `bun run`.
+Prerequisites: [Bun](https://bun.sh) (the npm scripts delegate to `bun run`),
+Node.js, Python 3, and a C/C++ toolchain — Xcode Command Line Tools on macOS,
+Visual Studio 2022 Build Tools on Windows, `build-essential` on Linux. The
+install step rebuilds the native modules (`better-sqlite3`, `node-pty`) for
+Electron via node-gyp, which is what needs Node and Python.
 
 ```bash
 # Clone the repository
@@ -152,8 +158,9 @@ bun run dist:win     # Windows
 
 ## Keyboard Shortcuts
 
-Bare `Ctrl` chords always pass through to the terminal (SIGINT, readline, tmux),
-so app actions use `Cmd` on macOS and `Ctrl+Shift` on Windows/Linux.
+Bare `Ctrl` chords are left to the terminal (SIGINT, readline, tmux) wherever
+possible, so app actions use `Cmd` on macOS and `Ctrl+Shift` on Windows/Linux —
+`Ctrl+Tab` session switching is the deliberate exception.
 
 | Action | macOS | Windows / Linux |
 |--------|-------|-----------------|

--- a/relay/README.md
+++ b/relay/README.md
@@ -151,7 +151,8 @@ defaults emit a warning instead.
   session cannot mint invites). Invites can be addressed to a specific GitHub
   login — enforced at redemption — or left open.
 - Grants are session-scoped (the relay never learns session ids) and either
-  time-boxed or valid until revoked. The protocol defines `viewer` and
+  time-boxed or valid until revoked — restarting the shared session also ends
+  the share. The protocol defines `viewer` and
   `operator` roles, but only watch-only (`viewer`) grants are offered today.
   Every join still requires the owner's explicit approval on the desktop.
 - Access certificates are Ed25519-signed by the machine and bound to the relay

--- a/relay/README.md
+++ b/relay/README.md
@@ -4,10 +4,10 @@ Multi-tenant cloud relay for Bodhilander remote hosting. Lets a signed-in user
 reach their desktop Bodhilander from a browser or phone when they're **off-LAN**,
 without standing up their own tunnel.
 
-> **Status: Milestone 1 (M1).** This is the service skeleton — config, logging,
-> SQLite schema + migrations, a `/health` endpoint, and a `/ws` endpoint that
-> upgrades and immediately closes `1013 not implemented`. Auth, machine linking,
-> and the real relay protocol land in later milestones (see [Milestones](#milestones)).
+The service is live and feature-complete for its current scope: GitHub OAuth
+sign-in (with an optional org gate), machine linking, the end-to-end-encrypted
+relay tunnel, session sharing, rate limiting, and a mobile-first web client.
+See [What's implemented](#whats-implemented).
 
 ## Runtime
 
@@ -28,7 +28,7 @@ bun run typecheck         # tsc --noEmit
 Quick check once it's running:
 
 ```bash
-curl -s localhost:8080/health   # {"ok":true,"version":"0.1.0","uptime":...}
+curl -s localhost:8080/health   # {"ok":true,"version":"...","uptime":...}
 ```
 
 ## Deploy (Docker)
@@ -126,16 +126,52 @@ All configuration is environment-driven; see [`.env.example`](./.env.example)
 for the annotated list. Invalid values fail fast at startup; insecure dev
 defaults emit a warning instead.
 
-## Milestones
+## What's implemented
 
-| Milestone | Scope | Status |
-| --------- | ----- | ------ |
-| **M1** | Service skeleton: config, logging, DB schema + migrations, `/health`, `/ws`. | ✅ done |
-| **M2** | GitHub OAuth sign-in (+ optional org gate), machine linking via link codes, agent WS challenge/response presence, minimal web client. | ✅ done |
-| **M3** | The live relay protocol — brokering a web/phone client ↔ desktop agent over `/ws` (E2E ciphertext). | next |
-| **M4+** | Full web client (terminal view) + web-push. | planned |
+**Auth & linking**
+- GitHub OAuth sign-in (`/auth/github/login` → `/auth/github/callback`), cookie
+  sessions, `POST /auth/logout`. `ALLOWED_GITHUB_ORG` optionally gates sign-in
+  to org members.
+- Machine linking: the desktop agent registers over `POST /link` with an
+  Ed25519 signature and gets a short link code; the signed-in user claims it
+  via `POST /link/claim` (or from the web client).
 
-The layout of the M1 schema (users, sessions, machines with keypairs, link
-codes, push subscriptions) anticipates these; the tables exist but are unused
-until their milestone.
-```
+**The tunnel**
+- `/ws` (agents) and `/ws/client` (browsers). Agents authenticate by signing a
+  server nonce with their machine key; browser clients authenticate with the
+  session cookie at upgrade time.
+- The relay is a **blind router**: client↔agent frames carry an opaque payload
+  the relay forwards without reading. Terminal traffic is end-to-end encrypted
+  between the browser and the desktop (X25519 ECDH → HKDF-SHA256 →
+  AES-256-GCM, fresh ephemeral keys per channel, an Ed25519 handshake proof
+  against MITM, and a fingerprint shown in the web client for verification).
+
+**Session sharing**
+- Owners mint single-use invites, signed by the machine key (a stolen relay
+  session cannot mint invites). Invites can be addressed to a specific GitHub
+  login — enforced at redemption — or left open.
+- Grants are session-scoped (the relay never learns session ids) and either
+  time-boxed or valid until revoked. The protocol defines `viewer` and
+  `operator` roles, but only watch-only (`viewer`) grants are offered today.
+  Every join still requires the owner's explicit approval on the desktop.
+- Access certificates are Ed25519-signed by the machine and bound to the relay
+  origin, so a certificate minted against one relay is useless on another.
+
+**Web client** (`web/`)
+- A dependency-light TypeScript SPA ("Bodhilander Remote") served by the relay:
+  GitHub sign-in, machine list, session list with live state, a full xterm
+  terminal, session/group creation, invite redemption at `/i/:code`, and a
+  watch-only mode for guests. Mobile-first: the phone's screen size drives the
+  PTY dimensions.
+
+**Operational**
+- Fixed-window rate limiting per IP (and per machine key for `/link`),
+  `/health`, structured logging, SQLite schema + migrations, and a periodic
+  reaper for expired sessions, link codes, invites, and grants.
+
+**Not implemented:** web push from the relay. (Push notifications exist only on
+the desktop app's LAN path.)
+
+Design history lives in
+[`docs/designs/remote-hosting-relay.md`](../docs/designs/remote-hosting-relay.md)
+and [`docs/designs/session-sharing.md`](../docs/designs/session-sharing.md).


### PR DESCRIPTION
## Description
Truth pass over the two READMEs so the docs match the code at HEAD. Docs-only: the diff is exactly `README.md` and `relay/README.md`.

**README.md**
- Tech stack corrected: `sqlite-vec`, `tree-sitter`, and `onnxruntime-node` removed — none appear in `package.json`; Express and Bun added.
- Repositioned as a multi-provider AI-CLI session manager. The seven providers are listed verbatim from `src/main/providers/index.ts`, with Claude as the flagship (hooks + accounts, per `claude.ts`).
- Mobile section: mDNS/Tailscale/HTTPS claims removed. What exists is plain `node:http` on port 8443 with a private-network allowlist, and that is what the section now says.
- New "Remote Hosting & Session Sharing" section, grounded in `e2e.ts`/`crypto.ts` (X25519 → HKDF-SHA256 → AES-256-GCM, Ed25519 proof), `ShareSessionModal` (addressed/open invites, until-revoke), `GuestJoinRequestModal`, the `SessionRow` watching badge, and `applyWatchOnly`.
- Settings list is now the nine real tab labels from `SettingsModal.tsx` ("Mobile App", "Claude Accounts" — the code's labels).
- Keyboard shortcuts rebuilt from `menu.ts`. The old table documented Cmd+Q as "Focus Sidebar" — that chord quits the app. The real bindings: mod+B, Ctrl+Tab / Ctrl+Shift+Tab, +Shift+J next-waiting, mod+1/2/3 views, mod+K clear.
- Roadmap table replaced with a short status paragraph; build-from-source instructions are now Bun-based.
- macOS "unsigned + xattr" note removed after direct verification (see below).

**relay/README.md**
- "Milestone 1 skeleton / `/ws` closes 1013" status replaced with the shipped feature set: OAuth + org gate, Ed25519 device linking, blind-router E2E tunnel, sharing endpoints, rate limiting, reaper, web client.
- Explicitly states web push is NOT implemented, and that invite minting is desktop-only (the web client only redeems invites).
- Deploy runbook kept untouched.

**Fix commit `30c1377`** (lands the Gate 3 findings — exactly the five prescribed edits):
- Auto-Update beta bullet now states the immediate-downgrade truth: leaving the beta channel means "the app will move you back to the latest stable release (a downgrade if no stable ≥ your beta exists yet)" — grounded in `auto-updater.ts` (`allowDowngrade = !isBeta` plus the immediate re-check).
- Build-from-Source gained a real prerequisites line: Bun + Node.js + Python 3 + a C/C++ toolchain, because `postinstall` runs electron-rebuild via node-gyp — `release.yml` itself installs setup-node/setup-python.
- Bare-Ctrl described as "wherever possible", with the Ctrl+Tab exception named.
- "or until the shared session restarts" added to both sharing passages.
- Ollama named as the always-present Arena contestant.

## Related issue
Closes #193

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Hotfix
- [ ] Refactor / chore
- [x] Docs

## How was this tested?
- `verify.sh Bodhilander=feat/193-Bodhilander` — GREEN. Tests and lint honestly SKIP: this is a docs-only change and no doc tests exist.
- `git diff --name-only origin/development...HEAD` — exactly `README.md` and `relay/README.md`.
- macOS signing claim verified directly, not from memory: downloaded the v3.5.0 arm64 DMG; `codesign -dv` shows Developer ID with hardened runtime, TeamIdentifier `QP8YC3HAB9`; `spctl` accepts with `source=Notarized Developer ID`; `stapler validate` passes. That is why the "unsigned + xattr" note is removed rather than reworded.
- Not verified: nothing was executed beyond the above and the gate runs listed below — every other corrected claim is grounded by reading the code at HEAD (files cited per bullet), not by running the features.

## Gate results
- **Gate 3 (fact-check reviewer), first pass: RED** with two sentence-level findings: the pre-existing auto-update claim was the opposite of the updater's actual behavior, and "requires Bun" omitted the node-gyp toolchain. Everything else survived a line-by-line audit — all 10 shortcut rows match `menu.ts` on three platforms, the nine tab labels are verbatim, sharing enforcement traced to `ROLE_CAPS`/`permits()` fail-closed, the mobile transport claims match `http-server.ts`, the entire relay README traced to `relay/src` with no overclaims, and the macOS signing claim was confirmed version-safe for betas (same jobs and secrets on both channels).
- **Fix commit `30c1377` → GREEN.** The diff was confirmed to be exactly the five prescribed edits, meeting the reviewer's pre-declared green condition.
- **Verification:** relay suite executed on the branch — 176 passed / 0 failed. `verify.sh` GREEN (tests/lint honestly SKIP — docs-only). Mutation testing N/A for a docs change.
- One additional finding recorded on epic #179 (listed below): `package.json` says `"license": "ISC"` while the LICENSE file is MIT.

## Findings recorded on other issues
Surfaced during the pass, not changed here, each already tracked:
- `bonjour-service` dead dependency + stale mDNS comment — epic #179.
- CLAUDE.md's false `sodium-native` claim — #179.
- `package.json` `"license": "ISC"` vs the MIT LICENSE file — epic #179.
- No desktop renderer UI for listing/revoking guests: `relayListShares`/`relayRevokeShare` IPC is wired but has no caller. The web client from #184 covers this browser-side.

## Checklist
- [x] Tests pass locally (verify.sh GREEN; tests/lint SKIP — docs-only, no doc tests exist; relay suite 176/0 at Gate 3)
- [x] Self-reviewed the changes
- [x] Docs updated where needed
- [x] Linked the related issue above

<!-- bodhi:merge-order -->
**Merge position 1 of 1.** Nothing merges before this one.
Order: Bodhilander
<!-- bodhi:merge-order -->
