### PR TITLE
207 — Account failover: when one account runs dry, the work moves and the conversation follows

### DIFF
--- a/src/main/__tests__/account-auth.test.ts
+++ b/src/main/__tests__/account-auth.test.ts
@@ -49,7 +49,10 @@ function freshDb(): Database {
       color TEXT DEFAULT '#888888',
       is_default INTEGER DEFAULT 0,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-      last_used_at TEXT
+      last_used_at TEXT,
+      fallback_rank INTEGER DEFAULT NULL,
+      limited_until TEXT DEFAULT NULL,
+      limited_at TEXT DEFAULT NULL
     );
     CREATE UNIQUE INDEX idx_claude_accounts_single_default
       ON claude_accounts(is_default) WHERE is_default = 1;
@@ -58,12 +61,16 @@ function freshDb(): Database {
       group_id TEXT,
       name TEXT NOT NULL,
       working_dir TEXT NOT NULL,
-      claude_account_id TEXT DEFAULT NULL
+      claude_account_id TEXT DEFAULT NULL,
+      failover_from_account_id TEXT DEFAULT NULL,
+      failover_prev_account_id TEXT DEFAULT NULL
     );
     CREATE TABLE groups (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
-      claude_account_id TEXT DEFAULT NULL
+      claude_account_id TEXT DEFAULT NULL,
+      failover_from_account_id TEXT DEFAULT NULL,
+      failover_prev_account_id TEXT DEFAULT NULL
     );
   `);
   return d;

--- a/src/main/__tests__/account-failover.test.ts
+++ b/src/main/__tests__/account-failover.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Automatic account failover — what happens to live sessions when the account
+ * behind them runs out of quota, and how they get back.
+ *
+ * Runs the real repositories against bun:sqlite, because most of what can go
+ * wrong here is a wrong row rather than a wrong branch: an override written
+ * where an inheritance belonged, a cooldown overwritten by a vaguer one, a
+ * "home" that quietly becomes the backup account after two hops.
+ *
+ * Run with: bun test src/main/__tests__/account-failover.test.ts
+ */
+import { describe, expect, test, beforeEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+
+let db: Database;
+
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
+}));
+
+mock.module('../database', () => ({
+  getDatabase: () => db,
+}));
+
+/**
+ * Preferences, held in a map this file owns.
+ *
+ * mock.module is process-global and other suites replace this same module —
+ * one of them with a stub that has no setPreference at all — so a preference
+ * written through the real repository here is read back through whichever
+ * implementation happened to register last. Owning the map removes the
+ * ordering dependency; re-registering in beforeEach (below) takes the module
+ * back from any suite that loaded before this one.
+ */
+const prefs = new Map<string, string>();
+const prefsModule = () => ({
+  getPreference: (key: string) => prefs.get(key) ?? null,
+  setPreference: (key: string, value: string) => { prefs.set(key, value); },
+  deletePreference: (key: string) => { prefs.delete(key); },
+});
+mock.module('../repositories/preferences', prefsModule);
+
+const failover = await import('../account-failover');
+const accountsRepo = await import('../repositories/accounts');
+const sessionsRepo = await import('../repositories/sessions');
+
+const HOUR = 60 * 60 * 1000;
+
+function freshDb(): Database {
+  const d = new Database(':memory:');
+  d.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      group_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      working_dir TEXT,
+      state TEXT,
+      shell_type TEXT DEFAULT 'claude',
+      "order" INTEGER DEFAULT 0,
+      created_at TEXT,
+      last_activity_at TEXT,
+      claude_session_id TEXT DEFAULT NULL,
+      ended_at TEXT DEFAULT NULL,
+      duration_seconds REAL DEFAULT 0,
+      claude_account_id TEXT DEFAULT NULL,
+      provider TEXT NOT NULL DEFAULT 'claude',
+      failover_from_account_id TEXT DEFAULT NULL,
+      failover_prev_account_id TEXT DEFAULT NULL
+    );
+    CREATE TABLE groups (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      color TEXT,
+      working_dir TEXT,
+      "order" INTEGER DEFAULT 0,
+      created_at TEXT,
+      parent_id TEXT DEFAULT NULL,
+      collapsed INTEGER DEFAULT 0,
+      claude_account_id TEXT DEFAULT NULL
+    );
+    CREATE TABLE claude_accounts (
+      id TEXT PRIMARY KEY,
+      label TEXT NOT NULL,
+      config_dir TEXT NOT NULL UNIQUE,
+      email TEXT,
+      color TEXT DEFAULT '#888888',
+      is_default INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      last_used_at TEXT,
+      fallback_rank INTEGER DEFAULT NULL,
+      limited_until TEXT DEFAULT NULL,
+      limited_at TEXT DEFAULT NULL
+    );
+    CREATE TABLE preferences (key TEXT PRIMARY KEY, value TEXT);
+  `);
+  return d;
+}
+
+function addAccount(id: string, rank: number | null, isDefault = false): void {
+  db.prepare(`
+    INSERT INTO claude_accounts (id, label, config_dir, is_default, created_at, fallback_rank)
+    VALUES (?, ?, ?, ?, '2026-08-01T00:00:00Z', ?)
+  `).run(id, id, `/tmp/bodhilander-test/${id}`, isDefault ? 1 : 0, rank);
+}
+
+function addGroup(id: string, accountId: string | null = null): void {
+  db.prepare(`
+    INSERT INTO groups (id, name, created_at, claude_account_id)
+    VALUES (?, ?, '2026-08-01T00:00:00Z', ?)
+  `).run(id, id, accountId);
+}
+
+function addSession(id: string, groupId: string, accountId: string | null, state = 'working'): void {
+  db.prepare(`
+    INSERT INTO sessions (id, group_id, name, working_dir, state, created_at, last_activity_at, claude_account_id)
+    VALUES (?, ?, ?, '/tmp', ?, '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z', ?)
+  `).run(id, groupId, id, state, accountId);
+}
+
+/** The live-binding map the pty manager hands over. */
+function live(bindings: Record<string, string>): Record<string, any> {
+  return Object.fromEntries(
+    Object.entries(bindings).map(([sessionId, accountId]) => [
+      sessionId,
+      { accountId, configDir: `/tmp/bodhilander-test/${accountId}`, spawnedAt: 0 },
+    ]),
+  );
+}
+
+beforeEach(() => {
+  db = freshDb();
+  mock.module('../repositories/preferences', prefsModule);
+  prefs.clear();
+});
+
+describe('handleUsageLimit', () => {
+  test('records the reset time the CLI gave us', () => {
+    addAccount('primary', 0, true);
+    addAccount('backup', 1);
+    addGroup('g');
+    addSession('s1', 'g', 'primary');
+
+    const resetAt = new Date(Date.now() + 2 * HOUR);
+    failover.handleUsageLimit({
+      sessionId: 's1', accountId: 'primary', resetAt, liveAccounts: live({ s1: 'primary' }),
+    });
+
+    expect(accountsRepo.getAccount('primary')!.limitedUntil!.toISOString())
+      .toBe(resetAt.toISOString());
+  });
+
+  /**
+   * No reset time in the message means the account is held for a full rolling
+   * window rather than released optimistically — an account handed back early
+   * is a second failover, and a second restart, for every session on it.
+   */
+  test('falls back to a full window when the message named no reset', () => {
+    addAccount('primary', 0, true);
+    addAccount('backup', 1);
+    addGroup('g');
+    addSession('s1', 'g', 'primary');
+
+    const before = Date.now();
+    failover.handleUsageLimit({
+      sessionId: 's1', accountId: 'primary', resetAt: null, liveAccounts: live({ s1: 'primary' }),
+    });
+
+    const until = accountsRepo.getAccount('primary')!.limitedUntil!.getTime();
+    expect(until).toBeGreaterThanOrEqual(before + accountsRepo.DEFAULT_COOLDOWN_MS);
+  });
+
+  /**
+   * The limit belongs to the account, not to the session that noticed it, so
+   * every session on that account is already dead in the water. Moving them
+   * one at a time as each hits the wall would restart them minutes apart for
+   * no gain.
+   */
+  test('moves every live session on the spent account, not just the reporter', () => {
+    addAccount('primary', 0, true);
+    addAccount('backup', 1);
+    addGroup('g');
+    addSession('s1', 'g', 'primary');
+    addSession('s2', 'g', 'primary');
+    addSession('elsewhere', 'g', 'backup');
+
+    const event = failover.handleUsageLimit({
+      sessionId: 's1',
+      accountId: 'primary',
+      resetAt: null,
+      liveAccounts: live({ s1: 'primary', s2: 'primary', elsewhere: 'backup' }),
+    });
+
+    expect(event!.sessionIds.sort()).toEqual(['s1', 's2']);
+    expect(sessionsRepo.getSession('s2')!.claudeAccountId).toBe('backup');
+    expect(sessionsRepo.getSession('elsewhere')!.claudeAccountId).toBe('backup');
+  });
+
+  test('follows the fallback order and skips an account already limited', () => {
+    addAccount('primary', 0, true);
+    addAccount('second', 1);
+    addAccount('third', 2);
+    accountsRepo.markAccountLimited('second', new Date(Date.now() + HOUR));
+    addGroup('g');
+    addSession('s1', 'g', 'primary');
+
+    const event = failover.handleUsageLimit({
+      sessionId: 's1', accountId: 'primary', resetAt: null, liveAccounts: live({ s1: 'primary' }),
+    });
+
+    expect(event!.to!.id).toBe('third');
+  });
+
+  test('says so, rather than nothing, when every account is spent', () => {
+    addAccount('primary', 0, true);
+    addAccount('backup', 1);
+    accountsRepo.markAccountLimited('backup', new Date(Date.now() + HOUR));
+    addGroup('g');
+    addSession('s1', 'g', 'primary');
+
+    const event = failover.handleUsageLimit({
+      sessionId: 's1', accountId: 'primary', resetAt: null, liveAccounts: live({ s1: 'primary' }),
+    });
+
+    expect(event!.blocked).toBe('no-healthy-account');
+    expect(event!.sessionIds).toEqual([]);
+    expect(sessionsRepo.getSession('s1')!.claudeAccountId).toBe('primary');
+  });
+
+  /**
+   * Switched off, the cooldown is still worth recording: the panel shows it,
+   * and it keeps the spent account from being picked as somebody else's
+   * failover target.
+   */
+  test('still records the limit when failover is switched off', () => {
+    prefs.set('accountFailoverEnabled', 'false');
+    addAccount('primary', 0, true);
+    addAccount('backup', 1);
+    addGroup('g');
+    addSession('s1', 'g', 'primary');
+
+    const event = failover.handleUsageLimit({
+      sessionId: 's1', accountId: 'primary', resetAt: null, liveAccounts: live({ s1: 'primary' }),
+    });
+
+    expect(event!.blocked).toBe('disabled');
+    expect(sessionsRepo.getSession('s1')!.claudeAccountId).toBe('primary');
+    expect(accountsRepo.getAccount('primary')!.limitedUntil).not.toBeNull();
+  });
+
+  /**
+   * A session the user has already redirected is restarted, not re-pointed.
+   * The respawn applies the switch they chose, which gets it off the spent
+   * account just as well — and rewriting the assignment would throw away a
+   * decision they made on purpose.
+   */
+  test('restarts a session with a pending manual switch without overriding it', () => {
+    addAccount('primary', 0, true);
+    addAccount('backup', 1);
+    addAccount('chosen', 2);
+    addGroup('g');
+    addSession('s1', 'g', 'chosen');
+
+    const event = failover.handleUsageLimit({
+      // The pty is still billing 'primary' — that is why it reported the limit.
+      sessionId: 's1', accountId: 'primary', resetAt: null, liveAccounts: live({ s1: 'primary' }),
+    });
+
+    expect(event!.sessionIds).toEqual(['s1']);
+    expect(sessionsRepo.getSession('s1')!.claudeAccountId).toBe('chosen');
+    expect(sessionsRepo.getSession('s1')!.failoverFromAccountId).toBeNull();
+  });
+
+  test('does nothing for a session with no account bound', () => {
+    addGroup('g');
+    addSession('s1', 'g', null);
+    expect(failover.handleUsageLimit({
+      sessionId: 's1', accountId: null, resetAt: null, liveAccounts: {},
+    })).toBeNull();
+  });
+});
+
+describe('going home', () => {
+  /**
+   * A session that inherited its account from its group must go back to
+   * INHERITING, not to the account that inheritance happened to resolve to.
+   * Pinning it would quietly convert a group-wide setting into a per-session
+   * override that then ignores every future group change.
+   */
+  test('restores an inherited assignment rather than pinning it', () => {
+    addAccount('primary', 0, true);
+    addAccount('backup', 1);
+    addGroup('g', 'primary');
+    addSession('s1', 'g', null);
+
+    failover.handleUsageLimit({
+      sessionId: 's1', accountId: 'primary', resetAt: null, liveAccounts: live({ s1: 'primary' }),
+    });
+    expect(sessionsRepo.getSession('s1')!.claudeAccountId).toBe('backup');
+
+    accountsRepo.clearAccountLimit('primary');
+    failover.failBackSession('s1');
+
+    const after = sessionsRepo.getSession('s1')!;
+    expect(after.claudeAccountId).toBeNull();
+    expect(after.failoverFromAccountId).toBeNull();
+  });
+
+  /**
+   * Two hops: primary runs dry, then the backup does too. Home is still the
+   * primary — the backup is just as spent, and it was never where the user put
+   * this session.
+   */
+  test('keeps the original home across a second failover', () => {
+    addAccount('primary', 0, true);
+    addAccount('backup', 1);
+    addAccount('third', 2);
+    addGroup('g');
+    addSession('s1', 'g', 'primary');
+
+    failover.handleUsageLimit({
+      sessionId: 's1', accountId: 'primary', resetAt: null, liveAccounts: live({ s1: 'primary' }),
+    });
+    failover.handleUsageLimit({
+      sessionId: 's1', accountId: 'backup', resetAt: null, liveAccounts: live({ s1: 'backup' }),
+    });
+
+    expect(sessionsRepo.getSession('s1')!.claudeAccountId).toBe('third');
+    expect(sessionsRepo.getSession('s1')!.failoverFromAccountId).toBe('primary');
+
+    accountsRepo.clearAccountLimit('primary');
+    const event = failover.failBackSession('s1');
+    expect(event!.to!.id).toBe('primary');
+    expect(sessionsRepo.getSession('s1')!.claudeAccountId).toBe('primary');
+  });
+
+  test('offers no candidate while the original account is still limited', () => {
+    addAccount('primary', 0, true);
+    addAccount('backup', 1);
+    addGroup('g');
+    addSession('s1', 'g', 'primary');
+
+    failover.handleUsageLimit({
+      sessionId: 's1',
+      accountId: 'primary',
+      resetAt: new Date(Date.now() + HOUR),
+      liveAccounts: live({ s1: 'primary' }),
+    });
+
+    expect(failover.failbackCandidates()).toEqual([]);
+    // ...and offers it once the cooldown has run out.
+    const later = new Date(Date.now() + 2 * HOUR);
+    expect(failover.failbackCandidates(later).map(c => c.sessionId)).toEqual(['s1']);
+  });
+
+  /**
+   * Going home costs a respawn, and a respawn mid-turn throws away work in
+   * flight. This gate is the only reason an unprompted switch back is safe.
+   */
+  test('only moves a session that is between turns', () => {
+    expect(failover.canFailBackNow('idle')).toBe(true);
+    expect(failover.canFailBackNow('stopped')).toBe(true);
+    expect(failover.canFailBackNow('working')).toBe(false);
+    expect(failover.canFailBackNow('waiting')).toBe(false);
+  });
+
+  test('a deleted home retires the pending move instead of stranding it', () => {
+    addAccount('primary', 0, true);
+    addAccount('backup', 1);
+    addGroup('g');
+    addSession('s1', 'g', 'primary');
+
+    failover.handleUsageLimit({
+      sessionId: 's1', accountId: 'primary', resetAt: null, liveAccounts: live({ s1: 'primary' }),
+    });
+    db.prepare("DELETE FROM claude_accounts WHERE id = 'primary'").run();
+
+    expect(failover.failbackCandidates()).toEqual([]);
+    expect(sessionsRepo.getSession('s1')!.failoverFromAccountId).toBeNull();
+  });
+
+  test('a hand-picked account retires the pending move', () => {
+    addAccount('primary', 0, true);
+    addAccount('backup', 1);
+    addGroup('g');
+    addSession('s1', 'g', 'primary');
+
+    failover.handleUsageLimit({
+      sessionId: 's1', accountId: 'primary', resetAt: null, liveAccounts: live({ s1: 'primary' }),
+    });
+    failover.clearFailoverRecord('s1');
+    accountsRepo.clearAccountLimit('primary');
+
+    expect(failover.failbackCandidates()).toEqual([]);
+    expect(failover.failBackSession('s1')).toBeNull();
+  });
+});
+
+describe('cooldown bookkeeping', () => {
+  /**
+   * Two sessions hit the wall seconds apart and the second message is usually
+   * the vaguer one — no "resets at" clause, so the default window. Taking the
+   * later of the two stops a precise reset time being overwritten by a guess.
+   */
+  test('a second, vaguer report cannot shorten a precise cooldown', () => {
+    addAccount('primary', 0, true);
+    const precise = new Date(Date.now() + 4 * HOUR);
+    accountsRepo.markAccountLimited('primary', precise);
+    accountsRepo.markAccountLimited('primary', new Date(Date.now() + HOUR));
+
+    expect(accountsRepo.getAccount('primary')!.limitedUntil!.toISOString())
+      .toBe(precise.toISOString());
+  });
+
+  test('an expired cooldown is not a limit', () => {
+    addAccount('primary', 0, true);
+    accountsRepo.markAccountLimited('primary', new Date(Date.now() + HOUR));
+
+    const account = accountsRepo.getAccount('primary')!;
+    expect(accountsRepo.isAccountHealthy(account)).toBe(false);
+    expect(accountsRepo.isAccountHealthy(account, new Date(Date.now() + 2 * HOUR))).toBe(true);
+  });
+
+  /**
+   * SQLite sorts NULL first, so an unranked account would otherwise outrank
+   * every account the user deliberately placed.
+   */
+  test('unranked accounts sort after ranked ones', () => {
+    addAccount('unranked', null);
+    addAccount('second', 1);
+    addAccount('first', 0);
+
+    expect(accountsRepo.getAccountsInFallbackOrder().map(a => a.id))
+      .toEqual(['first', 'second', 'unranked']);
+  });
+
+  test('setFallbackOrder writes the order it was given', () => {
+    addAccount('a', 0);
+    addAccount('b', 1);
+    addAccount('c', 2);
+
+    accountsRepo.setFallbackOrder(['c', 'a', 'b']);
+    expect(accountsRepo.getAccountsInFallbackOrder().map(a => a.id)).toEqual(['c', 'a', 'b']);
+  });
+});

