### PR TITLE
185 — Guest arrival and sizing polish: land in the terminal, honest copy, Fit to my screen

### DIFF
--- a/docs/designs/session-sharing.md
+++ b/docs/designs/session-sharing.md
@@ -499,9 +499,15 @@ If neither lands, cut phone guests from M5.2 rather than ship an illegible prima
 
 The request travels as `terminal:resize-request {sessionId, cols, rows}`, which requires only
 `view`: it resizes nothing, so a guest role never needs `resize`. The tunnel clamps the size,
-scopes it to a live subscription, throttles it (each one interrupts the owner) and forwards it
-to the renderer, which performs the resize itself on accept. Declining sends nothing back, so
-a refusal reaches the guest as silence and their view is left exactly as it was.
+scopes it to a live subscription, throttles it **per grant** — a guest may open as many sockets
+as they like, so a per-socket throttle is one refresh away from free — and forwards it to the
+renderer, which performs the resize itself on accept. Declining sends nothing back, so a
+refusal reaches the guest as silence and their view is left exactly as it was.
+
+An accepted fit is **held** against that window's own re-fits until the owner takes it back
+through the existing `Resume desktop size` banner. Without the hold the next focus or window
+resize re-measures an unchanged container and pushes the desktop grid back — undoing the grant
+silently, seconds after it was given, with the guest panning again and nobody told.
 
 **Ending states get distinct copy**, driven by a reason enum the agent already knows —
 `revoked` / `expired` / `session_ended` / `machine_unlinked`. Telling a guest *"Will revoked

--- a/docs/designs/session-sharing.md
+++ b/docs/designs/session-sharing.md
@@ -497,6 +497,12 @@ size with horizontal panning (`overflow-x:auto`, two-axis drag) plus an honest b
 request that surfaces on the owner's desktop as a one-tap `[ Resize once ] [ Keep my size ]`.
 If neither lands, cut phone guests from M5.2 rather than ship an illegible primary surface.
 
+The request travels as `terminal:resize-request {sessionId, cols, rows}`, which requires only
+`view`: it resizes nothing, so a guest role never needs `resize`. The tunnel clamps the size,
+scopes it to a live subscription, throttles it (each one interrupts the owner) and forwards it
+to the renderer, which performs the resize itself on accept. Declining sends nothing back, so
+a refusal reaches the guest as silence and their view is left exactly as it was.
+
 **Ending states get distinct copy**, driven by a reason enum the agent already knows —
 `revoked` / `expired` / `session_ended` / `machine_unlinked`. Telling a guest *"Will revoked
 your access"* when Will merely closed a terminal is a false, socially loaded story.

--- a/fixtures/sharing-v1.json
+++ b/fixtures/sharing-v1.json
@@ -58,7 +58,10 @@
       "reachable. 'owner' is NOT a certificate role -- there is deliberately no persisted",
       "owner certificate (§3), so it never appears in mintableRoles.",
       "'create' and 'browse' belong to no guest role, which is what keeps session:create,",
