### PR TITLE
196 — Claude Accounts show logged in when the config dir says they are

### DIFF
--- a/src/main/__tests__/account-auth.test.ts
+++ b/src/main/__tests__/account-auth.test.ts
@@ -222,6 +222,24 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void
   throw new Error('condition was never met');
 }
 
+type MainWindow = Parameters<typeof accountAuth.confirmLoginMacOS>[0];
+
+interface SentEvent {
+  channel: string;
+  data: { accountId: string; email: string | null; verified: boolean };
+}
+
+/** Captures what the renderer is told, which is the claim the overlay words. */
+function fakeWindow(): { sent: SentEvent[]; win: MainWindow } {
+  const sent: SentEvent[] = [];
+  const win = {
+    webContents: {
+      send: (channel: string, data: SentEvent['data']) => { sent.push({ channel, data }); },
+    },
+  };
+  return { sent, win: win as unknown as MainWindow };
+}
+
 /**
  * Which writes into the config dir mean "a login landed". The watch used to
  * answer that with the presence of a token file, which a platform holding its
@@ -283,6 +301,39 @@ describe('login detection', () => {
 
     expect(storedEmail(account.id)).toBeNull();
     expect(storedAccounts()).toEqual([{ id: account.id, isDefault: true }]);
+    accountAuth.cancelLoginFlow(pty, ptyId, false);
+  });
+
+  // The button can be pressed before OAuth finishes. Main writes no address in
+  // that case, so it must not let the overlay say the account is signed in
+  // while the panel behind it reads the same empty dir and says otherwise.
+  test('a confirmation main could not corroborate is reported as unverified', async () => {
+    const pty = fakePtyManager();
+    const { win, sent } = fakeWindow();
+    const { ptyId } = await accountAuth.startLoginFlow(pty, win, 'Work');
+
+    accountAuth.confirmLoginMacOS(win, ptyId);
+
+    const completed = sent.filter((e) => e.channel === 'accounts:login-completed');
+    expect(completed).toHaveLength(1);
+    expect(completed[0].data.verified).toBe(false);
+    expect(completed[0].data.email).toBeNull();
+    accountAuth.cancelLoginFlow(pty, ptyId, false);
+  });
+
+  test('a login main found on disk is reported verified, with its email', async () => {
+    const pty = fakePtyManager();
+    const { win, sent } = fakeWindow();
+    const { account, ptyId } = await accountAuth.startLoginFlow(pty, win, 'Work');
+
+    writeConfigFile(account.configDir, '.claude.json', {
+      oauthAccount: { accountUuid: 'u-1', emailAddress: 'will@acme.test' },
+    });
+    accountAuth.confirmLoginMacOS(win, ptyId);
+
+    const completed = sent.filter((e) => e.channel === 'accounts:login-completed');
+    expect(completed[0].data.verified).toBe(true);
+    expect(completed[0].data.email).toBe('will@acme.test');
     accountAuth.cancelLoginFlow(pty, ptyId, false);
   });
 });

--- a/src/main/__tests__/account-auth.test.ts
+++ b/src/main/__tests__/account-auth.test.ts
@@ -202,6 +202,91 @@ describe('startLoginFlow legacy seeding', () => {
   });
 });
 
+function storedEmail(id: string): string | null {
+  const row = db.prepare('SELECT email FROM claude_accounts WHERE id = ?').get(id) as
+    { email: string | null } | undefined;
+  return row?.email ?? null;
+}
+
+function writeConfigFile(configDir: string, name: string, contents: unknown): void {
+  fs.writeFileSync(path.join(configDir, name), JSON.stringify(contents));
+}
+
+/** fs.watch delivers asynchronously, so the assertion has to outlast it. */
+async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error('condition was never met');
+}
+
+/**
+ * Which writes into the config dir mean "a login landed". The watch used to
+ * answer that with the presence of a token file, which a platform holding its
+ * tokens in a keyring never writes.
+ */
+describe('login detection', () => {
+  test('a login that writes only a profile completes the flow and takes its email', async () => {
+    const pty = fakePtyManager();
+    const { account, ptyId } = await accountAuth.startLoginFlow(pty, null, 'Work');
+
+    // What Claude Code leaves in a dir it has started in but nobody has logged
+    // into: the file is there, the profile block is not.
+    writeConfigFile(account.configDir, '.claude.json', { userID: 'u1', projects: {} });
+    await new Promise((r) => setTimeout(r, 150));
+    expect(storedEmail(account.id)).toBeNull();
+
+    writeConfigFile(account.configDir, '.claude.json', {
+      userID: 'u1',
+      oauthAccount: { accountUuid: 'u-1', emailAddress: 'will@acme.test' },
+    });
+    await waitFor(() => storedEmail(account.id) === 'will@acme.test');
+
+    // And it got there without the artifact the old check demanded.
+    expect(fs.existsSync(path.join(account.configDir, '.credentials.json'))).toBe(false);
+
+    accountAuth.cancelLoginFlow(pty, ptyId, false);
+  });
+
+  test('a token file appearing still completes the flow', async () => {
+    const pty = fakePtyManager();
+    const { account, ptyId } = await accountAuth.startLoginFlow(pty, null, 'Work');
+
+    writeConfigFile(account.configDir, '.credentials.json', {
+      claudeAiOauth: { accessToken: 'not-a-real-token', subscriptionEmail: 'will@linux.test' },
+    });
+    await waitFor(() => storedEmail(account.id) === 'will@linux.test');
+
+    accountAuth.cancelLoginFlow(pty, ptyId, false);
+  });
+
+  test('the manual confirmation records the email the watch would have', async () => {
+    const pty = fakePtyManager();
+    const { account, ptyId } = await accountAuth.startLoginFlow(pty, null, 'Work');
+
+    writeConfigFile(account.configDir, '.claude.json', {
+      oauthAccount: { accountUuid: 'u-1', emailAddress: 'will@acme.test' },
+    });
+    accountAuth.confirmLoginMacOS(null, ptyId);
+
+    expect(storedEmail(account.id)).toBe('will@acme.test');
+    accountAuth.cancelLoginFlow(pty, ptyId, false);
+  });
+
+  test('confirming with nothing on disk keeps the account rather than inventing an email', async () => {
+    const pty = fakePtyManager();
+    const { account, ptyId } = await accountAuth.startLoginFlow(pty, null, 'Work');
+
+    accountAuth.confirmLoginMacOS(null, ptyId);
+
+    expect(storedEmail(account.id)).toBeNull();
+    expect(storedAccounts()).toEqual([{ id: account.id, isDefault: true }]);
+    accountAuth.cancelLoginFlow(pty, ptyId, false);
+  });
+});
+
 describe('cancelLoginFlow', () => {
   test('a rejecting kill is swallowed and cleanup still runs to completion', async () => {
     const pty = fakePtyManager();

--- a/src/main/__tests__/account-identity.test.ts
+++ b/src/main/__tests__/account-identity.test.ts
@@ -1,0 +1,230 @@
+/**
+ * What a config dir must contain before a surface may call the account logged
+ * in, pinned against the layouts Claude Code leaves on each platform. Nothing
+ * here is mocked: the subject is a directory read.
+ */
+
+// Run with: bun test src/main/__tests__/account-identity.test.ts
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { LOGIN_ARTIFACTS, resolveAccountIdentity, withAccountIdentity } from '../account-identity';
+import { ClaudeAccount } from '../../shared/types';
+
+let configDir = '';
+
+beforeEach(() => {
+  configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bodhi-identity-'));
+});
+
+afterEach(() => {
+  fs.rmSync(configDir, { recursive: true, force: true });
+});
+
+function write(name: string, contents: unknown): void {
+  fs.writeFileSync(path.join(configDir, name), JSON.stringify(contents));
+}
+
+/**
+ * The macOS layout: tokens live in the Keychain, so the config dir holds no
+ * credential file at all — only the profile block .claude.json gains at login.
+ * Trimmed to the keys the resolver reads; the real file carries ~20 more.
+ */
+function writeMacOsLayout(emailAddress = 'will@acme.test'): void {
+  write('.claude.json', {
+    userID: 'abc123',
+    oauthAccount: {
+      accountUuid: '11111111-2222-3333-4444-555555555555',
+      emailAddress,
+      organizationName: 'Acme',
+      organizationUuid: '66666666-7777-8888-9999-000000000000',
+    },
+  });
+}
+
+/** The Linux/Windows layout: the same profile block plus a plaintext token file. */
+function writeTokenFileLayout(): void {
+  write('.credentials.json', {
+    claudeAiOauth: {
+      accessToken: 'not-a-real-token',
+      subscriptionEmail: 'will@linux.test',
+    },
+  });
+}
+
+/** A dir Claude Code has started in but nobody has logged into. */
+function writeFreshLayout(): void {
+  write('.claude.json', {
+    userID: 'abc123',
+    hasCompletedOnboarding: false,
+    projects: {},
+  });
+}
+
+function account(overrides: Partial<ClaudeAccount> = {}): ClaudeAccount {
+  return {
+    id: 'a1',
+    label: 'Personal',
+    configDir,
+    email: null,
+    color: '#61afef',
+    isDefault: false,
+    createdAt: new Date(),
+    lastUsedAt: null,
+    ...overrides,
+  };
+}
+
+describe('resolveAccountIdentity', () => {
+  test('reads a macOS login as logged in, though it never writes a credential file', () => {
+    writeMacOsLayout();
+    expect(fs.existsSync(path.join(configDir, '.credentials.json'))).toBe(false);
+    expect(resolveAccountIdentity(configDir)).toEqual({
+      loggedIn: true,
+      email: 'will@acme.test',
+    });
+  });
+
+  test('reads the plaintext-token layout as logged in, and takes its email', () => {
+    writeTokenFileLayout();
+    expect(resolveAccountIdentity(configDir)).toEqual({
+      loggedIn: true,
+      email: 'will@linux.test',
+    });
+  });
+
+  test('a token file with no address still proves the login', () => {
+    write('.credentials.json', { claudeAiOauth: { accessToken: 'not-a-real-token' } });
+    expect(resolveAccountIdentity(configDir)).toEqual({ loggedIn: true, email: null });
+  });
+
+  test('the older auth.json name is honoured too', () => {
+    write('auth.json', { account: { email: 'will@old.test' } });
+    expect(resolveAccountIdentity(configDir)).toEqual({
+      loggedIn: true,
+      email: 'will@old.test',
+    });
+  });
+
+  test('a profile with a uuid but no address is a login, not an anonymous dir', () => {
+    write('.claude.json', { oauthAccount: { accountUuid: 'u1', organizationName: 'Acme' } });
+    expect(resolveAccountIdentity(configDir)).toEqual({ loggedIn: true, email: null });
+  });
+
+  test('a started-but-never-logged-in dir is logged out', () => {
+    writeFreshLayout();
+    expect(resolveAccountIdentity(configDir)).toEqual({ loggedIn: false, email: null });
+  });
+
+  test('an empty config dir is logged out', () => {
+    expect(resolveAccountIdentity(configDir)).toEqual({ loggedIn: false, email: null });
+  });
+
+  test('a dir that does not exist is logged out rather than throwing', () => {
+    expect(resolveAccountIdentity(path.join(configDir, 'nope'))).toEqual({
+      loggedIn: false,
+      email: null,
+    });
+  });
+
+  test('a config dir the row never recorded is logged out', () => {
+    expect(resolveAccountIdentity('')).toEqual({ loggedIn: false, email: null });
+  });
+
+  test('a truncated .claude.json falls through to the token file beside it', () => {
+    fs.writeFileSync(path.join(configDir, '.claude.json'), '{"oauthAcc');
+    writeTokenFileLayout();
+    expect(resolveAccountIdentity(configDir)).toEqual({
+      loggedIn: true,
+      email: 'will@linux.test',
+    });
+  });
+
+  test('a truncated token file still counts, since only writing it creates it', () => {
+    fs.writeFileSync(path.join(configDir, '.credentials.json'), '{"claudeAiOau');
+    expect(resolveAccountIdentity(configDir)).toEqual({ loggedIn: true, email: null });
+  });
+
+  test('an oauthAccount of the wrong shape is not mistaken for a profile', () => {
+    write('.claude.json', { oauthAccount: 'will@acme.test' });
+    expect(resolveAccountIdentity(configDir)).toEqual({ loggedIn: false, email: null });
+  });
+
+  test('a blank address is as unidentified as a missing one', () => {
+    write('.claude.json', { oauthAccount: { accountUuid: 'u1', emailAddress: '  ' } });
+    expect(resolveAccountIdentity(configDir)).toEqual({ loggedIn: true, email: null });
+  });
+
+  test('an address is trimmed, so the chip spends its one line on the address', () => {
+    write('.claude.json', { oauthAccount: { emailAddress: ' will@acme.test\n' } });
+    expect(resolveAccountIdentity(configDir).email).toBe('will@acme.test');
+  });
+
+  test('the profile wins over a stale token file, being what the login refreshes', () => {
+    writeMacOsLayout('current@acme.test');
+    writeTokenFileLayout();
+    expect(resolveAccountIdentity(configDir).email).toBe('current@acme.test');
+  });
+});
+
+describe('LOGIN_ARTIFACTS', () => {
+  test('covers every file the resolver can draw a conclusion from', () => {
+    expect([...LOGIN_ARTIFACTS].sort()).toEqual(
+      ['.claude.json', '.credentials.json', 'auth.json']
+    );
+  });
+});
+
+describe('withAccountIdentity', () => {
+  test('a used account resolves logged in, whatever the row remembers', () => {
+    writeMacOsLayout();
+    const resolved = withAccountIdentity(account({ email: null }));
+    expect(resolved.loggedIn).toBe(true);
+    expect(resolved.email).toBe('will@acme.test');
+  });
+
+  test('an account with no evidence anywhere is reported logged out', () => {
+    writeFreshLayout();
+    const resolved = withAccountIdentity(account({ email: null }));
+    expect(resolved.loggedIn).toBe(false);
+    expect(resolved.email).toBeNull();
+  });
+
+  test('a stored email keeps an account logged in if the probe finds nothing', () => {
+    writeFreshLayout();
+    const resolved = withAccountIdentity(account({ email: 'stored@acme.test' }));
+    expect(resolved.loggedIn).toBe(true);
+    expect(resolved.email).toBe('stored@acme.test');
+  });
+
+  test('a stored blank email is no evidence at all', () => {
+    const resolved = withAccountIdentity(account({ email: '   ' }));
+    expect(resolved.loggedIn).toBe(false);
+    expect(resolved.email).toBeNull();
+  });
+
+  test('the live profile overrides an email the row captured under an old login', () => {
+    writeMacOsLayout('new@acme.test');
+    expect(withAccountIdentity(account({ email: 'old@acme.test' })).email).toBe('new@acme.test');
+  });
+
+  test('the rest of the row is carried through untouched', () => {
+    writeMacOsLayout();
+    const row = account({ label: 'Work', color: '#98c379', isDefault: true });
+    const resolved = withAccountIdentity(row);
+    expect(resolved.id).toBe('a1');
+    expect(resolved.label).toBe('Work');
+    expect(resolved.color).toBe('#98c379');
+    expect(resolved.isDefault).toBe(true);
+    expect(resolved.configDir).toBe(configDir);
+  });
+
+  test('the stored row is not mutated, so a caller cannot cache a resolved copy', () => {
+    writeMacOsLayout();
+    const row = account({ email: null });
+    withAccountIdentity(row);
+    expect(row.email).toBeNull();
+    expect(row.loggedIn).toBeUndefined();
+  });
+});

--- a/src/main/__tests__/account-identity.test.ts
+++ b/src/main/__tests__/account-identity.test.ts
@@ -146,6 +146,25 @@ describe('resolveAccountIdentity', () => {
     expect(resolveAccountIdentity(configDir)).toEqual({ loggedIn: true, email: null });
   });
 
+  // Claude Code rewrites .claude.json about once a minute. On the macOS layout
+  // there is no token file to fall through to, so reading a torn file as
+  // logged out is the reported bug coming back at random.
+  test('a torn read on the macOS layout is unknown, never logged out', () => {
+    fs.writeFileSync(path.join(configDir, '.claude.json'), '{"oauthAccount": {"emai');
+    expect(fs.existsSync(path.join(configDir, '.credentials.json'))).toBe(false);
+    expect(resolveAccountIdentity(configDir).loggedIn).toBeUndefined();
+  });
+
+  test('an unparseable .claude.json is unknown rather than evidence of nothing', () => {
+    fs.writeFileSync(path.join(configDir, '.claude.json'), 'not json at all');
+    expect(resolveAccountIdentity(configDir).loggedIn).toBeUndefined();
+  });
+
+  test('a file holding bare JSON null is no login, not an unreadable one', () => {
+    fs.writeFileSync(path.join(configDir, '.claude.json'), 'null');
+    expect(resolveAccountIdentity(configDir)).toEqual({ loggedIn: false, email: null });
+  });
+
   test('an oauthAccount of the wrong shape is not mistaken for a profile', () => {
     write('.claude.json', { oauthAccount: 'will@acme.test' });
     expect(resolveAccountIdentity(configDir)).toEqual({ loggedIn: false, email: null });
@@ -191,11 +210,32 @@ describe('withAccountIdentity', () => {
     expect(resolved.email).toBeNull();
   });
 
-  test('a stored email keeps an account logged in if the probe finds nothing', () => {
+  // The login flow records an address on every platform now, so every account
+  // will have one. If a stored address could outvote a readable config dir, a
+  // logout would never surface again on any of them.
+  test('a readable dir showing no login outranks the address the row kept', () => {
     writeFreshLayout();
+    const resolved = withAccountIdentity(account({ email: 'stored@acme.test' }));
+    expect(resolved.loggedIn).toBe(false);
+  });
+
+  test('a config dir that is gone is logged out, however healthy the row looks', () => {
+    const resolved = withAccountIdentity(
+      account({ configDir: path.join(configDir, 'moved'), email: 'stored@acme.test' })
+    );
+    expect(resolved.loggedIn).toBe(false);
+  });
+
+  test('a stored email stands in only where the dir could not be read', () => {
+    fs.writeFileSync(path.join(configDir, '.claude.json'), '{"oauthAcc');
     const resolved = withAccountIdentity(account({ email: 'stored@acme.test' }));
     expect(resolved.loggedIn).toBe(true);
     expect(resolved.email).toBe('stored@acme.test');
+  });
+
+  test('an unreadable dir and no stored email makes no claim at all', () => {
+    fs.writeFileSync(path.join(configDir, '.claude.json'), '{"oauthAcc');
+    expect(withAccountIdentity(account({ email: null })).loggedIn).toBeUndefined();
   });
 
   test('a stored blank email is no evidence at all', () => {

--- a/src/main/__tests__/preload.test.ts
+++ b/src/main/__tests__/preload.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The context bridge between main's events and the renderer that words a claim
+ * from them. It forwards each payload by hand, so a field main added can be
+ * dropped here and the renderer would never know it was told anything.
+ */
+
+// Run with: bun test src/main/__tests__/preload.test.ts
+
+import { describe, expect, test, mock } from 'bun:test';
+
+type Listener = (event: unknown, data: unknown) => void;
+
+let exposed: Record<string, unknown> = {};
+const listeners = new Map<string, Listener[]>();
+
+/**
+ * Covers what preload reaches for, and no more: it is the only consumer here.
+ * The suite runs under `bun test --isolate`, so this registration cannot become
+ * the subject of a file that drives electron for real.
+ */
+mock.module('electron', () => ({
+  contextBridge: {
+    exposeInMainWorld: (_name: string, api: Record<string, unknown>) => { exposed = api; },
+  },
+  ipcRenderer: {
+    on: (channel: string, listener: Listener) => {
+      const existing = listeners.get(channel) ?? [];
+      existing.push(listener);
+      listeners.set(channel, existing);
+    },
+    removeListener: (channel: string, listener: Listener) => {
+      const existing = listeners.get(channel) ?? [];
+      listeners.set(channel, existing.filter((l) => l !== listener));
+    },
+    invoke: async () => undefined,
+    send: () => undefined,
+  },
+}));
+
+await import('../preload');
+
+function emit(channel: string, data: unknown): void {
+  for (const listener of listeners.get(channel) ?? []) listener({}, data);
+}
+
+const onLoginCompleted = () =>
+  exposed.onAccountLoginCompleted as (
+    cb: (data: { accountId: string; email: string | null; verified: boolean }) => void,
+  ) => () => void;
+
+describe('onAccountLoginCompleted', () => {
+  test('hands the renderer the whole payload, verification included', () => {
+    const seen: unknown[] = [];
+    const off = onLoginCompleted()((data) => { seen.push(data); });
+
+    emit('accounts:login-completed', {
+      accountId: 'a1',
+      email: 'will@acme.test',
+      verified: true,
+    });
+
+    expect(seen).toEqual([{ accountId: 'a1', email: 'will@acme.test', verified: true }]);
+    off();
+  });
+
+  // The renderer decides between "signed in" and "could not confirm" on this
+  // one field, so a bridge that dropped it would leave the overlay asserting
+  // the confident wording on every login.
+  test('an unverified completion arrives unverified, not merely absent', () => {
+    const seen: { verified: boolean }[] = [];
+    const off = onLoginCompleted()((data) => { seen.push(data); });
+
+    emit('accounts:login-completed', { accountId: 'a1', email: null, verified: false });
+
+    expect(seen[0].verified).toBe(false);
+    expect('verified' in seen[0]).toBe(true);
+    off();
+  });
+
+  test('the returned unsubscribe detaches the listener it registered', () => {
+    const seen: unknown[] = [];
+    const off = onLoginCompleted()((data) => { seen.push(data); });
+
+    off();
+    emit('accounts:login-completed', { accountId: 'a1', email: null, verified: true });
+
+    expect(seen).toEqual([]);
+  });
+
+  test('two subscribers are independent, so closing one overlay keeps the panel fed', () => {
+    const first: unknown[] = [];
+    const second: unknown[] = [];
+    const offFirst = onLoginCompleted()((d) => { first.push(d); });
+    const offSecond = onLoginCompleted()((d) => { second.push(d); });
+
+    offFirst();
+    emit('accounts:login-completed', { accountId: 'a1', email: null, verified: true });
+
+    expect(first).toEqual([]);
+    expect(second).toHaveLength(1);
+    offSecond();
+  });
+});

--- a/src/main/account-auth.ts
+++ b/src/main/account-auth.ts
@@ -1,18 +1,11 @@
 /**
  * Account login-flow orchestration (BDHLNDR-31).
  *
- * Each registered Claude account owns an isolated CLAUDE_CONFIG_DIR under
- * <userData>/claude-accounts/<id>/.claude. This module:
- *   1. Creates that directory and inserts the account row.
- *   2. Spawns an in-app login pty running `claude` with CLAUDE_CONFIG_DIR set.
- *   3. Watches for the credentials file to appear (Linux/Windows) and parses
- *      the account email for display.
- *   4. Cleans up the pty, watcher, row, and directory on cancel/delete.
- *
- * macOS note: Claude Code stores tokens in Keychain rather than a plain file
- * when running on macOS, so the watcher will not fire for the OAuth-login
- * path. The renderer must let the user confirm "I'm logged in" manually on
- * macOS; the pty exit alone isn't sufficient evidence.
+ * Each registered account owns an isolated CLAUDE_CONFIG_DIR under
+ * <userData>/claude-accounts/<id>/.claude. This module creates it, spawns an
+ * in-app login pty against it, watches it for the artifacts that mean a login
+ * landed, and tears all of it down on cancel or delete. What counts as such an
+ * artifact is account-identity's to decide, not this module's.
  */
 
 import * as fs from 'fs';
@@ -25,6 +18,7 @@ import log from 'electron-log';
 // process that loads this file, including the test runner.
 import type { PtyManager } from './pty-manager';
 import * as accountsRepo from './repositories/accounts';
+import { LOGIN_ARTIFACTS, resolveAccountIdentity } from './account-identity';
 import { registerHooks } from './mcp-config';
 import { seedLegacyConversations } from './legacy-claude-seed';
 import { ClaudeAccount } from '../shared/types';
@@ -135,14 +129,14 @@ export async function startLoginFlow(
 
   const watcher = fs.watch(configDir, (_eventType, filename) => {
     if (!filename) return;
-    const name = filename.toString();
-    if (name === '.credentials.json' || name === 'auth.json') {
-      const flow = activeFlows.get(ptyId);
-      if (flow && !flow.completed) {
-        flow.completed = true;
-        handleLoginCompleted(ptyId, mainWindow);
-      }
-    }
+    if (!LOGIN_ARTIFACTS.has(filename.toString())) return;
+    const flow = activeFlows.get(ptyId);
+    if (!flow || flow.completed) return;
+    // .claude.json is written from the first run onward, so the write itself
+    // is not the signal — only what the file says once it lands.
+    if (!resolveAccountIdentity(configDir).loggedIn) return;
+    flow.completed = true;
+    handleLoginCompleted(ptyId, mainWindow);
   });
 
   const exitListener = (event: { id: string; exitCode: number }) => {
@@ -176,7 +170,7 @@ function handleLoginCompleted(ptyId: string, mainWindow: BrowserWindow | null): 
   const flow = activeFlows.get(ptyId);
   if (!flow) return;
 
-  const email = parseAccountEmail(flow.configDir);
+  const { email } = resolveAccountIdentity(flow.configDir);
   accountsRepo.updateAccount(flow.accountId, { email });
 
   mainWindow?.webContents.send('accounts:login-completed', {
@@ -187,32 +181,9 @@ function handleLoginCompleted(ptyId: string, mainWindow: BrowserWindow | null): 
 }
 
 /**
- * Best-effort parse of the logged-in account's email from the credentials file.
- * Shapes vary across Claude Code versions, so we check several common paths
- * and silently return null if none match.
- */
-function parseAccountEmail(configDir: string): string | null {
-  try {
-    const credsPath = path.join(configDir, '.credentials.json');
-    if (!fs.existsSync(credsPath)) return null;
-    const creds = JSON.parse(fs.readFileSync(credsPath, 'utf-8'));
-    return (
-      creds?.claudeAiOauth?.subscriptionEmail ??
-      creds?.claudeAiOauth?.email ??
-      creds?.account?.email ??
-      creds?.email ??
-      null
-    );
-  } catch (err) {
-    log.warn('[Accounts] Failed to parse credentials for email:', err);
-    return null;
-  }
-}
-
-/**
- * Called when the user confirms macOS login manually (where the credentials
- * file doesn't appear because Keychain is used instead). Marks the flow
- * completed and emits the same event as the file watcher path.
+ * The macOS button's override, for a login the watcher did not catch: a Claude
+ * version that records the profile somewhere new, or writes the watch missed.
+ * Emits the same event the watched path does, so the renderer sees one story.
  */
 export function confirmLoginMacOS(
   mainWindow: BrowserWindow | null,

--- a/src/main/account-auth.ts
+++ b/src/main/account-auth.ts
@@ -18,7 +18,7 @@ import log from 'electron-log';
 // process that loads this file, including the test runner.
 import type { PtyManager } from './pty-manager';
 import * as accountsRepo from './repositories/accounts';
-import { LOGIN_ARTIFACTS, resolveAccountIdentity } from './account-identity';
+import { AccountIdentity, LOGIN_ARTIFACTS, resolveAccountIdentity } from './account-identity';
 import { registerHooks } from './mcp-config';
 import { seedLegacyConversations } from './legacy-claude-seed';
 import { ClaudeAccount } from '../shared/types';
@@ -134,9 +134,12 @@ export async function startLoginFlow(
     if (!flow || flow.completed) return;
     // .claude.json is written from the first run onward, so the write itself
     // is not the signal — only what the file says once it lands.
-    if (!resolveAccountIdentity(configDir).loggedIn) return;
+    const identity = resolveAccountIdentity(configDir);
+    if (!identity.loggedIn) return;
     flow.completed = true;
-    handleLoginCompleted(ptyId, mainWindow);
+    // Hand on what we just read: a re-read here can catch the next rewrite
+    // mid-flight and under-report the login we came in holding.
+    handleLoginCompleted(ptyId, mainWindow, identity);
   });
 
   const exitListener = (event: { id: string; exitCode: number }) => {
@@ -166,11 +169,15 @@ export async function startLoginFlow(
   return { account, ptyId };
 }
 
-function handleLoginCompleted(ptyId: string, mainWindow: BrowserWindow | null): void {
+function handleLoginCompleted(
+  ptyId: string,
+  mainWindow: BrowserWindow | null,
+  known?: AccountIdentity,
+): void {
   const flow = activeFlows.get(ptyId);
   if (!flow) return;
 
-  const { email, loggedIn } = resolveAccountIdentity(flow.configDir);
+  const { email, loggedIn } = known ?? resolveAccountIdentity(flow.configDir);
   accountsRepo.updateAccount(flow.accountId, { email });
 
   // `verified` separates a login the config dir showed us from one the user

--- a/src/main/account-auth.ts
+++ b/src/main/account-auth.ts
@@ -170,12 +170,15 @@ function handleLoginCompleted(ptyId: string, mainWindow: BrowserWindow | null): 
   const flow = activeFlows.get(ptyId);
   if (!flow) return;
 
-  const { email } = resolveAccountIdentity(flow.configDir);
+  const { email, loggedIn } = resolveAccountIdentity(flow.configDir);
   accountsRepo.updateAccount(flow.accountId, { email });
 
+  // `verified` separates a login the config dir showed us from one the user
+  // asserted with a button, so the renderer never claims more than we know.
   mainWindow?.webContents.send('accounts:login-completed', {
     accountId: flow.accountId,
     email,
+    verified: loggedIn === true,
   });
   log.info(`[Accounts] Login completed for ${flow.accountId}${email ? ` (${email})` : ''}`);
 }

--- a/src/main/account-identity.ts
+++ b/src/main/account-identity.ts
@@ -1,0 +1,100 @@
+/**
+ * Login evidence for one account's isolated CLAUDE_CONFIG_DIR. A token file
+ * exists only where the OS has no secret store; .claude.json is written
+ * everywhere, and gains an `oauthAccount` block at login.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ClaudeAccount } from '../shared/types';
+
+export interface AccountIdentity {
+  /** True when the config dir carries evidence that a login completed. */
+  loggedIn: boolean;
+  /** The logged-in profile's address, when the artifact records one. */
+  email: string | null;
+}
+
+const LOGGED_OUT: AccountIdentity = { loggedIn: false, email: null };
+
+/** The plaintext token stores, present only on platforms without a keyring. */
+const CREDENTIAL_FILES = ['.credentials.json', 'auth.json'];
+
+/** Every filename whose arrival or rewrite can mean a login just finished. */
+export const LOGIN_ARTIFACTS: ReadonlySet<string> = new Set([
+  ...CREDENTIAL_FILES,
+  '.claude.json',
+]);
+
+function readJsonFile(filePath: string): any | null {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A blank address identifies an account no better than a missing one, and the
+ * value can arrive with the file's trailing newline still attached.
+ */
+function normalizeEmail(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  return value.trim() || null;
+}
+
+/**
+ * A config dir that has been started but never logged into has the file
+ * without the profile block, so the block — not the file — is the signal.
+ */
+function identityFromProfile(configDir: string): AccountIdentity | null {
+  const data = readJsonFile(path.join(configDir, '.claude.json'));
+  const profile = data?.oauthAccount;
+  if (!profile || typeof profile !== 'object') return null;
+
+  const email = normalizeEmail(profile.emailAddress) ?? normalizeEmail(profile.email);
+  // An organization login can withhold the address; the uuid still proves one.
+  if (!email && !profile.accountUuid) return null;
+  return { loggedIn: true, email };
+}
+
+/**
+ * Presence is the evidence here — the token file only exists once OAuth wrote
+ * it. The address inside is a bonus whose shape moves between Claude versions.
+ */
+function identityFromTokenFile(configDir: string): AccountIdentity | null {
+  for (const name of CREDENTIAL_FILES) {
+    const filePath = path.join(configDir, name);
+    if (!fs.existsSync(filePath)) continue;
+
+    const creds = readJsonFile(filePath);
+    const email =
+      normalizeEmail(creds?.claudeAiOauth?.subscriptionEmail) ??
+      normalizeEmail(creds?.claudeAiOauth?.email) ??
+      normalizeEmail(creds?.account?.email) ??
+      normalizeEmail(creds?.email);
+    return { loggedIn: true, email };
+  }
+  return null;
+}
+
+/** What the account's config dir currently says about its login. */
+export function resolveAccountIdentity(configDir: string): AccountIdentity {
+  if (!configDir) return LOGGED_OUT;
+  return identityFromProfile(configDir) ?? identityFromTokenFile(configDir) ?? LOGGED_OUT;
+}
+
+/**
+ * Overlay the on-disk truth onto a stored account row. The stored email is
+ * kept as a fallback: it was only ever written when a login completed, so it
+ * still corroborates one if Claude Code moves the artifacts probed above.
+ */
+export function withAccountIdentity(account: ClaudeAccount): ClaudeAccount {
+  const identity = resolveAccountIdentity(account.configDir);
+  const storedEmail = normalizeEmail(account.email);
+  return {
+    ...account,
+    email: identity.email ?? storedEmail,
+    loggedIn: identity.loggedIn || storedEmail !== null,
+  };
+}

--- a/src/main/account-identity.ts
+++ b/src/main/account-identity.ts
@@ -9,13 +9,14 @@ import * as path from 'path';
 import { ClaudeAccount } from '../shared/types';
 
 export interface AccountIdentity {
-  /** True when the config dir carries evidence that a login completed. */
-  loggedIn: boolean;
-  /** The logged-in profile's address, when the artifact records one. */
+  /** True on evidence of a login, false on none, undefined if unreadable. */
+  loggedIn: boolean | undefined;
+  /** The profile's address, when the artifact records one. */
   email: string | null;
 }
 
 const LOGGED_OUT: AccountIdentity = { loggedIn: false, email: null };
+const UNKNOWN: AccountIdentity = { loggedIn: undefined, email: null };
 
 /** The plaintext token stores, present only on platforms without a keyring. */
 const CREDENTIAL_FILES = ['.credentials.json', 'auth.json'];
@@ -26,11 +27,18 @@ export const LOGIN_ARTIFACTS: ReadonlySet<string> = new Set([
   '.claude.json',
 ]);
 
-function readJsonFile(filePath: string): any | null {
+/**
+ * What one artifact had to say: an identity, nothing to say, or a file that is
+ * there and unreadable — which is not the same as never having logged in.
+ */
+type Probe = AccountIdentity | 'absent' | 'unreadable';
+
+/** Parsed contents, or undefined when the file cannot be read or parsed. */
+function readJson(filePath: string): unknown {
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
   } catch {
-    return null;
+    return undefined;
   }
 }
 
@@ -43,18 +51,35 @@ function normalizeEmail(value: unknown): string | null {
   return value.trim() || null;
 }
 
+interface ProfileFile {
+  oauthAccount?: { emailAddress?: unknown; email?: unknown; accountUuid?: unknown };
+}
+
+interface TokenFile {
+  claudeAiOauth?: { subscriptionEmail?: unknown; email?: unknown };
+  account?: { email?: unknown };
+  email?: unknown;
+}
+
 /**
- * A config dir that has been started but never logged into has the file
- * without the profile block, so the block — not the file — is the signal.
+ * A dir started in but never logged into holds the file without the profile
+ * block, so the block is the signal. Claude rewrites this file about once a
+ * minute, which makes a torn read ordinary rather than exceptional.
  */
-function identityFromProfile(configDir: string): AccountIdentity | null {
-  const data = readJsonFile(path.join(configDir, '.claude.json'));
-  const profile = data?.oauthAccount;
-  if (!profile || typeof profile !== 'object') return null;
+function probeProfile(configDir: string): Probe {
+  const filePath = path.join(configDir, '.claude.json');
+  if (!fs.existsSync(filePath)) return 'absent';
+
+  const data = readJson(filePath);
+  if (data === undefined) return 'unreadable';
+  if (typeof data !== 'object' || data === null) return 'absent';
+
+  const profile = (data as ProfileFile).oauthAccount;
+  if (!profile || typeof profile !== 'object') return 'absent';
 
   const email = normalizeEmail(profile.emailAddress) ?? normalizeEmail(profile.email);
   // An organization login can withhold the address; the uuid still proves one.
-  if (!email && !profile.accountUuid) return null;
+  if (!email && !profile.accountUuid) return 'absent';
   return { loggedIn: true, email };
 }
 
@@ -62,12 +87,12 @@ function identityFromProfile(configDir: string): AccountIdentity | null {
  * Presence is the evidence here — the token file only exists once OAuth wrote
  * it. The address inside is a bonus whose shape moves between Claude versions.
  */
-function identityFromTokenFile(configDir: string): AccountIdentity | null {
+function probeTokenFile(configDir: string): Probe {
   for (const name of CREDENTIAL_FILES) {
     const filePath = path.join(configDir, name);
     if (!fs.existsSync(filePath)) continue;
 
-    const creds = readJsonFile(filePath);
+    const creds = readJson(filePath) as TokenFile | undefined;
     const email =
       normalizeEmail(creds?.claudeAiOauth?.subscriptionEmail) ??
       normalizeEmail(creds?.claudeAiOauth?.email) ??
@@ -75,26 +100,36 @@ function identityFromTokenFile(configDir: string): AccountIdentity | null {
       normalizeEmail(creds?.email);
     return { loggedIn: true, email };
   }
-  return null;
+  return 'absent';
 }
 
 /** What the account's config dir currently says about its login. */
 export function resolveAccountIdentity(configDir: string): AccountIdentity {
   if (!configDir) return LOGGED_OUT;
-  return identityFromProfile(configDir) ?? identityFromTokenFile(configDir) ?? LOGGED_OUT;
+
+  let unreadable = false;
+  for (const probe of [probeProfile, probeTokenFile]) {
+    const result = probe(configDir);
+    if (result === 'unreadable') unreadable = true;
+    else if (result !== 'absent') return result;
+  }
+
+  // An artifact we could not read is not an account that never logged in, and
+  // withholding the claim is what keeps the label off a working account.
+  return unreadable ? UNKNOWN : LOGGED_OUT;
 }
 
 /**
- * Overlay the on-disk truth onto a stored account row. The stored email is
- * kept as a fallback: it was only ever written when a login completed, so it
- * still corroborates one if Claude Code moves the artifacts probed above.
+ * Overlay what the config dir says onto a stored row. The recorded email
+ * stands in only where the dir could not be read; a readable dir showing no
+ * login is the authority, or a logout could never surface.
  */
 export function withAccountIdentity(account: ClaudeAccount): ClaudeAccount {
   const identity = resolveAccountIdentity(account.configDir);
   const storedEmail = normalizeEmail(account.email);
-  return {
-    ...account,
-    email: identity.email ?? storedEmail,
-    loggedIn: identity.loggedIn || storedEmail !== null,
-  };
+
+  let loggedIn = identity.loggedIn;
+  if (loggedIn === undefined && storedEmail !== null) loggedIn = true;
+
+  return { ...account, email: identity.email ?? storedEmail, loggedIn };
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,7 @@ import * as chatEventsRepo from './repositories/chat-events';
 import { ChatParser } from './api/chat-parser';
 import * as accountsRepo from './repositories/accounts';
 import * as accountAuth from './account-auth';
+import { withAccountIdentity } from './account-identity';
 import * as accountSwitch from './account-switch';
 import { exportSessions, ExportFormat } from './session-export';
 import { exportGroupsAndSessions, importGroupsAndSessions, importFromClaudeLander } from './group-import-export';
@@ -808,8 +809,11 @@ ipcMain.handle('db:sessions:delete', async (_, id: string) => {
 });
 
 // Claude account IPC handlers (BDHLNDR-31)
+// Login state is resolved from each config dir here rather than read off the
+// row: the stored email is a one-shot write from the login flow, so accounts
+// that logged in without producing one present as logged out forever.
 safeHandle('accounts:list', () => {
-  return accountsRepo.getAllAccounts();
+  return accountsRepo.getAllAccounts().map(withAccountIdentity);
 });
 
 safeHandle('accounts:startLogin', (label: string) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -4,6 +4,13 @@ import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount,
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
 
+/** `verified` is false when only the user's button says the login happened. */
+interface LoginCompleted {
+  accountId: string;
+  email: string | null;
+  verified: boolean;
+}
+
 contextBridge.exposeInMainWorld('electronAPI', {
   platform: process.platform,
   homedir,
@@ -348,8 +355,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('accounts:assignToSession', sessionId, accountId),
   assignAccountToGroup: (groupId: string, accountId: string | null): Promise<AccountSwitchResult> =>
     ipcRenderer.invoke('accounts:assignToGroup', groupId, accountId),
-  onAccountLoginCompleted: (callback: (data: { accountId: string; email: string | null }) => void) => {
-    const listener = (_: Electron.IpcRendererEvent, data: { accountId: string; email: string | null }) => callback(data);
+  onAccountLoginCompleted: (callback: (data: LoginCompleted) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, data: LoginCompleted) => callback(data);
     ipcRenderer.on('accounts:login-completed', listener);
     return () => ipcRenderer.removeListener('accounts:login-completed', listener);
   },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -45,18 +45,21 @@ function chevronAriaLabel(collapsed: boolean, filtering: boolean, kind: 'group' 
  *
  * The label alone does not say which login an account is: two accounts both
  * called "Work" are indistinguishable in the menu, and after a login the email
- * is the only thing that tells them apart. Accounts that never wrote an email
- * — the normal case on macOS, where Claude Code keeps its tokens in the
- * Keychain rather than in the config dir — say so, so a blank tail can never be
- * read as "this one has no second account behind it".
+ * is the only thing that tells them apart. Only an account resolved as logged
+ * out says so; one that simply recorded no address trails off, because the tail
+ * is there to identify a login, not to grade it.
  *
  * MenuItem.label is a string, so the swatch that carries colour elsewhere
  * cannot come along; label + email identifies the account without it, which is
  * the accessible baseline the swatch was never allowed to be responsible for.
  */
 export function accountMenuLabel(acc: ClaudeAccount, isCurrent: boolean): string {
+  let tail = '';
+  if (acc.email) tail = ` — ${acc.email}`;
+  else if (acc.loggedIn === false) tail = ' — not yet logged in';
+
   return `${isCurrent ? '✓ ' : '   '}Use "${acc.label}"`
-    + (acc.email ? ` — ${acc.email}` : ' — not yet logged in')
+    + tail
     + (acc.isDefault ? ' (default)' : '');
 }
 

--- a/src/renderer/__tests__/App.accounts.test.ts
+++ b/src/renderer/__tests__/App.accounts.test.ts
@@ -148,8 +148,21 @@ describe('accountMenuLabel', () => {
     expect(a).not.toBe(b);
   });
 
-  test('an account with no email says so instead of trailing off', () => {
-    expect(accountMenuLabel(personal, false)).toContain('not yet logged in');
+  test('an account resolved as logged out says so instead of trailing off', () => {
+    const fresh = { ...personal, loggedIn: false } as ClaudeAccount;
+    expect(accountMenuLabel(fresh, false)).toContain('not yet logged in');
+  });
+
+  // A login that records no address is still a login, and on macOS that is the
+  // normal case rather than the exception.
+  test('a logged-in account that recorded no address is not called logged out', () => {
+    const noAddress = { ...personal, loggedIn: true } as ClaudeAccount;
+    expect(accountMenuLabel(noAddress, false)).not.toContain('not yet logged in');
+    expect(accountMenuLabel(noAddress, false)).toContain('Use "Personal"');
+  });
+
+  test('an unresolved account withholds the claim rather than guessing at it', () => {
+    expect(accountMenuLabel(personal, false)).not.toContain('not yet logged in');
   });
 
   test('the default account is marked, and the current one is ticked', () => {

--- a/src/renderer/components/AccountChip.tsx
+++ b/src/renderer/components/AccountChip.tsx
@@ -36,8 +36,8 @@ const DEFAULT_SWATCH = '#888888';
  * One account, named the same way everywhere (#165).
  *
  * An account has no email until a login records one, and not every login
- * does; accounts registered before #165 are all the same grey. So neither the
- * swatch nor the email identifies an account on its own.
+ * does; the oldest accounts are all the same grey. So neither the swatch nor
+ * the email identifies an account on its own.
  * The label always carries the identity; the swatch is decoration (aria-hidden,
  * next to real text) and the email is enrichment.
  *
@@ -59,16 +59,11 @@ export const AccountChip: React.FC<AccountChipProps> = ({
 }) => {
   const label = account ? account.label : emptyLabel;
 
-  // Deliberately not `??`. parseAccountEmail (account-auth.ts) resolves its
-  // candidate paths with a ?? chain, so a credentials file carrying an empty
-  // email yields '' rather than null, and mapAccountRow preserves it. A blank
-  // email is as unidentified as a missing one, so both must reach
-  // noEmailLabel — which nullish coalescing would not do.
-  //
-  // The trimmed value is also what renders. The same parse can hand back an
-  // email with the file's trailing newline still on it, and a chip that has
-  // one line of room for "label email" must not spend it on whitespace — nor
-  // may the tooltip disagree with the text beside it (#165).
+  // Deliberately not `??`, and trimmed. A stored row can carry an empty or
+  // padded address, and a blank one is as unidentified as a missing one, so
+  // both must reach noEmailLabel — which nullish coalescing would not do. The
+  // chip has one line of room for "label email", so it may not spend it on
+  // whitespace, nor let the tooltip disagree with the text beside it.
   const trimmedEmail = account?.email?.trim();
   let emailText = noEmailLabel;
   if (trimmedEmail) emailText = trimmedEmail;

--- a/src/renderer/components/AccountChip.tsx
+++ b/src/renderer/components/AccountChip.tsx
@@ -35,9 +35,9 @@ const DEFAULT_SWATCH = '#888888';
 /**
  * One account, named the same way everywhere (#165).
  *
- * An account has no email until a login writes one, and on macOS the login
- * usually never writes one; accounts registered before #165 are all the same
- * grey. So neither the swatch nor the email identifies an account on its own.
+ * An account has no email until a login records one, and not every login
+ * does; accounts registered before #165 are all the same grey. So neither the
+ * swatch nor the email identifies an account on its own.
  * The label always carries the identity; the swatch is decoration (aria-hidden,
  * next to real text) and the email is enrichment.
  *

--- a/src/renderer/components/AccountChip.tsx
+++ b/src/renderer/components/AccountChip.tsx
@@ -17,12 +17,6 @@ export interface AccountChipProps {
   announceDetail?: boolean;
   /** Label used when `account` is null. Default 'Default (~/.claude)'. */
   emptyLabel?: string;
-  /**
-   * Rendered in place of the email for an account that never captured one.
-   * Only the accounts panel passes it: there "Not yet logged in" describes a
-   * row the user can act on. Nowhere else may say it — see below.
-   */
-  noEmailLabel?: string;
 }
 
 /**
@@ -41,13 +35,11 @@ const DEFAULT_SWATCH = '#888888';
  * The label always carries the identity; the swatch is decoration (aria-hidden,
  * next to real text) and the email is enrichment.
  *
- * Which is why a missing email renders nothing at all by default. It used to
- * fall back to "Not yet logged in", and in the session header that produced a
- * chip reading "Work — Not yet logged in" next to a Claude Code that was
- * actively producing output and being billed. On the setup where no email is
- * ever captured that was not an edge case but the normal reading, and on the
- * back of #164 — where a switch silently did nothing — "not logged in" is
- * exactly the wrong thing to tell someone about a session that is working.
+ * Which is why a missing email renders nothing at all. This chip once fell
+ * back to "Not yet logged in", which put that text beside a Claude Code that
+ * was actively producing output and being billed. An absent address is not a
+ * login state, and the two are answered from different places: callers that
+ * want to report a login pass a resolved one and render it themselves.
  */
 export const AccountChip: React.FC<AccountChipProps> = ({
   account,
@@ -55,19 +47,14 @@ export const AccountChip: React.FC<AccountChipProps> = ({
   detail,
   announceDetail = false,
   emptyLabel = 'Default (~/.claude)',
-  noEmailLabel,
 }) => {
   const label = account ? account.label : emptyLabel;
 
-  // Deliberately not `??`, and trimmed. A stored row can carry an empty or
-  // padded address, and a blank one is as unidentified as a missing one, so
-  // both must reach noEmailLabel — which nullish coalescing would not do. The
-  // chip has one line of room for "label email", so it may not spend it on
-  // whitespace, nor let the tooltip disagree with the text beside it.
+  // Trimmed, and blank treated as missing. A stored row can carry an empty or
+  // padded address; the chip has one line of room for "label email", so it may
+  // not spend it on whitespace, nor let the tooltip disagree with the text.
   const trimmedEmail = account?.email?.trim();
-  let emailText = noEmailLabel;
-  if (trimmedEmail) emailText = trimmedEmail;
-  const email = account ? emailText : null;
+  const email = trimmedEmail || null;
 
   // Same reasoning: an account row written with an empty colour falls back to
   // the shared default rather than painting the swatch with nothing.

--- a/src/renderer/components/AccountChip.tsx
+++ b/src/renderer/components/AccountChip.tsx
@@ -50,11 +50,14 @@ export const AccountChip: React.FC<AccountChipProps> = ({
 }) => {
   const label = account ? account.label : emptyLabel;
 
-  // Trimmed, and blank treated as missing. A stored row can carry an empty or
-  // padded address; the chip has one line of room for "label email", so it may
-  // not spend it on whitespace, nor let the tooltip disagree with the text.
+  // Trimmed, and blank treated as missing — a stored row can carry an empty or
+  // padded address. Deliberately a truthiness check and not `??`: '' is a
+  // value, so nullish coalescing would keep it and hand the chip an address
+  // that identifies nothing. The chip has one line of room for "label email",
+  // so it may not spend it on whitespace or disagree with its own tooltip.
   const trimmedEmail = account?.email?.trim();
-  const email = trimmedEmail || null;
+  let email: string | null = null;
+  if (trimmedEmail) email = trimmedEmail;
 
   // Same reasoning: an account row written with an empty colour falls back to
   // the shared default rather than painting the swatch with nothing.

--- a/src/renderer/components/ClaudeAccountsModal.css
+++ b/src/renderer/components/ClaudeAccountsModal.css
@@ -101,6 +101,18 @@
   white-space: nowrap;
 }
 
+/* Amber where both other tags are blue, and stating the condition in words
+   rather than a tint, so a signed-out account stays legible without colour. */
+.claude-accounts-panel .account-row .signed-out-tag {
+  font-size: 10px;
+  color: #e5c07b;
+  background: rgba(229, 192, 123, 0.12);
+  border: 1px solid rgba(229, 192, 123, 0.35);
+  padding: 1px 6px;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+
 .claude-accounts-panel .account-row .row-actions {
   display: flex;
   gap: 6px;

--- a/src/renderer/components/ClaudeAccountsModal.tsx
+++ b/src/renderer/components/ClaudeAccountsModal.tsx
@@ -318,6 +318,40 @@ interface ClaudeAccountLoginModalProps {
   onCancel: (deleteAccount: boolean) => void;
 }
 
+export interface LoginHintProps {
+  completed: boolean;
+  /** Whether main saw the login in the config dir, rather than being told. */
+  verified: boolean;
+  exited: boolean;
+  isMac: boolean;
+}
+
+/**
+ * What the overlay is allowed to claim. An unverified completion is the user
+ * pressing the button before OAuth finished, and saying "signed in" there
+ * contradicts the panel behind it, which reads the same config dir we just did.
+ */
+export const LoginHint: React.FC<LoginHintProps> = ({ completed, verified, exited, isMac }) => {
+  if (completed && verified) {
+    return <>Login detected{' — '}this account is signed in. You can close this window.</>;
+  }
+  if (completed) {
+    return (
+      <>
+        Recorded{' — '}but no login was found in this account's config directory yet.
+        If OAuth hasn't finished, run <code>/login</code> again before closing.
+      </>
+    );
+  }
+  if (exited) {
+    return <>The login process exited before credentials were saved. Abort and try again, or close this window to keep the empty account.</>;
+  }
+  if (isMac) {
+    return <>Run <code>/login</code> in the terminal below and complete OAuth in your browser. This window closes itself once the login lands; macOS keeps the tokens in Keychain, so click "I'm logged in" if it doesn't.</>;
+  }
+  return <>Run <code>/login</code> in the terminal below and complete OAuth in your browser. This window will close itself once your credentials are saved.</>;
+};
+
 const ClaudeAccountLoginModal: React.FC<ClaudeAccountLoginModalProps> = ({
   account,
   ptyId,
@@ -325,6 +359,7 @@ const ClaudeAccountLoginModal: React.FC<ClaudeAccountLoginModalProps> = ({
   onCancel,
 }) => {
   const [completed, setCompleted] = useState(false);
+  const [verified, setVerified] = useState(false);
   const [exited, setExited] = useState(false);
   const isMac = useMemo(() => window.electronAPI.platform === 'darwin', []);
 
@@ -332,6 +367,7 @@ const ClaudeAccountLoginModal: React.FC<ClaudeAccountLoginModalProps> = ({
     const offCompleted = window.electronAPI.onAccountLoginCompleted((data) => {
       if (data.accountId === account.id) {
         setCompleted(true);
+        setVerified(data.verified);
       }
     });
     const offExited = window.electronAPI.onAccountLoginExited((data) => {
@@ -373,18 +409,12 @@ const ClaudeAccountLoginModal: React.FC<ClaudeAccountLoginModalProps> = ({
       >
         <h3 id="claude-account-login-title">Log in to "{account.label}"</h3>
         <p className="hint">
-          {completed ? (
-            <>Login detected{' — '}this account is signed in. You can close this window.</>
-          ) : exited ? (
-            <>The login process exited before credentials were saved. Abort and try again, or close this window to keep the empty account.</>
-          ) : isMac ? (
-            <>Run <code>/login</code> in the terminal below and complete OAuth in your browser. This window closes itself once the login lands; macOS keeps the tokens in Keychain, so click "I'm logged in" if it doesn't.</>
-          ) : (
-            <>Run <code>/login</code> in the terminal below and complete OAuth in your browser. This window will close itself once your credentials are saved.</>
-          )}
+          <LoginHint completed={completed} verified={verified} exited={exited} isMac={isMac} />
         </p>
 
-        {completed && <div className="completion-banner">Login saved. It's safe to close this window.</div>}
+        {completed && verified && (
+          <div className="completion-banner">Login saved. It's safe to close this window.</div>
+        )}
 
         <div className="terminal-host">
           <Terminal

--- a/src/renderer/components/ClaudeAccountsModal.tsx
+++ b/src/renderer/components/ClaudeAccountsModal.tsx
@@ -210,9 +210,15 @@ export const AccountRow: React.FC<AccountRowProps> = ({
   return (
     <li className="account-row">
       {/* The one surface where "Not yet logged in" describes something the
-          user can act on — this row has the buttons. Everywhere else a missing
-          email renders nothing rather than a status about a working session. */}
-      <AccountChip account={account} size="md" noEmailLabel="Not yet logged in" />
+          user can act on — this row has the buttons. Keyed to the resolved
+          login state and never to a missing email: an account can be logged in
+          and hold no address, and a row the user runs sessions on must not be
+          told otherwise. */}
+      <AccountChip
+        account={account}
+        size="md"
+        noEmailLabel={account.loggedIn === false ? 'Not yet logged in' : undefined}
+      />
       {account.isDefault && <span className="default-tag">default</span>}
       {runningSessions > 0 && (
         <span
@@ -299,9 +305,10 @@ const AddAccountButton: React.FC<{ onAdd: (label: string) => Promise<void>; disa
 };
 
 // -----------------------------------------------------------------------------
-// Login modal — embeds a Terminal attached to the login pty. Auto-closes when
-// the credentials file appears (Linux/Windows). On macOS, shows an explicit
-// "I'm logged in" button since tokens go to Keychain.
+// Login modal — embeds a Terminal attached to the login pty, and reports the
+// login as soon as main sees one land in the config dir. macOS also gets an
+// explicit "I'm logged in" button, as the platform whose token store is the
+// one main cannot read directly.
 // -----------------------------------------------------------------------------
 
 interface ClaudeAccountLoginModalProps {
@@ -367,11 +374,11 @@ const ClaudeAccountLoginModal: React.FC<ClaudeAccountLoginModalProps> = ({
         <h3 id="claude-account-login-title">Log in to "{account.label}"</h3>
         <p className="hint">
           {completed ? (
-            <>Login detected{' — '}credentials were saved to this account's isolated config directory. You can close this window.</>
+            <>Login detected{' — '}this account is signed in. You can close this window.</>
           ) : exited ? (
             <>The login process exited before credentials were saved. Abort and try again, or close this window to keep the empty account.</>
           ) : isMac ? (
-            <>Run <code>/login</code> in the terminal below and complete OAuth in your browser. Because macOS stores tokens in Keychain, click "I'm logged in" once you see "Logged in" in the terminal.</>
+            <>Run <code>/login</code> in the terminal below and complete OAuth in your browser. This window closes itself once the login lands; macOS keeps the tokens in Keychain, so click "I'm logged in" if it doesn't.</>
           ) : (
             <>Run <code>/login</code> in the terminal below and complete OAuth in your browser. This window will close itself once your credentials are saved.</>
           )}

--- a/src/renderer/components/ClaudeAccountsModal.tsx
+++ b/src/renderer/components/ClaudeAccountsModal.tsx
@@ -209,16 +209,21 @@ export const AccountRow: React.FC<AccountRowProps> = ({
   const plural = runningSessions === 1 ? 'session' : 'sessions';
   return (
     <li className="account-row">
-      {/* The one surface where "Not yet logged in" describes something the
-          user can act on — this row has the buttons. Keyed to the resolved
-          login state and never to a missing email: an account can be logged in
-          and hold no address, and a row the user runs sessions on must not be
-          told otherwise. */}
-      <AccountChip
-        account={account}
-        size="md"
-        noEmailLabel={account.loggedIn === false ? 'Not yet logged in' : undefined}
-      />
+      <AccountChip account={account} size="md" />
+      {/* The status is a tag beside the address, not a replacement for it: the
+          address is what says WHICH account this is, and the one surface where
+          a signed-out account can be acted on is the one that must still name
+          it. Only an explicit false speaks — undefined means nothing was read,
+          and a working account may never be accused on a failed read. */}
+      {account.loggedIn === false && (
+        <span
+          className="signed-out-tag"
+          title="No completed login found in this account's config directory — log in again before using it"
+          aria-label="Not signed in"
+        >
+          not signed in
+        </span>
+      )}
       {account.isDefault && <span className="default-tag">default</span>}
       {runningSessions > 0 && (
         <span
@@ -352,6 +357,21 @@ export const LoginHint: React.FC<LoginHintProps> = ({ completed, verified, exite
   return <>Run <code>/login</code> in the terminal below and complete OAuth in your browser. This window will close itself once your credentials are saved.</>;
 };
 
+export interface LoginBannerProps {
+  completed: boolean;
+  verified: boolean;
+}
+
+/**
+ * The most emphatic thing the overlay says, extracted so its gate sits where a
+ * test can hold it: only a login main found in the config dir may be called
+ * saved, because the panel behind reads that same dir.
+ */
+export const LoginBanner: React.FC<LoginBannerProps> = ({ completed, verified }) => {
+  if (!completed || !verified) return null;
+  return <div className="completion-banner">Login saved. It's safe to close this window.</div>;
+};
+
 const ClaudeAccountLoginModal: React.FC<ClaudeAccountLoginModalProps> = ({
   account,
   ptyId,
@@ -412,9 +432,7 @@ const ClaudeAccountLoginModal: React.FC<ClaudeAccountLoginModalProps> = ({
           <LoginHint completed={completed} verified={verified} exited={exited} isMac={isMac} />
         </p>
 
-        {completed && verified && (
-          <div className="completion-banner">Login saved. It's safe to close this window.</div>
-        )}
+        <LoginBanner completed={completed} verified={verified} />
 
         <div className="terminal-host">
           <Terminal

--- a/src/renderer/components/__tests__/AccountChip.test.tsx
+++ b/src/renderer/components/__tests__/AccountChip.test.tsx
@@ -59,15 +59,20 @@ describe('AccountChip', () => {
   });
 
   test('a whitespace-only email is as unidentified as a missing one', () => {
-    render(<AccountChip account={account({ email: '   ' })} noEmailLabel="Not yet logged in" />);
-    expect(screen.getByText('Not yet logged in')).toBeTruthy();
+    render(<AccountChip account={account({ email: '   ' })} />);
+    expect(document.querySelector('.account-chip-email')).toBeNull();
     // And the tooltip agrees — it used to append an empty parenthetical.
     expect(chip().getAttribute('title')).toBe('Claude account: Personal');
   });
 
-  test('a caller that can act on a missing login may name it', () => {
-    render(<AccountChip account={account({ email: null })} noEmailLabel="Not yet logged in" />);
-    expect(screen.getByText('Not yet logged in')).toBeTruthy();
+  // The chip names an account; it never grades one. A login state is resolved
+  // from the config dir and rendered by the caller that can act on it, so no
+  // absent address anywhere can be dressed up as a report about a login.
+  test('a missing address is never rendered as a login state', () => {
+    render(<AccountChip account={account({ email: null })} />);
+    expect(document.body.textContent).not.toContain('logged in');
+    expect(document.body.textContent).not.toContain('signed in');
+    expect(screen.getByText('Personal')).toBeTruthy();
   });
 
   test('the detail can be spoken as well as hovered', () => {

--- a/src/renderer/components/__tests__/AccountChip.test.tsx
+++ b/src/renderer/components/__tests__/AccountChip.test.tsx
@@ -65,6 +65,16 @@ describe('AccountChip', () => {
     expect(chip().getAttribute('title')).toBe('Claude account: Personal');
   });
 
+  // '' is a value, not an absence, so it survives every nullish check on the
+  // way here. It still identifies nothing, so the chip must render no address
+  // rather than an empty one, and must not widen its tooltip for it either.
+  test('an empty-string email renders no address, not an empty one', () => {
+    render(<AccountChip account={account({ email: '' })} />);
+    expect(document.querySelector('.account-chip-email')).toBeNull();
+    expect(chip().getAttribute('title')).toBe('Claude account: Personal');
+    expect(document.querySelector('.account-chip-text')!.textContent).toBe('Personal');
+  });
+
   // The chip names an account; it never grades one. A login state is resolved
   // from the config dir and rendered by the caller that can act on it, so no
   // absent address anywhere can be dressed up as a report about a login.

--- a/src/renderer/components/__tests__/AccountChip.test.tsx
+++ b/src/renderer/components/__tests__/AccountChip.test.tsx
@@ -46,11 +46,11 @@ describe('AccountChip', () => {
   });
 
   test('a padded email renders trimmed, in the text and the tooltip alike', () => {
-    // The stored value is whatever parseAccountEmail read out of the
-    // credentials file, newline and all. The falsiness check below already
-    // treated '   ' as unidentified; rendering the untrimmed string meant a
-    // real address still arrived with its padding attached, so the chip's one
-    // line of room went on whitespace and the tooltip disagreed with the text.
+    // The stored value is whatever was written to the row, padding and all.
+    // The falsiness check below already treats '   ' as unidentified; an
+    // untrimmed real address would still arrive with its padding attached, so
+    // the chip's one line of room goes on whitespace and the tooltip disagrees
+    // with the text beside it.
     render(<AccountChip account={account({ email: '  a@b.com  ' })} />);
     const rendered = document.querySelector('.account-chip-email') as HTMLElement;
     expect(rendered.textContent).toBe('a@b.com');

--- a/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
+++ b/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { describe, expect, test, afterEach } from 'bun:test';
 import { act, render, screen, cleanup, fireEvent } from '@testing-library/react';
-import { AccountRow, ClaudeAccountsPanel, LoginHint } from '../ClaudeAccountsModal';
+import { AccountRow, ClaudeAccountsPanel, LoginBanner, LoginHint } from '../ClaudeAccountsModal';
 import { ClaudeAccount } from '../../../shared/types';
 
 afterEach(cleanup);
@@ -47,6 +47,7 @@ function renderRow(overrides: Partial<ClaudeAccount> = {}, runningSessions = 0) 
 }
 
 const inUse = () => document.querySelector('.in-use-tag') as HTMLElement;
+const signedOut = () => document.querySelector('.signed-out-tag') as HTMLElement;
 
 describe('AccountRow', () => {
   test('names the account through the shared chip', () => {
@@ -61,9 +62,10 @@ describe('AccountRow', () => {
     expect(inUse()).toBeNull();
   });
 
-  test('an account resolved as logged out is the one told to log in', () => {
+  test('an account resolved as signed out is the one told to log in', () => {
     renderRow({ email: null, loggedIn: false });
-    expect(screen.getByText('Not yet logged in')).toBeTruthy();
+    expect(signedOut()).toBeTruthy();
+    expect(signedOut().getAttribute('aria-label')).toBe('Not signed in');
   });
 
   // The status follows the resolved login, not the address: on macOS a healthy
@@ -71,19 +73,29 @@ describe('AccountRow', () => {
   // being told — wrongly — that none of their accounts had ever logged in.
   test('a logged-in account with no address is not told to log in', () => {
     renderRow({ email: null, loggedIn: true });
-    expect(screen.queryByText('Not yet logged in')).toBeNull();
+    expect(signedOut()).toBeNull();
     expect(screen.getByText('Personal')).toBeTruthy();
   });
 
   test('an unresolved account makes no claim about its login either way', () => {
     renderRow({ email: null });
-    expect(screen.queryByText('Not yet logged in')).toBeNull();
+    expect(signedOut()).toBeNull();
   });
 
-  test('an address, once known, outranks the status it would replace', () => {
+  // The address used to outrank the status and hide it. That was a safety net
+  // for a login state that could not be trusted; now that it can, and now that
+  // every login records an address, that rule would hide every logout instead.
+  // The two answer different questions, so the row carries both.
+  test('a signed-out account keeps its address AND says it is signed out', () => {
     renderRow({ email: 'me@example.com', loggedIn: false });
     expect(screen.getByText('me@example.com')).toBeTruthy();
-    expect(screen.queryByText('Not yet logged in')).toBeNull();
+    expect(signedOut()).toBeTruthy();
+  });
+
+  test('the status reads without colour, in the tag and its accessible name', () => {
+    renderRow({ email: 'me@example.com', loggedIn: false });
+    expect(signedOut().textContent).toContain('not signed in');
+    expect(signedOut().getAttribute('title')).toContain('log in again');
   });
 
   test('usage is reported as a number, not a tint', () => {
@@ -228,5 +240,37 @@ describe('LoginHint', () => {
     const text = hint({ isMac: false });
     expect(text).not.toContain("I'm logged in");
     expect(text).toContain('/login');
+  });
+});
+
+/**
+ * The banner is the overlay's most emphatic claim, and the one a user acts on
+ * by closing the window. It may only appear for a login main actually found.
+ */
+describe('LoginBanner', () => {
+  const banner = () => document.querySelector('.completion-banner');
+
+  test('a verified completion is the only thing called saved', () => {
+    render(<LoginBanner completed verified />);
+    expect(banner()!.textContent).toContain('Login saved');
+  });
+
+  // The user can press "I'm logged in" before OAuth finishes. Main then finds
+  // no login, and the panel behind this overlay says so — a banner here would
+  // be the same account described two ways on one screen.
+  test('a completion main could not confirm is never called saved', () => {
+    render(<LoginBanner completed verified={false} />);
+    expect(banner()).toBeNull();
+    expect(document.body.textContent).not.toContain('Login saved');
+  });
+
+  test('nothing is claimed before the login completes at all', () => {
+    render(<LoginBanner completed={false} verified />);
+    expect(banner()).toBeNull();
+  });
+
+  test('an unstarted login claims nothing either', () => {
+    render(<LoginBanner completed={false} verified={false} />);
+    expect(banner()).toBeNull();
   });
 });

--- a/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
+++ b/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { describe, expect, test, afterEach } from 'bun:test';
 import { act, render, screen, cleanup, fireEvent } from '@testing-library/react';
-import { AccountRow, ClaudeAccountsPanel } from '../ClaudeAccountsModal';
+import { AccountRow, ClaudeAccountsPanel, LoginHint } from '../ClaudeAccountsModal';
 import { ClaudeAccount } from '../../../shared/types';
 
 afterEach(cleanup);
@@ -175,5 +175,58 @@ describe('ClaudeAccountsPanel delete confirmation', () => {
     await act(async () => { fireEvent.click(screen.getByText('Delete')); });
 
     expect(messages[0]).not.toContain('running session');
+  });
+});
+
+/**
+ * The login overlay's copy. It sits on top of the accounts panel, which reads
+ * the same config dir main just read, so any claim it makes that main could
+ * not confirm puts two answers about one account on screen at once.
+ */
+describe('LoginHint', () => {
+  function hint(props: Partial<React.ComponentProps<typeof LoginHint>> = {}) {
+    render(
+      <LoginHint
+        completed={false}
+        verified={false}
+        exited={false}
+        isMac={false}
+        {...props}
+      />
+    );
+    return document.body.textContent ?? '';
+  }
+
+  test('a login main actually saw is reported as signed in', () => {
+    expect(hint({ completed: true, verified: true })).toContain('signed in');
+  });
+
+  // The user can press "I'm logged in" before OAuth finishes: main resolves no
+  // login, writes no address, and the panel behind renders "Not yet logged in".
+  test('a completion main could not confirm never claims the account is signed in', () => {
+    const text = hint({ completed: true, verified: false, isMac: true });
+    expect(text).not.toContain('signed in');
+    expect(text).toContain('Recorded');
+    expect(text).toContain('/login');
+  });
+
+  test('an exited login is reported as exited, not as completed', () => {
+    const text = hint({ exited: true });
+    expect(text).toContain('exited before credentials were saved');
+    expect(text).not.toContain('signed in');
+  });
+
+  test('a completed login outranks an exit that followed it', () => {
+    expect(hint({ completed: true, verified: true, exited: true })).toContain('signed in');
+  });
+
+  test('macOS is told about the button it alone is shown', () => {
+    expect(hint({ isMac: true })).toContain("I'm logged in");
+  });
+
+  test('every other platform is not offered a button it does not have', () => {
+    const text = hint({ isMac: false });
+    expect(text).not.toContain("I'm logged in");
+    expect(text).toContain('/login');
   });
 });

--- a/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
+++ b/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
@@ -61,6 +61,31 @@ describe('AccountRow', () => {
     expect(inUse()).toBeNull();
   });
 
+  test('an account resolved as logged out is the one told to log in', () => {
+    renderRow({ email: null, loggedIn: false });
+    expect(screen.getByText('Not yet logged in')).toBeTruthy();
+  });
+
+  // The status follows the resolved login, not the address: on macOS a healthy
+  // account records no address, and this is the row where a user would act on
+  // being told — wrongly — that none of their accounts had ever logged in.
+  test('a logged-in account with no address is not told to log in', () => {
+    renderRow({ email: null, loggedIn: true });
+    expect(screen.queryByText('Not yet logged in')).toBeNull();
+    expect(screen.getByText('Personal')).toBeTruthy();
+  });
+
+  test('an unresolved account makes no claim about its login either way', () => {
+    renderRow({ email: null });
+    expect(screen.queryByText('Not yet logged in')).toBeNull();
+  });
+
+  test('an address, once known, outranks the status it would replace', () => {
+    renderRow({ email: 'me@example.com', loggedIn: false });
+    expect(screen.getByText('me@example.com')).toBeTruthy();
+    expect(screen.queryByText('Not yet logged in')).toBeNull();
+  });
+
   test('usage is reported as a number, not a tint', () => {
     renderRow({}, 2);
     expect(inUse().textContent).toContain('2');

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -177,7 +177,7 @@ interface ElectronAPI {
   setDefaultAccount: (id: string) => Promise<boolean>;
   assignAccountToSession: (sessionId: string, accountId: string | null) => Promise<AccountSwitchResult>;
   assignAccountToGroup: (groupId: string, accountId: string | null) => Promise<AccountSwitchResult>;
-  onAccountLoginCompleted: (callback: (data: { accountId: string; email: string | null }) => void) => () => void;
+  onAccountLoginCompleted: (callback: (data: { accountId: string; email: string | null; verified: boolean }) => void) => () => void;
   onAccountLoginExited: (callback: (data: { accountId: string; exitCode: number }) => void) => () => void;
 
   // Update channel (BDHLNDR-32)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -262,12 +262,12 @@ export interface ClaudeAccount {
   label: string;
   /** Absolute path to the account's isolated .claude directory. */
   configDir: string;
-  /** Email of the logged-in profile, for display. */
+  /** Address last recorded for this account, for display. */
   email: string | null;
   /**
-   * Whether the config dir shows a completed login. Resolved from disk when
-   * accounts are listed, and absent on rows read straight from the database —
-   * where nothing was consulted, so nothing may claim the account is logged out.
+   * Whether a completed login was found — resolved from the config dir, and
+   * from a recorded address only where that dir could not be read. Undefined
+   * when nothing was consulted, so no surface may call the account logged out.
    */
   loggedIn?: boolean;
   /** Hex color for UI badge. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -262,8 +262,14 @@ export interface ClaudeAccount {
   label: string;
   /** Absolute path to the account's isolated .claude directory. */
   configDir: string;
-  /** Email parsed from credentials after login, for display. */
+  /** Email of the logged-in profile, for display. */
   email: string | null;
+  /**
+   * Whether the config dir shows a completed login. Resolved from disk when
+   * accounts are listed, and absent on rows read straight from the database —
+   * where nothing was consulted, so nothing may claim the account is logged out.
+   */
+  loggedIn?: boolean;
   /** Hex color for UI badge. */
   color: string;
   /** True for the single account used as the global default fallback. */


### PR DESCRIPTION
## Description

Settings → Claude Accounts reported every account as "not yet logged in" on macOS, including three accounts that had completed login and been used for sessions since.

**Root cause.** The status was never derived from a credential artifact at all. It came from `acc.email`, and `email` was only ever written by `parseAccountEmail()` parsing `<configDir>/.credentials.json` at login time. `AccountChip` rendered "Not yet logged in" whenever email was blank. macOS never writes that file — Claude Code puts the tokens in the Keychain — so the column stayed NULL and every healthy account read as logged out.

**Ground truth on the reporter's machine.** All three account config dirs are heavily used. None contains `.credentials.json` or `auth.json`. All three carry `.claude/.claude.json` with a populated `oauthAccount` block holding a distinct address, which confirms both the hypothesis and that per-config-dir isolation is working. (Directory listings and JSON key names only — no file contents and no secrets were read or recorded.)

**When it broke: never worked on macOS.** `parseAccountEmail` and the label both landed 2026-04-17 with the original accounts feature, so this is not a regression from the recent accounts work. #165 narrowed where the label appears, which is why it showed precisely in Settings → Claude Accounts.

**The fix.** A new `src/main/account-identity.ts` probes the account's config dir in order:

1. `<configDir>/.claude.json` → `oauthAccount` — primary, and correct on every platform. It requires an object carrying `emailAddress` or `accountUuid`, because the file itself exists from first run and so its presence proves nothing; the block is the signal.
2. `.credentials.json` / `auth.json` presence — the fallback for platforms that write a plaintext token store.
3. The recorded row address — and only where the config dir could not be read at all.

`accounts:list` maps through `withAccountIdentity`, so one boundary feeds every renderer surface.

**`loggedIn` is a tri-state, not a boolean.** `undefined` means "not consulted, or consulted and unreadable" — it is never "logged out". A `.claude.json` that exists but will not parse yields UNKNOWN rather than logged-out. That matters concretely: Claude Code rewrites that file roughly once a minute, so a torn read is a real event, and under a two-state flag it would have reproduced the reported bug intermittently and at random. Both surfaces test `=== false`, so a surface that consulted nothing cannot accuse an account of being logged out — the exact shape this bug took.

**The address fallback is narrow on purpose.** A recorded address stands in for the probe *only* where the directory could not be read:

```ts
let loggedIn = identity.loggedIn;
if (loggedIn === undefined && storedEmail !== null) loggedIn = true;
```

A readable directory showing no login is authoritative. So `/logout`, and a config dir that has been moved or is on an unmounted volume, now surface as `false` instead of being masked by a stale address.

**The completion event carries `verified`.** The field runs main → preload → `electron.d.ts` → renderer, so the login overlay words itself from what main actually resolved rather than asserting "this account is signed in" on the strength of a button press. Unverified now reads "Recorded — but no login was found in this account's config directory yet".

**The panel pairs address with status.** Rows carry the account's address *and* an explicit `not signed in` tag beside the existing `default` / `in use` tags. The old email-over-label precedence was a safety net for a login state that could not be trusted; now that the state is authoritative and every login records an address, that same rule would have hidden every logout rather than protecting against a false one. `noEmailLabel` was deleted from `AccountChip` entirely, because it existed only to render a missing address as a login status — the exact conflation this fix removes.

**The login watcher** is keyed to `LOGIN_ARTIFACTS` and gated on the same resolver, so a macOS login auto-detects instead of waiting on the manual confirm button.

**Why probe rather than persist our own marker.** A `loggedInAt` marker would not fix any existing account without probing anyway; it records a past event rather than current state; on macOS it would be pure self-report; and it misses logins performed outside the app.

**Keychain deliberately not consulted.** Reading it requires a prompt-triggering `security` call, and its item is not demonstrably keyed per `CLAUDE_CONFIG_DIR`, whereas `.claude.json` is.

## Related issue

Closes #196

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Hotfix
- [ ] Refactor / chore
- [ ] Docs

## How was this tested?

**Automated, at head `855bf17`.**

| suite | tests |
| --- | --- |
| `account-identity.test.ts` (new) | 29 |
| `account-auth.test.ts` | 10 |
| `preload.test.ts` (new) | 4 |
| `ClaudeAccountsModal.test.tsx` | 23 |
| `AccountChip.test.tsx` | 12 |
| `App.accounts.test.ts` | 18 |

`account-identity.test.ts` uses zero mocks — it builds real fixture directories laid out per platform.

```
full root suite:  987 pass / 0 fail across 66 files
tsc (main):       clean
tsc (renderer):   clean
```

**CI at `855bf17`: all four checks green** — SonarQube Quality Gate, `quality-gate`, `test`, GitGuardian.

**Sonar's one new issue was resolved without obeying it.** It flagged the blank-address collapse in `AccountChip`. The suggested `??` would have been wrong: `''` is not nullish, so nullish coalescing preserves it and hands the chip an empty address that identifies nothing. It was rewritten instead as the explicit truthiness guard the file already uses for its colour swatch two lines below, which is both correct and consistent with its neighbour. A new test pins that an empty-string email renders no address at all.

**Harness.** `scripts/verify.sh Bodhilander=feat/196-Bodhilander`, run from the copy pinned in `team.yaml` (`.../bodhi-marketplace/bodhi/2.18.4`):

```
16 file(s) changed
21% of added lines are comment (172/832)
running: bun test --isolate src/main/__tests__/account-auth.test.ts …
specs:   19 enumerated (never a glob)

UNVERIFIED   coverage
PASS         tests
SKIP         lint
PASS         seams
```

It enumerates the specs reachable from the diff — **19** here, never a glob — and runs them under `bun test --isolate`. Tests **PASS**, seams **PASS**. It is RED on exactly one row, `coverage`, for `src/main/index.ts`; both gates examined that row specifically and accepted the justification recorded under Gate results.

**`lint` SKIP is verified-absent, not a detection failure.** This repo has no `lint` script in `package.json` and no eslint, biome or oxlint configuration anywhere in the tree. There is no lint step to run, so `null` is the correct record rather than a missed one.

The suite and typecheck evidence above came from direct runs, and the suite is independently enforced by the `test` check on this PR.

**Not verified.** No manual run against a live macOS install was performed on this branch. The macOS behaviour is pinned by fixture directories reproducing the reporter's layout and by the verifier's read of the reporter's three real config dirs, not by an end-to-end login through the UI. The Windows and Linux paths are covered by fixtures rather than by a real login on those platforms. `src/main/index.ts` carries no direct coverage — see the coverage note under Gate results.

## For review attention

1. `oauthAccount` is a profile cache that most likely survives `/logout`, so the honest reading of the flag is "has completed a login" rather than "holds a valid token" — a revoked or expired token still reads as logged in. This is deliberate: the alternative is prompting the user for Keychain access on every list.
2. Tier 1 couples us to Claude Code's on-disk shape. If `.claude.json` or `oauthAccount` is restructured upstream, only accounts whose directory is unreadable fall through to the recorded address.
3. `confirmLoginMacOS` keeps its name while now serving as a general manual override. Renaming it ripples through IPC, preload, types and renderer, so the name was left as-is and is flagged here rather than changed silently.
4. The `.claude.json` watcher parses on each write during the login window. That is bounded by the window itself and by the completed guard.

## Gate results
- **Gate 3 (adversarial reviewer), first pass: RED** — two ways the UI could still state something false to the user. Addressed, and the re-check came back **GREEN**.
- **Final re-check: GREEN.** The banner mutation that survived the earlier pass is now killed. The reviewer ran a full five-state render matrix over the new status tag, killed six mutations on it, measured its contrast at **7.44:1 (AAA)**, confirmed it is distinguishable from its sibling tags without relying on colour, and confirmed **zero `noEmailLabel` remnants** anywhere in `src/`.
- **Gate 4 (verifier): VERIFIED.** Test counts reproduced independently against a real in-memory database, with no weakened assertions. The verifier also confirmed directly that the reporter's three real accounts resolve as logged in, from artifacts the old code could never have read.
- **One equivalent-mutant pair, analysed and accepted.** Two individually correct guards mutually mask each other's substitution, so neither mutation alone is caught. Removing **both** fails the two tests that assert the invariant. That is redundancy between the guards, not a gap in coverage.
- **Coverage.** `src/main/index.ts` remains the single unverified file, for the stated reasons: 1486 lines, 91 IPC registrations, and import-time side effects pulling in Electron, the database and `node-pty`. Moving the identity overlay into the accounts repository to clear the gate was considered and **rejected** — it would put filesystem I/O into a database repository that is called on every PTY spawn.

## Checklist
- [x] Tests pass locally (987 pass / 0 fail across 66 files; both typechecks clean; all four CI checks green)
- [x] Self-reviewed the changes
- [x] Docs updated where needed — no user-facing or contributor doc describes login-state derivation, so none needed changing
- [x] Linked the related issue above

<!-- bodhi:merge-order -->
**Merge position 1 of 1.** Nothing merges before this one.
Order: Bodhilander
<!-- bodhi:merge-order -->