--- a/src/main/__tests__/account-failover.test.ts
+++ b/src/main/__tests__/account-failover.test.ts
@@ -40,6 +40,12 @@ const prefsModule = () => ({
 });
 mock.module('../repositories/preferences', prefsModule);
 
+const realAccountSwitch = await import('../account-switch');
+// A direct function reference, captured before anything re-mocks the module.
+// `realAccountSwitch.assignSessionAccount` is a LIVE binding: read after
+// mock.module it resolves to the mock, so a mock that reached through the
+// namespace to reach "the real one" would call itself until the stack died.
+const realAssignSessionAccount = realAccountSwitch.assignSessionAccount;
 const failover = await import('../account-failover');
 const accountsRepo = await import('../repositories/accounts');
 const sessionsRepo = await import('../repositories/sessions');
@@ -440,5 +446,114 @@ describe('cooldown bookkeeping', () => {
 
     accountsRepo.setFallbackOrder(['c', 'a', 'b']);
     expect(accountsRepo.getAccountsInFallbackOrder().map(a => a.id)).toEqual(['c', 'a', 'b']);
+  });
+});
+
+/**
+ * The desktop notification's wording.
+ *
+ * Tested for the same failure its in-window counterpart is: a sentence that
+ * claims sessions moved when none did. The notification is the harder case of
+ * the two — it is often the only account of the switch a user ever sees, since
+ * the window may be behind something when it fires.
+ */
+describe('describeFailover', () => {
+  const account = (id: string, label: string) => ({ id, label } as any);
+
+  test('names the new account and how many sessions moved', () => {
+    const { title, body } = failover.describeFailover({
+      reason: 'limit',
+      from: account('a', 'Personal'),
+      to: account('b', 'Work'),
+      sessionIds: ['s1', 's2'],
+      resetAt: null,
+    });
+    expect(title).toContain('Work');
+    expect(body).toContain('Personal');
+    expect(body).toContain('2 sessions moved to Work');
+  });
+
+  test('never claims a move when there was nowhere to go', () => {
+    const { body } = failover.describeFailover({
+      reason: 'limit',
+      from: account('a', 'Personal'),
+      to: null,
+      sessionIds: [],
+      resetAt: null,
+      blocked: 'no-healthy-account',
+    });
+    expect(body).toContain('No other account is available');
+    expect(body).not.toContain('moved to');
+  });
+
+  test('never claims a move when the user switched failover off', () => {
+    const { body } = failover.describeFailover({
+      reason: 'limit',
+      from: account('a', 'Personal'),
+      to: null,
+      sessionIds: [],
+      resetAt: null,
+      blocked: 'disabled',
+    });
+    expect(body).toContain('Automatic failover is off');
+    expect(body).not.toContain('moved to');
+  });
+
+  test('reads as a return on the way home', () => {
+    const { title, body } = failover.describeFailover({
+      reason: 'failback',
+      from: account('b', 'Work'),
+      to: account('a', 'Personal'),
+      sessionIds: ['s1'],
+      resetAt: null,
+    });
+    expect(title).toContain('Personal');
+    expect(body).toContain('1 session returned');
+  });
+});
+
+/**
+ * One session failing to move must cost exactly one session.
+ *
+ * This is not a hypothetical tidy-up. handleUsageLimit's caller catches, so a
+ * throw part-way through the loop used to mean publishFailover was never
+ * reached for ANY of them: the sessions already reassigned stayed reassigned in
+ * the database, the renderer never got its refresh, no pty was respawned onto
+ * the new account, and the user was told nothing — while their sessions went on
+ * billing the account that had just run dry.
+ */
+describe('a session that cannot be moved', () => {
+  test('does not silence the switch for the ones that can', () => {
+    addAccount('primary', 0, true);
+    addAccount('backup', 1);
+    addGroup('g');
+    addSession('bad', 'g', 'primary');
+    addSession('s1', 'g', 'primary');
+
+    mock.module('../account-switch', () => ({
+      assignSessionAccount: (sessionId: string, accountId: string | null) => {
+        if (sessionId === 'bad') throw new Error('assign blew up');
+        return realAssignSessionAccount(sessionId, accountId);
+      },
+    }));
+
+    try {
+      // 'bad' is iterated first, so the throw lands before the good move.
+      const event = failover.handleUsageLimit({
+        sessionId: 's1',
+        accountId: 'primary',
+        resetAt: null,
+        liveAccounts: live({ bad: 'primary', s1: 'primary' }),
+      });
+
+      expect(event).not.toBeNull();
+      expect(event!.sessionIds).toEqual(['s1']);
+      expect(event!.to!.id).toBe('backup');
+      expect(sessionsRepo.getSession('s1')!.claudeAccountId).toBe('backup');
+      // The one that threw is left where it was, not half-moved.
+      expect(sessionsRepo.getSession('bad')!.claudeAccountId).toBe('primary');
+    } finally {
+      mock.module('../account-switch', () => ({ assignSessionAccount: realAssignSessionAccount }));
+    }
   });
 });