-      "group:create and dirs:list unreachable for any guest, ever (a v1 non-goal)."
+      "group:create and dirs:list unreachable for any guest, ever (a v1 non-goal).",
+      "'terminal:resize-request' requires only 'view' because it resizes nothing: the guest",
+      "asks, and the owner's desktop decides. If it ever needs 'resize', a phone has been",
+      "given the ability to reflow somebody else's terminal and that is the finding."
     ],
     "caps": ["view", "list", "input", "resize", "create", "browse"],
     "roleCaps": {
@@ -74,6 +77,7 @@
       "terminal:unsubscribe": "view",
       "terminal:input": "input",
       "terminal:resize": "resize",
+      "terminal:resize-request": "view",
       "session:create": "create",
       "group:create": "create",
       "dirs:list": "browse"

--- a/relay/web/src/arrival.test.ts
+++ b/relay/web/src/arrival.test.ts
@@ -10,6 +10,7 @@ import {
   machineMenuTitle,
   machineSections,
   planArrival,
+  showSectionTitles,
   type ArrivalMachine,
 } from './arrival';
 
@@ -108,7 +109,13 @@ describe('machineSections', () => {
 
 describe('machineMenuTitle', () => {
   test('a guest never reads the word "machines" as though they owned any', () => {
-    expect(machineMenuTitle([shared(), shared({ id: 'g2' })])).toBe('Shared with you');
+    expect(machineMenuTitle([shared(), shared({ id: 'g2' })])).toBe('Shared with me');
+  });
+
+  test('the sheet and the section inside it say the same thing, in one voice', () => {
+    // Two names for one list on one screen reads as two different lists.
+    const machines = [shared(), shared({ id: 'g2' })];
+    expect(machineSections(machines)[0]!.title).toBe(machineMenuTitle(machines));
   });
 
   test('anyone with one of their own gets the owner heading', () => {
@@ -116,23 +123,48 @@ describe('machineMenuTitle', () => {
   });
 });
 
+describe('showSectionTitles', () => {
+  test('headings appear when there is someone else\'s machine to separate', () => {
+    expect(showSectionTitles(machineSections([mine(), shared()]))).toBe(true);
+    expect(showSectionTitles(machineSections([shared(), shared({ id: 'g2' })]))).toBe(true);
+  });
+
+  test('an owner with only their own machines gets no new heading over them', () => {
+    // "MY MACHINES" over the only section labels nothing — it was not there
+    // before sharing existed and it earns nothing now.
+    expect(showSectionTitles(machineSections([mine(), mine({ id: 'm2' })]))).toBe(false);
+  });
+});
+
 describe('autoOpenSessionId', () => {
   const landing = planArrival([shared()], null);
+  const fresh = { landed: false, activeId: null };
 
   test('one grant, one session — open it', () => {
-    expect(autoOpenSessionId(landing, ['s1'])).toBe('s1');
+    expect(autoOpenSessionId(landing, ['s1'], fresh)).toBe('s1');
   });
 
   test('a grant covering several sessions is a list, not a guess', () => {
-    expect(autoOpenSessionId(landing, ['s1', 's2'])).toBeNull();
+    expect(autoOpenSessionId(landing, ['s1', 's2'], fresh)).toBeNull();
   });
 
   test('nothing in scope yet opens nothing', () => {
-    expect(autoOpenSessionId(landing, [])).toBeNull();
+    expect(autoOpenSessionId(landing, [], fresh)).toBeNull();
   });
 
   test('anyone who was offered a picker chose for themselves', () => {
-    expect(autoOpenSessionId(planArrival([mine()], null), ['s1'])).toBeNull();
-    expect(autoOpenSessionId(null, ['s1'])).toBeNull();
+    expect(autoOpenSessionId(planArrival([mine()], null), ['s1'], fresh)).toBeNull();
+    expect(autoOpenSessionId(null, ['s1'], fresh)).toBeNull();
+  });
+
+  test('landing happens once — Back must stay back', () => {
+    // The session list is polled every couple of seconds. Without this the
+    // next refresh reopens the terminal the guest just left, and every one
+    // after it, so leaving is impossible.
+    expect(autoOpenSessionId(landing, ['s1'], { landed: true, activeId: null })).toBeNull();
+  });
+
+  test('a terminal already on screen is not replaced by another landing', () => {
+    expect(autoOpenSessionId(landing, ['s1'], { landed: false, activeId: 's1' })).toBeNull();
   });
 });

--- a/relay/web/src/arrival.test.ts
+++ b/relay/web/src/arrival.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Arrival: what a guest sees first. The rule under test is that a single-grant
+ * guest is never asked to choose — not between machines, and not between one
+ * session and nothing.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  autoOpenSessionId,
+  machineLabel,
+  machineMenuTitle,
+  machineSections,
+  planArrival,
+  type ArrivalMachine,
+} from './arrival';
+
+const mine = (over: Partial<ArrivalMachine> = {}): ArrivalMachine => ({
+  id: 'm1',
+  name: 'laptop',
+  relation: 'owner',
+  ownerName: null,
+  ...over,
+});
+
+const shared = (over: Partial<ArrivalMachine> = {}): ArrivalMachine => ({
+  id: 'g1',
+  name: 'laptop',
+  relation: 'grantee',
+  ownerName: 'Will',
+  ...over,
+});
+
+describe('planArrival', () => {
+  test('a guest with exactly one grant lands in the terminal, with no picker', () => {
+    const arrival = planArrival([shared()], null)!;
+    expect(arrival.landInTerminal).toBe(true);
+    expect(arrival.showPicker).toBe(false);
+    expect(arrival.machine.id).toBe('g1');
+  });
+
+  test('a guest with two grants gets the picker and no automatic landing', () => {
+    const arrival = planArrival([shared(), shared({ id: 'g2', ownerName: 'Dana' })], null)!;
+    expect(arrival.landInTerminal).toBe(false);
+    expect(arrival.showPicker).toBe(true);
+  });
+
+  test('an owner with one machine keeps the pill — it is also how they link another', () => {
+    const arrival = planArrival([mine()], null)!;
+    expect(arrival.landInTerminal).toBe(false);
+    expect(arrival.showPicker).toBe(true);
+  });
+
+  test('one grant plus a machine of your own is still a choice', () => {
+    const arrival = planArrival([mine(), shared()], null)!;
+    expect(arrival.landInTerminal).toBe(false);
+    expect(arrival.showPicker).toBe(true);
+  });
+
+  test('the remembered machine wins, and a stale one falls back to the first', () => {
+    const machines = [mine(), mine({ id: 'm2', name: 'desktop' })];
+    expect(planArrival(machines, 'm2')!.machine.id).toBe('m2');
+    expect(planArrival(machines, 'gone')!.machine.id).toBe('m1');
+  });
+
+  test('nothing to arrive at', () => {
+    expect(planArrival([], null)).toBeNull();
+  });
+});
+
+describe('machineLabel', () => {
+  test('a shared machine is named after its person', () => {
+    expect(machineLabel(shared())).toBe("Will's laptop");
+  });
+
+  test('an unknown owner degrades to the machine name rather than an empty possessive', () => {
+    expect(machineLabel(shared({ ownerName: null }))).toBe('laptop');
+  });
+
+  test('your own machine is just itself', () => {
+    expect(machineLabel(mine())).toBe('laptop');
+  });
+});
+
+describe('machineSections', () => {
+  test('yours and theirs are separate, and theirs are labelled by person', () => {
+    const sections = machineSections([mine(), shared()]);
+    expect(sections.map((s) => s.title)).toEqual(['My machines', 'Shared with me']);
+    expect(sections[1]!.items.map(machineLabel)).toEqual(["Will's laptop"]);
+  });
+
+  test('shared rows cluster by person so one owner is not scattered', () => {
+    const sections = machineSections([
+      shared({ id: 'a', ownerName: 'Will', name: 'desktop' }),
+      shared({ id: 'b', ownerName: 'Dana', name: 'mac mini' }),
+      shared({ id: 'c', ownerName: 'Will', name: 'laptop' }),
+    ]);
+    expect(sections[0]!.items.map(machineLabel)).toEqual([
+      "Dana's mac mini",
+      "Will's desktop",
+      "Will's laptop",
+    ]);
+  });
+
+  test('a section with nothing in it is not rendered', () => {
+    expect(machineSections([shared()]).map((s) => s.title)).toEqual(['Shared with me']);
+    expect(machineSections([mine()]).map((s) => s.title)).toEqual(['My machines']);
+  });
+});
+
+describe('machineMenuTitle', () => {
+  test('a guest never reads the word "machines" as though they owned any', () => {
+    expect(machineMenuTitle([shared(), shared({ id: 'g2' })])).toBe('Shared with you');
+  });
+
+  test('anyone with one of their own gets the owner heading', () => {
+    expect(machineMenuTitle([mine(), shared()])).toBe('Machines');
+  });
+});
+
+describe('autoOpenSessionId', () => {
+  const landing = planArrival([shared()], null);
+
+  test('one grant, one session — open it', () => {
+    expect(autoOpenSessionId(landing, ['s1'])).toBe('s1');
+  });
+
+  test('a grant covering several sessions is a list, not a guess', () => {
+    expect(autoOpenSessionId(landing, ['s1', 's2'])).toBeNull();
+  });
+
+  test('nothing in scope yet opens nothing', () => {
+    expect(autoOpenSessionId(landing, [])).toBeNull();
+  });
+
+  test('anyone who was offered a picker chose for themselves', () => {
+    expect(autoOpenSessionId(planArrival([mine()], null), ['s1'])).toBeNull();
+    expect(autoOpenSessionId(null, ['s1'])).toBeNull();
+  });
+});

--- a/relay/web/src/arrival.test.ts
+++ b/relay/web/src/arrival.test.ts
@@ -124,15 +124,16 @@ describe('machineMenuTitle', () => {
 });
 
 describe('showSectionTitles', () => {
-  test('headings appear when there is someone else\'s machine to separate', () => {
+  test('headings appear when there are two sections to tell apart', () => {
     expect(showSectionTitles(machineSections([mine(), shared()]))).toBe(true);
-    expect(showSectionTitles(machineSections([shared(), shared({ id: 'g2' })]))).toBe(true);
   });
 
-  test('an owner with only their own machines gets no new heading over them', () => {
-    // "MY MACHINES" over the only section labels nothing — it was not there
-    // before sharing existed and it earns nothing now.
+  test('the only section is never headed — either side of the relation', () => {
+    // A heading over the only section labels nothing and repeats the sheet's
+    // own title directly above it. True for an owner with only their own
+    // machines, and equally true for a guest holding only other people's.
     expect(showSectionTitles(machineSections([mine(), mine({ id: 'm2' })]))).toBe(false);
+    expect(showSectionTitles(machineSections([shared(), shared({ id: 'g2' })]))).toBe(false);
   });
 });
 

--- a/relay/web/src/arrival.ts
+++ b/relay/web/src/arrival.ts
@@ -46,8 +46,6 @@ export function planArrival<T extends ArrivalMachine>(machines: T[], preferredId
 
 export interface MachineSection<T extends ArrivalMachine = ArrivalMachine> {
   title: string;
-  /** Whose they are. Drives whether the headings are worth showing at all. */
-  kind: 'mine' | 'shared';
   items: T[];
 }
 
@@ -63,18 +61,18 @@ export function machineSections<T extends ArrivalMachine>(machines: T[]): Machin
     .slice()
     .sort((a, b) => (a.ownerName ?? '').localeCompare(b.ownerName ?? '') || a.name.localeCompare(b.name));
   const sections: MachineSection<T>[] = [];
-  if (mine.length) sections.push({ title: 'My machines', kind: 'mine', items: mine });
-  if (shared.length) sections.push({ title: 'Shared with me', kind: 'shared', items: shared });
+  if (mine.length) sections.push({ title: 'My machines', items: mine });
+  if (shared.length) sections.push({ title: 'Shared with me', items: shared });
   return sections;
 }
 
 /**
- * Whether the headings earn their place. They separate yours from someone
- * else's, so with nothing of anyone else's in the list there is nothing to
- * separate — and "MY MACHINES" over the only section is a label, not an aid.
+ * Whether the headings earn their place. A heading separates one section from
+ * another, so the only section has nothing to separate itself from — and it
+ * would repeat the sheet's own title directly underneath it.
  */
 export function showSectionTitles(sections: MachineSection<ArrivalMachine>[]): boolean {
-  return sections.some((section) => section.kind === 'shared');
+  return sections.length > 1;
 }
 
 /**

--- a/relay/web/src/arrival.ts
+++ b/relay/web/src/arrival.ts
@@ -33,13 +33,9 @@ export function machineLabel(m: ArrivalMachine): string {
 }
 
 /**
- * How to open for this person.
- *
- * A guest holding exactly one grant gets no picker and no session-list detour:
- * choosing between one thing is not a choice, and every step before the
- * terminal is a step away from the session they were actually sent to. Anyone
- * with a machine of their own keeps the pill, because for them it is also the
- * route to linking another.
+ * How to open for this person. One grant and nothing of their own means no
+ * picker and no list: choosing between one thing is not a choice. Anyone with
+ * a machine of their own keeps the pill — it is also how they link another.
  */
 export function planArrival<T extends ArrivalMachine>(machines: T[], preferredId: string | null): Arrival<T> | null {
   if (!machines.length) return null;
@@ -54,11 +50,9 @@ export interface MachineSection<T extends ArrivalMachine = ArrivalMachine> {
 }
 
 /**
- * The picker's rows, split by whose they are.
- *
- * Shared entries are grouped under one heading and each row is named after the
- * person who shared it — "SHARED WITH ME" over "Will's laptop" — so a guest
- * reads the list as people rather than as inventory.
+ * The picker's rows, split by whose they are. Shared rows are named after the
+ * person who shared them — "SHARED WITH ME" over "Will's laptop" — so the
+ * list reads as people rather than as inventory.
  */
 export function machineSections<T extends ArrivalMachine>(machines: T[]): MachineSection<T>[] {
   const mine = machines.filter((m) => !isGuestMachine(m));
@@ -78,11 +72,9 @@ export function machineMenuTitle(machines: ArrivalMachine[]): string {
 }
 
 /**
- * The session to open without being asked, or null when there is a real choice.
- *
- * Only ever for the single-grant guest, and only when their scope holds one
- * session: a grant covering several is a list they have to read, and picking
- * one for them would hide the others.
+ * The session to open without being asked, or null when there is a real
+ * choice: a grant covering several sessions is a list they have to read, and
+ * picking one for them would hide the others.
  */
 export function autoOpenSessionId(arrival: Arrival | null, sessionIds: string[]): string | null {
   if (!arrival?.landInTerminal) return null;

--- a/relay/web/src/arrival.ts
+++ b/relay/web/src/arrival.ts
@@ -46,6 +46,8 @@ export function planArrival<T extends ArrivalMachine>(machines: T[], preferredId
 
 export interface MachineSection<T extends ArrivalMachine = ArrivalMachine> {
   title: string;
+  /** Whose they are. Drives whether the headings are worth showing at all. */
+  kind: 'mine' | 'shared';
   items: T[];
 }
 
@@ -61,22 +63,49 @@ export function machineSections<T extends ArrivalMachine>(machines: T[]): Machin
     .slice()
     .sort((a, b) => (a.ownerName ?? '').localeCompare(b.ownerName ?? '') || a.name.localeCompare(b.name));
   const sections: MachineSection<T>[] = [];
-  if (mine.length) sections.push({ title: 'My machines', items: mine });
-  if (shared.length) sections.push({ title: 'Shared with me', items: shared });
+  if (mine.length) sections.push({ title: 'My machines', kind: 'mine', items: mine });
+  if (shared.length) sections.push({ title: 'Shared with me', kind: 'shared', items: shared });
   return sections;
 }
 
-/** The picker's own heading. Someone with no machines of their own owns none. */
+/**
+ * Whether the headings earn their place. They separate yours from someone
+ * else's, so with nothing of anyone else's in the list there is nothing to
+ * separate — and "MY MACHINES" over the only section is a label, not an aid.
+ */
+export function showSectionTitles(sections: MachineSection<ArrivalMachine>[]): boolean {
+  return sections.some((section) => section.kind === 'shared');
+}
+
+/**
+ * The picker's own heading. It says the same thing as the section inside it,
+ * in the same voice — two names for one list on one screen is a wobble.
+ */
 export function machineMenuTitle(machines: ArrivalMachine[]): string {
-  return machines.length > 0 && machines.every(isGuestMachine) ? 'Shared with you' : 'Machines';
+  return machines.length > 0 && machines.every(isGuestMachine) ? 'Shared with me' : 'Machines';
+}
+
+/** What the app has already opened, so landing happens once and only once. */
+export interface Opened {
+  /** True once this arrival has landed, even if they have since gone Back. */
+  landed: boolean;
+  /** The terminal on screen right now, if any. */
+  activeId: string | null;
 }
 
 /**
  * The session to open without being asked, or null when there is a real
- * choice: a grant covering several sessions is a list they have to read, and
- * picking one for them would hide the others.
+ * choice: a grant covering several sessions is a list to read, and picking
+ * one would hide the others.
  */
-export function autoOpenSessionId(arrival: Arrival | null, sessionIds: string[]): string | null {
-  if (!arrival?.landInTerminal) return null;
+export function autoOpenSessionId(
+  arrival: Arrival | null,
+  sessionIds: string[],
+  opened: Opened,
+): string | null {
+  // `landed` outlives `activeId` on purpose: going Back clears the terminal
+  // but not the fact of having arrived, and the list is polled every couple of
+  // seconds — without it each refresh would drag the guest straight back in.
+  if (!arrival?.landInTerminal || opened.landed || opened.activeId) return null;
   return sessionIds.length === 1 ? sessionIds[0]! : null;
 }

--- a/relay/web/src/arrival.ts
+++ b/relay/web/src/arrival.ts
@@ -1,0 +1,90 @@
+/**
+ * Where a person lands when the app opens, and how the machine picker reads.
+ * Apart from main.ts so it can be tested: main.ts pulls in xterm and runs
+ * boot() at import time, so nothing in it is reachable from a unit test.
+ */
+
+/** The `/api/machines` fields these decisions read. */
+export interface ArrivalMachine {
+  id: string;
+  name: string;
+  /** How you reach it. Guests get a certificate; owners get null. */
+  relation?: 'owner' | 'grantee';
+  ownerName?: string | null;
+}
+
+export interface Arrival<T extends ArrivalMachine = ArrivalMachine> {
+  /** The machine to connect to. */
+  machine: T;
+  /** Whether the machine pill — and the picker behind it — is offered at all. */
+  showPicker: boolean;
+  /** Skip the session list on arrival: see `planArrival`. */
+  landInTerminal: boolean;
+}
+
+export const isGuestMachine = (m: ArrivalMachine): boolean => m.relation === 'grantee';
+
+/**
+ * Label by PERSON for a guest. "Machine" is owner vocabulary: a guest was
+ * invited to a session by someone, and has no relationship with the hardware.
+ */
+export function machineLabel(m: ArrivalMachine): string {
+  return isGuestMachine(m) && m.ownerName ? `${m.ownerName}'s ${m.name}` : m.name;
+}
+
+/**
+ * How to open for this person.
+ *
+ * A guest holding exactly one grant gets no picker and no session-list detour:
+ * choosing between one thing is not a choice, and every step before the
+ * terminal is a step away from the session they were actually sent to. Anyone
+ * with a machine of their own keeps the pill, because for them it is also the
+ * route to linking another.
+ */
+export function planArrival<T extends ArrivalMachine>(machines: T[], preferredId: string | null): Arrival<T> | null {
+  if (!machines.length) return null;
+  const machine = machines.find((m) => m.id === preferredId) ?? machines[0]!;
+  const single = machines.length === 1 && isGuestMachine(machines[0]!);
+  return { machine, showPicker: !single, landInTerminal: single };
+}
+
+export interface MachineSection<T extends ArrivalMachine = ArrivalMachine> {
+  title: string;
+  items: T[];
+}
+
+/**
+ * The picker's rows, split by whose they are.
+ *
+ * Shared entries are grouped under one heading and each row is named after the
+ * person who shared it — "SHARED WITH ME" over "Will's laptop" — so a guest
+ * reads the list as people rather than as inventory.
+ */
+export function machineSections<T extends ArrivalMachine>(machines: T[]): MachineSection<T>[] {
+  const mine = machines.filter((m) => !isGuestMachine(m));
+  const shared = machines
+    .filter(isGuestMachine)
+    .slice()
+    .sort((a, b) => (a.ownerName ?? '').localeCompare(b.ownerName ?? '') || a.name.localeCompare(b.name));
+  const sections: MachineSection<T>[] = [];
+  if (mine.length) sections.push({ title: 'My machines', items: mine });
+  if (shared.length) sections.push({ title: 'Shared with me', items: shared });
+  return sections;
+}
+
+/** The picker's own heading. Someone with no machines of their own owns none. */
+export function machineMenuTitle(machines: ArrivalMachine[]): string {
+  return machines.length > 0 && machines.every(isGuestMachine) ? 'Shared with you' : 'Machines';
+}
+
+/**
+ * The session to open without being asked, or null when there is a real choice.
+ *
+ * Only ever for the single-grant guest, and only when their scope holds one
+ * session: a grant covering several is a list they have to read, and picking
+ * one for them would hide the others.
+ */
+export function autoOpenSessionId(arrival: Arrival | null, sessionIds: string[]): string | null {
+  if (!arrival?.landInTerminal) return null;
+  return sessionIds.length === 1 ? sessionIds[0]! : null;
+}

--- a/relay/web/src/guest-copy.test.ts
+++ b/relay/web/src/guest-copy.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Guest voice. Two rules are pinned here: the copy names the person who
+ * shared, and the only capability vocabulary that reaches a reader is one of
+ * the two role words.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  connectionProblemCopy,
+  fitAskedCopy,
+  guestSubtitle,
+  offlineCopy,
+  ownerPossessive,
+  waitingCopy,
+  wideBannerCopy,
+} from './guest-copy';
+
+describe('ownerPossessive', () => {
+  test('names the owner when we know them', () => {
+    expect(ownerPossessive('Will')).toBe("Will's");
+  });
+
+  test('degrades to a pronoun rather than an empty possessive', () => {
+    expect(ownerPossessive(null)).toBe('their');
+    expect(ownerPossessive(undefined)).toBe('their');
+    expect(ownerPossessive('')).toBe('their');
+  });
+});
+
+describe('offlineCopy', () => {
+  test("the guest is told whose machine it is, and that we'll keep asking", () => {
+    expect(offlineCopy(true, 'Will')).toBe(
+      "Will's machine is offline right now. We'll ask again as soon as it's back.",
+    );
+  });
+
+  test('an owner keeps owner vocabulary — it is their machine', () => {
+    expect(offlineCopy(false, null)).toBe("This machine is offline. It'll appear here when it reconnects.");
+  });
+
+  test('an unknown owner still reads as somebody else\'s machine', () => {
+    expect(offlineCopy(true, null)).toContain('their machine is offline');
+  });
+});
+
+describe('connectionProblemCopy', () => {
+  test('a specific reason is never replaced by a friendlier vague one', () => {
+    const detail = 'This machine failed identity verification. The connection may be tampered with.';
+    expect(connectionProblemCopy(true, 'Will', detail)).toBe(detail);
+    expect(connectionProblemCopy(false, null, detail)).toBe(detail);
+  });
+
+  test('without a reason, each side gets its own voice', () => {
+    expect(connectionProblemCopy(true, 'Will')).toBe("Can't reach Will's machine right now.");
+    expect(connectionProblemCopy(false, null)).toBe('Connection problem.');
+  });
+});
+
+describe('waitingCopy', () => {
+  test('names the person being waited on', () => {
+    const copy = waitingCopy('Will');
+    expect(copy.title).toBe('Waiting for Will to let you in…');
+    expect(copy.body).toContain('Keep this page open');
+  });
+
+  test('says the same thing without inventing a name', () => {
+    const copy = waitingCopy(null);
+    expect(copy.title).toBe('Waiting to be let in…');
+    expect(copy.body).toContain("it'll update on its own");
+    expect(copy.body).not.toContain('null');
+  });
+});
+
+describe('guestSubtitle', () => {
+  test('shared by a person, and what you can do, in the two words', () => {
+    expect(guestSubtitle('Will', 'viewer')).toBe('Shared by Will · watching');
+    expect(guestSubtitle('Will', 'operator')).toBe('Shared by Will · watching and typing');
+  });
+
+  test('an unknown role reads as the smaller capability, never as a promise', () => {
+    expect(guestSubtitle('Will', null)).toBe('Shared by Will · watching');
+    expect(guestSubtitle('Will', 'admin')).toBe('Shared by Will · watching');
+  });
+
+  test('server role names never reach the reader', () => {
+    for (const role of ['viewer', 'operator', 'admin', null]) {
+      const line = guestSubtitle('Will', role);
+      expect(line).not.toContain('viewer');
+      expect(line).not.toContain('operator');
+      expect(line).not.toContain('grant');
+    }
+  });
+
+  test('an unknown owner still says the session came from someone', () => {
+    expect(guestSubtitle(null, 'viewer')).toBe('Shared with you · watching');
+  });
+});
+
+describe('wideBannerCopy', () => {
+  test('says whose screen it is sized for, and what to do about it', () => {
+    expect(wideBannerCopy('Will', 164)).toBe("Sized for Will's screen (164 columns). Drag sideways to read.");
+    expect(wideBannerCopy(null, 100)).toBe('Sized for their screen (100 columns). Drag sideways to read.');
+  });
+});
+
+describe('fitAskedCopy', () => {
+  test('promises nothing — the owner may say no, and then nothing changes', () => {
+    expect(fitAskedCopy('Will')).toBe(
+      'Asked Will to resize. Nothing changes unless they say yes — you can keep reading meanwhile.',
+    );
+    expect(fitAskedCopy(null)).toContain('Asked them to resize.');
+  });
+});

--- a/relay/web/src/guest-copy.test.ts
+++ b/relay/web/src/guest-copy.test.ts
@@ -37,8 +37,12 @@ describe('offlineCopy', () => {
     expect(offlineCopy(false, null)).toBe("This machine is offline. It'll appear here when it reconnects.");
   });
 
-  test('an unknown owner still reads as somebody else\'s machine', () => {
-    expect(offlineCopy(true, null)).toContain('their machine is offline');
+  test('an unknown owner still reads as somebody else\'s machine — and as a sentence', () => {
+    // display_name is nullable on the relay, so this is a real state, not a
+    // defensive branch: it must not open a sentence in lower case.
+    expect(offlineCopy(true, null)).toBe(
+      "Their machine is offline right now. We'll ask again as soon as it's back.",
+    );
   });
 });
 

--- a/relay/web/src/guest-copy.test.ts
+++ b/relay/web/src/guest-copy.test.ts
@@ -107,9 +107,13 @@ describe('wideBannerCopy', () => {
 });
 
 describe('fitAskedCopy', () => {
-  test('promises nothing — the owner may say no, and then nothing changes', () => {
+  test('promises nothing — not a resize, and not even that it was seen', () => {
+    // Two paths end in silence with the owner never prompted: a prompt
+    // already on their screen holds its place, and a size below the floor is
+    // refused. The copy must not leave someone waiting on an answer that was
+    // never going to come.
     expect(fitAskedCopy('Will')).toBe(
-      'Asked Will to resize. Nothing changes unless they say yes — you can keep reading meanwhile.',
+      'Asked Will to resize. They may not be at their desk — nothing changes unless they say yes, so keep reading meanwhile.',
     );
     expect(fitAskedCopy(null)).toContain('Asked them to resize.');
   });

--- a/relay/web/src/guest-copy.ts
+++ b/relay/web/src/guest-copy.ts
@@ -1,11 +1,7 @@
 /**
- * What the app says to a guest, in the guest's voice.
- *
- * A guest was invited by a person, so the copy names that person. Owner
- * vocabulary — "this machine", "your sessions" — describes a relationship they
- * do not have, and reads as though the app has mistaken them for someone else.
- * Apart from main.ts so it can be tested: main.ts pulls in xterm and runs
- * boot() at import time.
+ * What the app says to a guest, in the guest's voice: a guest was invited by a
+ * person, so the copy names that person. Owner vocabulary describes a
+ * relationship they do not have. Apart from main.ts so it can be tested.
  */
 
 import { roleWord } from './shares';
@@ -55,10 +51,9 @@ export function waitingCopy(ownerName?: string | null): WaitingCopy {
 }
 
 /**
- * The terminal subtitle: who shared this, and what you can do with it.
- *
- * The role reaches the reader as one of the two words and nothing else —
- * `viewer`, `operator`, `scope` and `grant` are our vocabulary, not theirs.
+ * The terminal subtitle: who shared this, and what you can do with it. The
+ * role reaches the reader as one of the two words and nothing else — `viewer`
+ * and `operator` are our vocabulary, not theirs.
  */
 export function guestSubtitle(ownerName: string | null | undefined, role: string | null | undefined): string {
   const who = ownerName ? `Shared by ${ownerName}` : 'Shared with you';

--- a/relay/web/src/guest-copy.ts
+++ b/relay/web/src/guest-copy.ts
@@ -78,11 +78,11 @@ export function wideBannerCopy(ownerName: string | null | undefined, cols: numbe
 export const FIT_ACTION = 'Fit to my screen';
 
 /**
- * After the ask. It promises nothing: the request surfaces as a prompt the
- * owner may decline, and a declined request changes nothing here — so this
- * says exactly that instead of implying a resize is on its way.
+ * After the ask. It promises nothing — not even that the request was seen: a
+ * prompt already up holds its place against a second one, and the owner may
+ * be nowhere near their desk. Silence is expected, so this makes it so.
  */
 export function fitAskedCopy(ownerName?: string | null): string {
   const who = ownerName ?? 'them';
-  return `Asked ${who} to resize. Nothing changes unless they say yes — you can keep reading meanwhile.`;
+  return `Asked ${who} to resize. They may not be at their desk — nothing changes unless they say yes, so keep reading meanwhile.`;
 }

--- a/relay/web/src/guest-copy.ts
+++ b/relay/web/src/guest-copy.ts
@@ -1,0 +1,87 @@
+/**
+ * What the app says to a guest, in the guest's voice.
+ *
+ * A guest was invited by a person, so the copy names that person. Owner
+ * vocabulary — "this machine", "your sessions" — describes a relationship they
+ * do not have, and reads as though the app has mistaken them for someone else.
+ * Apart from main.ts so it can be tested: main.ts pulls in xterm and runs
+ * boot() at import time.
+ */
+
+import { roleWord } from './shares';
+
+/** "Will's" when the name is known, "their" when it is not. Never a blank. */
+export function ownerPossessive(ownerName?: string | null): string {
+  return ownerName ? `${ownerName}'s` : 'their';
+}
+
+/**
+ * The offline state. The guest version promises the retry that actually
+ * happens — the client keeps re-opening the channel until the agent appears —
+ * rather than telling someone to wait for a machine they cannot see.
+ */
+export function offlineCopy(guest: boolean, ownerName?: string | null): string {
+  if (!guest) return "This machine is offline. It'll appear here when it reconnects.";
+  return `${ownerPossessive(ownerName)} machine is offline right now. We'll ask again as soon as it's back.`;
+}
+
+/**
+ * A connection problem. `detail` is the specific reason when there is one
+ * (identity verification, an unsupported agent) and is preferred over any
+ * voice, because a specific true sentence beats a friendly vague one.
+ */
+export function connectionProblemCopy(guest: boolean, ownerName: string | null | undefined, detail?: string): string {
+  if (detail) return detail;
+  return guest ? `Can't reach ${ownerPossessive(ownerName)} machine right now.` : 'Connection problem.';
+}
+
+export interface WaitingCopy {
+  title: string;
+  body: string;
+}
+
+/**
+ * Waiting on the owner to answer. The most-travelled path in the feature and
+ * the guest's whole first impression, so it says what is happening, that it is
+ * normal, and what to do.
+ */
+export function waitingCopy(ownerName?: string | null): WaitingCopy {
+  return {
+    title: ownerName ? `Waiting for ${ownerName} to let you in…` : 'Waiting to be let in…',
+    body: ownerName
+      ? `${ownerName} will get a prompt on their machine. Keep this page open — it'll update on its own.`
+      : "They'll get a prompt on their machine. Keep this page open — it'll update on its own.",
+  };
+}
+
+/**
+ * The terminal subtitle: who shared this, and what you can do with it.
+ *
+ * The role reaches the reader as one of the two words and nothing else —
+ * `viewer`, `operator`, `scope` and `grant` are our vocabulary, not theirs.
+ */
+export function guestSubtitle(ownerName: string | null | undefined, role: string | null | undefined): string {
+  const who = ownerName ? `Shared by ${ownerName}` : 'Shared with you';
+  return `${who} · ${roleWord(role ?? '').toLowerCase()}`;
+}
+
+/**
+ * Why the view is wider than the screen. Without it the horizontal cut-off
+ * reads as a rendering bug rather than as somebody else's terminal.
+ */
+export function wideBannerCopy(ownerName: string | null | undefined, cols: number): string {
+  return `Sized for ${ownerPossessive(ownerName)} screen (${cols} columns). Drag sideways to read.`;
+}
+
+/** The action that asks the owner to resize once. */
+export const FIT_ACTION = 'Fit to my screen';
+
+/**
+ * After the ask. It promises nothing: the request surfaces as a prompt the
+ * owner may decline, and a declined request changes nothing here — so this
+ * says exactly that instead of implying a resize is on its way.
+ */
+export function fitAskedCopy(ownerName?: string | null): string {
+  const who = ownerName ?? 'them';
+  return `Asked ${who} to resize. Nothing changes unless they say yes — you can keep reading meanwhile.`;
+}

--- a/relay/web/src/guest-copy.ts
+++ b/relay/web/src/guest-copy.ts
@@ -11,6 +11,12 @@ export function ownerPossessive(ownerName?: string | null): string {
   return ownerName ? `${ownerName}'s` : 'their';
 }
 
+/** The same, starting a sentence: `display_name` is nullable in the relay. */
+function openingPossessive(ownerName?: string | null): string {
+  const word = ownerPossessive(ownerName);
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
 /**
  * The offline state. The guest version promises the retry that actually
  * happens — the client keeps re-opening the channel until the agent appears —
@@ -18,7 +24,7 @@ export function ownerPossessive(ownerName?: string | null): string {
  */
 export function offlineCopy(guest: boolean, ownerName?: string | null): string {
   if (!guest) return "This machine is offline. It'll appear here when it reconnects.";
-  return `${ownerPossessive(ownerName)} machine is offline right now. We'll ask again as soon as it's back.`;
+  return `${openingPossessive(ownerName)} machine is offline right now. We'll ask again as soon as it's back.`;
 }
 
 /**

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -8,6 +8,23 @@ import { createReconnectScheduler } from './reconnect';
 import { clearAccountState, INVITE_STASH } from './account';
 import { endedCopy } from './ended';
 import {
+  autoOpenSessionId,
+  machineLabel,
+  machineMenuTitle,
+  machineSections,
+  planArrival,
+  type Arrival,
+} from './arrival';
+import {
+  connectionProblemCopy,
+  FIT_ACTION,
+  fitAskedCopy,
+  guestSubtitle,
+  offlineCopy,
+  waitingCopy,
+  wideBannerCopy,
+} from './guest-copy';
+import {
   confirmCopy,
   guestShareRows,
   ownerShareRows,
@@ -84,7 +101,7 @@ function toggleTheme() { const d = !isDark(); root.setAttribute('data-theme', d 
 // ---------------------------------------------------------------------------
 // App state
 // ---------------------------------------------------------------------------
-const app = { conn: null as RelayConnection | null, user: null as Me | null, machine: null as Machine | null, machines: [] as Machine[], sessions: [] as RSession[], groups: [] as RGroup[], activeId: null as string | null, fp: '', fpVerified: false, devLogin: false };
+const app = { conn: null as RelayConnection | null, user: null as Me | null, machine: null as Machine | null, machines: [] as Machine[], sessions: [] as RSession[], groups: [] as RGroup[], activeId: null as string | null, fp: '', fpVerified: false, devLogin: false, arrival: null as Arrival<Machine> | null, landed: false };
 const rootEl = document.getElementById('root')!;
 
 // history-layer nav so Back works within the app
@@ -237,25 +254,51 @@ async function renderRedeem(code: string): Promise<void> {
     return;
   }
 
+  const grant = (await res.json().catch(() => ({}))) as { grant?: { id?: string } };
   history.replaceState(null, '', '/');
-  renderWaitingForApproval();
+  renderWaitingForApproval(grant.grant?.id ?? null);
 }
 
 /**
  * The most-travelled path in the whole feature, and the guest's entire first
  * impression. It must say what is happening, that it is normal, and what to
  * do — a spinner alone reads as broken.
+ *
+ * The person is named as soon as we know who they are, which is not at
+ * redemption: `/api/machines` lists only countersigned grants, so the owner's
+ * name comes from the guest's own share list instead. Until it lands the copy
+ * says the same thing without inventing a name.
  */
-function renderWaitingForApproval(): void {
-  rootEl.innerHTML = `<div class="screen-center"><div class="card-center">
-    <div class="logo">⏳</div>
-    <h1>Waiting to be let in…</h1>
-    <p>They'll get a prompt on their machine. Keep this page open — it'll update on its own.</p>
-    <div class="spinner" style="margin:18px auto"></div>
-    <button class="btn ghost" id="checkNow">Check now</button>
-  </div></div>`;
-  $('#checkNow')!.onclick = () => void pollForGrant(true);
+function renderWaitingForApproval(grantId: string | null): void {
+  const paint = (ownerName: string | null) => {
+    const copy = waitingCopy(ownerName);
+    rootEl.innerHTML = `<div class="screen-center"><div class="card-center">
+      <div class="logo">⏳</div>
+      <h1>${esc(copy.title)}</h1>
+      <p>${esc(copy.body)}</p>
+      <div class="spinner" style="margin:18px auto"></div>
+      <button class="btn ghost" id="checkNow">Check now</button>
+    </div></div>`;
+    $('#checkNow')!.onclick = () => void pollForGrant(true);
+  };
+  paint(null);
+  // Repaint only if this screen is still the one on show — the owner may have
+  // answered while the lookup was in flight, and the terminal must not be
+  // replaced by a waiting screen that is no longer true.
+  if (grantId) void nameTheOwner(grantId).then((name) => { if (name && $('#checkNow')) paint(name); });
   void pollForGrant(false);
+}
+
+/** Who the guest is waiting on, from their own share list. Null if unknown. */
+async function nameTheOwner(grantId: string): Promise<string | null> {
+  try {
+    const res = await api('/api/shares');
+    if (!res.ok) return null;
+    const body = (await res.json()) as { grants: WireMyShare[] };
+    return body.grants.find((g) => g.id === grantId)?.ownerName ?? null;
+  } catch {
+    return null;
+  }
 }
 
 let waitTimer: ReturnType<typeof setTimeout> | null = null;
@@ -321,13 +364,22 @@ function renderApp(machines: Machine[]) {
     return;
   }
   // Pick the last machine the user chose here, else the first. A machine
-  // switcher (the pill) lets them change it or link another.
-  //
-  // A guest with exactly one grant should never see a picker: choosing
-  // between one thing is not a choice, and "machine" is owner vocabulary
-  // anyway — they were invited to a session by a person.
-  const preferredId = localStorage.getItem('bodhi.machineId');
-  app.machine = machines.find((m) => m.id === preferredId) ?? machines[0]!;
+  // switcher (the pill) lets them change it or link another — except for the
+  // single-grant guest, who is offered neither: choosing between one thing is
+  // not a choice, and "machine" is owner vocabulary anyway. They were invited
+  // to a session by a person, so that is where they land.
+  app.arrival = planArrival(machines, localStorage.getItem('bodhi.machineId'));
+  app.machine = app.arrival!.machine;
+  app.landed = false;
+  // No pill at all for the single-grant guest: it would be a switcher with
+  // nothing to switch to, over a word ("machine") that describes a
+  // relationship they don't have. The connection state reaches them through
+  // the terminal's own strip instead — that is the pane they land on.
+  const pill = app.arrival!.showPicker
+    ? `<button class="machine-pill" id="machineBtn"><span class="dot off" id="mdot"></span> <span>${esc(
+        machineLabel(app.machine),
+      )}</span></button>`
+    : '';
 
   rootEl.innerHTML = `
   <div class="app">
@@ -337,11 +389,7 @@ function renderApp(machines: Machine[]) {
         <button class="iconbtn" id="theme" aria-label="Toggle light/dark theme">◐</button>
         ${accountButton()}
       </header>
-      <div class="pill-row"><button class="machine-pill" id="machineBtn"><span class="dot off" id="mdot"></span> <span>${esc(
-        app.machine.relation === 'grantee' && app.machine.ownerName
-          ? `${app.machine.ownerName}'s ${app.machine.name}`
-          : app.machine.name,
-      )}</span></button><button class="sharebtn" id="shareBtn"><span aria-hidden="true">🤝</span> ${isGuest() ? 'Your access' : 'Sharing'}</button></div>
+      <div class="pill-row">${pill}<button class="sharebtn" id="shareBtn"><span aria-hidden="true">🤝</span> ${isGuest() ? 'Your access' : 'Sharing'}</button></div>
       <div class="list-head"><h2>Sessions</h2><span class="attn-count hidden" id="attn"></span></div>
       <ul class="sessions" id="sessions"><li class="empty-note"><div class="spinner"></div><p style="margin-top:14px">Connecting securely…</p></li></ul>
       <button class="fab" id="fab" aria-label="New session">＋</button>
@@ -353,6 +401,7 @@ function renderApp(machines: Machine[]) {
         <div class="term-title grow"><div class="t-name" id="tName">—</div><div class="t-meta" id="tMeta"></div></div>
         <button class="iconbtn" id="fpBtn2" aria-label="Connection details">🔒</button>
       </header>
+      <div class="conn-strip hidden" id="connStrip" role="status"></div>
       <div class="screen" id="screen"></div>
       <div class="compose">
         <div class="attn-banner hidden" id="attnBanner">✻ This session is waiting for your response</div>
@@ -372,11 +421,16 @@ function renderApp(machines: Machine[]) {
   $('#acct')!.onclick = openAccount;
   $('#fab')!.onclick = openCreate;
   $('#fpBtn')!.onclick = openFp; $('#fpBtn2')!.onclick = openFp;
-  $('#machineBtn')!.onclick = openMachineMenu;
+  const machineBtn = $('#machineBtn');
+  if (machineBtn) machineBtn.onclick = openMachineMenu;
   $('#shareBtn')!.onclick = () => (isGuest() ? openMyShares() : openSharing());
   $('#back')!.onclick = () => history.back();
-  if (isGuest()) applyWatchOnly();
-  else { buildKeys(); setupCompose(); }
+  if (isGuest()) {
+    applyWatchOnly();
+    // Creating sessions belongs to no guest role, so the button could only
+    // ever produce a refusal. Offering it is a promise the machine will break.
+    $('#fab')?.remove();
+  } else { buildKeys(); setupCompose(); }
   connect();
 }
 
@@ -427,8 +481,18 @@ function applyWatchOnly(): void {
 }
 
 /**
- * Tell a guest their view is wider than their screen, and whose screen it is
- * sized for. Without this the horizontal cut-off reads as a rendering bug.
+ * How long the "asked" state stands before the ask is offered again. The
+ * owner may simply not have been at their desk, and a button that claims a
+ * request is still live forever is a worse lie than letting them ask twice.
+ */
+const FIT_ASK_MS = 45_000;
+let fitAskedAt = 0;
+let wideBannerKey = '';
+
+/**
+ * Tell a guest their view is wider than their screen, whose screen it is
+ * sized for, and offer the one thing they can do about it. Without this the
+ * horizontal cut-off reads as a rendering bug.
  */
 function updateWideBanner(screenEl: HTMLElement): void {
   const id = 'wideBanner';
@@ -437,15 +501,49 @@ function updateWideBanner(screenEl: HTMLElement): void {
   let banner = document.getElementById(id);
 
   if (!overflows || !cols) {
+    // It fits — which is also what an accepted request looks like from here.
     banner?.remove();
+    wideBannerKey = '';
+    fitAskedAt = 0;
     return;
   }
   if (!banner) {
     banner = h('div', { id, class: 'wide-banner', role: 'status' });
     screenEl.parentElement?.insertBefore(banner, screenEl);
+    wideBannerKey = '';
   }
-  const owner = app.machine?.ownerName;
-  banner.textContent = `Sized for ${owner ? `${owner}'s` : 'their'} screen (${cols} columns). Drag sideways to read.`;
+  const owner = app.machine?.ownerName ?? null;
+  const asked = Date.now() - fitAskedAt < FIT_ASK_MS;
+  // Rebuilt only when it would actually read differently: this runs on every
+  // resize and every terminal:size, and replacing the markup underneath a
+  // finger takes the button away mid-press.
+  const key = `${asked}|${cols}|${owner ?? ''}`;
+  if (key === wideBannerKey) return;
+  wideBannerKey = key;
+  banner.innerHTML = `<span class="wide-text">${esc(asked ? fitAskedCopy(owner) : wideBannerCopy(owner, cols))}</span>${
+    asked ? '' : `<button class="fitbtn" id="fitBtn">${esc(FIT_ACTION)}</button>`
+  }`;
+  const fit = $<HTMLButtonElement>('#fitBtn');
+  if (fit) fit.onclick = requestFit;
+}
+
+/**
+ * Ask the owner to resize this session to fit our screen.
+ *
+ * A guest never sends `terminal:resize` — their phone must not reflow somebody
+ * else's terminal. This is a request: the owner's desktop turns it into a
+ * one-tap prompt, and a declined one changes nothing here, which is why the
+ * copy below promises nothing.
+ */
+function requestFit(): void {
+  if (!term || !fitAddon || !app.activeId) return;
+  const dims = fitAddon.proposeDimensions();
+  if (!dims?.cols || !dims.rows || !isFinite(dims.cols) || !isFinite(dims.rows)) return;
+  app.conn?.command({ type: 'terminal:resize-request', sessionId: app.activeId, cols: dims.cols, rows: dims.rows });
+  fitAskedAt = Date.now();
+  const refresh = () => { const el = $<HTMLElement>('#screen'); if (el) updateWideBanner(el); };
+  refresh();
+  setTimeout(refresh, FIT_ASK_MS + 500); // unanswered long enough — offer the ask again
 }
 
 // ---------------------------------------------------------------------------
@@ -500,12 +598,27 @@ function renderEnded(reason: string): void {
   </div></div>`;
 }
 
+/**
+ * The connection's state where a guest can actually see it.
+ *
+ * A guest who landed straight in the terminal never looks at the session
+ * list, so the list's own empty note reaches nobody — the strip sits above
+ * their screen instead. Empty text hides it rather than leaving a gap.
+ */
+function setConnStrip(text: string | null): void {
+  const strip = $('#connStrip');
+  if (!strip) return;
+  strip.textContent = text ?? '';
+  strip.classList.toggle('hidden', !text);
+}
+
 function onConnState(s: ConnState, detail?: string) {
   if (s === 'denied') return renderEnded(detail ?? 'revoked');
   const dot = $('#mdot'); const list = $('#sessions');
   if (s === 'ready') {
     machineOffline = false;
     reconnector.cancel();
+    setConnStrip(null);
     dot?.classList.remove('off');
     app.conn!.command({ type: 'groups:list' });
     app.conn!.command({ type: 'sessions:list' });
@@ -513,16 +626,23 @@ function onConnState(s: ConnState, detail?: string) {
   } else if (s === 'offline') {
     machineOffline = true;
     stopPolling(); dot?.classList.add('off');
-    if (list) list.innerHTML = `<li class="empty-note"><div style="font-size:28px">🌙</div><p>This machine is offline. It'll appear here when it reconnects.</p></li>`;
+    // Whose machine it is, and that we keep asking — a guest cannot go and
+    // look at the desktop, so "it'll appear here" is advice for its owner.
+    const offline = offlineCopy(isGuest(), app.machine?.ownerName);
+    if (list) list.innerHTML = `<li class="empty-note"><div style="font-size:28px">🌙</div><p>${esc(offline)}</p></li>`;
+    setConnStrip(offline);
     reconnector.schedule(3000); // agent not connected yet — keep polling until it appears
   } else if (s === 'error') {
     // A hard error (e.g. identity-verification failure) should surface, not retry.
     // Cancel any reconnect queued by a prior offline/closed so it can't fire on top.
     reconnector.cancel();
     stopPolling(); dot?.classList.add('off');
-    if (list) list.innerHTML = `<li class="empty-note"><div style="font-size:28px">⚠️</div><p>${esc(detail || 'Connection problem.')}</p></li>`;
+    const problem = connectionProblemCopy(isGuest(), app.machine?.ownerName, detail);
+    if (list) list.innerHTML = `<li class="empty-note"><div style="font-size:28px">⚠️</div><p>${esc(problem)}</p></li>`;
+    setConnStrip(problem);
   } else if (s === 'closed') {
     stopPolling(); dot?.classList.add('off');
+    setConnStrip('Reconnecting…');
     reconnector.schedule(3000); // socket dropped — reconnect
   }
 }
@@ -537,6 +657,7 @@ function onAgentMessage(m: Inner) {
     lastSessionsJson = j;
     app.sessions = list;
     renderSessions();
+    maybeLandInTerminal();
     updateTermHeader(); // keep the open terminal's state chip / attention banner live
     return;
   }
@@ -557,6 +678,22 @@ function onAgentMessage(m: Inner) {
   }
   if (m.type === 'terminal:exit') { if (m.sessionId === app.activeId && term) term.write('\r\n\x1b[90m[session exited]\x1b[0m\r\n'); return; }
   if (m.type === 'error') { /* surface transient errors */ console.warn('agent error:', m.message); }
+}
+
+/**
+ * The single-grant guest's arrival: open the one session they were sent to.
+ *
+ * Once only. The list is polled every couple of seconds, so re-deciding on
+ * every refresh would drag someone who tapped Back straight into the terminal
+ * again — landing is an arrival, not a policy.
+ */
+function maybeLandInTerminal(): void {
+  if (app.landed || app.activeId) return;
+  const id = autoOpenSessionId(app.arrival, app.sessions.map((x) => x.id));
+  const session = app.sessions.find((x) => x.id === id);
+  if (!session) return;
+  app.landed = true;
+  openTerminal(session);
 }
 
 // ---------------------------------------------------------------------------
@@ -761,13 +898,25 @@ function syncTermPane() {
   tp.style.top = vv.offsetTop + 'px';
 }
 
+/**
+ * The subtitle under the session name.
+ *
+ * A guest is told who shared this and what they can do with it, in the two
+ * role words and nothing else. The folder a session lives in is the owner's
+ * context, and is not disclosed to a guest anywhere else either.
+ */
+function termMeta(s: RSession): string {
+  if (isGuest()) return esc(guestSubtitle(app.machine?.ownerName, app.machine?.role));
+  const gp = groupPath(s.groupId);
+  return `<span>${s.state === 'waiting' ? '● waiting for you' : esc(s.state)}</span> · ${esc(gp.label)}`;
+}
+
 function updateTermHeader() {
   if (!app.activeId) return;
   const s = app.sessions.find((x) => x.id === app.activeId);
   const meta = $('#tMeta'); const banner = $('#attnBanner');
   if (!s || !meta) return;
-  const gp = groupPath(s.groupId);
-  meta.innerHTML = `<span>${s.state === 'waiting' ? '● waiting for you' : esc(s.state)}</span> · ${esc(gp.label)}`;
+  meta.innerHTML = termMeta(s);
   banner?.classList.toggle('hidden', s.state !== 'waiting');
 }
 
@@ -776,8 +925,7 @@ function openTerminal(s: RSession) {
   ensureTerm();
   term!.clear();
   $('#tName')!.textContent = s.name;
-  const gp = groupPath(s.groupId);
-  $('#tMeta')!.innerHTML = `<span class="${s.state === 'waiting' ? '' : ''}">${s.state === 'waiting' ? '● waiting for you' : s.state}</span> · ${esc(gp.label)}`;
+  $('#tMeta')!.innerHTML = termMeta(s);
   $('#attnBanner')!.classList.toggle('hidden', s.state !== 'waiting');
   document.body.setAttribute('data-view', 'term');
   syncTermPane();
@@ -1223,11 +1371,12 @@ async function del(path: string): Promise<number | null> {
 // Machine switching + linking
 // ---------------------------------------------------------------------------
 function openMachineMenu() {
+  const title = machineMenuTitle(app.machines);
   const scrim = document.createElement('div');
   scrim.className = 'sheet-scrim open';
   scrim.innerHTML = `<div class="sheet" role="dialog" aria-modal="true" aria-labelledby="mmh">
-    <div class="sheet-head"><h3 id="mmh">Machines</h3><button class="iconbtn" id="mmx" aria-label="Close">✕</button></div>
-    <ul class="grouptree" id="mmList" role="listbox" aria-label="Choose a machine"></ul>
+    <div class="sheet-head"><h3 id="mmh">${esc(title)}</h3><button class="iconbtn" id="mmx" aria-label="Close">✕</button></div>
+    <ul class="grouptree" id="mmList" role="listbox" aria-label="${escAttr(title)}"></ul>
     <button class="newgroup" id="mmLink">＋ Link another machine</button>
   </div>`;
   document.body.appendChild(scrim);
@@ -1235,16 +1384,25 @@ function openMachineMenu() {
   scrim.onclick = (e) => { if (e.target === scrim) history.back(); };
   $('#mmx')!.onclick = () => history.back();
   const list = $('#mmList')!;
-  for (const m of app.machines) {
-    const sel = m.id === app.machine?.id;
-    const b = h('button', { class: 'gitem', role: 'option', 'aria-selected': String(sel) },
-      `<span class="g-dot" style="background:${sel ? 'var(--idle)' : 'var(--stop)'}"></span><span class="g-name">${esc(m.name)}</span><span class="g-check">✓</span>`);
-    b.onclick = () => {
-      if (sel) { history.back(); return; }
-      localStorage.setItem('bodhi.machineId', m.id);
-      location.reload();
-    };
-    const li = document.createElement('li'); li.appendChild(b); list.appendChild(li);
+  // Sectioned, and shared rows labelled by the person who shared them:
+  // "SHARED WITH ME" over "Will's laptop". A guest reads the list as people.
+  for (const section of machineSections(app.machines)) {
+    const head = document.createElement('li');
+    head.className = 'gsection';
+    head.setAttribute('role', 'presentation');
+    head.textContent = section.title;
+    list.appendChild(head);
+    for (const m of section.items) {
+      const sel = m.id === app.machine?.id;
+      const b = h('button', { class: 'gitem machine', role: 'option', 'aria-selected': String(sel) },
+        `<span class="g-dot" style="background:${sel ? 'var(--idle)' : 'var(--stop)'}"></span><span class="g-name">${esc(machineLabel(m))}</span><span class="g-check">✓</span>`);
+      b.onclick = () => {
+        if (sel) { history.back(); return; }
+        localStorage.setItem('bodhi.machineId', m.id);
+        location.reload();
+      };
+      const li = document.createElement('li'); li.appendChild(b); list.appendChild(li);
+    }
   }
   // Stack the link sheet on top of the menu (like the create → new-group
   // flow). Do NOT history.back() first: popstate is async and would fire

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -482,8 +482,8 @@ function applyWatchOnly(): void {
 
 /**
  * How long the "asked" state stands before the ask is offered again. The
- * owner may simply not have been at their desk, and a button that claims a
- * request is still live forever is a worse lie than letting them ask twice.
+ * owner may not have been at their desk, and a button claiming a request is
+ * still live forever is a worse lie than letting someone ask twice.
  */
 const FIT_ASK_MS = 45_000;
 let fitAskedAt = 0;
@@ -528,12 +528,9 @@ function updateWideBanner(screenEl: HTMLElement): void {
 }
 
 /**
- * Ask the owner to resize this session to fit our screen.
- *
- * A guest never sends `terminal:resize` — their phone must not reflow somebody
- * else's terminal. This is a request: the owner's desktop turns it into a
- * one-tap prompt, and a declined one changes nothing here, which is why the
- * copy below promises nothing.
+ * Ask the owner to resize this session to fit our screen. A guest never sends
+ * `terminal:resize` — their phone must not reflow somebody else's terminal.
+ * A declined request changes nothing here, so the copy promises nothing.
  */
 function requestFit(): void {
   if (!term || !fitAddon || !app.activeId) return;
@@ -599,11 +596,9 @@ function renderEnded(reason: string): void {
 }
 
 /**
- * The connection's state where a guest can actually see it.
- *
- * A guest who landed straight in the terminal never looks at the session
- * list, so the list's own empty note reaches nobody — the strip sits above
- * their screen instead. Empty text hides it rather than leaving a gap.
+ * The connection's state where a guest can actually see it: one who landed
+ * straight in the terminal never looks at the session list, so that pane's
+ * empty note reaches nobody. Empty text hides the strip rather than gap it.
  */
 function setConnStrip(text: string | null): void {
   const strip = $('#connStrip');
@@ -682,10 +677,8 @@ function onAgentMessage(m: Inner) {
 
 /**
  * The single-grant guest's arrival: open the one session they were sent to.
- *
- * Once only. The list is polled every couple of seconds, so re-deciding on
- * every refresh would drag someone who tapped Back straight into the terminal
- * again — landing is an arrival, not a policy.
+ * Once only — the list is polled, so deciding again on each refresh would
+ * drag someone who tapped Back straight back in. An arrival, not a policy.
  */
 function maybeLandInTerminal(): void {
   if (app.landed || app.activeId) return;
@@ -899,11 +892,9 @@ function syncTermPane() {
 }
 
 /**
- * The subtitle under the session name.
- *
- * A guest is told who shared this and what they can do with it, in the two
- * role words and nothing else. The folder a session lives in is the owner's
- * context, and is not disclosed to a guest anywhere else either.
+ * The subtitle under the session name. A guest is told who shared this and
+ * what they can do with it; the folder it lives in is the owner's context,
+ * and is not disclosed to a guest anywhere else either.
  */
 function termMeta(s: RSession): string {
   if (isGuest()) return esc(guestSubtitle(app.machine?.ownerName, app.machine?.role));

--- a/relay/web/src/main.ts
+++ b/relay/web/src/main.ts
@@ -4,7 +4,7 @@ import { Terminal } from '@xterm/xterm';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { FitAddon } from '@xterm/addon-fit';
 import { RelayConnection, type ConnState, type Inner } from './connection';
-import { createReconnectScheduler } from './reconnect';
+import { createReconnectScheduler, readyCommands } from './reconnect';
 import { clearAccountState, INVITE_STASH } from './account';
 import { endedCopy } from './ended';
 import {
@@ -13,6 +13,7 @@ import {
   machineMenuTitle,
   machineSections,
   planArrival,
+  showSectionTitles,
   type Arrival,
 } from './arrival';
 import {
@@ -615,8 +616,10 @@ function onConnState(s: ConnState, detail?: string) {
     reconnector.cancel();
     setConnStrip(null);
     dot?.classList.remove('off');
-    app.conn!.command({ type: 'groups:list' });
-    app.conn!.command({ type: 'sessions:list' });
+    // Including the open terminal's subscription: a reconnect is a new socket
+    // and the agent's new client session has none, so without re-asking the
+    // page reads connected while nothing arrives on it ever again.
+    for (const c of readyCommands(app.activeId)) app.conn!.command(c);
     startPolling(); // keep the list live (new/removed sessions + state changes)
   } else if (s === 'offline') {
     machineOffline = true;
@@ -677,12 +680,11 @@ function onAgentMessage(m: Inner) {
 
 /**
  * The single-grant guest's arrival: open the one session they were sent to.
- * Once only — the list is polled, so deciding again on each refresh would
- * drag someone who tapped Back straight back in. An arrival, not a policy.
+ * Whether this is still owed is `autoOpenSessionId`'s decision, tested there.
  */
 function maybeLandInTerminal(): void {
-  if (app.landed || app.activeId) return;
-  const id = autoOpenSessionId(app.arrival, app.sessions.map((x) => x.id));
+  const opened = { landed: app.landed, activeId: app.activeId };
+  const id = autoOpenSessionId(app.arrival, app.sessions.map((x) => x.id), opened);
   const session = app.sessions.find((x) => x.id === id);
   if (!session) return;
   app.landed = true;
@@ -1159,12 +1161,17 @@ function openAccount() {
       </div>
     </div>
     ${handle}
-    <button class="btn ghost" id="accOut" style="margin-top:18px">Sign out</button>
+    <button class="btn ghost" id="accLink" style="margin-top:18px">Link a machine</button>
+    <button class="btn ghost" id="accOut" style="margin-top:10px">Sign out</button>
   </div>`;
   document.body.appendChild(scrim);
   pushLayer(() => scrim.remove());
   scrim.onclick = (e) => { if (e.target === scrim) history.back(); };
   $('#accx')!.onclick = () => history.back();
+  // The pill's menu is the other way in, and a single-grant guest has no pill.
+  // Someone who owns a machine and was then invited to a session must not lose
+  // the ability to link their own — this sheet is reachable from every screen.
+  $('#accLink')!.onclick = () => openLinkMachine();
   $('#accOut')!.onclick = (e) => void signOut({ btn: e.currentTarget as HTMLButtonElement });
 }
 
@@ -1377,12 +1384,16 @@ function openMachineMenu() {
   const list = $('#mmList')!;
   // Sectioned, and shared rows labelled by the person who shared them:
   // "SHARED WITH ME" over "Will's laptop". A guest reads the list as people.
-  for (const section of machineSections(app.machines)) {
-    const head = document.createElement('li');
-    head.className = 'gsection';
-    head.setAttribute('role', 'presentation');
-    head.textContent = section.title;
-    list.appendChild(head);
+  const sections = machineSections(app.machines);
+  const titled = showSectionTitles(sections);
+  for (const section of sections) {
+    if (titled) {
+      const head = document.createElement('li');
+      head.className = 'gsection';
+      head.setAttribute('role', 'presentation');
+      head.textContent = section.title;
+      list.appendChild(head);
+    }
     for (const m of section.items) {
       const sel = m.id === app.machine?.id;
       const b = h('button', { class: 'gitem machine', role: 'option', 'aria-selected': String(sel) },

--- a/relay/web/src/reconnect.test.ts
+++ b/relay/web/src/reconnect.test.ts
@@ -5,7 +5,7 @@
  * Run with: bun test relay/web/src/reconnect.test.ts
  */
 import { describe, expect, test } from 'bun:test';
-import { createReconnectScheduler } from './reconnect';
+import { createReconnectScheduler, readyCommands } from './reconnect';
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -59,5 +59,27 @@ describe('createReconnectScheduler', () => {
     s.schedule(10);
     await wait(25);
     expect(count).toBe(2);
+  });
+});
+
+describe('readyCommands', () => {
+  test('a channel with nothing open asks for the lists and no more', () => {
+    expect(readyCommands(null)).toEqual([{ type: 'groups:list' }, { type: 'sessions:list' }]);
+  });
+
+  test('an open terminal is re-subscribed on every ready, including a reconnect', () => {
+    // A reconnect is a NEW socket, and the agent's new client session holds no
+    // subscriptions. Without this the page reads connected — the strip clears,
+    // the dot goes green — while that terminal receives nothing ever again.
+    // A guest who landed straight in it has no row left to tap to fix it.
+    expect(readyCommands('s1')).toEqual([
+      { type: 'groups:list' },
+      { type: 'sessions:list' },
+      { type: 'terminal:subscribe', sessionId: 's1' },
+    ]);
+  });
+
+  test('the lists come first — the subscribe is the last thing sent', () => {
+    expect(readyCommands('s1').at(-1)).toEqual({ type: 'terminal:subscribe', sessionId: 's1' });
   });
 });

--- a/relay/web/src/reconnect.ts
+++ b/relay/web/src/reconnect.ts
@@ -16,6 +16,25 @@ export interface ReconnectScheduler {
   readonly pending: boolean;
 }
 
+/** A command to send, in the order it must be sent. Shaped as a wire frame. */
+export interface ReadyCommand {
+  type: string;
+  sessionId?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * What to send the moment a channel reports ready. A reconnect is a NEW
+ * socket whose client session has no subscriptions, so an open terminal
+ * receives nothing until it asks again — and a guest who landed directly in
+ * one has no row left to tap.
+ */
+export function readyCommands(activeSessionId: string | null): ReadyCommand[] {
+  const commands: ReadyCommand[] = [{ type: 'groups:list' }, { type: 'sessions:list' }];
+  if (activeSessionId) commands.push({ type: 'terminal:subscribe', sessionId: activeSessionId });
+  return commands;
+}
+
 export function createReconnectScheduler(opts: {
   isAlive: () => boolean;
   reconnect: () => void;

--- a/relay/web/src/reconnect.ts
+++ b/relay/web/src/reconnect.ts
@@ -24,10 +24,9 @@ export interface ReadyCommand {
 }
 
 /**
- * What to send the moment a channel reports ready. A reconnect is a NEW
- * socket whose client session has no subscriptions, so an open terminal
- * receives nothing until it asks again — and a guest who landed directly in
- * one has no row left to tap.
+ * What to send when a channel reports ready. A reconnect is a NEW socket
+ * whose client session has no subscriptions, so an open terminal receives
+ * nothing until it asks again — and a landed guest has no row left to tap.
  */
 export function readyCommands(activeSessionId: string | null): ReadyCommand[] {
   const commands: ReadyCommand[] = [{ type: 'groups:list' }, { type: 'sessions:list' }];

--- a/relay/web/src/styles.css
+++ b/relay/web/src/styles.css
@@ -254,7 +254,7 @@ input, textarea { font-family: inherit; }
   line-height: 1.4;
   color: var(--muted);
   background: var(--panel-2, rgba(127, 127, 127, 0.08));
-  border: 1px solid var(--border);
+  border: 1px solid var(--hair);
 }
 
 /* The screen is focusable for guests, so it must show focus. */
@@ -281,7 +281,7 @@ input, textarea { font-family: inherit; }
   line-height: 1.4;
   color: var(--muted);
   background: var(--panel-2, rgba(127, 127, 127, 0.08));
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--hair);
 }
 
 .wide-text { flex: 1; min-width: 0; }
@@ -309,7 +309,7 @@ input, textarea { font-family: inherit; }
   line-height: 1.4;
   color: var(--muted);
   background: var(--panel-2, rgba(127, 127, 127, 0.08));
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--hair);
 }
 
 /* --------------------------------------------------------------------------

--- a/relay/web/src/styles.css
+++ b/relay/web/src/styles.css
@@ -198,6 +198,11 @@ input, textarea { font-family: inherit; }
 .g-dot { width: 9px; height: 9px; border-radius: 3px; flex: none; }
 .g-name { font-weight: 600; font-size: 14px; white-space: nowrap; flex: none; max-width: 45%; overflow: hidden; text-overflow: ellipsis; }
 .g-name.subname { font-weight: 500; }
+/* Machine rows carry no path column, so the name gets the whole width — a
+   person-labelled one ("Will's laptop") is longer than a folder name. */
+.gitem.machine .g-name { flex: 1; max-width: none; }
+/* Whose machines these are. A heading, not an option: skipped by the listbox. */
+.gsection { font-size: 12px; font-family: var(--mono); text-transform: uppercase; letter-spacing: .05em; color: var(--faint); padding: 10px 11px 4px; }
 .g-dir { flex: 1; min-width: 0; text-align: right; font-family: var(--mono); font-size: 11px; color: var(--faint); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .g-check { color: var(--accent); font-size: 13px; opacity: 0; flex: none; }
 .gitem[aria-selected="true"] .g-check { opacity: 1; }
@@ -268,8 +273,39 @@ input, textarea { font-family: inherit; }
 }
 
 .wide-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   padding: 7px 12px;
   font-size: 12px;
+  line-height: 1.4;
+  color: var(--muted);
+  background: var(--panel-2, rgba(127, 127, 127, 0.08));
+  border-bottom: 1px solid var(--border);
+}
+
+.wide-text { flex: 1; min-width: 0; }
+
+/* The request half of the sizing story. 44×44 like every other new control. */
+.fitbtn {
+  flex: none;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0 14px;
+  border-radius: 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--accent-dim);
+}
+
+.fitbtn:active { background: color-mix(in srgb, var(--accent) 22%, transparent); }
+
+/* Connection state where a guest who landed in the terminal can see it —
+   they never look at the session list, which is where it used to be said. */
+.conn-strip {
+  padding: 8px 12px;
+  font-size: 12.5px;
   line-height: 1.4;
   color: var(--muted);
   background: var(--panel-2, rgba(127, 127, 127, 0.08));

--- a/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
+++ b/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
@@ -421,6 +421,38 @@ describe('scoped disclosure', () => {
     const output = h.opened('c1', key).filter((m) => m.type === 'terminal:output');
     expect(output.map((o) => o.data).join('')).toContain('OWNER SCROLLBACK');
   });
+
+  test('a replay clears the screen first, whoever it is for', async () => {
+    // The frame means "here is the whole buffer". A client that subscribes
+    // WITHOUT wiping its own screen first — a reconnect re-subscribing, rather
+    // than a tap that cleared locally — would otherwise draw the entire
+    // scrollback again underneath what it is already showing.
+    const h = harness();
+    const key = h.openChannel('c1', { principal: { userId: OWNER_ID } })!;
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    await Bun.sleep(5);
+
+    const output = h.opened('c1', key).filter((m) => m.type === 'terminal:output');
+    expect(String(output[0]!.data).startsWith('\x1b[2J\x1b[3J\x1b[H')).toBe(true);
+  });
+
+  test('re-subscribing after a reconnect does not stack a second copy', async () => {
+    // The shape of the regression: one socket drops, the client re-subscribes
+    // on the new one, and the buffer arrives again. Every replay must be
+    // preceded by its own clear, not just the first.
+    const h = harness();
+    const key = h.openChannel('c1', { principal: { userId: OWNER_ID } })!;
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    await Bun.sleep(5);
+    h.send('c1', key, 1, { type: 'terminal:subscribe', sessionId: 's1' });
+    await Bun.sleep(5);
+
+    const output = h.opened('c1', key).filter((m) => m.type === 'terminal:output');
+    const replays = output.filter((o) => String(o.data).includes('OWNER SCROLLBACK'));
+    const clears = output.filter((o) => String(o.data).includes('\x1b[2J'));
+    expect(replays).toHaveLength(2);
+    expect(clears).toHaveLength(2);
+  });
 });
 
 /**

--- a/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
+++ b/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
@@ -17,7 +17,14 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import crypto from 'crypto';
 import { SessionTunnel } from '../session-tunnel';
-import type { Principal, TunnelDeps, TunnelSessionRow, TunnelGroupRow, TunnelStoredGrant } from '../session-tunnel';
+import type {
+  GuestResizeRequest,
+  Principal,
+  TunnelDeps,
+  TunnelSessionRow,
+  TunnelGroupRow,
+  TunnelStoredGrant,
+} from '../session-tunnel';
 import { deriveSessionKey, sealJson, openJson, buildHandshakeProof } from '../e2e';
 import { COMMAND_CAPS } from '../grants';
 
@@ -929,5 +936,126 @@ describe('a refused command is not an ended session', () => {
     const seen = h.opened('c1', key);
     expect(seen.some((m) => m.type === 'denied' && m.reason === 'revoked')).toBe(true);
     expect(seen.some((m) => m.type === 'command:denied')).toBe(false);
+  });
+});
+
+describe('a guest asking to be fitted to their screen', () => {
+  /** A harness whose clock the test can move, plus the requests it forwarded. */
+  function askHarness() {
+    const requests: GuestResizeRequest[] = [];
+    const resizes: string[] = [];
+    let now = NOW;
+    const h = harness({
+      grantRow: storedGrant(),
+      now: () => now,
+      onResizeRequest: (request) => requests.push(request),
+    });
+    h.deps.pty.resize = (id, cols, rows) => resizes.push(`${id}:${cols}x${rows}`);
+    const key = h.openChannel('c1', { principal: { userId: GUEST_ID, githubLogin: 'dana-k' }, certificate: mintCertificate() })!;
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    return { h, key, requests, resizes, advance: (ms: number) => { now += ms; } };
+  }
+
+  test('a viewer may ask — and the ask resizes nothing', () => {
+    // The whole point of a request message: a phone must never reflow the
+    // owner's terminal, so this reaches the owner's UI and stops there.
+    const { h, key, requests, resizes } = askHarness();
+
+    h.send('c1', key, 1, { type: 'terminal:resize-request', sessionId: 's1', cols: 80, rows: 24 });
+
+    expect(requests).toEqual([
+      { sessionId: 's1', cols: 80, rows: 24, login: 'dana-k', displayName: null },
+    ]);
+    expect(resizes).toEqual([]);
+    expect(h.opened('c1', key).some((m) => m.type === 'command:denied')).toBe(false);
+  });
+
+  test('a client with no grant cannot ask at all', () => {
+    // DENY_ALL holds no capabilities, so the gate refuses this like anything
+    // else — asking is not a back door around having been let in.
+    const { h, key, requests } = askHarness();
+    h.tunnel.revokeClient('c1');
+
+    h.send('c1', key, 1, { type: 'terminal:resize-request', sessionId: 's1', cols: 80, rows: 24 });
+
+    expect(requests).toEqual([]);
+    expect(h.opened('c1', key).some((m) => m.type === 'command:denied' && m.command === 'terminal:resize-request')).toBe(true);
+  });
+
+  test('a session outside the grant is refused before the owner is disturbed', () => {
+    const { h, key, requests } = askHarness();
+
+    h.send('c1', key, 1, { type: 'terminal:resize-request', sessionId: 's2', cols: 80, rows: 24 });
+
+    expect(requests).toEqual([]);
+    expect(h.opened('c1', key).some((m) => m.type === 'command:denied' && m.command === 'terminal:resize-request')).toBe(true);
+  });
+
+  test('a session in scope but not being watched raises nothing', () => {
+    // Same rule as terminal:input: the ask is about the session in front of
+    // them, and a request for one they are not attached to is malformed.
+    const { h, key, requests } = askHarness();
+    h.send('c1', key, 1, { type: 'terminal:unsubscribe', sessionId: 's1' });
+
+    h.send('c1', key, 2, { type: 'terminal:resize-request', sessionId: 's1', cols: 80, rows: 24 });
+
+    expect(requests).toEqual([]);
+  });
+
+  test('a made-up size is clamped before it reaches the prompt', () => {
+    // The number lands in copy the owner reads and in a native resize if they
+    // accept, so it is sanitised on the way in like any other remote size.
+    const { h, key, requests } = askHarness();
+
+    h.send('c1', key, 1, { type: 'terminal:resize-request', sessionId: 's1', cols: 999_999, rows: 0.5 });
+
+    expect(requests).toEqual([
+      { sessionId: 's1', cols: 1000, rows: 2, login: 'dana-k', displayName: null },
+    ]);
+  });
+
+  test('a non-numeric size is dropped rather than clamped into something', () => {
+    const { h, key, requests } = askHarness();
+
+    h.send('c1', key, 1, { type: 'terminal:resize-request', sessionId: 's1', cols: 'wide', rows: null });
+
+    expect(requests).toEqual([]);
+  });
+
+  test('a flood of asks raises one prompt, not one per frame', () => {
+    // Each request interrupts the owner. A prompt a guest can raise at will
+    // is a way to make the desktop unusable.
+    const { h, key, requests } = askHarness();
+
+    for (let i = 0; i < 20; i++) {
+      h.send('c1', key, i + 1, { type: 'terminal:resize-request', sessionId: 's1', cols: 80 + i, rows: 24 });
+    }
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.cols).toBe(80);
+  });
+
+  test('after the interval they may ask again — a decline is not a ban', () => {
+    const { h, key, requests, advance } = askHarness();
+    h.send('c1', key, 1, { type: 'terminal:resize-request', sessionId: 's1', cols: 80, rows: 24 });
+
+    advance(11_000);
+    h.send('c1', key, 2, { type: 'terminal:resize-request', sessionId: 's1', cols: 90, rows: 30 });
+
+    expect(requests.map((r) => r.cols)).toEqual([80, 90]);
+  });
+
+  test('the owner learns who asked, by the identity they cannot change', () => {
+    const requests: GuestResizeRequest[] = [];
+    const h = harness({ grantRow: storedGrant(), onResizeRequest: (r) => requests.push(r) });
+    const key = h.openChannel('c1', {
+      principal: { userId: GUEST_ID, githubLogin: null, displayName: 'Dana K' },
+      certificate: mintCertificate(),
+    })!;
+    h.send('c1', key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+
+    h.send('c1', key, 1, { type: 'terminal:resize-request', sessionId: 's1', cols: 80, rows: 24 });
+
+    expect(requests[0]).toMatchObject({ login: null, displayName: 'Dana K' });
   });
 });

--- a/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
+++ b/src/main/api/relay/__tests__/session-tunnel-policy.test.ts
@@ -1035,6 +1035,52 @@ describe('a guest asking to be fitted to their screen', () => {
     expect(requests[0]!.cols).toBe(80);
   });
 
+  test('six sockets under one certificate are still one asker', () => {
+    // The relay mints a fresh clientId per socket and nothing caps how many a
+    // guest may open, so a throttle kept on the socket is a browser refresh
+    // away from free — six channels, six prompts, same instant.
+    const requests: GuestResizeRequest[] = [];
+    const h = harness({ grantRow: storedGrant(), onResizeRequest: (r) => requests.push(r) });
+
+    for (let i = 0; i < 6; i++) {
+      const id = `c${i}`;
+      const key = h.openChannel(id, { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+      h.send(id, key, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+      h.send(id, key, 1, { type: 'terminal:resize-request', sessionId: 's1', cols: 80 + i, rows: 24 });
+    }
+
+    expect(requests).toHaveLength(1);
+  });
+
+  test('two different people are not throttled against each other', () => {
+    // The key is the grant, not a global bucket: one guest asking must not
+    // silence another guest's first ask.
+    const requests: GuestResizeRequest[] = [];
+    const other = storedGrant({ id: 'grant-2', granteeUserId: 'guest-two' });
+    const h = harness({
+      onResizeRequest: (r) => requests.push(r),
+      grants: {
+        get: (id) => (id === 'grant-2' ? other : storedGrant()),
+        ownerUserId: () => OWNER_ID,
+        enforced: () => true,
+        latch: () => {},
+      },
+    });
+
+    const one = h.openChannel('c1', { principal: { userId: GUEST_ID }, certificate: mintCertificate() })!;
+    h.send('c1', one, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    h.send('c1', one, 1, { type: 'terminal:resize-request', sessionId: 's1', cols: 80, rows: 24 });
+
+    const two = h.openChannel('c2', {
+      principal: { userId: 'guest-two' },
+      certificate: mintCertificate({ grantId: 'grant-2', granteeUserId: 'guest-two' }),
+    })!;
+    h.send('c2', two, 0, { type: 'terminal:subscribe', sessionId: 's1' });
+    h.send('c2', two, 1, { type: 'terminal:resize-request', sessionId: 's1', cols: 90, rows: 30 });
+
+    expect(requests.map((r) => r.cols)).toEqual([80, 90]);
+  });
+
   test('after the interval they may ask again — a decline is not a ban', () => {
     const { h, key, requests, advance } = askHarness();
     h.send('c1', key, 1, { type: 'terminal:resize-request', sessionId: 's1', cols: 80, rows: 24 });

--- a/src/main/api/relay/grants.ts
+++ b/src/main/api/relay/grants.ts
@@ -68,6 +68,10 @@ export const COMMAND_CAPS: Readonly<Record<string, Cap>> = Object.freeze({
   'terminal:unsubscribe': 'view',
   'terminal:input': 'input',
   'terminal:resize': 'resize',
+  // ASKING is not resizing. A guest may say "this doesn't fit my screen" and
+  // the owner's desktop decides — so this needs only what watching already
+  // grants, and `resize` stays exactly as narrow as it was.
+  'terminal:resize-request': 'view',
   'session:create': 'create',
   'group:create': 'create',
   'dirs:list': 'browse',

--- a/src/main/api/relay/relay-client.ts
+++ b/src/main/api/relay/relay-client.ts
@@ -144,6 +144,10 @@ export class RelayClient extends EventEmitter {
       // Presence changes are status changes: the owner's surfaces are driven
       // off the same push everything else uses.
       onPresenceChange: () => this.emitStatus(),
+      // A guest asked to be fitted to their screen. Emitted rather than
+      // stored: the answer is a decision the owner takes at that terminal, and
+      // a request nobody was there to see is one the guest can simply repeat.
+      onResizeRequest: (request) => this.emit('resize-request', request),
     },
   );
 

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -147,6 +147,14 @@ export interface TunnelDeps {
    * must be able to see who is watching without going looking.
    */
   onPresenceChange?: () => void;
+  /**
+   * A guest asked for a session to be resized to fit their screen.
+   *
+   * A notification, not an action: this tunnel resizes nothing on a guest's
+   * word. The owner's renderer turns it into a prompt and performs the resize
+   * itself if they accept, so declining is indistinguishable from silence.
+   */
+  onResizeRequest?: (request: GuestResizeRequest) => void;
   /** The relay origin this agent is connected to, for certificate binding. */
   relayOrigin(): string;
   /** This machine's id as the relay knows it, or null before linking. */
@@ -159,6 +167,23 @@ export interface Principal {
   userId: string;
   githubLogin?: string | null;
   displayName?: string | null;
+}
+
+/**
+ * A guest asking for this session to be resized to fit their screen.
+ *
+ * The request half of the sizing story: a guest never sends `terminal:resize`,
+ * because a phone must not reflow the owner's terminal. This carries the size
+ * they would like and who is asking, and nothing happens until the owner says
+ * yes on their own machine.
+ */
+export interface GuestResizeRequest {
+  sessionId: string;
+  cols: number;
+  rows: number;
+  /** Who is asking, for the prompt. Relay-asserted; never authorization. */
+  login: string | null;
+  displayName: string | null;
 }
 
 /** One guest currently attached, as the owner's UI needs to see them. */
@@ -189,7 +214,19 @@ interface ClientSession {
    * the whole scrollback instead.
    */
   marks: Map<string, number>;
+  /** When this client last asked to be fitted to its screen. See the throttle. */
+  lastResizeAsk: number;
 }
+
+/**
+ * The shortest gap between two of one client's resize requests.
+ *
+ * Each one raises a prompt on the owner's screen, and a prompt a guest can
+ * raise at will is a way to make the desktop unusable. The web client waits
+ * far longer than this before offering the ask again, so a well-behaved guest
+ * never meets it.
+ */
+const RESIZE_ASK_INTERVAL_MS = 10_000;
 
 /** Decrypted command from a web client (union of every message's fields). */
 interface ClientFrame {
@@ -271,6 +308,7 @@ export class SessionTunnel {
         this.deps.pty.resize(inner.sessionId, size.cols, size.rows);
       }
     },
+    'terminal:resize-request': (_clientId, s, inner) => this.handleResizeRequest(s, inner),
     'session:create': (clientId, s, inner) => this.handleSessionCreate(clientId, s, inner),
     'group:create': (clientId, s, inner) => this.handleGroupCreate(clientId, s, inner),
     'dirs:list': (clientId, s, inner) => this.handleDirsList(clientId, s, inner),
@@ -408,6 +446,7 @@ export class SessionTunnel {
         grant,
         principal: principal ?? null,
         marks,
+        lastResizeAsk: 0,
       };
       this.sessions.set(clientId, session);
       this.startListening();
@@ -688,6 +727,35 @@ export class SessionTunnel {
       if (!s.subs.has(sessionId) || this.sessions.get(clientId) !== s) return;
       this.sealTo(clientId, { type: 'terminal:output', sessionId, data });
     }
+  }
+
+  /**
+   * A guest asked to be fitted to their screen.
+   *
+   * Nothing is resized here, and that is the point: the guest's phone must not
+   * reflow the owner's terminal, so the ask is forwarded to the owner's own UI
+   * and dies there if they say no. The size is clamped like any other
+   * network-supplied one, and scoped to a session this client is watching —
+   * asking about a session you cannot see would leak that it exists.
+   */
+  private handleResizeRequest(s: ClientSession, inner: ClientFrame): void {
+    const sessionId = inner.sessionId;
+    const size = sanitizeSize(inner.cols, inner.rows);
+    if (typeof sessionId !== 'string' || !size || !s.subs.has(sessionId)) return;
+
+    const now = this.deps.now();
+    if (now - s.lastResizeAsk < RESIZE_ASK_INTERVAL_MS) {
+      this.deps.log.warn('[Relay] dropped a repeated resize request', { sessionId });
+      return;
+    }
+    s.lastResizeAsk = now;
+    this.deps.onResizeRequest?.({
+      sessionId,
+      cols: size.cols,
+      rows: size.rows,
+      login: s.principal?.githubLogin ?? null,
+      displayName: s.principal?.displayName ?? null,
+    });
   }
 
   private handleDirsList(clientId: string, _s: ClientSession, inner: ClientFrame): void {

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -218,6 +218,9 @@ interface ClientSession {
  */
 const RESIZE_ASK_INTERVAL_MS = 10_000;
 
+/** Wipe viewport and scrollback, so a replay cannot stack on what is shown. */
+const CLEAR_SCREEN = '\x1b[2J\x1b[3J\x1b[H';
+
 /** Decrypted command from a web client (union of every message's fields). */
 interface ClientFrame {
   type?: string;
@@ -696,7 +699,7 @@ export class SessionTunnel {
       this.sealTo(clientId, {
         type: 'terminal:output',
         sessionId,
-        data: '\x1b[2J\x1b[3J\x1b[H── shared from here ──\r\n',
+        data: `${CLEAR_SCREEN}── shared from here ──\r\n`,
       });
       if (mark === null) return;
       const since = await this.deps.pty.getSerializedBufferSince(sessionId, mark);
@@ -712,6 +715,12 @@ export class SessionTunnel {
     // shared terminal without the scrollback garbling. Then live output streams.
     // Chunked so a long scrollback can't put a multi-megabyte frame on the wire
     // (xterm.js carries parser state across writes, so splitting is safe).
+    //
+    // Cleared first, like the guest branch above: this frame means "here is the
+    // whole buffer", so a client that subscribes without wiping its own screen
+    // — a reconnect re-subscribing, rather than a tap that cleared first —
+    // would otherwise render the entire scrollback again underneath itself.
+    this.sealTo(clientId, { type: 'terminal:output', sessionId, data: CLEAR_SCREEN });
     const history = await this.deps.pty.getSerializedBuffer(sessionId);
     for (const data of chunkText(history)) {
       // Re-check every chunk: the client may unsubscribe or drop mid-replay.

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -212,10 +212,9 @@ interface ClientSession {
 }
 
 /**
- * The shortest gap between two resize requests from the same asker: each
- * raises a prompt on the owner's screen. Keyed below by GRANT, not by socket:
- * a guest may open as many channels as they like, and six under one
- * certificate would otherwise be six prompts in the same instant.
+ * The shortest gap between two resize requests from the same asker, each of
+ * which raises a prompt. Keyed below by GRANT, not by socket: a guest opens
+ * as many channels as they like, and six is otherwise six prompts at once.
  */
 const RESIZE_ASK_INTERVAL_MS = 10_000;
 

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -148,11 +148,9 @@ export interface TunnelDeps {
    */
   onPresenceChange?: () => void;
   /**
-   * A guest asked for a session to be resized to fit their screen.
-   *
-   * A notification, not an action: this tunnel resizes nothing on a guest's
-   * word. The owner's renderer turns it into a prompt and performs the resize
-   * itself if they accept, so declining is indistinguishable from silence.
+   * A guest asked to be fitted to their screen. A notification, not an action:
+   * the owner's renderer turns it into a prompt and performs the resize itself
+   * on accept, so declining is indistinguishable from silence.
    */
   onResizeRequest?: (request: GuestResizeRequest) => void;
   /** The relay origin this agent is connected to, for certificate binding. */
@@ -170,12 +168,9 @@ export interface Principal {
 }
 
 /**
- * A guest asking for this session to be resized to fit their screen.
- *
- * The request half of the sizing story: a guest never sends `terminal:resize`,
- * because a phone must not reflow the owner's terminal. This carries the size
- * they would like and who is asking, and nothing happens until the owner says
- * yes on their own machine.
+ * A guest asking for a session to be resized to fit their screen. A guest
+ * never sends `terminal:resize` — a phone must not reflow the owner's
+ * terminal — so this carries the ask, and nothing happens until they agree.
  */
 export interface GuestResizeRequest {
   sessionId: string;
@@ -219,12 +214,9 @@ interface ClientSession {
 }
 
 /**
- * The shortest gap between two of one client's resize requests.
- *
- * Each one raises a prompt on the owner's screen, and a prompt a guest can
- * raise at will is a way to make the desktop unusable. The web client waits
- * far longer than this before offering the ask again, so a well-behaved guest
- * never meets it.
+ * The shortest gap between two of one client's resize requests: each raises a
+ * prompt on the owner's screen, and one a guest can raise at will makes the
+ * desktop unusable. The web client waits far longer before offering it again.
  */
 const RESIZE_ASK_INTERVAL_MS = 10_000;
 
@@ -730,13 +722,9 @@ export class SessionTunnel {
   }
 
   /**
-   * A guest asked to be fitted to their screen.
-   *
-   * Nothing is resized here, and that is the point: the guest's phone must not
-   * reflow the owner's terminal, so the ask is forwarded to the owner's own UI
-   * and dies there if they say no. The size is clamped like any other
-   * network-supplied one, and scoped to a session this client is watching —
-   * asking about a session you cannot see would leak that it exists.
+   * A guest asked to be fitted to their screen. Nothing is resized here: the
+   * ask goes to the owner's UI and dies there if they say no. The size is
+   * clamped, and scoped to a session this client is actually watching.
    */
   private handleResizeRequest(s: ClientSession, inner: ClientFrame): void {
     const sessionId = inner.sessionId;

--- a/src/main/api/relay/session-tunnel.ts
+++ b/src/main/api/relay/session-tunnel.ts
@@ -209,14 +209,13 @@ interface ClientSession {
    * the whole scrollback instead.
    */
   marks: Map<string, number>;
-  /** When this client last asked to be fitted to its screen. See the throttle. */
-  lastResizeAsk: number;
 }
 
 /**
- * The shortest gap between two of one client's resize requests: each raises a
- * prompt on the owner's screen, and one a guest can raise at will makes the
- * desktop unusable. The web client waits far longer before offering it again.
+ * The shortest gap between two resize requests from the same asker: each
+ * raises a prompt on the owner's screen. Keyed below by GRANT, not by socket:
+ * a guest may open as many channels as they like, and six under one
+ * certificate would otherwise be six prompts in the same instant.
  */
 const RESIZE_ASK_INTERVAL_MS = 10_000;
 
@@ -268,6 +267,8 @@ export class SessionTunnel {
    * create a number that survives the buffer it points into.
    */
   private readonly shareMarks = new Map<string, ShareWindow>();
+  /** Asker → when they last asked to be fitted. See RESIZE_ASK_INTERVAL_MS. */
+  private readonly lastResizeAsk = new Map<string, number>();
   /** Detaches the shared PTY listeners; null when not attached. */
   private detach: (() => void) | null = null;
   private readonly deps: TunnelDeps;
@@ -300,7 +301,7 @@ export class SessionTunnel {
         this.deps.pty.resize(inner.sessionId, size.cols, size.rows);
       }
     },
-    'terminal:resize-request': (_clientId, s, inner) => this.handleResizeRequest(s, inner),
+    'terminal:resize-request': (clientId, s, inner) => this.handleResizeRequest(clientId, s, inner),
     'session:create': (clientId, s, inner) => this.handleSessionCreate(clientId, s, inner),
     'group:create': (clientId, s, inner) => this.handleGroupCreate(clientId, s, inner),
     'dirs:list': (clientId, s, inner) => this.handleDirsList(clientId, s, inner),
@@ -438,7 +439,6 @@ export class SessionTunnel {
         grant,
         principal: principal ?? null,
         marks,
-        lastResizeAsk: 0,
       };
       this.sessions.set(clientId, session);
       this.startListening();
@@ -726,17 +726,22 @@ export class SessionTunnel {
    * ask goes to the owner's UI and dies there if they say no. The size is
    * clamped, and scoped to a session this client is actually watching.
    */
-  private handleResizeRequest(s: ClientSession, inner: ClientFrame): void {
+  private handleResizeRequest(clientId: string, s: ClientSession, inner: ClientFrame): void {
     const sessionId = inner.sessionId;
     const size = sanitizeSize(inner.cols, inner.rows);
     if (typeof sessionId !== 'string' || !size || !s.subs.has(sessionId)) return;
 
+    // The person, not the socket. A fresh channel per ask would otherwise
+    // reset the throttle, which is a browser refresh away from free.
+    const asker = s.grant.grantId ?? s.principal?.userId ?? clientId;
     const now = this.deps.now();
-    if (now - s.lastResizeAsk < RESIZE_ASK_INTERVAL_MS) {
+    const last = this.lastResizeAsk.get(asker);
+    if (last !== undefined && now - last < RESIZE_ASK_INTERVAL_MS) {
       this.deps.log.warn('[Relay] dropped a repeated resize request', { sessionId });
       return;
     }
-    s.lastResizeAsk = now;
+    this.sweepResizeAsks(now);
+    this.lastResizeAsk.set(asker, now);
     this.deps.onResizeRequest?.({
       sessionId,
       cols: size.cols,
@@ -744,6 +749,13 @@ export class SessionTunnel {
       login: s.principal?.githubLogin ?? null,
       displayName: s.principal?.displayName ?? null,
     });
+  }
+
+  /** Forget askers whose interval has passed, so the map cannot grow. */
+  private sweepResizeAsks(now: number): void {
+    for (const [asker, at] of this.lastResizeAsk) {
+      if (now - at >= RESIZE_ASK_INTERVAL_MS) this.lastResizeAsk.delete(asker);
+    }
   }
 
   private handleDirsList(clientId: string, _s: ClientSession, inner: ClientFrame): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,6 +35,7 @@ import { registerHooks, cleanupLegacyMcpServer } from './mcp-config';
 import log from 'electron-log';
 import { getApiServer } from './api';
 import { getRelayClient } from './api/relay';
+import type { GuestResizeRequest } from './api/relay/session-tunnel';
 import { remoteSessionEvents } from './api/relay/remote-sessions';
 import { openInEditor, detectAvailableEditors, getEditorOptions, EditorType } from './editor-launcher';
 import { dispatchAttentionPush } from './api/web-push/dispatcher';
@@ -513,6 +514,13 @@ function createWindow(): void {
 
   getRelayClient().on('grants-changed', () => {
     mainWindow?.webContents.send('relay:status', getRelayClient().getStatus());
+  });
+
+  // A guest asked for a session to be resized to fit their screen. No OS
+  // notification: unlike a join request this decides nothing about access,
+  // and the answer is a one-tap prompt on the terminal it is about.
+  getRelayClient().on('resize-request', (request: GuestResizeRequest) => {
+    mainWindow?.webContents.send('relay:resize-request', request);
   });
 
   getRelayClient().on('status', (status) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare } from '../shared/types';
+import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -41,6 +41,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('pty:exit', listener);
     return () => {
       ipcRenderer.removeListener('pty:exit', listener);
+    };
+  },
+  // A guest asked for a session to be resized to fit their screen. A request,
+  // not a resize: the prompt it raises is what decides, and declining changes
+  // nothing on either end.
+  onRelayResizeRequest: (callback: (request: RelayResizeRequest) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, request: RelayResizeRequest) => callback(request);
+    ipcRenderer.on('relay:resize-request', listener);
+    return () => {
+      ipcRenderer.removeListener('relay:resize-request', listener);
     };
   },
   // Dynamic sizing: the PTY was resized (possibly by a remote/mobile viewer).

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { Terminal as XTerm } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import { WebglAddon } from 'xterm-addon-webgl';
-import { ProviderInstallHint } from '../../shared/types';
+import { ProviderInstallHint, RelayResizeRequest } from '../../shared/types';
 import { ProviderInstallModal } from './ProviderInstallModal';
+import { KEEP_MY_SIZE, RESIZE_ONCE, resizeRequestCopy, shouldPrompt } from './resizeRequestPrompt';
 // The keyboard scheme lives in one place — see the table at the top of
 // useKeyboardShortcuts.ts. Importing the predicates (instead of re-deriving
 // them here) is what keeps the xterm allowlist and the app handler in sync.
@@ -93,6 +94,9 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   // unrequested) from our own.
   const desktopSizeRef = useRef<{ cols: number; rows: number } | null>(null);
   const [mobileSize, setMobileSize] = useState<{ cols: number; rows: number } | null>(null);
+  // A guest asked to be fitted to their screen. Held until the owner answers:
+  // guests never resize this PTY themselves, so nothing has happened yet.
+  const [resizeRequest, setResizeRequest] = useState<RelayResizeRequest | null>(null);
 
   // Track isActive in a ref so handleResize (set up in the main effect which
   // does NOT depend on isActive) can skip background sessions without a layout
@@ -201,6 +205,30 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       }
     });
   }, [sessionId]);
+
+  // A guest asked for this session to be fitted to their screen. It is a
+  // request and only a request: it reaches a prompt, never the PTY.
+  useEffect(() => {
+    return window.electronAPI.onRelayResizeRequest((request) => {
+      if (!shouldPrompt(request, sessionId, desktopSizeRef.current)) return;
+      setResizeRequest(request);
+    });
+  }, [sessionId]);
+
+  // Once. The size this window asks for on its next fit is unchanged, which is
+  // exactly what "Resize once" promises — and the mobile-resize banner that
+  // follows is the standing offer to take it back.
+  const acceptResizeRequest = useCallback(() => {
+    const request = resizeRequest;
+    setResizeRequest(null);
+    if (!request) return;
+    try { xtermRef.current?.resize(request.cols, request.rows); } catch { /* disposed */ }
+    window.electronAPI.resizeSession(sessionId, request.cols, request.rows);
+  }, [resizeRequest, sessionId]);
+
+  // Declining tells the guest nothing and changes nothing: their view stays
+  // exactly as it was, and they may ask again later.
+  const declineResizeRequest = useCallback(() => setResizeRequest(null), []);
 
   // Surface provider launch failures (spawn ENOENT / command not found)
   // detected by main for this session's pty.
@@ -882,6 +910,17 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
         className="terminal-container"
         onContextMenu={handleContextMenu}
       />
+      {resizeRequest && (
+        <div className="resize-request-banner" role="status">
+          <span className="resize-request-text">
+            👀 {resizeRequestCopy(resizeRequest, desktopSizeRef.current)}
+          </span>
+          <div className="resize-request-actions">
+            <button className="primary" onClick={acceptResizeRequest}>{RESIZE_ONCE}</button>
+            <button onClick={declineResizeRequest}>{KEEP_MY_SIZE}</button>
+          </div>
+        </div>
+      )}
       {mobileSize && (
         <div className="mobile-resize-banner">
           <span className="mobile-resize-banner-text">

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -97,6 +97,8 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   // A guest asked to be fitted to their screen. Held until the owner answers:
   // guests never resize this PTY themselves, so nothing has happened yet.
   const [resizeRequest, setResizeRequest] = useState<RelayResizeRequest | null>(null);
+  // Whether this window is currently holding a size it granted to a guest.
+  const heldFitRef = useRef(false);
 
   // Track isActive in a ref so handleResize (set up in the main effect which
   // does NOT depend on isActive) can skip background sessions without a layout
@@ -139,6 +141,12 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     // early-out spares the layout flush below for every background session on
     // each window resize.
     if (!isActiveRef.current) return;
+    // A fit granted to a guest is held until this window takes it back on
+    // purpose. Without this the next focus, window resize or session switch
+    // re-measures an unchanged container and pushes the desktop grid back —
+    // silently, and with no message to the guest, who cannot ask again for
+    // ten seconds and is panning a 164-column terminal in the meantime.
+    if (heldFitRef.current) return;
     // …but isActive only tracks which SESSION is selected; it says nothing
     // about which CONTENT VIEW is showing. App.tsx hides the whole
     // .terminal-area with display:none while Analytics or Arena is active, and
@@ -180,8 +188,10 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
     }
   }, [sessionId]);
 
-  // Resume the desktop's own size (undo a mobile viewer's shrink).
+  // Resume the desktop's own size (undo a mobile viewer's shrink, or a fit
+  // this window granted to a guest — taking it back is a deliberate act).
   const resumeDesktopSize = useCallback(() => {
+    heldFitRef.current = false;
     setMobileSize(null);
     handleResize();
   }, [handleResize]);
@@ -196,6 +206,9 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
       const desk = desktopSizeRef.current;
       if (!desk) return; // haven't fit yet — nothing to compare against
       if (cols === desk.cols && rows === desk.rows) {
+        // Back at this window's own size by some other route — whatever was
+        // being held for a guest is over, so re-fitting is allowed again.
+        heldFitRef.current = false;
         setMobileSize(null);
         return;
       }
@@ -211,17 +224,24 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
   useEffect(() => {
     return window.electronAPI.onRelayResizeRequest((request) => {
       if (!shouldPrompt(request, sessionId, desktopSizeRef.current)) return;
-      setResizeRequest(request);
+      // The prompt in front of the owner is the one they answer. Replacing it
+      // means the size they read is not the size they agree to — a second
+      // guest asking between the reading and the click would resize this
+      // terminal to a number nobody ever saw.
+      setResizeRequest((pending) => pending ?? request);
     });
   }, [sessionId]);
 
-  // Once. The size this window asks for on its next fit is unchanged, which is
-  // exactly what "Resize once" promises — and the mobile-resize banner that
-  // follows is the standing offer to take it back.
+  // Accepting resizes once — one act, not a standing rule. The size is then
+  // HELD against this window's own re-fits until the owner takes it back
+  // through the banner below, because a fit that dies at the next focus is a
+  // promise to the guest that this window quietly breaks.
   const acceptResizeRequest = useCallback(() => {
     const request = resizeRequest;
     setResizeRequest(null);
     if (!request) return;
+    heldFitRef.current = true;
+    setMobileSize({ cols: request.cols, rows: request.rows });
     try { xtermRef.current?.resize(request.cols, request.rows); } catch { /* disposed */ }
     window.electronAPI.resizeSession(sessionId, request.cols, request.rows);
   }, [resizeRequest, sessionId]);
@@ -911,7 +931,7 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
         onContextMenu={handleContextMenu}
       />
       {resizeRequest && (
-        <div className="resize-request-banner" role="status">
+        <output className="resize-request-banner">
           <span className="resize-request-text">
             👀 {resizeRequestCopy(resizeRequest, desktopSizeRef.current)}
           </span>
@@ -919,7 +939,7 @@ const Terminal: React.FC<TerminalProps> = ({ sessionId, cwd, launchClaude = true
             <button className="primary" onClick={acceptResizeRequest}>{RESIZE_ONCE}</button>
             <button onClick={declineResizeRequest}>{KEEP_MY_SIZE}</button>
           </div>
-        </div>
+        </output>
       )}
       {mobileSize && (
         <div className="mobile-resize-banner">

--- a/src/renderer/components/__tests__/Terminal.resizeRequest.test.tsx
+++ b/src/renderer/components/__tests__/Terminal.resizeRequest.test.tsx
@@ -14,12 +14,16 @@ class FakeBuffer {
 
 const noop = () => {};
 
+/** The grid this window's container measures to, unchanged all test long. */
+const CONTAINER = { cols: 164, rows: 48 };
+
 /** Resizes xterm was asked to make locally, so a stale render can be spotted. */
 let termResizes: string[] = [];
+let liveTerm: FakeTerm | null = null;
 
 class FakeTerm {
-  cols = 164;
-  rows = 48;
+  cols = CONTAINER.cols;
+  rows = CONTAINER.rows;
   buffer = new FakeBuffer();
   loadAddon = noop;
   open = noop;
@@ -28,15 +32,32 @@ class FakeTerm {
   focus = noop;
   selectAll = noop;
   scrollToBottom = noop;
-  resize = (cols: number, rows: number) => { termResizes.push(`${cols}x${rows}`); };
+  // A real resize MOVES the grid. A double that only records it cannot show a
+  // later fit putting the size back, which is the whole subject here.
+  resize = (cols: number, rows: number) => {
+    termResizes.push(`${cols}x${rows}`);
+    this.cols = cols;
+    this.rows = rows;
+  };
   getSelection = () => '';
   attachCustomKeyEventHandler = noop;
   onData = noop;
   dispose = noop;
+  constructor() { liveTerm = this; }
 }
 
 mock.module('xterm', () => ({ Terminal: FakeTerm }));
-mock.module('xterm-addon-fit', () => ({ FitAddon: class { fit = noop; } }));
+// fit() re-measures the container and reflows the terminal to it — the real
+// behaviour, and the thing that used to undo an accepted fit on any focus.
+mock.module('xterm-addon-fit', () => ({
+  FitAddon: class {
+    fit = () => {
+      if (!liveTerm) return;
+      liveTerm.cols = CONTAINER.cols;
+      liveTerm.rows = CONTAINER.rows;
+    };
+  },
+}));
 mock.module('xterm-addon-webgl', () => ({
   WebglAddon: class { onContextLoss = noop; dispose = noop; },
 }));
@@ -45,6 +66,7 @@ const Terminal = (await import('../Terminal')).default;
 
 let ptyResizes: string[] = [];
 let deliverRequest: ((request: RelayResizeRequest) => void) | null = null;
+let deliverPtyResize: ((id: string, cols: number, rows: number) => void) | null = null;
 
 const request = (over: Partial<RelayResizeRequest> = {}): RelayResizeRequest => ({
   sessionId: 's1',
@@ -55,10 +77,19 @@ const request = (over: Partial<RelayResizeRequest> = {}): RelayResizeRequest => 
   ...over,
 });
 
+/** handleResize measures the container; happy-dom reports every box as zero. */
+let realRect: typeof HTMLElement.prototype.getBoundingClientRect;
+
 beforeEach(() => {
   termResizes = [];
   ptyResizes = [];
   deliverRequest = null;
+  deliverPtyResize = null;
+  liveTerm = null;
+
+  realRect = HTMLElement.prototype.getBoundingClientRect;
+  HTMLElement.prototype.getBoundingClientRect = () =>
+    ({ width: 1200, height: 600, top: 0, left: 0, right: 1200, bottom: 600, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
 
   (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
     observe = noop;
@@ -73,7 +104,10 @@ beforeEach(() => {
     primePty: () => {},
     killSession: async () => {},
     onPtyData: noopSub,
-    onPtyResize: noopSub,
+    onPtyResize: (cb: (id: string, cols: number, rows: number) => void) => {
+      deliverPtyResize = cb;
+      return () => { deliverPtyResize = null; };
+    },
     onRelayResizeRequest: (cb: (r: RelayResizeRequest) => void) => {
       deliverRequest = cb;
       return () => { deliverRequest = null; };
@@ -90,6 +124,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  HTMLElement.prototype.getBoundingClientRect = realRect;
   delete (window as unknown as { electronAPI?: unknown }).electronAPI;
 });
 
@@ -158,13 +193,72 @@ describe('a guest asking to be fitted to their screen', () => {
     expect(screen.getByText(/@dana-k/)).toBeTruthy();
   });
 
-  test('a second ask replaces the first rather than stacking prompts', async () => {
+  test('the prompt in front of the owner is the one they answer', async () => {
+    // A second guest asking between the reading and the click must not swap
+    // the number under the button: the owner would agree to a size they never
+    // saw, and sanitizeSize's floor of 2×2 is the worst case of that.
     await renderTerminal();
     await ask();
-    await ask({ cols: 100, rows: 30 });
+    await ask({ cols: 100, rows: 30, login: 'someone-else' });
 
     expect(screen.getAllByText('Resize once')).toHaveLength(1);
+    expect(screen.getByText(/80×24/)).toBeTruthy();
     await act(async () => { screen.getByText('Resize once').click(); });
-    expect(ptyResizes).toEqual(['100x30']);
+    expect(ptyResizes).toEqual(['80x24']);
+  });
+});
+
+describe('an accepted fit is held until the owner takes it back', () => {
+  test('the owner alt-tabbing away and back does not quietly undo it', async () => {
+    // The bug: focus → handleResize → fit() re-measures the unchanged
+    // container → the desktop grid is pushed straight back, the guest is
+    // panning 164 columns again, and nobody is told. One focus event was
+    // enough, and the guest cannot ask again for ten seconds.
+    await renderTerminal();
+    await ask();
+    await act(async () => { screen.getByText('Resize once').click(); });
+    expect(ptyResizes).toEqual(['80x24']);
+
+    await act(async () => { window.dispatchEvent(new Event('focus')); });
+    await act(async () => { window.dispatchEvent(new Event('resize')); });
+
+    expect(ptyResizes).toEqual(['80x24']);
+    // And the standing offer to take it back is still on screen.
+    expect(screen.getByText('Resume desktop size')).toBeTruthy();
+  });
+
+  test('taking the size back is one deliberate click', async () => {
+    await renderTerminal();
+    await ask();
+    await act(async () => { screen.getByText('Resize once').click(); });
+
+    await act(async () => { screen.getByText('Resume desktop size').click(); });
+
+    expect(ptyResizes).toEqual(['80x24', '164x48']);
+    expect(screen.queryByText('Resume desktop size')).toBeNull();
+  });
+
+  test('a window that granted nothing still re-fits on focus as it always did', async () => {
+    // The hold must be scoped to a granted fit. Breaking the ordinary path —
+    // where focus and window resize keep the PTY matched to the container —
+    // would be a far larger regression than the one being fixed.
+    await renderTerminal();
+
+    await act(async () => { window.dispatchEvent(new Event('focus')); });
+
+    expect(ptyResizes).toEqual(['164x48']);
+  });
+
+  test('after the size comes back by another route, re-fitting is allowed again', async () => {
+    // The desktop grid arriving on pty:resized means whatever was held for a
+    // guest is over — otherwise this window would refuse to fit for good.
+    await renderTerminal();
+    await ask();
+    await act(async () => { screen.getByText('Resize once').click(); });
+
+    await act(async () => { deliverPtyResize!('s1', 164, 48); });
+    await act(async () => { window.dispatchEvent(new Event('focus')); });
+
+    expect(ptyResizes).toEqual(['80x24', '164x48']);
   });
 });

--- a/src/renderer/components/__tests__/Terminal.resizeRequest.test.tsx
+++ b/src/renderer/components/__tests__/Terminal.resizeRequest.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * The owner's end of "Fit to my screen".
+ *
+ * The rule these hold: a guest's request reaches a prompt and never the PTY,
+ * accepting resizes once, and declining is indistinguishable from silence —
+ * nothing is sent, and the guest's view is left exactly as it was.
+ *
+ * xterm and its addons are mocked for the same reason Terminal.restart.test.tsx
+ * mocks them: a real xterm wants a canvas and a laid-out container, neither of
+ * which happy-dom provides, and none of it is what is under test here.
+ *
+ * Run with: bun test src/renderer/components/__tests__/Terminal.resizeRequest.test.tsx
+ */
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { RelayResizeRequest } from '../../../shared/types';
+
+class FakeBuffer {
+  active = { baseY: 0, viewportY: 0 };
+}
+
+const noop = () => {};
+
+/** Resizes xterm was asked to make locally, so a stale render can be spotted. */
+let termResizes: string[] = [];
+
+class FakeTerm {
+  cols = 164;
+  rows = 48;
+  buffer = new FakeBuffer();
+  loadAddon = noop;
+  open = noop;
+  write = noop;
+  clear = noop;
+  focus = noop;
+  selectAll = noop;
+  scrollToBottom = noop;
+  resize = (cols: number, rows: number) => { termResizes.push(`${cols}x${rows}`); };
+  getSelection = () => '';
+  attachCustomKeyEventHandler = noop;
+  onData = noop;
+  dispose = noop;
+}
+
+mock.module('xterm', () => ({ Terminal: FakeTerm }));
+mock.module('xterm-addon-fit', () => ({ FitAddon: class { fit = noop; } }));
+mock.module('xterm-addon-webgl', () => ({
+  WebglAddon: class { onContextLoss = noop; dispose = noop; },
+}));
+
+const Terminal = (await import('../Terminal')).default;
+
+let ptyResizes: string[] = [];
+let deliverRequest: ((request: RelayResizeRequest) => void) | null = null;
+
+const request = (over: Partial<RelayResizeRequest> = {}): RelayResizeRequest => ({
+  sessionId: 's1',
+  cols: 80,
+  rows: 24,
+  login: 'dana-k',
+  displayName: 'Dana K',
+  ...over,
+});
+
+beforeEach(() => {
+  termResizes = [];
+  ptyResizes = [];
+  deliverRequest = null;
+
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe = noop;
+    disconnect = noop;
+  };
+
+  const noopSub = () => () => {};
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    createSession: async () => {},
+    writeToSession: () => {},
+    resizeSession: (_id: string, cols: number, rows: number) => { ptyResizes.push(`${cols}x${rows}`); },
+    primePty: () => {},
+    killSession: async () => {},
+    onPtyData: noopSub,
+    onPtyResize: noopSub,
+    onRelayResizeRequest: (cb: (r: RelayResizeRequest) => void) => {
+      deliverRequest = cb;
+      return () => { deliverRequest = null; };
+    },
+    onProviderInstallHint: noopSub,
+    onMenuCopy: noopSub,
+    onMenuPaste: noopSub,
+    onMenuSelectAll: noopSub,
+    onMenuClearTerminal: noopSub,
+    openExternal: () => {},
+    runProviderInstall: async () => ({ ptyId: 'x', command: 'x' }),
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+});
+
+/**
+ * Mount, then let the startup path settle: creating the pty sends one resize
+ * of its own, and that is not what any of these tests are about.
+ */
+async function renderTerminal() {
+  const rendered = render(<Terminal sessionId="s1" cwd="/tmp" launchClaude provider="claude" isActive />);
+  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 60)); });
+  ptyResizes = [];
+  termResizes = [];
+  return rendered;
+}
+
+async function ask(over: Partial<RelayResizeRequest> = {}) {
+  await act(async () => { deliverRequest!(request(over)); });
+}
+
+describe('a guest asking to be fitted to their screen', () => {
+  test('nothing happens until the owner answers', async () => {
+    await renderTerminal();
+    await ask();
+
+    // The prompt names the size being asked for; the PTY has not moved.
+    expect(screen.getByText(/asked to fit this session to their screen/)).toBeTruthy();
+    expect(screen.getByText(/80×24/)).toBeTruthy();
+    expect(ptyResizes).toEqual([]);
+  });
+
+  test('accepting resizes once, and says so by its own name', async () => {
+    await renderTerminal();
+    await ask();
+
+    await act(async () => { screen.getByText('Resize once').click(); });
+
+    expect(ptyResizes).toEqual(['80x24']);
+    // Rendered locally too, so the owner's window is not showing a grid the
+    // PTY has stopped using.
+    expect(termResizes).toContain('80x24');
+    expect(screen.queryByText('Resize once')).toBeNull();
+  });
+
+  test('declining sends nothing at all — the guest is told by silence', async () => {
+    await renderTerminal();
+    await ask();
+
+    await act(async () => { screen.getByText('Keep my size').click(); });
+
+    expect(ptyResizes).toEqual([]);
+    expect(termResizes).toEqual([]);
+    expect(screen.queryByText(/asked to fit this session/)).toBeNull();
+  });
+
+  test('a request for another session is not this terminal\'s to answer', async () => {
+    await renderTerminal();
+    await ask({ sessionId: 's2' });
+
+    expect(screen.queryByText(/asked to fit this session/)).toBeNull();
+  });
+
+  test('the person is named by the handle they cannot change', async () => {
+    await renderTerminal();
+    await ask();
+
+    expect(screen.getByText(/@dana-k/)).toBeTruthy();
+  });
+
+  test('a second ask replaces the first rather than stacking prompts', async () => {
+    await renderTerminal();
+    await ask();
+    await ask({ cols: 100, rows: 30 });
+
+    expect(screen.getAllByText('Resize once')).toHaveLength(1);
+    await act(async () => { screen.getByText('Resize once').click(); });
+    expect(ptyResizes).toEqual(['100x30']);
+  });
+});

--- a/src/renderer/components/__tests__/Terminal.resizeRequest.test.tsx
+++ b/src/renderer/components/__tests__/Terminal.resizeRequest.test.tsx
@@ -1,15 +1,7 @@
 /**
- * The owner's end of "Fit to my screen".
- *
- * The rule these hold: a guest's request reaches a prompt and never the PTY,
- * accepting resizes once, and declining is indistinguishable from silence —
- * nothing is sent, and the guest's view is left exactly as it was.
- *
- * xterm and its addons are mocked for the same reason Terminal.restart.test.tsx
- * mocks them: a real xterm wants a canvas and a laid-out container, neither of
- * which happy-dom provides, and none of it is what is under test here.
- *
- * Run with: bun test src/renderer/components/__tests__/Terminal.resizeRequest.test.tsx
+ * The owner's end of "Fit to my screen": a request reaches a prompt and never
+ * the PTY, accepting resizes once, declining sends nothing. xterm is mocked as
+ * in Terminal.restart.test.tsx — a real one wants a canvas we cannot give it.
  */
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';

--- a/src/renderer/components/__tests__/Terminal.restart.test.tsx
+++ b/src/renderer/components/__tests__/Terminal.restart.test.tsx
@@ -106,6 +106,7 @@ beforeEach(() => {
     },
     onPtyData: noopSub,
     onPtyResize: noopSub,
+    onRelayResizeRequest: noopSub,
     onProviderInstallHint: noopSub,
     onMenuCopy: noopSub,
     onMenuPaste: noopSub,

--- a/src/renderer/components/__tests__/resizeRequestPrompt.test.ts
+++ b/src/renderer/components/__tests__/resizeRequestPrompt.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The owner's prompt for a guest's "Fit to my screen" request: when it is
+ * worth interrupting them, and what the question actually claims.
+ */
+import { describe, expect, test } from 'bun:test';
+import { RelayResizeRequest } from '../../../shared/types';
+import {
+  KEEP_MY_SIZE,
+  RESIZE_ONCE,
+  resizeRequestCopy,
+  shouldPrompt,
+  whoIsAsking,
+} from '../resizeRequestPrompt';
+
+const request = (over: Partial<RelayResizeRequest> = {}): RelayResizeRequest => ({
+  sessionId: 's1',
+  cols: 80,
+  rows: 24,
+  login: 'dana-k',
+  displayName: 'Dana K',
+  ...over,
+});
+
+describe('shouldPrompt', () => {
+  test('a request for this session, at a different size, asks', () => {
+    expect(shouldPrompt(request(), 's1', { cols: 164, rows: 48 })).toBe(true);
+  });
+
+  test('a request for another session belongs to another terminal', () => {
+    expect(shouldPrompt(request({ sessionId: 's2' }), 's1', { cols: 164, rows: 48 })).toBe(false);
+  });
+
+  test('a request for the size we are already at asks for nothing', () => {
+    // Interrupting the owner to offer them a no-op spends attention for
+    // nothing, and makes the next real prompt easier to dismiss unread.
+    expect(shouldPrompt(request(), 's1', { cols: 80, rows: 24 })).toBe(false);
+  });
+
+  test('one differing dimension is still a real request', () => {
+    expect(shouldPrompt(request(), 's1', { cols: 80, rows: 48 })).toBe(true);
+    expect(shouldPrompt(request(), 's1', { cols: 100, rows: 24 })).toBe(true);
+  });
+
+  test('before this window has measured itself, the ask still stands', () => {
+    expect(shouldPrompt(request(), 's1', null)).toBe(true);
+  });
+
+  test('a size that could not fit anything is refused rather than rendered', () => {
+    expect(shouldPrompt(request({ cols: 0 }), 's1', { cols: 164, rows: 48 })).toBe(false);
+    expect(shouldPrompt(request({ rows: 0 }), 's1', { cols: 164, rows: 48 })).toBe(false);
+  });
+});
+
+describe('whoIsAsking', () => {
+  test('the immutable handle wins over a display name anyone can change', () => {
+    expect(whoIsAsking(request())).toBe('@dana-k');
+  });
+
+  test('a display name is used only when there is no handle', () => {
+    expect(whoIsAsking(request({ login: null }))).toBe('Dana K');
+  });
+
+  test('with neither, the prompt still says a person asked', () => {
+    expect(whoIsAsking(request({ login: null, displayName: null }))).toBe('Someone watching');
+  });
+});
+
+describe('resizeRequestCopy', () => {
+  test('names the requested size and the one it would replace', () => {
+    expect(resizeRequestCopy(request(), { cols: 164, rows: 48 })).toBe(
+      '@dana-k asked to fit this session to their screen (80×24) — yours is 164×48.',
+    );
+  });
+
+  test('claims no current size it does not know', () => {
+    const copy = resizeRequestCopy(request(), null);
+    expect(copy).toBe('@dana-k asked to fit this session to their screen (80×24).');
+    expect(copy).not.toContain('yours');
+  });
+
+  test('the answers are one-tap and say what they do', () => {
+    // "Resize once" is the whole promise: the next fit of this window takes
+    // the size back, and the button must not imply otherwise.
+    expect(RESIZE_ONCE).toBe('Resize once');
+    expect(KEEP_MY_SIZE).toBe('Keep my size');
+  });
+});

--- a/src/renderer/components/__tests__/resizeRequestPrompt.test.ts
+++ b/src/renderer/components/__tests__/resizeRequestPrompt.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, test } from 'bun:test';
 import { RelayResizeRequest } from '../../../shared/types';
 import {
   KEEP_MY_SIZE,
+  MIN_REQUEST_COLS,
+  MIN_REQUEST_ROWS,
   RESIZE_ONCE,
   resizeRequestCopy,
   shouldPrompt,
@@ -49,6 +51,15 @@ describe('shouldPrompt', () => {
     expect(shouldPrompt(request({ cols: 0 }), 's1', { cols: 164, rows: 48 })).toBe(false);
     expect(shouldPrompt(request({ rows: 0 }), 's1', { cols: 164, rows: 48 })).toBe(false);
   });
+
+  test('a size this window would refuse to send its own PTY never becomes a button', () => {
+    // The wire clamp floors at 2×2. Offering the owner a one-tap way to put
+    // their own terminal there — while they read a number that arrived a
+    // moment earlier — is the shape of the mistake this guard exists for.
+    expect(shouldPrompt(request({ cols: 2, rows: 2 }), 's1', { cols: 164, rows: 48 })).toBe(false);
+    expect(shouldPrompt(request({ cols: 9 }), 's1', { cols: 164, rows: 48 })).toBe(false);
+    expect(shouldPrompt(request({ cols: MIN_REQUEST_COLS, rows: MIN_REQUEST_ROWS }), 's1', null)).toBe(true);
+  });
 });
 
 describe('whoIsAsking', () => {
@@ -79,8 +90,8 @@ describe('resizeRequestCopy', () => {
   });
 
   test('the answers are one-tap and say what they do', () => {
-    // "Resize once" is the whole promise: the next fit of this window takes
-    // the size back, and the button must not imply otherwise.
+    // "Resize once" is one act rather than a standing rule — the owner takes
+    // the size back through the banner, not by alt-tabbing away and back.
     expect(RESIZE_ONCE).toBe('Resize once');
     expect(KEEP_MY_SIZE).toBe('Keep my size');
   });

--- a/src/renderer/components/resizeRequestPrompt.ts
+++ b/src/renderer/components/resizeRequestPrompt.ts
@@ -1,9 +1,7 @@
 /**
  * The owner's side of "Fit to my screen": whether a guest's request is worth
- * asking about, and what the question says.
- *
- * Pure, and apart from Terminal.tsx, so the decision can be tested without a
- * canvas, a laid-out container or an xterm.
+ * asking about, and what the question says. Apart from Terminal.tsx so it can
+ * be tested without a canvas, a laid-out container or an xterm.
  */
 
 import { RelayResizeRequest } from '../../shared/types';
@@ -17,11 +15,9 @@ export interface TerminalSize {
 }
 
 /**
- * Whether to raise the prompt at all.
- *
- * A request for another session belongs to another terminal, and one that
- * already matches this size asks for nothing — interrupting the owner to
- * offer them a no-op spends their attention for nothing.
+ * Whether to raise the prompt at all. A request for another session belongs
+ * to another terminal, and one already at this size asks for nothing —
+ * interrupting the owner with a no-op spends their attention for nothing.
  */
 export function shouldPrompt(
   request: RelayResizeRequest,

--- a/src/renderer/components/resizeRequestPrompt.ts
+++ b/src/renderer/components/resizeRequestPrompt.ts
@@ -1,0 +1,54 @@
+/**
+ * The owner's side of "Fit to my screen": whether a guest's request is worth
+ * asking about, and what the question says.
+ *
+ * Pure, and apart from Terminal.tsx, so the decision can be tested without a
+ * canvas, a laid-out container or an xterm.
+ */
+
+import { RelayResizeRequest } from '../../shared/types';
+
+export const RESIZE_ONCE = 'Resize once';
+export const KEEP_MY_SIZE = 'Keep my size';
+
+export interface TerminalSize {
+  cols: number;
+  rows: number;
+}
+
+/**
+ * Whether to raise the prompt at all.
+ *
+ * A request for another session belongs to another terminal, and one that
+ * already matches this size asks for nothing — interrupting the owner to
+ * offer them a no-op spends their attention for nothing.
+ */
+export function shouldPrompt(
+  request: RelayResizeRequest,
+  sessionId: string,
+  current: TerminalSize | null,
+): boolean {
+  if (request.sessionId !== sessionId) return false;
+  if (request.cols < 1 || request.rows < 1) return false;
+  return !current || current.cols !== request.cols || current.rows !== request.rows;
+}
+
+/**
+ * Who is asking. The GitHub login is the immutable identity, so it is
+ * preferred over a display name the account holder can change to anything.
+ */
+export function whoIsAsking(request: RelayResizeRequest): string {
+  if (request.login) return `@${request.login}`;
+  return request.displayName ?? 'Someone watching';
+}
+
+/**
+ * The question. It names the size being asked for and the one it replaces,
+ * because "resize this terminal" without numbers asks the owner to agree to
+ * something they cannot see the shape of.
+ */
+export function resizeRequestCopy(request: RelayResizeRequest, current: TerminalSize | null): string {
+  const asked = `${request.cols}×${request.rows}`;
+  const mine = current ? ` — yours is ${current.cols}×${current.rows}` : '';
+  return `${whoIsAsking(request)} asked to fit this session to their screen (${asked})${mine}.`;
+}

--- a/src/renderer/components/resizeRequestPrompt.ts
+++ b/src/renderer/components/resizeRequestPrompt.ts
@@ -15,6 +15,14 @@ export interface TerminalSize {
 }
 
 /**
+ * The smallest grid worth offering, mirroring Terminal's own MIN_COLS/MIN_ROWS:
+ * a size this window refuses to send its own PTY must not arrive as a button
+ * that sends it. The wire clamp floors at 2×2, legible to nobody.
+ */
+export const MIN_REQUEST_COLS = 10;
+export const MIN_REQUEST_ROWS = 2;
+
+/**
  * Whether to raise the prompt at all. A request for another session belongs
  * to another terminal, and one already at this size asks for nothing —
  * interrupting the owner with a no-op spends their attention for nothing.
@@ -25,7 +33,7 @@ export function shouldPrompt(
   current: TerminalSize | null,
 ): boolean {
   if (request.sessionId !== sessionId) return false;
-  if (request.cols < 1 || request.rows < 1) return false;
+  if (request.cols < MIN_REQUEST_COLS || request.rows < MIN_REQUEST_ROWS) return false;
   return !current || current.cols !== request.cols || current.rows !== request.rows;
 }
 

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare } from '../shared/types';
+import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -19,6 +19,8 @@ interface ElectronAPI {
   onPtyData: (callback: (id: string, data: string) => void) => () => void;
   onPtyExit: (callback: (id: string, exitCode: number) => void) => () => void;
   onPtyResize: (callback: (id: string, cols: number, rows: number) => void) => () => void;
+  /** A guest asked to be fitted to their screen — a request the owner answers. */
+  onRelayResizeRequest: (callback: (request: RelayResizeRequest) => void) => () => void;
   onStateChange: (callback: (event: { sessionId: string; state: string; event: string; timestamp: number }) => void) => () => void;
   onSessionsRefresh: (callback: () => void) => () => void;
   onGroupsRefresh: (callback: () => void) => () => void;

--- a/src/renderer/styles/terminal.css
+++ b/src/renderer/styles/terminal.css
@@ -257,6 +257,59 @@
   background: #4dd3e1;
 }
 
+/* A guest asked to be fitted to their screen. Shares the slot with the
+   mobile-resize banner — which is the state accepting produces — so when both
+   are up the question stays above the thing it caused. */
+.resize-request-banner {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  z-index: 11;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 10px 14px;
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border-control);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.resize-request-banner ~ .mobile-resize-banner { top: 62px; }
+
+.resize-request-text { flex: 1; min-width: 240px; }
+
+.resize-request-actions {
+  display: flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.resize-request-actions button {
+  padding: 6px 12px;
+  border-radius: var(--radius-sm, 4px);
+  font-size: 12px;
+  cursor: pointer;
+  border: none;
+  background: var(--color-hover);
+  color: var(--color-text);
+}
+
+.resize-request-actions button:hover { background: var(--color-border); }
+
+.resize-request-actions .primary {
+  background: var(--color-accent);
+  color: var(--color-text-on-accent);
+  font-weight: 500;
+}
+
+.resize-request-actions .primary:hover { background: var(--color-accent-hover); }
+
 .provider-install-banner code {
   color: #ffd890;
   background: rgba(0, 0, 0, 0.25);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -148,6 +148,22 @@ export interface RelayStatus {
   pendingShares: RelayPendingShare[];
 }
 
+/**
+ * A guest asking for a session to be resized to fit their screen.
+ *
+ * Mirrors the tunnel's `GuestResizeRequest`. It is a request and nothing else:
+ * guests never resize the owner's terminal, so this only ever becomes a prompt
+ * the owner may decline — after which the guest's view is exactly as it was.
+ */
+export interface RelayResizeRequest {
+  sessionId: string;
+  cols: number;
+  rows: number;
+  /** Who is asking. Relay-asserted identity, never authorization. */
+  login: string | null;
+  displayName: string | null;
+}
+
 export interface RelayAttachedGuest {
   clientId: string;
   grantId: string | null;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -149,11 +149,9 @@ export interface RelayStatus {
 }
 
 /**
- * A guest asking for a session to be resized to fit their screen.
- *
- * Mirrors the tunnel's `GuestResizeRequest`. It is a request and nothing else:
- * guests never resize the owner's terminal, so this only ever becomes a prompt
- * the owner may decline — after which the guest's view is exactly as it was.
+ * A guest asking for a session to be resized to fit their screen. Mirrors the
+ * tunnel's `GuestResizeRequest`, and is a request and nothing else: it becomes
+ * a prompt the owner may decline, leaving the guest's view exactly as it was.
  */
 export interface RelayResizeRequest {
   sessionId: string;


### PR DESCRIPTION
## Description

The four arrival-and-reading gaps the session-sharing design (§7, Guest) specifies and that didn't land with M5.2. A guest now arrives somewhere, is told the truth about what's happening in their own voice, and can ask a wide desktop terminal to fit their screen.

### 1. Single-grant arrival — new `relay/web/src/arrival.ts`

One machine plus a relation of grantee means no machine pill, no picker: the one session the grant covers opens as soon as the list arrives. The decision is made **once**, and the guard lives in `autoOpenSessionId()` where it is tested. The list polls every 2.5s, and re-deciding on each poll would drag a guest who tapped Back straight back into the terminal.

A single grant covering two or more sessions still shows the list — deliberate, because there is a real choice to make. At two or more grants the picker returns, sectioned "My machines" / "Shared with me", with rows labelled by person, and the sheet titled "Shared with you" when the person owns nothing themselves. Section headings render only when there is more than one section to separate, symmetric across owner and guest.

The `＋` new-session button is removed for guests: `create` belongs to no guest role, so for a guest it could only ever produce a refusal. "Link a machine" moved into the account sheet so it stays reachable when the machine pill is suppressed.

### 2. Guest-voice copy — new `relay/web/src/guest-copy.ts`

"Will's machine is offline right now. We'll ask again as soon as it's back." and "Waiting for Will to let you in…".

The owner's name is not in the redeem response, so it comes from `/api/shares`, which lists pending grants with `ownerName`, and repaints only if the waiting screen is still the thing on screen. Where no name is known the fallback reads "Their machine is offline right now…", capitalised, with a test pinning the exact string.

A guest who lands directly in a terminal never sees the session list — which was the only place connection state was ever stated — so the same copy is repeated on a `#connStrip` above their screen.

### 3. Role words

`guestSubtitle()` builds on the existing `roleWord()` in `shares.ts`: "Shared by Will · watching", "Shared by Will · watching and typing". Both `openTerminal` and `updateTermHeader` render through it, so a poll cannot overwrite the subtitle with a raw role. Tests assert that `viewer`, `operator` and `grant` never reach the string.

### 4. Fit to my screen

The guest's wide-terminal banner gains a 44×44 button. Asking flips it to copy that promises nothing and reverts after 45s, so an ask that goes unanswered can simply be repeated:

> Asked Will to resize. They may not be at their desk — nothing changes unless they say yes, so keep reading meanwhile.

Two paths end in silence by design — a requested size below the floor, and a second guest asking while a prompt already stands — and that copy makes silence an expected outcome rather than a mystery.

The owner's terminal shows `👀 @dana-k asked to fit this session to their screen (80×24) — yours is 164×48.` with `[ Resize once ] [ Keep my size ]`. Declining sends nothing at all, so a refusal reaches the guest as silence followed by the 45s revert.

**An accepted fit is held.** `Terminal.tsx` carries `heldFitRef`; `handleResize` early-returns while a granted fit stands, so focus, window-resize and session-activation can no longer re-measure and push the desktop grid back over the guest. The hold clears exactly two ways: the owner clicking "Resume desktop size" — now genuinely the take-back — or the desktop size arriving over `pty:resized`. Accepting also sets `mobileSize`, so a held fit always implies the banner is on screen and the take-back is always reachable.

### The message it travels as

`terminal:resize-request {sessionId, cols, rows}`, client→agent, in the existing `terminal:*` vocabulary.

It requires only the `view` capability — asking is not resizing. Viewer and operator capabilities are unchanged, and `resize` stays owner-only. The tunnel:

- clamps through the existing `sanitizeSize`
- requires a live subscription to that session, because asking about a session you cannot see would leak that it exists
- **throttles per grant, not per socket** — a tunnel-level map keyed `grantId ?? userId ?? clientId`, swept so it cannot grow without bound. Six channels open under one certificate raise one prompt, not six.
- forwards through a new `onResizeRequest` dep, and never calls `pty.resize` itself

`shouldPrompt` refuses anything below 10×2, so the wire floor cannot become a button. The read/click race between two arriving requests is closed first-wins, via `setResizeRequest((pending) => pending ?? request)`.

Added to `fixtures/sharing-v1.json` commandCaps with a note recording that needing `resize` here would itself be the finding. The message, the per-grant throttle and the held fit are written into `docs/designs/session-sharing.md` §7.

### Two fixes that reach beyond guests

**A reconnected client re-subscribes.** `readyCommands(activeSessionId)` now returns groups → sessions → `terminal:subscribe` when a terminal is open. This was a pre-existing owner bug too; landing guests directly in a terminal made it the default path and so made it visible.

**Owner replays clear the screen first.** `\x1b[2J\x1b[3J\x1b[H` is emitted before the owner's chunks, through a single `CLEAR_SCREEN` constant both branches share, which kills a duplicate-scrollback regression the re-subscribe fix introduced. The invariant belongs with the sender: the frame is what claims "here is the whole buffer", and `readyCommands` deliberately knows nothing about the terminal widget.

## Related issue

Closes #185

Part of #177.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Hotfix
- [ ] Refactor / chore
- [x] Docs

## How was this tested?

```
$ bun test --isolate                 # repo root
1007 pass, 0 fail (68 files)

$ cd relay && bun test --isolate
268 pass, 0 fail (14 files)

$ cd relay && bun run typecheck      # relay server
$ cd relay && bun run typecheck:web  # relay web
$ bun run build:main                 # tsc -p tsconfig.main.json
$ tsc -p tsconfig.json --noEmit      # renderer + shared
all four clean, no diagnostics

$ cd relay && bun run build:web
bundles
```

Harness `verify.sh` is green on tests, seams and the comment-wall check.

Two test doubles were themselves wrong, and were part of why the held-fit defect stayed invisible: `FitAddon.fit` now re-measures against a fixed container, and `FakeTerm.resize` actually moves the grid. Before that, a double reported a resize it had not performed.

### What was not verified

**Coverage is RED in `verify.sh`, across four files — not three.**

Three are pure wiring: `relay-client.ts`, `src/main/index.ts` and `src/main/preload.ts`. Each received between 3 and 8 lines with no branch in any of them — construct the dep, forward the IPC, expose the bridge. The repo has no spec for any of the three today, because covering them requires `mock.module('electron')`, which is exactly what the design doc's dependency-injection argument exists to avoid. All behaviour behind that wiring is tested on both sides of it.

The fourth is different, and is a **false green rather than a stated exemption**. `relay/web/src/main.ts` is reported as covered and is not. The checker's `importing_specs` builds its needle from the file stem — here `main`, which is not in `GENERIC_STEMS` — and then matches `/main['"./]`. The literal `src/main/` in an import satisfies that pattern, so **29 specs across the repo match, of which none import this file**; an account-auth test under `src/main/` is credited as covering a browser entry point it has never loaded. Verified at `54e15dc`: no spec imports `relay/web/src/main.ts`, and `requestFit`, `maybeLandInTerminal` and `updateWideBanner` are module-private and referenced by zero specs.

The logic those three call was extracted precisely so it could be tested — `arrival.ts` and `guest-copy.ts` are covered directly — but the wiring inside `main.ts` that calls them is executed by no spec, and the checker will not tell you so.

Also not verified: no manual end-to-end run of the fit request against a real phone and a real desktop. The round trip is covered by tests on each side and at the tunnel, not by one live exercise of the whole path.

## Gate results

**Gate 4 — verifier: VERIFIED.** Every count above was reproduced independently. The tunnel tests drive the production dispatch path rather than a re-implementation, and pin the deny cases. The new capability entry is held by a pre-existing exact-equality assertion against the policy fixture, so the code and the fixture cannot drift apart without a test failing.

**Gate 3 — reviewer: first pass RED**, three majors, each proven by running a probe rather than by reasoning about the code:

1. An accepted fit was undone by a single window-focus event.
2. The throttle was per socket, so six tabs raised six prompts.
3. A reconnected guest never re-subscribed, while the page still read as connected.

**Delta re-check: GREEN.** Both probes were re-run byte-identical and both flipped — the fit held at 80 cols, and six sockets raised one prompt. Four mutations were killed, including the arrival guard that survived the first round. The hold was verified as an invariant across all five `heldFitRef` call sites, so an owner cannot be stranded at a phone-sized terminal.

## For review attention

**(a) Picker sectioning.** The design writes `SHARED WITH ME — Will's laptop`. That was read as "section header plus row", so it is implemented as one "Shared with me" section with person-labelled rows sorted by owner, rather than one section per person. If per-person headings were what was meant, that is a one-line change in `machineSections()`.

**(b) The owner prompt renders on the terminal it is about.** An owner sitting in Analytics or in another session will not see it. This is deliberate: the prompt decides nothing about access, so unlike a join request it does not bypass `shouldNotify()` and does not raise an OS notification. The guest's 45s revert is what keeps that honest — an unseen ask expires and can be asked again. The banner is an `<output>` element rather than `role="status"`.

**(c) "Resize once" now means "until you take it back", not "until the next repaint".** This is the one review finding that changed the shipped behaviour rather than the code behind it, so the button's label is worth a second opinion: it still reads `Resize once`, while the hold persists until the owner clicks "Resume desktop size" or a desktop size arrives over `pty:resized`.

**(d) Test doubles.** `Terminal.restart.test.tsx`'s `electronAPI` stub was extended with `onRelayResizeRequest` — a faithful superset. The new `Terminal.resizeRequest.test.tsx` mocks xterm the same way that file does. Both rely on `--isolate`.

## Merge note

Initiative #183 (web push) is concurrently editing `relay/web/src/main.ts` and `sw.js`. Whichever of the two lands second will need a merge-forward before it goes in. This PR's changes to `main.ts` are substantial, so that merge wants a real read rather than an automatic resolution.

## Checklist
- [x] Tests pass locally
- [x] Self-reviewed the changes
- [x] Docs updated where needed
- [x] Linked the related issue above

<!-- bodhi:merge-order -->
**Merge position 1 of 1.** Nothing merges before this one.
Order: Bodhilander
<!-- bodhi:merge-order -->