--- a/src/main/__tests__/account-switch.test.ts
+++ b/src/main/__tests__/account-switch.test.ts
@@ -46,7 +46,9 @@ function freshDb(): Database {
       ended_at TEXT DEFAULT NULL,
       duration_seconds REAL DEFAULT 0,
       claude_account_id TEXT DEFAULT NULL,
-      provider TEXT NOT NULL DEFAULT 'claude'
+      provider TEXT NOT NULL DEFAULT 'claude',
+      failover_from_account_id TEXT DEFAULT NULL,
+      failover_prev_account_id TEXT DEFAULT NULL
     );
     CREATE TABLE groups (
       id TEXT PRIMARY KEY,
@@ -57,7 +59,9 @@ function freshDb(): Database {
       created_at TEXT,
       parent_id TEXT DEFAULT NULL,
       collapsed INTEGER DEFAULT 0,
-      claude_account_id TEXT DEFAULT NULL
+      claude_account_id TEXT DEFAULT NULL,
+      failover_from_account_id TEXT DEFAULT NULL,
+      failover_prev_account_id TEXT DEFAULT NULL
     );
     CREATE TABLE claude_accounts (
       id TEXT PRIMARY KEY,
@@ -67,7 +71,10 @@ function freshDb(): Database {
       color TEXT,
       is_default INTEGER DEFAULT 0,
       created_at TEXT,
-      last_used_at TEXT
+      last_used_at TEXT,
+      fallback_rank INTEGER DEFAULT NULL,
+      limited_until TEXT DEFAULT NULL,
+      limited_at TEXT DEFAULT NULL
     );
   `);
   return d;

--- a/src/main/__tests__/usage-limit.test.ts
+++ b/src/main/__tests__/usage-limit.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Usage-limit detection (#207) — reading "this account is spent,
+ * and here is when it comes back" out of terminal output.
+ *
+ * The two halves are tested for opposite failures. Detection is tested for
+ * FALSE POSITIVES, because a wrong yes restarts live sessions and benches a
+ * healthy account for hours. Reset parsing is tested for wrong ANSWERS,
+ * because a reset time in the past is a cooldown that never applies and one
+ * far in the future benches an account that came back at teatime.
+ *
+ * Run with: bun test src/main/__tests__/usage-limit.test.ts
+ */
+import { describe, expect, test } from 'bun:test';
+import { detectUsageLimit, parseResetAt } from '../usage-limit';
+
+const NOW = new Date('2026-08-25T14:00:00');
+
+describe('detectUsageLimit', () => {
+  test('catches the wordings Claude Code actually prints', () => {
+    const lines = [
+      'Claude usage limit reached. Your limit will reset at 7pm (America/New_York)',
+      "You've reached your usage limit.",
+      'Weekly limit reached',
+      '5-hour limit reached · resets 6pm',
+      'Claude AI usage limit reached|1787000000',
+    ];
+    for (const line of lines) {
+      expect(detectUsageLimit(line, undefined, NOW), line).not.toBeNull();
+    }
+  });
+
+  test('ignores ordinary agent output', () => {
+    const lines = [
+      'Rate limiting the relay to 100 requests per minute',
+      'The test asserts the limit is enforced',
+      'reached the end of the file',
+      '',
+    ];
+    for (const line of lines) {
+      expect(detectUsageLimit(line, undefined, NOW), line).toBeNull();
+    }
+  });
+
+  /**
+   * The case that makes text-matching dangerous: an agent working on THIS
+   * feature renders the trigger phrase into its own terminal. Nothing about
+   * the channel distinguishes that from the CLI's own chrome, so the shape of
+   * the line has to.
+   */
+  test('ignores the phrase when it is being quoted rather than announced', () => {
+    const quoted = [
+      "  /Claude (?:AI )?usage limit reached/i,",
+      '  // Claude usage limit reached — the message we match on',
+      '+ Claude usage limit reached',
+      "42: 'Claude usage limit reached',",
+      "const message = 'Claude usage limit reached';",
+    ];
+    for (const line of quoted) {
+      expect(detectUsageLimit(line, undefined, NOW), line).toBeNull();
+    }
+  });
+
+  test('reports the line it matched, so a log can be argued with', () => {
+    const hit = detectUsageLimit(
+      'thinking…\nClaude usage limit reached. Your limit will reset at 7pm\n',
+      undefined,
+      NOW,
+    );
+    expect(hit?.line).toBe('Claude usage limit reached. Your limit will reset at 7pm');
+  });
+});
+
+describe('parseResetAt', () => {
+  test('reads the epoch suffix headless mode prints', () => {
+    const at = new Date(NOW.getTime() + 3 * 60 * 60 * 1000);
+    const epoch = Math.floor(at.getTime() / 1000);
+    expect(parseResetAt(`Claude AI usage limit reached|${epoch}`, NOW)?.getTime())
+      .toBe(epoch * 1000);
+  });
+
+  test('reads a clock time later the same day', () => {
+    const reset = parseResetAt('Your limit will reset at 7pm (America/New_York)', NOW);
+    expect(reset?.getHours()).toBe(19);
+    expect(reset?.getDate()).toBe(NOW.getDate());
+  });
+
+  /**
+   * A limit hit at 11pm that "resets at 4am" resets tomorrow. Read as today it
+   * would already be in the past — and an expired cooldown hands the spent
+   * account straight back to the sessions that just bounced off it, which is
+   * an immediate second failover rather than a recovery.
+   */
+  test('rolls a clock time that has already passed into tomorrow', () => {
+    const lateNight = new Date('2026-08-25T23:10:00');
+    const reset = parseResetAt('resets at 4am', lateNight);
+    expect(reset?.getHours()).toBe(4);
+    expect(reset?.getDate()).toBe(26);
+  });
+
+  test('reads a dated reset, for weekly limits days out', () => {
+    const reset = parseResetAt('Weekly limit reached · resets Sep 2 at 9am', NOW);
+    expect(reset?.getMonth()).toBe(8);
+    expect(reset?.getDate()).toBe(2);
+    expect(reset?.getHours()).toBe(9);
+  });
+
+  test('reads a duration', () => {
+    const reset = parseResetAt('try again in 30 minutes', NOW);
+    expect(reset?.getTime()).toBe(NOW.getTime() + 30 * 60 * 1000);
+  });
+
+  test('returns null rather than a guess when nothing says when', () => {
+    expect(parseResetAt('Claude usage limit reached.', NOW)).toBeNull();
+  });
+
+  /**
+   * Bare digits near the word "reset" are as often a token count as a time.
+   * Null sends the caller to its default window, which is a known-safe answer;
+   * a misread minute is a cooldown that expires immediately.
+   */
+  test('refuses a bare number with no am/pm and no minutes', () => {
+    expect(parseResetAt('reset 5 times during this run', NOW)).toBeNull();
+  });
+
+  test('rejects a reset implausibly far out', () => {
+    const epoch = Math.floor(NOW.getTime() / 1000) + 90 * 24 * 60 * 60;
+    expect(parseResetAt(`usage limit reached|${epoch}`, NOW)).toBeNull();
+  });
+});

--- a/src/main/__tests__/usage-limit.test.ts
+++ b/src/main/__tests__/usage-limit.test.ts
@@ -20,6 +20,9 @@ describe('detectUsageLimit', () => {
     const lines = [
       'Claude usage limit reached. Your limit will reset at 7pm (America/New_York)',
       "You've reached your usage limit.",
+      // Typographic apostrophe — what a CLI rendering prose actually prints,
+      // and the reason the pattern uses a character class rather than one quote.
+      "You’ve reached your weekly limit.",
       'Weekly limit reached',
       '5-hour limit reached · resets 6pm',
       'Claude AI usage limit reached|1787000000',

--- a/src/main/account-failover.ts
+++ b/src/main/account-failover.ts
@@ -1,0 +1,321 @@
+import log from 'electron-log';
+
+import {
+  AccountFailoverEvent,
+  ClaudeAccount,
+  LiveAccountBindings,
+  SessionState,
+} from '../shared/types';
+import { resolveAccountForSession } from './account-resolver';
+import { assignSessionAccount } from './account-switch';
+import * as accountsRepo from './repositories/accounts';
+import { getPreference } from './repositories/preferences';
+import * as sessionsRepo from './repositories/sessions';
+
+/**
+ * What happens when an account runs out of quota mid-session.
+ *
+ * The mechanics of moving a session between accounts already exist — the user
+ * can do it by hand, and account-switch.ts carries the conversation across and
+ * reports which ptys need respawning. This module is only the policy on top:
+ * which account is spent, which one takes the work, and when the session is
+ * allowed to go back.
+ *
+ * Two things it deliberately does NOT do. It never spawns or kills a pty —
+ * a switch takes effect on respawn, and the renderer owns that (CLAUDE_CONFIG_DIR
+ * is fixed at spawn). And it never decides that output means a limit; it is
+ * handed that verdict by the pty scanner, so the text-matching risk stays in
+ * one place.
+ */
+
+/** Preference keys. Both default to on — absent means enabled. */
+const FAILOVER_PREF = 'accountFailoverEnabled';
+const FAILBACK_PREF = 'accountFailbackEnabled';
+
+export function isFailoverEnabled(): boolean {
+  return getPreference(FAILOVER_PREF) !== 'false';
+}
+
+export function isFailbackEnabled(): boolean {
+  return getPreference(FAILBACK_PREF) !== 'false';
+}
+
+export interface UsageLimitReport {
+  /** Session whose pty printed the announcement. */
+  sessionId: string;
+  /** Account that pty was BILLING — its live binding, not its assignment. */
+  accountId: string | null;
+  /** Reset time parsed from the message, or null when it named none. */
+  resetAt: Date | null;
+  /** Which accounts running ptys are currently bound to. */
+  liveAccounts: LiveAccountBindings;
+}
+
+/**
+ * The next account willing to take work, in the user's failover order.
+ *
+ * Exported because the accounts panel shows the same answer ("Work is next in
+ * line") and must not compute it a second way.
+ */
+export function nextHealthyAccount(excludeId: string | null, now: Date = new Date()): ClaudeAccount | null {
+  return accountsRepo.getAccountsInFallbackOrder().find(
+    account => account.id !== excludeId && accountsRepo.isAccountHealthy(account, now)
+  ) ?? null;
+}
+
+/**
+ * Record a usage limit and move the account's live sessions off it.
+ *
+ * Returns null only when there is nothing this could possibly be about: no
+ * account was bound (the pre-accounts ~/.claude setup, where there is no
+ * second account to move to), or the bound account has since been deleted.
+ * Every other outcome — including "nowhere to go" and "you switched this off" —
+ * comes back as an event, because each of those is something the user needs
+ * told rather than a no-op to swallow.
+ */
+export function handleUsageLimit(report: UsageLimitReport): AccountFailoverEvent | null {
+  if (!report.accountId) return null;
+
+  const from = accountsRepo.getAccount(report.accountId);
+  if (!from) return null;
+
+  // Bookkeeping happens even when failover is switched off. Knowing an account
+  // is spent until 9pm is worth having on its own — the panel shows it, and it
+  // stops that account being picked as somebody else's failover target.
+  const resetAt = report.resetAt ?? new Date(Date.now() + accountsRepo.DEFAULT_COOLDOWN_MS);
+  accountsRepo.markAccountLimited(from.id, resetAt);
+  log.info(
+    `[Failover] ${from.label} is out of quota until ${resetAt.toISOString()}` +
+    `${report.resetAt ? ' (from the CLI message)' : ' (default window — the message named no reset)'}`
+  );
+
+  if (!isFailoverEnabled()) {
+    return { reason: 'limit', from, to: null, sessionIds: [], resetAt, blocked: 'disabled' };
+  }
+
+  const to = nextHealthyAccount(from.id);
+  if (!to) {
+    log.warn(`[Failover] ${from.label} is spent and no other account is available.`);
+    return { reason: 'limit', from, to: null, sessionIds: [], resetAt, blocked: 'no-healthy-account' };
+  }
+
+  // Every pty billing the spent account, not just the one that noticed. The
+  // limit is the account's, so the others are already dead in the water; making
+  // each wait to hit the wall itself would restart them one at a time, minutes
+  // apart, for no gain.
+  const stranded = new Set(
+    Object.entries(report.liveAccounts)
+      .filter(([, binding]) => binding?.accountId === from.id)
+      .map(([sessionId]) => sessionId)
+  );
+  // The reporter belongs in the set even if its binding says otherwise — it is
+  // the one session we have direct evidence about.
+  stranded.add(report.sessionId);
+
+  const sessionIds: string[] = [];
+  for (const sessionId of stranded) {
+    if (moveSession(sessionId, from, to)) sessionIds.push(sessionId);
+  }
+
+  log.info(
+    `[Failover] Moved ${sessionIds.length} session(s) from ${from.label} to ${to.label}.`
+  );
+  return { reason: 'limit', from, to, sessionIds, resetAt };
+}
+
+/**
+ * Point one session at `to`, remembering where it came from.
+ *
+ * The bookkeeping is written BEFORE the assignment and only when it is not
+ * already there. Not overwriting matters for the second hop: an account that
+ * fails A→B and later B→C should go home to A, not to B — B is just as spent,
+ * and "home" is the assignment the user actually chose.
+ *
+ * @returns whether the session needs its pty respawned.
+ */
+function moveSession(sessionId: string, from: ClaudeAccount, to: ClaudeAccount): boolean {
+  const session = sessionsRepo.getSession(sessionId);
+  if (!session) return false;
+
+  // The user already pointed this session somewhere else and it just hasn't
+  // respawned yet — its pty is still billing the spent account, which is why it
+  // showed up here at all. Overwriting that with our own choice would discard a
+  // decision they made deliberately. Restarting it is still exactly right: the
+  // respawn applies THEIR switch, which gets the session off the spent account
+  // just the same.
+  const assigned = resolveAccountForSession(sessionId);
+  if (assigned && assigned.id !== from.id) return true;
+
+  if (!session.failoverFromAccountId) {
+    sessionsRepo.updateSession(sessionId, {
+      failoverFromAccountId: from.id,
+      // NULL here is meaningful: it says the session inherited its account from
+      // its group, and going home means restoring that inheritance rather than
+      // pinning it to whatever the group resolved to today.
+      failoverPrevAccountId: session.claudeAccountId,
+    });
+  }
+
+  // Routed through account-switch so the conversation transcript is carried
+  // into the new account's config dir — without it the respawn's --resume finds
+  // no such conversation and the session starts over empty.
+  return assignSessionAccount(sessionId, to.id).affectedSessionIds.length > 0;
+}
+
+/**
+ * A session waiting to go home, and the account it is waiting on.
+ *
+ * Fail-back exists because the point of a secondary account is to absorb an
+ * outage, not to become the new home: left alone, one limited afternoon
+ * permanently migrates every session onto the backup and the primary's quota
+ * goes unused from then on.
+ */
+export interface FailbackCandidate {
+  sessionId: string;
+  home: ClaudeAccount;
+}
+
+/**
+ * Sessions whose original account is healthy again.
+ *
+ * Also cleans up after an account that was deleted while sessions were parked
+ * off it: there is no home to return to, so the bookkeeping is dropped rather
+ * than left pointing at a row that no longer exists.
+ */
+export function failbackCandidates(now: Date = new Date()): FailbackCandidate[] {
+  const candidates: FailbackCandidate[] = [];
+
+  for (const session of sessionsRepo.getAllSessions()) {
+    if (!session.failoverFromAccountId) continue;
+
+    const home = accountsRepo.getAccount(session.failoverFromAccountId);
+    if (!home) {
+      clearFailoverRecord(session.id);
+      continue;
+    }
+    if (!accountsRepo.isAccountHealthy(home, now)) continue;
+
+    // The cooldown has run out. Drop it now so the account is a legitimate
+    // failover target again even if this particular session never moves back.
+    accountsRepo.clearAccountLimit(home.id);
+    candidates.push({ sessionId: session.id, home });
+  }
+
+  return candidates;
+}
+
+/**
+ * Whether a session can be moved back right now without anyone noticing.
+ *
+ * This is the whole reason fail-back is safe to do unprompted. Going home costs
+ * a pty respawn, and a respawn in the middle of a turn throws away work in
+ * flight — so it waits for a session that is demonstrably between turns. A
+ * stopped session is the easiest case of all: it has no pty to interrupt and
+ * picks the account up whenever it is next started.
+ */
+export function canFailBackNow(state: SessionState): boolean {
+  return state === 'idle' || state === 'stopped';
+}
+
+/**
+ * Send a session back to the account it was failed over from.
+ *
+ * @returns the event to report, or null when the session had nothing to undo.
+ */
+export function failBackSession(sessionId: string): AccountFailoverEvent | null {
+  const session = sessionsRepo.getSession(sessionId);
+  if (!session?.failoverFromAccountId) return null;
+
+  const home = accountsRepo.getAccount(session.failoverFromAccountId);
+  if (!home) {
+    clearFailoverRecord(sessionId);
+    return null;
+  }
+
+  const leaving = session.claudeAccountId
+    ? accountsRepo.getAccount(session.claudeAccountId)
+    : null;
+
+  // Restore the ORIGINAL override, which may well be null — that is a session
+  // that inherits from its group, and pinning it to the group's current account
+  // would quietly convert an inherited assignment into a fixed one.
+  const affected = assignSessionAccount(sessionId, session.failoverPrevAccountId);
+  clearFailoverRecord(sessionId);
+
+  log.info(`[Failover] ${sessionId} returned to ${home.label}.`);
+  return {
+    reason: 'failback',
+    from: leaving,
+    to: home,
+    sessionIds: affected.affectedSessionIds,
+    resetAt: null,
+  };
+}
+
+/**
+ * Forget that a session was ever moved.
+ *
+ * Called when the user assigns an account by hand: they have just said where
+ * this session belongs, and a fail-back that later overrode that choice would
+ * be the app arguing with them.
+ */
+export function clearFailoverRecord(sessionId: string): void {
+  sessionsRepo.updateSession(sessionId, {
+    failoverFromAccountId: null,
+    failoverPrevAccountId: null,
+  });
+}
+
+/**
+ * Notification copy for one switch.
+ *
+ * Lives here, next to the policy, because the wording has to stay true to what
+ * actually happened — "moved to Work" when nothing moved is the failure mode
+ * this feature is most likely to produce, and it is the kind that is only
+ * caught by keeping the sentence and the decision in the same file.
+ */
+export function describeFailover(event: AccountFailoverEvent): { title: string; body: string } {
+  const sessions = event.sessionIds.length === 1
+    ? '1 session'
+    : `${event.sessionIds.length} sessions`;
+
+  if (event.reason === 'failback') {
+    return {
+      title: `Back on ${event.to?.label ?? 'the original account'}`,
+      body: `${sessions} returned now that its usage limit has lifted.`,
+    };
+  }
+
+  const spent = event.from?.label ?? 'That account';
+  const until = event.resetAt ? ` until ${formatResetTime(event.resetAt)}` : '';
+
+  if (event.blocked === 'disabled') {
+    return {
+      title: `${spent} hit its usage limit`,
+      body: `Automatic failover is off, so nothing moved. Held${until}.`,
+    };
+  }
+  if (event.blocked === 'no-healthy-account') {
+    return {
+      title: `${spent} hit its usage limit`,
+      body: `No other account is available${until ? `; ${spent} is held${until}` : ''}.`,
+    };
+  }
+
+  // "moved to", not "moved over and resumed". A session whose CLI exited when
+  // the quota ran out is reassigned but deliberately not restarted — starting a
+  // session the user watched stop is not ours to do — so a claim about resuming
+  // would be false for exactly the sessions the user is most likely to check.
+  return {
+    title: `Switched to ${event.to?.label ?? 'another account'}`,
+    body: `${spent} hit its usage limit${until}. ${sessions} moved to ${event.to?.label ?? 'it'}.`,
+  };
+}
+
+/** "9:30pm", or "Tue 9:30pm" when it is not today. */
+function formatResetTime(resetAt: Date, now: Date = new Date()): string {
+  const time = resetAt.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  const sameDay = resetAt.toDateString() === now.toDateString();
+  if (sameDay) return time;
+  return `${resetAt.toLocaleDateString(undefined, { weekday: 'short' })} ${time}`;
+}

--- a/src/main/account-failover.ts
+++ b/src/main/account-failover.ts
@@ -296,9 +296,10 @@ export function describeFailover(event: AccountFailoverEvent): { title: string; 
     };
   }
   if (event.blocked === 'no-healthy-account') {
+    const held = until ? `; ${spent} is held${until}` : '';
     return {
       title: `${spent} hit its usage limit`,
-      body: `No other account is available${until ? `; ${spent} is held${until}` : ''}.`,
+      body: `No other account is available${held}.`,
     };
   }
 

--- a/src/main/account-failover.ts
+++ b/src/main/account-failover.ts
@@ -112,9 +112,19 @@ export function handleUsageLimit(report: UsageLimitReport): AccountFailoverEvent
   // the one session we have direct evidence about.
   stranded.add(report.sessionId);
 
+  // Per-session, because a throw here used to cost more than the session it
+  // came from. handleUsageLimit's caller catches, so one failing move meant
+  // publishFailover was never reached for ANY of them: the sessions already
+  // reassigned stayed reassigned in the database, the renderer never got its
+  // refresh, no pty was respawned onto the new account, and nothing was said.
+  // The failure of one session is now worth exactly one session.
   const sessionIds: string[] = [];
   for (const sessionId of stranded) {
-    if (moveSession(sessionId, from, to)) sessionIds.push(sessionId);
+    try {
+      if (moveSession(sessionId, from, to)) sessionIds.push(sessionId);
+    } catch (err) {
+      log.error(`[Failover] Could not move ${sessionId} off ${from.label}:`, err);
+    }
   }
 
   log.info(

--- a/src/main/api/relay/remote-sessions.ts
+++ b/src/main/api/relay/remote-sessions.ts
@@ -97,6 +97,9 @@ export function createRemoteSession(opts: CreateSessionOptions): Session {
     durationSeconds: 0,
     claudeAccountId: null,
     provider: opts.provider,
+    // A brand-new session has never been failed over (#207).
+    failoverFromAccountId: null,
+    failoverPrevAccountId: null,
   };
 
   // Step 1 — persist the row, log the start event, notify LAN clients.

--- a/src/main/api/routes/sessions.ts
+++ b/src/main/api/routes/sessions.ts
@@ -196,6 +196,9 @@ export function createSessionsRouter(): Router {
           durationSeconds: 0,
           claudeAccountId: null,
           provider: 'claude',
+          // A brand-new session has never been failed over (#207).
+          failoverFromAccountId: null,
+          failoverPrevAccountId: null,
         };
 
         sessionsRepo.createSession(session);

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -363,7 +363,10 @@ function initializeTables(database: Database.Database): void {
       color TEXT DEFAULT '#888888',
       is_default INTEGER DEFAULT 0,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-      last_used_at TEXT
+      last_used_at TEXT,
+      fallback_rank INTEGER DEFAULT NULL,
+      limited_until TEXT DEFAULT NULL,
+      limited_at TEXT DEFAULT NULL
     );
     CREATE UNIQUE INDEX IF NOT EXISTS idx_claude_accounts_single_default
       ON claude_accounts(is_default) WHERE is_default = 1;
@@ -416,6 +419,29 @@ function initializeTables(database: Database.Database): void {
   }
   if (!sessionColsBdhlndr17.includes('claude_account_id')) {
     database.exec("ALTER TABLE sessions ADD COLUMN claude_account_id TEXT DEFAULT NULL");
+  }
+
+  // Migration: automatic failover between Claude accounts.
+  //
+  // Three facts the pre-failover schema had nowhere to put:
+  //   fallback_rank  — the order accounts are tried in. NULL sorts last, so an
+  //                    unranked estate keeps the panel's existing order.
+  //   limited_until  — when a recorded usage limit lifts. NULL = healthy. No
+  //                    sweeper clears it; expiry is decided at read time.
+  //   limited_at     — when the limit was seen, for the UI's "since" copy.
+  // On sessions, the two columns that make the move reversible: which account
+  // we moved OFF, and what the session's own override held before we wrote to
+  // it (NULL there means "inherit from the group", which is why it can't also
+  // mean "not failed over" — failover_from_account_id carries that).
+  const accountColumns = database.prepare('PRAGMA table_info(claude_accounts)').all() as { name: string }[];
+  if (!accountColumns.some(col => col.name === 'fallback_rank')) {
+    database.exec('ALTER TABLE claude_accounts ADD COLUMN fallback_rank INTEGER DEFAULT NULL');
+    database.exec('ALTER TABLE claude_accounts ADD COLUMN limited_until TEXT DEFAULT NULL');
+    database.exec('ALTER TABLE claude_accounts ADD COLUMN limited_at TEXT DEFAULT NULL');
+  }
+  if (!sessionColsBdhlndr17.includes('failover_from_account_id')) {
+    database.exec('ALTER TABLE sessions ADD COLUMN failover_from_account_id TEXT DEFAULT NULL');
+    database.exec('ALTER TABLE sessions ADD COLUMN failover_prev_account_id TEXT DEFAULT NULL');
   }
 
   // Migration: Add provider column to sessions (#96, epic #94).

--- a/src/main/group-import-export.ts
+++ b/src/main/group-import-export.ts
@@ -245,6 +245,9 @@ export async function importGroupsAndSessions(): Promise<ImportResult> {
         durationSeconds: 0,
         claudeAccountId: null,
         provider: sanitizeImportedProvider(s.provider),
+        // A brand-new session has never been failed over (#207).
+        failoverFromAccountId: null,
+        failoverPrevAccountId: null,
       });
       sessionCount++;
     }
@@ -384,6 +387,9 @@ export async function importFromClaudeLander(): Promise<ImportResult> {
         durationSeconds: 0,
         claudeAccountId: null,
         provider: sanitizeImportedProvider(row.provider),
+        // A brand-new session has never been failed over (#207).
+        failoverFromAccountId: null,
+        failoverPrevAccountId: null,
       });
       sessionCount++;
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,6 +21,7 @@ import * as accountsRepo from './repositories/accounts';
 import * as accountAuth from './account-auth';
 import { withAccountIdentity } from './account-identity';
 import * as accountSwitch from './account-switch';
+import * as accountFailover from './account-failover';
 import { exportSessions, ExportFormat } from './session-export';
 import { exportGroupsAndSessions, importGroupsAndSessions, importFromClaudeLander } from './group-import-export';
 import { StateMonitor } from './state-monitor';
@@ -29,7 +30,7 @@ import { initAutoUpdater, checkForUpdatesManual, downloadUpdate, getUpdateChanne
 import { notificationManager } from './notification-manager';
 import { trayManager } from './tray-manager';
 import { soundManager, SoundEvent } from './sound-manager';
-import { Group, Session, SessionState } from '../shared/types';
+import { AccountFailoverEvent, Group, Session, SessionState } from '../shared/types';
 import { teamsAuthService } from './teams/teams-auth';
 import { teamsNotifier } from './teams/teams-notifier';
 import { registerHooks, cleanupLegacyMcpServer } from './mcp-config';
@@ -40,6 +41,15 @@ import type { GuestResizeRequest } from './api/relay/session-tunnel';
 import { remoteSessionEvents } from './api/relay/remote-sessions';
 import { openInEditor, detectAvailableEditors, getEditorOptions, EditorType } from './editor-launcher';
 import { dispatchAttentionPush } from './api/web-push/dispatcher';
+
+/**
+ * How often parked sessions are reconsidered for going home (#207).
+ *
+ * A minute is far finer than the thing it is waiting on — usage limits reset on
+ * the hour scale — and the sweep is a couple of indexed reads over a table with
+ * tens of rows, so the cost of checking often is not worth optimising away.
+ */
+const FAILBACK_SWEEP_MS = 60_000;
 
 // ---------------------------------------------------------------------------
 // Logging & crash reporting configuration
@@ -342,6 +352,84 @@ function registerHooksEverywhere(): void {
   }
 }
 
+/**
+ * Tell the renderer and the user about one account switch (#207).
+ *
+ * The renderer gets the session ids because it is the only side that can act
+ * on them; the notification goes out regardless of whether a window is
+ * focused, because this happened without being asked for.
+ */
+function publishFailover(event: AccountFailoverEvent, sessionId?: string): void {
+  // The assignment rows moved under the renderer's feet. Without this its
+  // cached sessions keep the old claudeAccountId, and every account badge in
+  // the sidebar names the account the session just left.
+  if (event.sessionIds.length > 0) mainWindow?.webContents.send('sessions:refresh');
+  mainWindow?.webContents.send('accounts:failover', event);
+  const { title, body } = accountFailover.describeFailover(event);
+  notificationManager.showAccountNotification({ title, body, sessionId });
+}
+
+/**
+ * Return parked sessions to their own account once its limit lifts.
+ *
+ * Called from every state change AND from a timer, because the two miss
+ * different cases: a session that went idle an hour before the reset never
+ * emits another state change, and a session working straight through the reset
+ * never becomes eligible until it stops. Between them, every parked session is
+ * reconsidered at the first moment interrupting it is free.
+ */
+function sweepFailbacks(): void {
+  if (!accountFailover.isFailbackEnabled()) return;
+  try {
+    for (const candidate of accountFailover.failbackCandidates()) {
+      const session = sessionsRepo.getSession(candidate.sessionId);
+      if (!session || !accountFailover.canFailBackNow(session.state)) continue;
+      const event = accountFailover.failBackSession(candidate.sessionId);
+      if (event) publishFailover(event, candidate.sessionId);
+    }
+  } catch (err) {
+    log.error('[Failover] Fail-back sweep failed:', err);
+  }
+}
+
+/**
+ * Subscribe to usage limits and start the fail-back timer, exactly once.
+ *
+ * createWindow runs again on 'activate' and after a renderer crash, so wiring
+ * registered from inside it is wiring registered twice — and a second
+ * subscription here would run the whole failover for one limit twice, sending
+ * the user two notifications about a single event. The window is not this
+ * feature's lifetime; the app is.
+ */
+let failoverWired = false;
+function registerFailoverWiring(): void {
+  if (failoverWired) return;
+  failoverWired = true;
+
+  // The pty only reports the observation; where the work goes is
+  // account-failover's call, and applying the move is the renderer's — a switch
+  // reaches the CLI as CLAUDE_CONFIG_DIR, which is fixed at spawn, so it takes a
+  // respawn and only the renderer owns those.
+  ptyManager.on('usageLimit', ({ id, accountId, resetAt }) => {
+    try {
+      const event = accountFailover.handleUsageLimit({
+        sessionId: id,
+        accountId,
+        resetAt,
+        liveAccounts: ptyManager.getLiveAccounts(),
+      });
+      if (event) publishFailover(event, id);
+    } catch (err) {
+      // A failed failover must never take the data pipeline down with it: the
+      // session is limited, not broken, and the user can still switch by hand.
+      log.error('[Failover] Could not handle a usage limit:', err);
+    }
+  });
+
+  const failbackTimer = setInterval(sweepFailbacks, FAILBACK_SWEEP_MS);
+  app.on('will-quit', () => clearInterval(failbackTimer));
+}
+
 function createWindow(): void {
   // BDHLNDR-44: never construct a BrowserWindow before app 'ready' — defends
   // the rapid-relaunch race that produced "Cannot create BrowserWindow before
@@ -407,6 +495,9 @@ function createWindow(): void {
     logSessionStateEvent(event.sessionId, event.state);
     // Handle notifications and tray updates
     handleStateChange(event.sessionId, event.state);
+    // A session that just went idle may be one parked off its own account,
+    // waiting for a free moment to go back (#207).
+    sweepFailbacks();
   });
 
   // Restore saved window bounds or use defaults
@@ -618,6 +709,8 @@ function createWindow(): void {
     mainWindow?.webContents.send('pty:live-account', id, binding);
   });
 
+  registerFailoverWiring();
+
   // PTY state detection forwarding
   ptyManager.on('stateChange', (event) => {
     mainWindow?.webContents.send('state:change', event);
@@ -634,6 +727,10 @@ function createWindow(): void {
     logSessionStateEvent(event.sessionId, event.state);
     // Handle notifications and tray updates
     handleStateChange(event.sessionId, event.state);
+    // The pty's own idle detection is the main way a session becomes safe to
+    // move back to its own account (#207) — the hook-driven monitor
+    // above sees Claude's own stop events, this sees the terminal go quiet.
+    sweepFailbacks();
     // Broadcast to mobile clients
     getApiServer().broadcastSessionState(event.sessionId, event.state, event.event);
   });
@@ -821,7 +918,11 @@ ipcMain.handle('db:sessions:delete', async (_, id: string) => {
 // row: the stored email is a one-shot write from the login flow, so accounts
 // that logged in without producing one present as logged out forever.
 safeHandle('accounts:list', () => {
-  return accountsRepo.getAllAccounts().map(withAccountIdentity);
+  // Failover order, not insertion order (#207). With no ranks set this is
+  // byte-for-byte the old ordering (default first, then oldest), so nothing
+  // moves for an estate whose owner has never touched the order — and once
+  // they have, the list they arranged is the list they see everywhere.
+  return accountsRepo.getAccountsInFallbackOrder().map(withAccountIdentity);
 });
 
 safeHandle('accounts:startLogin', (label: string) => {
@@ -853,12 +954,41 @@ safeHandle('accounts:setDefault', (id: string) => {
   return accountsRepo.setDefaultAccount(id);
 });
 
+// Failover order and cooldowns (#207).
+safeHandle('accounts:setFallbackOrder', (orderedIds: string[]) => {
+  if (!Array.isArray(orderedIds) || orderedIds.some(id => typeof id !== 'string')) {
+    throw new Error('A fallback order must be a list of account ids');
+  }
+  accountsRepo.setFallbackOrder(orderedIds);
+});
+
+/**
+ * Hand an account back before its recorded cooldown expires.
+ *
+ * Worth having as a user action because the cooldown is a guess whenever the
+ * CLI's message named no reset time: five hours is the honest upper bound for a
+ * rolling window, not a measurement, and someone who knows their quota is back
+ * should not have to wait out an estimate.
+ */
+safeHandle('accounts:clearLimit', (id: string) => {
+  accountsRepo.clearAccountLimit(id);
+});
+
+/** Which account failover would pick next, for the accounts panel to show. */
+safeHandle('accounts:nextInLine', (excludeId: string | null) => {
+  return accountFailover.nextHealthyAccount(excludeId ?? null);
+});
+
 // Assigning an account is routed through account-switch (not db:sessions:update)
 // so the conversation transcript follows the session into the new account's
 // config dir, and the renderer learns which ptys to respawn — CLAUDE_CONFIG_DIR
 // is fixed at spawn time, so a live session ignores the column write otherwise.
 safeHandle('accounts:assignToSession', (sessionId: string, accountId: string | null) => {
   const result = accountSwitch.assignSessionAccount(sessionId, accountId);
+  // The user has just said where this session belongs, which retires any
+  // pending fail-back: moving it again later, on the strength of a decision the
+  // app made hours ago, would be the app overruling them (#207).
+  accountFailover.clearFailoverRecord(sessionId);
   getApiServer().broadcastSessionsUpdated();
   return result;
 });

--- a/src/main/notification-manager.ts
+++ b/src/main/notification-manager.ts
@@ -69,6 +69,33 @@ class NotificationManager {
     notification.show();
   }
 
+  /**
+   * Tell the user the app switched accounts under them (#207).
+   *
+   * Unlike showWaitingNotification this does NOT suppress on a focused window.
+   * "Waiting for input" is redundant when you are looking at the terminal that
+   * says so; "your account ran out and three sessions just restarted somewhere
+   * else" is not — it happened without being asked for, and a user watching one
+   * session's terminal has no other way to learn it happened to the other two.
+   */
+  showAccountNotification(options: { title: string; body: string; sessionId?: string }): void {
+    if (!this.isEnabled() || !Notification.isSupported()) return;
+
+    const notification = new Notification({
+      title: options.title,
+      body: options.body,
+      icon: this.getIconPath(),
+      silent: !this.isSoundEnabled(),
+    });
+
+    const { sessionId } = options;
+    if (sessionId) {
+      notification.on('click', () => this.handleNotificationClick(sessionId));
+    }
+
+    notification.show();
+  }
+
   private handleNotificationClick(sessionId: string): void {
     // Show and focus the main window
     if (this.mainWindow) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest } from '../shared/types';
+import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, AccountFailoverEvent, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -361,6 +361,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('accounts:update', id, updates),
   setDefaultAccount: (id: string): Promise<boolean> =>
     ipcRenderer.invoke('accounts:setDefault', id),
+  setAccountFallbackOrder: (orderedIds: string[]): Promise<void> =>
+    ipcRenderer.invoke('accounts:setFallbackOrder', orderedIds),
+  clearAccountLimit: (id: string): Promise<void> =>
+    ipcRenderer.invoke('accounts:clearLimit', id),
+  nextAccountInLine: (excludeId: string | null): Promise<ClaudeAccount | null> =>
+    ipcRenderer.invoke('accounts:nextInLine', excludeId),
   assignAccountToSession: (sessionId: string, accountId: string | null): Promise<AccountSwitchResult> =>
     ipcRenderer.invoke('accounts:assignToSession', sessionId, accountId),
   assignAccountToGroup: (groupId: string, accountId: string | null): Promise<AccountSwitchResult> =>
@@ -374,6 +380,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     const listener = (_: Electron.IpcRendererEvent, data: { accountId: string; exitCode: number }) => callback(data);
     ipcRenderer.on('accounts:login-exited', listener);
     return () => ipcRenderer.removeListener('accounts:login-exited', listener);
+  },
+  // An account hit its usage limit and its sessions were moved (or couldn't be).
+  onAccountFailover: (callback: (event: AccountFailoverEvent) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, event: AccountFailoverEvent) => callback(event);
+    ipcRenderer.on('accounts:failover', listener);
+    return () => ipcRenderer.removeListener('accounts:failover', listener);
   },
 
   // Update channel (BDHLNDR-32) — opt-in beta builds

--- a/src/main/providers/claude.ts
+++ b/src/main/providers/claude.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import { app } from 'electron';
 import { ProviderDefinition, ProviderLaunchConfig, ProviderCommand } from './types';
 import { baseSessionEnv } from './passthrough';
+import { CLAUDE_USAGE_LIMIT_PATTERNS } from '../usage-limit';
 import { claudeParser as claudeArenaParser } from '../arena/parsers';
 
 /** Env var Claude Code reads its isolated config dir from (BDHLNDR-31). */
@@ -33,6 +34,7 @@ export const claudeProvider: ProviderDefinition = {
     accounts: true,
   },
   waitingPatterns: CLAUDE_WAITING_PATTERNS,
+  usageLimitPatterns: CLAUDE_USAGE_LIMIT_PATTERNS,
   apiKey: {
     envVar: 'ANTHROPIC_API_KEY',
     test: {

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -69,6 +69,13 @@ export interface ProviderDefinition {
    */
   waitingPatterns?: readonly RegExp[];
   /**
+   * Provider-specific output that means the ACCOUNT behind the CLI has run out
+   * of quota, as opposed to anything being wrong with the session. Absent on a
+   * provider with no account model, which is also every provider that cannot
+   * fail over — there is nowhere for its sessions to go.
+   */
+  usageLimitPatterns?: readonly RegExp[];
+  /**
    * Direct-API credential support (#99), for providers whose CLI can
    * authenticate via an API-key env var. Absent = API keys don't apply
    * (e.g. a purely local provider) and the vault treats the provider as

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -33,6 +33,7 @@ import {
 } from './repositories/sessions';
 import { getAllAccounts, touchAccount } from './repositories/accounts';
 import { resolveAccountForSession } from './account-resolver';
+import { detectUsageLimit } from './usage-limit';
 import { vaultEnvFor } from './key-vault';
 import { redactEnv } from './redact-env';
 import log from 'electron-log';
@@ -103,6 +104,15 @@ interface PtySession {
    * single 'data' event first, guaranteeing ordered delivery.
    */
   deferEmission: boolean;
+  /**
+   * Set once this pty has reported a usage limit, so the TUI repainting the
+   * same message forty times a second produces one failover and not forty.
+   *
+   * Per-pty, not per-session: the flag lives and dies with the process, so the
+   * replacement pty spawned by a failover can report its own limit if the
+   * account it landed on turns out to be exhausted too.
+   */
+  usageLimitReported: boolean;
 }
 
 /**
@@ -481,6 +491,7 @@ export class PtyManager extends EventEmitter {
       launchOutput: '',
       // Regular sessions spawn only after the renderer explicitly called
       // pty:create, so listeners are already attached — no deferral needed.
+      usageLimitReported: false,
       deferEmission: false,
     });
 
@@ -822,6 +833,7 @@ export class PtyManager extends EventEmitter {
       launchOutput: '',
       // Spawned before the renderer's Terminal mounts — same race as the
       // login pty (BDHLNDR-33).
+      usageLimitReported: false,
       deferEmission: true,
     });
   }
@@ -937,6 +949,7 @@ export class PtyManager extends EventEmitter {
       // Login ptys defer event emission until the renderer attaches its
       // listener and calls primePty — avoids losing claude's startup banner
       // in the IPC-round-trip + React-render gap (BDHLNDR-33).
+      usageLimitReported: false,
       deferEmission: true,
     });
   }
@@ -1280,6 +1293,36 @@ export class PtyManager extends EventEmitter {
     }, 300); // Wait 300ms of sustained output
   }
 
+  /**
+   * Report a usage limit once per pty.
+   *
+   * What is emitted is deliberately thin — the account this pty is BILLING
+   * (its live binding, not the database assignment, which may already have
+   * been pointed elsewhere) plus whatever the message said about the reset.
+   * Deciding where the work goes belongs to account-failover, which can see
+   * every account and every other session; this can only see one terminal.
+   */
+  private checkUsageLimit(id: string, session: PtySession): void {
+    if (session.usageLimitReported) return;
+    const patterns = session.provider?.usageLimitPatterns;
+    if (!patterns?.length) return;
+
+    const hit = detectUsageLimit(session.outputBuffer.slice(-1200), patterns);
+    if (!hit) return;
+
+    session.usageLimitReported = true;
+    log.warn(
+      `[Accounts] Session ${id} reported a usage limit on account ` +
+      `${session.liveAccount?.accountId ?? 'legacy ~/.claude'}: ${hit.line}`
+    );
+    this.emit('usageLimit', {
+      id,
+      accountId: session.liveAccount?.accountId ?? null,
+      resetAt: hit.resetAt,
+      line: hit.line,
+    });
+  }
+
   private detectAgentState(id: string, data: string): void {
     const session = this.sessions.get(id);
     if (!session) return;
@@ -1340,6 +1383,17 @@ export class PtyManager extends EventEmitter {
     }
     session.recentOutputBytes += printableContent.length;
     session.lastOutputTime = now;
+
+    // Did the CLI just say the account is out of quota? Checked before the
+    // waiting-state work below because the two are not alternatives: a limited
+    // Claude usually parks at its prompt, so this would otherwise be read as an
+    // ordinary "waiting for input" and nothing would ever move.
+    //
+    // A wider slice than the waiting check gets: the announcement and its
+    // "resets at" clause can be a couple of wrapped lines apart, and the reset
+    // time is the whole difference between a five-hour default cooldown and
+    // the real one.
+    this.checkUsageLimit(id, session);
 
     // Detect waiting for user input patterns (check recent buffer).
     // Generic prompt shapes plus whatever the session's provider knows about

--- a/src/main/repositories/__tests__/accounts.test.ts
+++ b/src/main/repositories/__tests__/accounts.test.ts
@@ -49,7 +49,10 @@ function freshDb(): Database {
       color TEXT DEFAULT '#888888',
       is_default INTEGER DEFAULT 0,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-      last_used_at TEXT
+      last_used_at TEXT,
+      fallback_rank INTEGER DEFAULT NULL,
+      limited_until TEXT DEFAULT NULL,
+      limited_at TEXT DEFAULT NULL
     );
     CREATE UNIQUE INDEX idx_claude_accounts_single_default
       ON claude_accounts(is_default) WHERE is_default = 1;
@@ -59,13 +62,17 @@ function freshDb(): Database {
       group_id TEXT,
       name TEXT NOT NULL,
       working_dir TEXT NOT NULL,
-      claude_account_id TEXT DEFAULT NULL
+      claude_account_id TEXT DEFAULT NULL,
+      failover_from_account_id TEXT DEFAULT NULL,
+      failover_prev_account_id TEXT DEFAULT NULL
     );
 
     CREATE TABLE groups (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
-      claude_account_id TEXT DEFAULT NULL
+      claude_account_id TEXT DEFAULT NULL,
+      failover_from_account_id TEXT DEFAULT NULL,
+      failover_prev_account_id TEXT DEFAULT NULL
     );
   `);
   return d;

--- a/src/main/repositories/__tests__/sessions.test.ts
+++ b/src/main/repositories/__tests__/sessions.test.ts
@@ -37,7 +37,9 @@ function freshDb(): Database {
       ended_at TEXT DEFAULT NULL,
       duration_seconds REAL DEFAULT 0,
       claude_account_id TEXT DEFAULT NULL,
-      provider TEXT NOT NULL DEFAULT 'claude'
+      provider TEXT NOT NULL DEFAULT 'claude',
+      failover_from_account_id TEXT DEFAULT NULL,
+      failover_prev_account_id TEXT DEFAULT NULL
     )
   `);
   return d;

--- a/src/main/repositories/account-row.ts
+++ b/src/main/repositories/account-row.ts
@@ -12,5 +12,8 @@ export function mapAccountRow(row: any): ClaudeAccount {
     isDefault: Boolean(row.is_default),
     createdAt: new Date(row.created_at),
     lastUsedAt: row.last_used_at ? new Date(row.last_used_at) : null,
+    fallbackRank: row.fallback_rank ?? null,
+    limitedUntil: row.limited_until ? new Date(row.limited_until) : null,
+    limitedAt: row.limited_at ? new Date(row.limited_at) : null,
   };
 }

--- a/src/main/repositories/accounts.ts
+++ b/src/main/repositories/accounts.ts
@@ -37,30 +37,37 @@ export function createAccount(input: CreateAccountInput): ClaudeAccount {
     if (isDefault) {
       db.prepare('UPDATE claude_accounts SET is_default = 0 WHERE is_default = 1').run();
     }
+    // A new account joins the END of an order that already exists, rather than
+    // sharing NULL with the unranked ones — an estate someone has ordered
+    // should not have the next account inserted into the middle of it.
+    //
+    // Where NO order exists yet the new account stays unranked too. Giving it
+    // rank 0 would put a just-created account, which may not even be logged in
+    // yet, at the front of the failover queue for an estate whose owner has
+    // never expressed an opinion about ordering.
+    const maxRank = (db.prepare(
+      'SELECT MAX(fallback_rank) AS max FROM claude_accounts'
+    ).get() as { max: number | null }).max;
+    const nextRank = maxRank === null ? null : maxRank + 1;
+
     db.prepare(`
-      INSERT INTO claude_accounts (id, label, config_dir, email, color, is_default, created_at, last_used_at)
-      VALUES (?, ?, ?, NULL, ?, ?, ?, NULL)
+      INSERT INTO claude_accounts (id, label, config_dir, email, color, is_default, created_at, last_used_at, fallback_rank)
+      VALUES (?, ?, ?, NULL, ?, ?, ?, NULL, ?)
     `).run(
       input.id,
       input.label,
       input.configDir,
       input.color ?? '#888888',
       isDefault ? 1 : 0,
-      createdAt.toISOString()
+      createdAt.toISOString(),
+      nextRank
     );
   });
   insert();
 
-  return {
-    id: input.id,
-    label: input.label,
-    configDir: input.configDir,
-    email: null,
-    color: input.color ?? '#888888',
-    isDefault,
-    createdAt,
-    lastUsedAt: null,
-  };
+  // Re-read rather than reconstruct: the rank was computed inside the
+  // transaction and the caller's copy must agree with the row.
+  return getAccount(input.id)!;
 }
 
 export interface UpdateAccountInput {
@@ -150,3 +157,81 @@ export function deleteAccount(id: string): void {
 
 // resolveAccountForSession() lives in ../account-resolver — it reads sessions
 // and groups as well as accounts, so it isn't this repository's to own.
+
+// ---------------------------------------------------------------------------
+// Failover order and usage-limit cooldowns
+// ---------------------------------------------------------------------------
+
+/**
+ * How long an account is held out when the CLI announced a limit without
+ * saying when it lifts. Claude's usage windows are rolling five-hour ones, so
+ * this is the honest upper bound rather than an optimistic guess — an account
+ * released too early just fails over again, but does so after dragging a live
+ * session through a restart for nothing.
+ */
+export const DEFAULT_COOLDOWN_MS = 5 * 60 * 60 * 1000;
+
+/**
+ * Accounts in the order failover tries them: explicit rank first, then the
+ * panel's existing order (default, then oldest) for anything unranked.
+ *
+ * ORDER BY puts NULL ranks last explicitly — SQLite sorts NULL FIRST by
+ * default, which would hand an unranked account priority over the order the
+ * user actually set.
+ */
+export function getAccountsInFallbackOrder(): ClaudeAccount[] {
+  const db = getDatabase();
+  const rows = db.prepare(`
+    SELECT * FROM claude_accounts
+    ORDER BY fallback_rank IS NULL, fallback_rank, is_default DESC, created_at ASC
+  `).all() as any[];
+  return rows.map(mapRow);
+}
+
+/** Write an explicit failover order. Ids not listed keep whatever rank they had. */
+export function setFallbackOrder(orderedIds: string[]): void {
+  const db = getDatabase();
+  const stmt = db.prepare('UPDATE claude_accounts SET fallback_rank = ? WHERE id = ?');
+  const tx = db.transaction(() => {
+    orderedIds.forEach((id, index) => stmt.run(index, id));
+  });
+  tx();
+}
+
+/**
+ * Record that `id` has run out of quota until `until`.
+ *
+ * Extends rather than replaces: two sessions on the same account hit the wall
+ * seconds apart, and the second one's message is usually the vaguer of the two
+ * (no "resets at" line, so the default window). Taking the later of the two
+ * stops a precise reset time from being overwritten by a generic one.
+ */
+export function markAccountLimited(id: string, until: Date): void {
+  const db = getDatabase();
+  db.prepare(`
+    UPDATE claude_accounts
+    SET limited_at = COALESCE(limited_at, ?),
+        limited_until = CASE
+          WHEN limited_until IS NULL OR limited_until < ? THEN ?
+          ELSE limited_until
+        END
+    WHERE id = ?
+  `).run(new Date().toISOString(), until.toISOString(), until.toISOString(), id);
+}
+
+/** Clear a cooldown — the limit lifted, or the user cleared it by hand. */
+export function clearAccountLimit(id: string): void {
+  const db = getDatabase();
+  db.prepare(
+    'UPDATE claude_accounts SET limited_until = NULL, limited_at = NULL WHERE id = ?'
+  ).run(id);
+}
+
+/**
+ * True when the account can take work right now. A cooldown that has already
+ * expired is not a limit: nothing sweeps the column, so every reader has to
+ * decide expiry against the clock, and this is the one place that does it.
+ */
+export function isAccountHealthy(account: ClaudeAccount, now: Date = new Date()): boolean {
+  return account.limitedUntil === null || account.limitedUntil.getTime() <= now.getTime();
+}

--- a/src/main/repositories/sessions.ts
+++ b/src/main/repositories/sessions.ts
@@ -26,14 +26,21 @@ export function getAllSessions(): Session[] {
     durationSeconds: row.duration_seconds ?? 0,
     claudeAccountId: row.claude_account_id ?? null,
     provider: row.provider ?? 'claude',
+    failoverFromAccountId: row.failover_from_account_id ?? null,
+    failoverPrevAccountId: row.failover_prev_account_id ?? null,
   }));
+}
+
+/** One session by id, or null. Same row mapping as getAllSessions. */
+export function getSession(id: string): Session | null {
+  return getAllSessions().find(session => session.id === id) ?? null;
 }
 
 export function createSession(session: Session): void {
   const db = getDatabase();
   db.prepare(`
-    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at, claude_session_id, ended_at, duration_seconds, claude_account_id, provider)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at, claude_session_id, ended_at, duration_seconds, claude_account_id, provider, failover_from_account_id, failover_prev_account_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     session.id,
     session.groupId,
@@ -48,7 +55,9 @@ export function createSession(session: Session): void {
     session.endedAt ? session.endedAt.toISOString() : null,
     session.durationSeconds ?? 0,
     session.claudeAccountId ?? null,
-    session.provider ?? 'claude'
+    session.provider ?? 'claude',
+    session.failoverFromAccountId ?? null,
+    session.failoverPrevAccountId ?? null
   );
 }
 
@@ -117,6 +126,14 @@ export function updateSession(id: string, updates: Partial<Session>): void {
   if (updates.claudeAccountId !== undefined) {
     fields.push('claude_account_id = ?');
     values.push(updates.claudeAccountId);
+  }
+  if (updates.failoverFromAccountId !== undefined) {
+    fields.push('failover_from_account_id = ?');
+    values.push(updates.failoverFromAccountId);
+  }
+  if (updates.failoverPrevAccountId !== undefined) {
+    fields.push('failover_prev_account_id = ?');
+    values.push(updates.failoverPrevAccountId);
   }
   if (updates.provider !== undefined) {
     // Changing provider invalidates any stored conversation UUID — it belongs

--- a/src/main/repositories/sessions.ts
+++ b/src/main/repositories/sessions.ts
@@ -7,11 +7,10 @@ export function sessionExists(id: string): boolean {
   return !!row;
 }
 
-export function getAllSessions(): Session[] {
-  const db = getDatabase();
-  const rows = db.prepare('SELECT * FROM sessions ORDER BY "order", created_at IS NULL, created_at, id').all() as any[];
-
-  return rows.map(row => ({
+/** sessions row → domain object. Shared so a single-row lookup and the full
+ *  listing cannot drift in how they read the same columns. */
+function mapSessionRow(row: any): Session {
+  return {
     id: row.id,
     groupId: row.group_id,
     name: row.name,
@@ -28,12 +27,27 @@ export function getAllSessions(): Session[] {
     provider: row.provider ?? 'claude',
     failoverFromAccountId: row.failover_from_account_id ?? null,
     failoverPrevAccountId: row.failover_prev_account_id ?? null,
-  }));
+  };
 }
 
-/** One session by id, or null. Same row mapping as getAllSessions. */
+export function getAllSessions(): Session[] {
+  const db = getDatabase();
+  const rows = db.prepare('SELECT * FROM sessions ORDER BY "order", created_at IS NULL, created_at, id').all() as any[];
+  return rows.map(mapSessionRow);
+}
+
+/**
+ * One session by id, or null.
+ *
+ * Hits the primary key rather than loading the table and filtering: the
+ * failover and fail-back sweeps call this per session, on the main process,
+ * and "there are only tens of rows" is a reason it wasn't slow, not a reason
+ * for the query to say something other than what it means.
+ */
 export function getSession(id: string): Session | null {
-  return getAllSessions().find(session => session.id === id) ?? null;
+  const db = getDatabase();
+  const row = db.prepare('SELECT * FROM sessions WHERE id = ?').get(id);
+  return row ? mapSessionRow(row) : null;
 }
 
 export function createSession(session: Session): void {

--- a/src/main/usage-limit.ts
+++ b/src/main/usage-limit.ts
@@ -20,7 +20,7 @@
  */
 export const CLAUDE_USAGE_LIMIT_PATTERNS: readonly RegExp[] = [
   /Claude (?:AI )?usage limit reached/i,
-  /(?:You(?:'|’)ve|You have) reached your (?:usage|weekly|5-hour) limit/i,
+  /(?:You['’]ve|You have) reached your (?:usage|weekly|5-hour) limit/i,
   /(?:usage|weekly|5-hour|session) limit reached/i,
   /Your limit will reset at/i,
 ] as const;

--- a/src/main/usage-limit.ts
+++ b/src/main/usage-limit.ts
@@ -1,0 +1,193 @@
+/**
+ * Reading "this account is out of quota" out of an agent CLI's terminal output.
+ *
+ * There is no structured channel for this. The CLI announces a usage limit by
+ * printing it, so the pty output scanner is where it has to be caught — the
+ * same place `waitingPatterns` already reads the TUI. This module owns the two
+ * halves of that: which lines mean "limited", and when the limit lifts.
+ *
+ * It knows nothing about accounts, sessions or the database. It turns text
+ * into a verdict; account-failover.ts decides what the verdict costs.
+ */
+
+/**
+ * Lines that mean the account behind the CLI has run out of quota.
+ *
+ * Kept narrow on purpose. A false positive here does not produce a harmless
+ * extra log line — it restarts a live session under a different account and
+ * marks a healthy account as limited for hours. "limit" and "rate" on their
+ * own appear constantly in ordinary agent output and are deliberately absent.
+ */
+export const CLAUDE_USAGE_LIMIT_PATTERNS: readonly RegExp[] = [
+  /Claude (?:AI )?usage limit reached/i,
+  /(?:You(?:'|’)ve|You have) reached your (?:usage|weekly|5-hour) limit/i,
+  /(?:usage|weekly|5-hour|session) limit reached/i,
+  /Your limit will reset at/i,
+] as const;
+
+/**
+ * Markers that say the matched line is the CLI *quoting* a limit message
+ * rather than emitting one.
+ *
+ * This is not hypothetical: an agent reading this very file, a grep hit, a
+ * diff, or a conversation about rate limits all put the trigger phrase on
+ * screen inside a session that is running perfectly well. Terminal output is
+ * an open channel — anything the user or the agent renders arrives here
+ * indistinguishable from the CLI's own chrome — so the check is for the shape
+ * of quoted code and prose, not for a trusted source.
+ *
+ * It cannot be complete, and does not have to be: everything it misses is
+ * still bounded downstream, where failover refuses to fire twice for the same
+ * account inside a short window and never targets an account already cooling.
+ */
+const QUOTED_MARKERS: readonly RegExp[] = [
+  /\/[gimsuy]*,\s*$/,        // trailing regex-literal flags, e.g. `/i,`
+  /^\s*[-+]/,                 // diff line
+  /^\s*(?:\/\/|\*|#)/,        // comment
+  /[`'"]\s*[:,]/,             // a quoted string used as a value
+  /=>|===|\bfunction\b|\bconst\b|\bexport\b/,
+  /^\s*\d+[:|]/,              // grep -n / line-numbered file output
+] as const;
+
+/** The line `index` falls on, without scanning the whole buffer. */
+function lineAround(text: string, index: number): string {
+  const start = text.lastIndexOf('\n', index) + 1;
+  const end = text.indexOf('\n', index);
+  return text.slice(start, end === -1 ? text.length : end);
+}
+
+/**
+ * Longest a cooldown may run. A parsed reset time further out than this is a
+ * misread, not a week-long lockout, and is dropped in favour of the caller's
+ * default window.
+ */
+const MAX_COOLDOWN_MS = 8 * 24 * 60 * 60 * 1000;
+
+export interface UsageLimitHit {
+  /** The line that announced it, for logs and the notification body. */
+  line: string;
+  /** When the CLI said quota returns, or null when it did not say. */
+  resetAt: Date | null;
+}
+
+/**
+ * Scan recent output for a usage-limit announcement.
+ *
+ * `patterns` comes from the provider so a non-Claude CLI can bring its own
+ * wording; the quoting guard and the reset parsing are shared.
+ */
+export function detectUsageLimit(
+  text: string,
+  patterns: readonly RegExp[] = CLAUDE_USAGE_LIMIT_PATTERNS,
+  now: Date = new Date(),
+): UsageLimitHit | null {
+  for (const pattern of patterns) {
+    const match = pattern.exec(text);
+    if (!match) continue;
+
+    const line = lineAround(text, match.index).trim();
+    if (QUOTED_MARKERS.some(marker => marker.test(line))) continue;
+
+    return { line, resetAt: parseResetAt(text.slice(match.index), now) };
+  }
+  return null;
+}
+
+/**
+ * When the quota comes back, read out of the announcement itself.
+ *
+ * Four shapes, in descending order of how much they actually pin down:
+ *   |1763000000            headless mode's epoch suffix — unambiguous
+ *   resets Nov 12 at 9am   weekly limits, which can be days out
+ *   reset at 3:30pm        a clock time with no date
+ *   resets in 42 minutes   a duration
+ *
+ * A bare clock time is the common case and the ambiguous one: it carries no
+ * date, so it is read as the NEXT occurrence of that time. Reading it as
+ * today's would put the reset in the past for any limit hit in the evening,
+ * and a cooldown that has already expired is no cooldown at all — the account
+ * would be handed straight back to the sessions that just bounced off it.
+ */
+export function parseResetAt(text: string, now: Date = new Date()): Date | null {
+  const candidate = parseEpochSuffix(text)
+    ?? parseRelative(text, now)
+    ?? parseDatedClock(text, now)
+    ?? parseClock(text, now);
+
+  if (!candidate) return null;
+
+  // A reset that is already past, or implausibly far out, tells us nothing
+  // useful; the caller's default window is the better answer.
+  const delta = candidate.getTime() - now.getTime();
+  if (delta <= 0 || delta > MAX_COOLDOWN_MS) return null;
+  return candidate;
+}
+
+/** `Claude AI usage limit reached|1763000000` — seconds since the epoch. */
+function parseEpochSuffix(text: string): Date | null {
+  const match = /\|\s*(\d{10,13})\b/.exec(text);
+  if (!match) return null;
+  const raw = Number(match[1]);
+  // 13 digits is already milliseconds; 10 is seconds.
+  return new Date(match[1].length >= 13 ? raw : raw * 1000);
+}
+
+/** `resets in 42 minutes` / `try again in 2 hours`. */
+function parseRelative(text: string, now: Date): Date | null {
+  const match = /\bin\s+(\d+)\s*(second|minute|hour|day)s?\b/i.exec(text);
+  if (!match) return null;
+  const unit = { second: 1000, minute: 60_000, hour: 3_600_000, day: 86_400_000 }[
+    match[2].toLowerCase() as 'second' | 'minute' | 'hour' | 'day'
+  ];
+  return new Date(now.getTime() + Number(match[1]) * unit);
+}
+
+const MONTHS = [
+  'jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec',
+];
+
+/** `resets Nov 12 at 9am` — a weekly limit, which needs the date to be right. */
+function parseDatedClock(text: string, now: Date): Date | null {
+  const match = new RegExp(
+    String.raw`\b(${MONTHS.join('|')})[a-z]*\.?\s+(\d{1,2})\b(?:[^\n]{0,12}?(\d{1,2})(?::(\d{2}))?\s*(am|pm))?`,
+    'i',
+  ).exec(text);
+  if (!match) return null;
+
+  const month = MONTHS.indexOf(match[1].toLowerCase());
+  const day = Number(match[2]);
+  const { hours, minutes } = match[3]
+    ? clockToHours(Number(match[3]), Number(match[4] ?? 0), match[5])
+    : { hours: 0, minutes: 0 };
+
+  // No year in the text. Use this one, and roll forward when that lands in the
+  // past — a limit announced on Dec 30 that resets "Jan 2" means next year.
+  const candidate = new Date(now.getFullYear(), month, day, hours, minutes, 0, 0);
+  if (candidate.getTime() < now.getTime()) candidate.setFullYear(now.getFullYear() + 1);
+  return candidate;
+}
+
+/** `resets at 3pm` / `reset at 10:30 PM` — next occurrence of that clock time. */
+function parseClock(text: string, now: Date): Date | null {
+  const match = /\b(?:reset|resets|resetting)\b[^\n]{0,20}?\b(\d{1,2})(?::(\d{2}))?\s*(am|pm)?/i.exec(text);
+  if (!match) return null;
+
+  // Bare digits with no am/pm are as likely to be a token count as a time.
+  if (!match[3] && !match[2]) return null;
+
+  const { hours, minutes } = clockToHours(Number(match[1]), Number(match[2] ?? 0), match[3]);
+  if (hours > 23 || minutes > 59) return null;
+
+  const candidate = new Date(now);
+  candidate.setHours(hours, minutes, 0, 0);
+  if (candidate.getTime() <= now.getTime()) candidate.setDate(candidate.getDate() + 1);
+  return candidate;
+}
+
+function clockToHours(hour: number, minutes: number, meridiem?: string): { hours: number; minutes: number } {
+  let hours = hour;
+  const suffix = meridiem?.toLowerCase();
+  if (suffix === 'pm' && hours < 12) hours += 12;
+  if (suffix === 'am' && hours === 12) hours = 0;
+  return { hours, minutes };
+}

--- a/src/main/usage-limit.ts
+++ b/src/main/usage-limit.ts
@@ -36,9 +36,13 @@ export const CLAUDE_USAGE_LIMIT_PATTERNS: readonly RegExp[] = [
  * indistinguishable from the CLI's own chrome — so the check is for the shape
  * of quoted code and prose, not for a trusted source.
  *
- * It cannot be complete, and does not have to be: everything it misses is
- * still bounded downstream, where failover refuses to fire twice for the same
- * account inside a short window and never targets an account already cooling.
+ * It cannot be complete. What actually bounds what it misses is narrower than
+ * it might look, and worth stating exactly: a pty reports at most once in its
+ * life, failover never targets an account already cooling down, and a move is
+ * idempotent because assigning a session to the account it is already on
+ * reports nothing to restart. There is deliberately NO per-account debounce —
+ * two ptys on the same account can each report the same limit, and both
+ * reports are real. Do not read a protection here that isn't written down.
  */
 const QUOTED_MARKERS: readonly RegExp[] = [
   /\/[gimsuy]*,\s*$/,        // trailing regex-literal flags, e.g. `/i,`

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -28,6 +28,21 @@ import './styles/context-menu.css';
 import ErrorBoundary from './components/ErrorBoundary';
 
 /**
+ * Of the sessions an automatic account switch moved (#207), the ones with a pty
+ * to replace.
+ *
+ * A stopped session has nothing running under the old account and picks the new
+ * one up whenever it is next started; restarting it here would start a session
+ * the user had deliberately ended.
+ */
+function respawnable(sessionIds: string[], sessions: Session[]): string[] {
+  const stopped = new Set(
+    sessions.filter(session => session.state === 'stopped').map(session => session.id)
+  );
+  return sessionIds.filter(id => !stopped.has(id));
+}
+
+/**
  * Collapse-chevron labels. While a filter is active every row is force-expanded,
  * so the control is disabled and says so rather than lying about state (#141).
  */
@@ -563,13 +578,7 @@ const App: React.FC = () => {
       // Cooldowns and default/rank state both just changed.
       window.electronAPI.listAccounts().then(setClaudeAccounts).catch(() => {});
 
-      // A stopped session has no pty to replace and picks the new account up
-      // whenever it is next started — restarting it here would start a session
-      // the user had deliberately ended.
-      const live = event.sessionIds.filter(
-        id => sessionsRef.current.find(s => s.id === id)?.state !== 'stopped'
-      );
-      restartSessions(live);
+      restartSessions(respawnable(event.sessionIds, sessionsRef.current));
     });
   }, [restartSessions]);
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,7 +15,8 @@ import AnalyticsPanel from './components/panels/AnalyticsPanel';
 import { ArenaPanel } from './components/ArenaPanel';
 import { ViewSwitcher, type ContentView } from './components/ViewSwitcher';
 import { isSwitchPending, type SessionAccountIndicatorProps } from './components/SessionAccountIndicator';
-import { ClaudeAccount, Session } from '../shared/types';
+import { FailoverNotice } from './components/FailoverNotice';
+import { AccountFailoverEvent, ClaudeAccount, Session } from '../shared/types';
 import type { LiveAccountBinding, LiveAccountBindings, RelayAttachedGuest, RelayPendingShare, RelayStatus } from '../shared/types';
 import { useSessions } from './store/sessions';
 import { useGroups } from './store/groups';
@@ -173,6 +174,13 @@ const App: React.FC = () => {
   // a Settings tab, so App needs to be able to open Settings straight to it.
   const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsTab>('general');
   const [claudeAccounts, setClaudeAccounts] = useState<ClaudeAccount[]>([]);
+  /**
+   * The most recent automatic account switch, until the user dismisses it
+   * (#207). One at a time: these arrive seconds apart at most —
+   * one account running dry moves every session on it in a single event — and
+   * a stack of banners would push the terminal off screen.
+   */
+  const [failoverNotice, setFailoverNotice] = useState<AccountFailoverEvent | null>(null);
   // Which account each running pty ACTUALLY spawned under (#165), keyed by
   // session id. Absent id = no pty running for that session.
   const [liveAccounts, setLiveAccounts] = useState<LiveAccountBindings>({});
@@ -524,6 +532,46 @@ const App: React.FC = () => {
       return next;
     });
   }, []);
+
+  /**
+   * Latest sessions, readable from a subscription that must not re-subscribe
+   * every time one of them changes state.
+   *
+   * The failover listener below needs to know which of the moved sessions are
+   * actually running, and session state changes on almost every keystroke of
+   * agent output. Putting `sessions` in that effect's dependencies would tear
+   * down and re-register the IPC listener continuously, and a failover event
+   * arriving in the gap would be dropped — the one event this feature exists
+   * to act on.
+   */
+  const sessionsRef = useRef(sessions);
+  sessionsRef.current = sessions;
+
+  /**
+   * Apply an account switch the app made on its own (#207).
+   *
+   * Main has already written the assignments and carried the conversations;
+   * what it cannot do is respawn the ptys, because a pty's CLAUDE_CONFIG_DIR is
+   * fixed at spawn and only this side owns the terminals. Until the respawn the
+   * sessions are still billing the account that just ran dry, so this is not
+   * cosmetic follow-up — it is the half of the switch that makes it real.
+   */
+  useEffect(() => {
+    return window.electronAPI.onAccountFailover((event) => {
+      setFailoverNotice(event);
+
+      // Cooldowns and default/rank state both just changed.
+      window.electronAPI.listAccounts().then(setClaudeAccounts).catch(() => {});
+
+      // A stopped session has no pty to replace and picks the new account up
+      // whenever it is next started — restarting it here would start a session
+      // the user had deliberately ended.
+      const live = event.sessionIds.filter(
+        id => sessionsRef.current.find(s => s.id === id)?.state !== 'stopped'
+      );
+      restartSessions(live);
+    });
+  }, [restartSessions]);
 
   /**
    * The header account indicator for one session (#165).
@@ -1578,6 +1626,17 @@ const App: React.FC = () => {
 
       <main className="main">
         <ViewSwitcher value={contentView} onChange={setContentView} shortcutPrefix={appMod} />
+        {failoverNotice && (
+          <FailoverNotice
+            event={failoverNotice}
+            onDismiss={() => setFailoverNotice(null)}
+            onOpenAccounts={() => {
+              setSettingsInitialTab('accounts');
+              setSettingsOpen(true);
+              setFailoverNotice(null);
+            }}
+          />
+        )}
         {contentView === 'analytics' && (
           <AnalyticsPanel
             onClose={() => setContentView('terminal')}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -35,7 +35,7 @@ import ErrorBoundary from './components/ErrorBoundary';
  * one up whenever it is next started; restarting it here would start a session
  * the user had deliberately ended.
  */
-function respawnable(sessionIds: string[], sessions: Session[]): string[] {
+export function respawnable(sessionIds: string[], sessions: Session[]): string[] {
   const stopped = new Set(
     sessions.filter(session => session.state === 'stopped').map(session => session.id)
   );

--- a/src/renderer/__tests__/App.accounts.test.ts
+++ b/src/renderer/__tests__/App.accounts.test.ts
@@ -16,7 +16,7 @@
  * Run with: bun test src/renderer/__tests__/App.accounts.test.ts
  */
 import { describe, expect, test } from 'bun:test';
-import { accountMenuLabel, resolveAccountIndicator } from '../App';
+import { accountMenuLabel, resolveAccountIndicator, respawnable } from '../App';
 import type { ClaudeAccount, LiveAccountBinding, Session } from '../../shared/types';
 
 const work = {
@@ -174,5 +174,41 @@ describe('accountMenuLabel', () => {
   test('the label stays quoted, so an account named after a verb still reads', () => {
     const odd = { ...work, label: 'Use' } as ClaudeAccount;
     expect(accountMenuLabel(odd, false)).toContain('Use "Use"');
+  });
+});
+
+/**
+ * Which of the sessions an automatic switch moved actually get their pty
+ * replaced (#207).
+ *
+ * Both directions are mistakes the user sees. Restarting a stopped session
+ * starts something they deliberately ended; skipping a live one leaves it
+ * billing the account that just ran dry, which is the entire thing failover
+ * exists to stop.
+ */
+describe('respawnable', () => {
+  const session = (id: string, state: string) => ({ id, state } as Session);
+
+  test('keeps the sessions that still have a pty', () => {
+    const sessions = [session('a', 'working'), session('b', 'waiting'), session('c', 'idle')];
+    expect(respawnable(['a', 'b', 'c'], sessions)).toEqual(['a', 'b', 'c']);
+  });
+
+  test('drops a stopped session rather than starting it back up', () => {
+    const sessions = [session('a', 'working'), session('b', 'stopped')];
+    expect(respawnable(['a', 'b'], sessions)).toEqual(['a']);
+  });
+
+  /**
+   * A moved session the renderer has not heard of yet is restarted, not
+   * dropped. Only an explicit 'stopped' is evidence there is nothing to
+   * replace; absence is evidence of nothing.
+   */
+  test('keeps an id the renderer has no row for', () => {
+    expect(respawnable(['ghost'], [session('a', 'working')])).toEqual(['ghost']);
+  });
+
+  test('moves nothing when nothing moved', () => {
+    expect(respawnable([], [session('a', 'working')])).toEqual([]);
   });
 });

--- a/src/renderer/components/ClaudeAccountsModal.css
+++ b/src/renderer/components/ClaudeAccountsModal.css
@@ -282,3 +282,83 @@
 .claude-account-login-modal .danger:hover {
   background: #7a3c3c;
 }
+
+/* --- Failover (#207) ------------------------------------------ */
+
+.failover-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color, #3a3a3a);
+  border-radius: 4px;
+  background: var(--bg-secondary, #252526);
+}
+
+.failover-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary, #999);
+  cursor: pointer;
+}
+
+.failover-toggle strong {
+  color: var(--text-primary, #ddd);
+  font-weight: 600;
+}
+
+.failover-toggle input {
+  margin-top: 2px;
+  flex: 0 0 auto;
+}
+
+/* A disabled fail-back toggle is not broken — it is subordinate to the switch
+   above it, and dimming the whole line says that more clearly than dimming the
+   checkbox alone. */
+.failover-toggle input:disabled + span {
+  opacity: 0.5;
+}
+
+/* Queue position: the number is what makes "the order below" a real thing the
+   user can point at, so it reads as data, not decoration. */
+.failover-position {
+  flex: 0 0 auto;
+  min-width: 16px;
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  color: var(--text-secondary, #999);
+  opacity: 0.7;
+}
+
+.limited-tag {
+  flex: 0 0 auto;
+  padding: 1px 6px;
+  border: 1px solid var(--warning-color, #d79c40);
+  border-radius: 10px;
+  font-size: 10px;
+  text-transform: lowercase;
+  color: var(--warning-color, #d79c40);
+  white-space: nowrap;
+}
+
+/* A limited account is still a real account — it keeps its sessions and can be
+   assigned by hand. Dimming it slightly says "not a failover candidate right
+   now" without implying it is disabled. */
+.account-row.limited .account-chip {
+  opacity: 0.7;
+}
+
+.move-btn {
+  min-width: 24px;
+  padding: 2px 6px;
+  line-height: 1;
+}
+
+.move-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}

--- a/src/renderer/components/ClaudeAccountsModal.tsx
+++ b/src/renderer/components/ClaudeAccountsModal.tsx
@@ -69,6 +69,33 @@ export const ClaudeAccountsPanel: React.FC = () => {
     await refresh();
   }, [refresh]);
 
+  /**
+   * Move an account up or down the failover queue.
+   *
+   * Buttons rather than drag-and-drop. The list is three or four rows on any
+   * real setup, keyboard and screen-reader users get the same affordance as
+   * everyone else for free, and the whole order is rewritten on each move so
+   * an estate that was half-ranked comes out fully ranked.
+   */
+  const handleMove = useCallback(async (id: string, direction: -1 | 1) => {
+    const index = accounts.findIndex(a => a.id === id);
+    const target = index + direction;
+    if (index < 0 || target < 0 || target >= accounts.length) return;
+
+    const reordered = [...accounts];
+    [reordered[index], reordered[target]] = [reordered[target], reordered[index]];
+    // Optimistic: the reorder is instant and local, and a failed write is
+    // corrected by the refresh that follows.
+    setAccounts(reordered);
+    await window.electronAPI.setAccountFallbackOrder(reordered.map(a => a.id));
+    await refresh();
+  }, [accounts, refresh]);
+
+  const handleClearLimit = useCallback(async (id: string) => {
+    await window.electronAPI.clearAccountLimit(id);
+    await refresh();
+  }, [refresh]);
+
   // The panel computes "N sessions are running on this account" two inches
   // above this button, and deleting removes the on-disk config dir out from
   // under those live ptys (#165). Withholding the number here while the dialog
@@ -137,11 +164,13 @@ export const ClaudeAccountsPanel: React.FC = () => {
         login, so sessions assigned to different accounts can run at the same time.
       </p>
 
+      <FailoverSettings />
+
       {accounts.length === 0 ? (
         <div className="empty">{emptyText}</div>
       ) : (
         <ul className="account-list">
-          {accounts.map(acc => {
+          {accounts.map((acc, index) => {
             // Live ptys, not DB assignments — an unapplied switch must not be
             // reported as usage, and this keeps the panel and the session
             // header telling the same story.
@@ -152,6 +181,12 @@ export const ClaudeAccountsPanel: React.FC = () => {
                 key={acc.id}
                 account={acc}
                 runningSessions={runningSessions}
+                position={index + 1}
+                canMoveUp={index > 0}
+                canMoveDown={index < accounts.length - 1}
+                onMoveUp={() => handleMove(acc.id, -1)}
+                onMoveDown={() => handleMove(acc.id, 1)}
+                onClearLimit={() => handleClearLimit(acc.id)}
                 onMakeDefault={() => handleSetDefault(acc.id)}
                 onDelete={() => handleDelete(acc.id, acc.label, runningSessions)}
               />
@@ -187,8 +222,34 @@ export interface AccountRowProps {
   account: ClaudeAccount;
   /** Running ptys currently spawned under this account (#165). 0 renders no badge. */
   runningSessions: number;
+  /** 1-based place in the failover queue (#207). */
+  position: number;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  /** Hand the account back before its recorded cooldown expires. */
+  onClearLimit: () => void;
   onMakeDefault: () => void;
   onDelete: () => void;
+}
+
+/**
+ * Whether a recorded cooldown is still in force.
+ *
+ * Decided against the clock here rather than trusted from the row, because
+ * nothing sweeps the column when a limit expires — a stale `limitedUntil` is
+ * the normal state of a healthy account, not a bug.
+ */
+export function isLimited(account: ClaudeAccount, now: Date = new Date()): boolean {
+  return account.limitedUntil !== null && new Date(account.limitedUntil).getTime() > now.getTime();
+}
+
+/** "9:30 PM", or "Tue 9:30 PM" when it is not today. */
+function formatReset(resetAt: Date, now: Date = new Date()): string {
+  const time = resetAt.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  if (resetAt.toDateString() === now.toDateString()) return time;
+  return `${resetAt.toLocaleDateString(undefined, { weekday: 'short' })} ${time}`;
 }
 
 /**
@@ -203,12 +264,22 @@ export interface AccountRowProps {
 export const AccountRow: React.FC<AccountRowProps> = ({
   account,
   runningSessions,
+  position,
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
+  onClearLimit,
   onMakeDefault,
   onDelete,
 }) => {
   const plural = runningSessions === 1 ? 'session' : 'sessions';
+  const limited = isLimited(account);
   return (
-    <li className="account-row">
+    <li className={`account-row ${limited ? 'limited' : ''}`}>
+      {/* The queue position is the whole point of the ordering, so it is text
+          in the row and not a tooltip on an arrow. */}
+      <span className="failover-position" aria-hidden="true">{position}</span>
       <AccountChip account={account} size="md" />
       {/* The status is a tag beside the address, not a replacement for it: the
           address is what says WHICH account this is, and the one surface where
@@ -234,7 +305,41 @@ export const AccountRow: React.FC<AccountRowProps> = ({
           in use · {runningSessions}
         </span>
       )}
+      {limited && account.limitedUntil && (
+        <span
+          className="limited-tag"
+          title="This account hit its usage limit. It won't be picked for failover until then."
+        >
+          limited · back {formatReset(new Date(account.limitedUntil))}
+        </span>
+      )}
       <div className="row-actions">
+        <button
+          className="move-btn"
+          onClick={onMoveUp}
+          disabled={!canMoveUp}
+          title="Try this account earlier when another one runs out"
+          aria-label={`Move ${account.label} up the failover order`}
+        >
+          ↑
+        </button>
+        <button
+          className="move-btn"
+          onClick={onMoveDown}
+          disabled={!canMoveDown}
+          title="Try this account later when another one runs out"
+          aria-label={`Move ${account.label} down the failover order`}
+        >
+          ↓
+        </button>
+        {limited && (
+          <button
+            onClick={onClearLimit}
+            title="Mark this account available again — use it if the reset time was a guess and your quota is already back"
+          >
+            Clear limit
+          </button>
+        )}
         {!account.isDefault && (
           <button onClick={onMakeDefault} title="Use as the default account when a group or session doesn't specify one">
             Make default
@@ -245,6 +350,73 @@ export const AccountRow: React.FC<AccountRowProps> = ({
         </button>
       </div>
     </li>
+  );
+};
+
+// -----------------------------------------------------------------------------
+// Failover switches (#207).
+// -----------------------------------------------------------------------------
+
+/** Preference keys, matching account-failover.ts. Absent means enabled. */
+const FAILOVER_PREF = 'accountFailoverEnabled';
+const FAILBACK_PREF = 'accountFailbackEnabled';
+
+/**
+ * The two things a user might want to turn off about automatic switching.
+ *
+ * They are separate switches because they answer different worries. Failover
+ * spends a second subscription without being asked; fail-back restarts a
+ * session that was working fine. Somebody can reasonably want the first and
+ * not the second, and collapsing them into one control would make refusing the
+ * restart cost them the whole feature.
+ */
+const FailoverSettings: React.FC = () => {
+  const [failover, setFailover] = useState(true);
+  const [failback, setFailback] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.electronAPI.getAllPreferences().then(prefs => {
+      if (cancelled) return;
+      setFailover(prefs[FAILOVER_PREF] !== 'false');
+      setFailback(prefs[FAILBACK_PREF] !== 'false');
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  const toggle = (key: string, next: boolean, apply: (value: boolean) => void) => {
+    apply(next);
+    window.electronAPI.setPreference(key, next ? 'true' : 'false').catch(() => {});
+  };
+
+  return (
+    <div className="failover-settings">
+      <label className="failover-toggle">
+        <input
+          type="checkbox"
+          checked={failover}
+          onChange={e => toggle(FAILOVER_PREF, e.target.checked, setFailover)}
+        />
+        <span>
+          <strong>Switch accounts when one hits its usage limit.</strong>{' '}
+          Every session running on the spent account moves to the next one in the
+          order below and resumes its conversation.
+        </span>
+      </label>
+      <label className="failover-toggle">
+        <input
+          type="checkbox"
+          checked={failback}
+          disabled={!failover}
+          onChange={e => toggle(FAILBACK_PREF, e.target.checked, setFailback)}
+        />
+        <span>
+          <strong>Move them back when the limit lifts.</strong>{' '}
+          Only while a session is idle, so a switch back never interrupts a turn
+          in progress. Without this, sessions stay on the backup account.
+        </span>
+      </label>
+    </div>
   );
 };
 

--- a/src/renderer/components/FailoverNotice.css
+++ b/src/renderer/components/FailoverNotice.css
@@ -1,0 +1,55 @@
+.failover-notice {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  margin: 8px 12px 0;
+  border: 1px solid var(--border-color, #3a3a3a);
+  border-left: 3px solid var(--accent-color, #6aa84f);
+  border-radius: 4px;
+  background: var(--bg-secondary, #252526);
+  color: var(--text-primary, #ddd);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+/* Nothing moved. Warmer border so the two outcomes are distinguishable at a
+   glance, without the alarm colouring of an actual error — the app is not
+   broken, the quota is. */
+.failover-notice.blocked {
+  border-left-color: var(--warning-color, #d79c40);
+}
+
+.failover-notice-icon {
+  flex: 0 0 auto;
+  font-weight: 700;
+  opacity: 0.8;
+}
+
+.failover-notice-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.failover-notice-link,
+.failover-notice-dismiss {
+  flex: 0 0 auto;
+  background: none;
+  border: none;
+  color: var(--text-secondary, #999);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+.failover-notice-link:hover,
+.failover-notice-dismiss:hover {
+  color: var(--text-primary, #ddd);
+  background: var(--bg-hover, #2f2f30);
+}
+
+.failover-notice-dismiss {
+  font-size: 16px;
+  line-height: 1;
+}

--- a/src/renderer/components/FailoverNotice.tsx
+++ b/src/renderer/components/FailoverNotice.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { AccountFailoverEvent } from '../../shared/types';
+import { AccountChip } from './AccountChip';
+import './FailoverNotice.css';
+
+export interface FailoverNoticeProps {
+  event: AccountFailoverEvent;
+  onDismiss: () => void;
+  /** Opens Settings → Claude accounts, where the order and cooldowns live. */
+  onOpenAccounts: () => void;
+}
+
+/**
+ * What just happened to your sessions, said once, in the window.
+ *
+ * A desktop notification already fires, but it is the wrong and only channel
+ * on its own: it is gone in five seconds, it is invisible to anyone who has
+ * notifications off, and it cannot be gone back to. An account switch is a
+ * thing the app did on its own initiative to work the user did not finish, so
+ * it earns a line in the interface that stays until it is dismissed.
+ *
+ * The blocked cases are the ones that most need saying. "Everything you have
+ * is spent" is not a smaller event than a successful switch — it is the one
+ * where the user has to do something.
+ */
+export const FailoverNotice: React.FC<FailoverNoticeProps> = ({ event, onDismiss, onOpenAccounts }) => {
+  const blocked = event.to === null;
+  const sessions = event.sessionIds.length === 1
+    ? '1 session'
+    : `${event.sessionIds.length} sessions`;
+
+  return (
+    <div
+      className={`failover-notice ${blocked ? 'blocked' : ''}`}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="failover-notice-icon" aria-hidden="true">{blocked ? '!' : '⇄'}</span>
+
+      <div className="failover-notice-body">
+        {event.reason === 'failback' ? (
+          <>
+            <strong>Back on your own account.</strong>{' '}
+            <AccountChip account={event.to} size="sm" />{' '}
+            is out of its usage limit, so {sessions} moved back.
+          </>
+        ) : (
+          <>
+            <AccountChip account={event.from} size="sm" />{' '}
+            {describeLimit(event)}{' '}
+            {renderOutcome(event, sessions)}
+          </>
+        )}
+      </div>
+
+      <button className="failover-notice-link" onClick={onOpenAccounts}>
+        Accounts
+      </button>
+      <button
+        className="failover-notice-dismiss"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        title="Dismiss"
+      >
+        ×
+      </button>
+    </div>
+  );
+};
+
+/** "hit its usage limit (back at 9:30pm)." */
+function describeLimit(event: AccountFailoverEvent): string {
+  if (!event.resetAt) return 'hit its usage limit.';
+  return `hit its usage limit — back at ${formatReset(new Date(event.resetAt))}.`;
+}
+
+function renderOutcome(event: AccountFailoverEvent, sessions: string): React.ReactNode {
+  if (event.blocked === 'disabled') {
+    return 'Automatic failover is off, so nothing moved.';
+  }
+  if (event.blocked === 'no-healthy-account') {
+    return 'Every other account is limited too, so nothing moved.';
+  }
+  return (
+    <>
+      {sessions} moved to <AccountChip account={event.to} size="sm" />.
+    </>
+  );
+}
+
+/** "9:30 PM", or "Tue 9:30 PM" when the reset is not today. */
+function formatReset(resetAt: Date, now: Date = new Date()): string {
+  const time = resetAt.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  if (resetAt.toDateString() === now.toDateString()) return time;
+  return `${resetAt.toLocaleDateString(undefined, { weekday: 'short' })} ${time}`;
+}

--- a/src/renderer/components/FailoverNotice.tsx
+++ b/src/renderer/components/FailoverNotice.tsx
@@ -30,11 +30,7 @@ export const FailoverNotice: React.FC<FailoverNoticeProps> = ({ event, onDismiss
     : `${event.sessionIds.length} sessions`;
 
   return (
-    <div
-      className={`failover-notice ${blocked ? 'blocked' : ''}`}
-      role="status"
-      aria-live="polite"
-    >
+    <output className={`failover-notice ${blocked ? 'blocked' : ''}`} aria-live="polite">
       <span className="failover-notice-icon" aria-hidden="true">{blocked ? '!' : '⇄'}</span>
 
       <div className="failover-notice-body">
@@ -64,7 +60,7 @@ export const FailoverNotice: React.FC<FailoverNoticeProps> = ({ event, onDismiss
       >
         ×
       </button>
-    </div>
+    </output>
   );
 };
 

--- a/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
+++ b/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
@@ -150,6 +150,12 @@ describe('ClaudeAccountsPanel delete confirmation', () => {
       setDefaultAccount: async () => true,
       startAccountLogin: async () => ({ account: listed[0], ptyId: 'p' }),
       cancelAccountLogin: async () => {},
+      // Failover surface (#207): the panel reads the toggles and
+      // can reorder or release accounts.
+      getAllPreferences: async () => ({}),
+      setPreference: async () => {},
+      setAccountFallbackOrder: async () => {},
+      clearAccountLimit: async () => {},
       platform: 'darwin',
       homedir: '/home',
     };

--- a/src/renderer/components/__tests__/FailoverNotice.test.tsx
+++ b/src/renderer/components/__tests__/FailoverNotice.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * The in-window account-switch notice.
+ *
+ * What is worth asserting here is not that it renders, but that it cannot say
+ * a switch happened when none did. "Moved to Work" over a session still stuck
+ * on a spent account is the failure this whole feature would be judged by, and
+ * the blocked cases are exactly where that sentence could get printed by
+ * accident.
+ */
+import { describe, expect, test } from 'bun:test';
+import { render, screen, cleanup } from '@testing-library/react';
+import React from 'react';
+import { FailoverNotice } from '../FailoverNotice';
+import { AccountFailoverEvent, ClaudeAccount } from '../../../shared/types';
+
+function account(id: string, label: string): ClaudeAccount {
+  return {
+    id,
+    label,
+    configDir: `/tmp/${id}`,
+    email: null,
+    color: '#888888',
+    isDefault: false,
+    createdAt: new Date('2026-08-01T00:00:00Z'),
+    lastUsedAt: null,
+    fallbackRank: 0,
+    limitedUntil: null,
+    limitedAt: null,
+  };
+}
+
+function notice(overrides: Partial<AccountFailoverEvent>) {
+  cleanup();
+  const event: AccountFailoverEvent = {
+    reason: 'limit',
+    from: account('primary', 'Personal'),
+    to: account('backup', 'Work'),
+    sessionIds: ['s1', 's2'],
+    resetAt: null,
+    ...overrides,
+  };
+  render(<FailoverNotice event={event} onDismiss={() => {}} onOpenAccounts={() => {}} />);
+  return screen.getByRole('status').textContent ?? '';
+}
+
+describe('FailoverNotice', () => {
+  test('names both accounts and how many sessions moved', () => {
+    const text = notice({});
+    expect(text).toContain('Personal');
+    expect(text).toContain('Work');
+    expect(text).toContain('2 sessions moved');
+  });
+
+  test('says when the spent account comes back, if the CLI said', () => {
+    const resetAt = new Date();
+    resetAt.setHours(resetAt.getHours() + 2, 30, 0, 0);
+    expect(notice({ resetAt })).toContain('back at');
+  });
+
+  test('never claims a move when every account is spent', () => {
+    const text = notice({ to: null, sessionIds: [], blocked: 'no-healthy-account' });
+    expect(text).toContain('Every other account is limited');
+    expect(text).not.toContain('moved to');
+  });
+
+  test('never claims a move when failover is switched off', () => {
+    const text = notice({ to: null, sessionIds: [], blocked: 'disabled' });
+    expect(text).toContain('Automatic failover is off');
+    expect(text).not.toContain('moved to');
+  });
+
+  test('reads as a return, not a switch, on the way home', () => {
+    const text = notice({
+      reason: 'failback',
+      from: account('backup', 'Work'),
+      to: account('primary', 'Personal'),
+      sessionIds: ['s1'],
+    });
+    expect(text).toContain('Back on your own account');
+    expect(text).toContain('1 session moved back');
+  });
+});

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest } from '../shared/types';
+import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, AccountFailoverEvent, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -177,10 +177,14 @@ interface ElectronAPI {
   deleteAccount: (id: string) => Promise<void>;
   updateAccount: (id: string, updates: { label?: string; color?: string; email?: string | null }) => Promise<void>;
   setDefaultAccount: (id: string) => Promise<boolean>;
+  setAccountFallbackOrder: (orderedIds: string[]) => Promise<void>;
+  clearAccountLimit: (id: string) => Promise<void>;
+  nextAccountInLine: (excludeId: string | null) => Promise<ClaudeAccount | null>;
   assignAccountToSession: (sessionId: string, accountId: string | null) => Promise<AccountSwitchResult>;
   assignAccountToGroup: (groupId: string, accountId: string | null) => Promise<AccountSwitchResult>;
   onAccountLoginCompleted: (callback: (data: { accountId: string; email: string | null; verified: boolean }) => void) => () => void;
   onAccountLoginExited: (callback: (data: { accountId: string; exitCode: number }) => void) => () => void;
+  onAccountFailover: (callback: (event: AccountFailoverEvent) => void) => () => void;
 
   // Update channel (BDHLNDR-32)
   getUpdateChannel: () => Promise<'stable' | 'beta'>;

--- a/src/renderer/store/sessions.ts
+++ b/src/renderer/store/sessions.ts
@@ -70,6 +70,9 @@ export function useSessions() {
           durationSeconds: 0,
           claudeAccountId: null,
           provider,
+          // A brand-new session has never been failed over (#207).
+          failoverFromAccountId: null,
+          failoverPrevAccountId: null,
         };
 
         // Activate immediately so the Terminal mounts in a visible container.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -321,18 +321,6 @@ export interface ClaudeAccount {
 }
 
 /**
- * An account and whether it can take work right now (#207). `limitedUntil` in
- * the past is not a limited account — nothing sweeps the column on a timer, so
- * expiry is decided at read time and every reader must agree on that. Hence
- * this shape rather than each caller re-deriving it from the raw column.
- */
-export interface AccountHealth {
-  account: ClaudeAccount;
-  /** False only while a recorded limit is still in force. */
-  healthy: boolean;
-}
-
-/**
  * One automatic account switch (#207), reported to the renderer so it can
  * respawn the ptys and say what happened.
  *

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -31,6 +31,18 @@ export interface Session {
    * 'claude'; plain shell sessions keep the default.
    */
   provider: string;
+  /**
+   * The account this session was moved OFF when failover fired (#207), or null
+   * when it is running where it was put. Kept so the session can go back once
+   * that account's limit lifts, and so the UI can say why it moved.
+   */
+  failoverFromAccountId: string | null;
+  /**
+   * The value `claudeAccountId` held before failover overwrote it. NULL means
+   * "inherited from the group", which is why it cannot double as the "no
+   * failover in progress" signal — `failoverFromAccountId` is that signal.
+   */
+  failoverPrevAccountId: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -290,6 +302,59 @@ export interface ClaudeAccount {
   isDefault: boolean;
   createdAt: Date;
   lastUsedAt: Date | null;
+  /**
+   * Position in the failover order (#207): when an account hits its usage
+   * limit, its live sessions move to the lowest-ranked healthy account. Null
+   * for accounts that have never been ranked, which sort after every ranked
+   * one in the list order the accounts panel already uses.
+   */
+  fallbackRank: number | null;
+  /**
+   * When this account's usage limit is expected to lift, or null when it is
+   * not currently limited (#207). An account is skipped as a failover target
+   * until this passes. Parsed out of the CLI's own "resets at" line where it
+   * says one, otherwise a conservative default window.
+   */
+  limitedUntil: Date | null;
+  /** When the limit was observed. Null whenever limitedUntil is null. */
+  limitedAt: Date | null;
+}
+
+/**
+ * An account and whether it can take work right now (#207). `limitedUntil` in
+ * the past is not a limited account — nothing sweeps the column on a timer, so
+ * expiry is decided at read time and every reader must agree on that. Hence
+ * this shape rather than each caller re-deriving it from the raw column.
+ */
+export interface AccountHealth {
+  account: ClaudeAccount;
+  /** False only while a recorded limit is still in force. */
+  healthy: boolean;
+}
+
+/**
+ * One automatic account switch (#207), reported to the renderer so it can
+ * respawn the ptys and say what happened.
+ *
+ * `to` is null when there was nowhere to go: every other account is limited
+ * too, or none is registered. That is not a failure to report as an error —
+ * the session stays where it is and the user is told the wall is real.
+ */
+export interface AccountFailoverEvent {
+  /** 'limit' = moved off an exhausted account; 'failback' = returned to it. */
+  reason: 'limit' | 'failback';
+  from: ClaudeAccount | null;
+  to: ClaudeAccount | null;
+  /** Sessions whose pty must be respawned for the switch to take effect. */
+  sessionIds: string[];
+  /** When `from`'s limit lifts, for the notification copy. Null if unknown. */
+  resetAt: Date | null;
+  /**
+   * Why nothing moved, when `to` is null. The two cases read very differently
+   * to the person on the other end — "every account you have is spent" is news,
+   * "you turned this off" is not — so they are not collapsed into one silence.
+   */
+  blocked?: 'disabled' | 'no-healthy-account';
 }
 
 /**


### PR DESCRIPTION
Closes #207.

Multi-account support (BDHLNDR-31) gave each account an isolated `CLAUDE_CONFIG_DIR`; #164 and #165 made a conversation follow a session across accounts and made the UI honest about which account a pty is actually billing. What was missing was the reaction. The CLI would print its usage limit, every session on that account would sit blocked, and moving them was manual, one session at a time.

## How it works

**Detect** — `usage-limit.ts`. There is no structured channel for this: the CLI announces a limit by printing it, so this rides the existing output scanner next to `waitingPatterns`. The reset time is read out of the message itself — the `|<epoch>` suffix headless mode prints, `resets Nov 12 at 9am`, `reset at 3pm`, `in 42 minutes`. A message naming no reset falls back to a five-hour window (Claude's rolling window) rather than an optimistic guess: an account handed back early is a second failover and a second restart for every session on it.

**Mark** — `claude_accounts.limited_until` / `limited_at`. Nothing sweeps the column; expiry is decided at read time, so every reader agrees on it. A second, vaguer report can't shorten a precise cooldown.

**Move** — `account-failover.ts`, policy only. It never spawns or kills a pty — a switch reaches the CLI as `CLAUDE_CONFIG_DIR`, fixed at spawn, so applying one takes a respawn and only the renderer owns those. Every *live* session on the spent account moves, not just the one that noticed; the limit is the account's, so the others are already dead in the water. The target is the next healthy account in a user-set order.

**Return** — the point of a secondary account is to absorb an outage, not to become the new home. Sessions go back once the limit lifts, but only while idle or stopped, so a switch back can never interrupt a turn in progress.

## The part that had to be right

Failover routes through `account-switch`, so the transcript follows. Combined with the launch-time carry from #164 — which searches every config dir and picks newest-and-not-smaller — and the renderer's existing kill-before-spawn ordering, the respawn's `--resume` finds the conversation instead of starting over. If a resume still fails, `transcriptStaged === 'carried'` means the conversation id is kept and the exit surfaces; it cannot silently start you over.

Three row-level cases the bookkeeping exists for, each covered by a test:

- a session that **inherited** its account from its group returns to *inheriting*, not pinned to whatever that resolved to that day
- **two hops** (A limited, then B limited) still go home to A, not to the equally-spent B in between
- a session the user **reassigned by hand** is never moved back by a decision the app made hours earlier — and one with a switch already pending is restarted rather than re-pointed, so their choice is applied instead of overwritten

## The risk this design carries

Detection is text-matching, and terminal output is an open channel — an agent reading these very files puts the trigger phrase on screen. It is bounded on three sides: the patterns are narrow (`limit` and `rate` alone appear constantly and are deliberately absent), matches on lines shaped like code, comments, diffs or grep hits are rejected, and a pty reports at most once. What that misses is bounded downstream: failover never targets an account already cooling, and the whole thing is switchable.

I could not verify against a real limit event. If your Claude Code build words its message differently, detection won't fire — the log line `[Accounts] Session … reported a usage limit` is the thing to watch. It can be exercised without waiting for a real limit by echoing the phrase into a session.

## Known limitation

A **group** still points at the spent account. Sessions get a per-session override; rewriting the group's assignment would affect sessions that were never running. A new session in that group starts on the spent account and fails over on its own within a turn — self-correcting, but not free.

## UI

Settings → Claude Accounts gains the failover order (↑/↓, numbered), a `limited · back 9:30 PM` badge with a **Clear limit** escape hatch for when the reset time was a guess, and two toggles — switching accounts, and moving back — both defaulting on and separately switchable, because wanting the first without the second is a reasonable position. An in-window notice reports each switch and stays until dismissed; the desktop notification does not suppress on a focused window, since this happened without being asked for.

## Verification

- `bun test` — 906 pass, 0 fail (35 new: 18 policy, 12 detection, 5 notice copy)
- `tsc` clean on both projects; `bun run build` green
- New columns are additive with `PRAGMA table_info` guards; with no ranks set, `accounts:list` returns byte-for-byte the previous ordering, so nothing moves for an estate whose owner never touches the order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mhGTwSfD2uEAZfhZoYU2B