### PR TITLE
209 — Detect the wording a real weekly limit actually produces

### DIFF
--- a/src/main/__tests__/usage-limit.test.ts
+++ b/src/main/__tests__/usage-limit.test.ts
@@ -65,6 +65,27 @@ describe('detectUsageLimit', () => {
     expect(detectUsageLimit('5-hour limit · resets 9pm', undefined, NOW)).not.toBeNull();
   });
 
+  /**
+   * The accepted false-positive surface, made visible.
+   *
+   * "You've hit your <something> limit" is a sentence other services say too,
+   * and this terminal shows their errors as readily as Claude's. A false
+   * positive is not inert — it restarts live sessions and benches a healthy
+   * account for hours — so the qualifier is an enumerated set of the windows
+   * Anthropic actually meters on, not any word at all.
+   */
+  test('does not treat another service\'s limit as a Claude usage limit', () => {
+    const foreign = [
+      "You've hit your credit limit",
+      "You've reached your spending limit",
+      "You have reached your character limit",
+      "You've hit your context limit",
+    ];
+    for (const line of foreign) {
+      expect(detectUsageLimit(line, undefined, NOW), line).toBeNull();
+    }
+  });
+
   test('ignores ordinary agent output', () => {
     const lines = [
       'Rate limiting the relay to 100 requests per minute',

--- a/src/main/__tests__/usage-limit.test.ts
+++ b/src/main/__tests__/usage-limit.test.ts
@@ -32,6 +32,39 @@ describe('detectUsageLimit', () => {
     }
   });
 
+  /**
+   * The message a real weekly limit produced, verbatim, on 2026-08-25.
+   *
+   * The first version of these patterns did not match it. Every one of them
+   * required the word "reached"; this says "hit", and joins the reset to the
+   * limit with a bullet rather than a sentence, so neither "limit reached" nor
+   * "will reset at" appears anywhere in it. Detection returned null and
+   * failover silently never fired — the exact failure the feature exists to
+   * prevent, arrived at by guessing the wording instead of observing it.
+   *
+   * It is pinned here as a literal because a paraphrase would not have caught
+   * it: the difference between the guess and the truth was one verb.
+   */
+  test('catches the weekly-limit message an actual run produced', () => {
+    const real = "You've hit your weekly limit · resets Aug 26 at 2pm (America/New_York)";
+    const hit = detectUsageLimit(real, undefined, NOW);
+    expect(hit).not.toBeNull();
+    expect(hit!.resetAt?.getMonth()).toBe(7); // August
+    expect(hit!.resetAt?.getDate()).toBe(26);
+    expect(hit!.resetAt?.getHours()).toBe(14);
+  });
+
+  test('catches it wrapped in the error line an agent reports it through', () => {
+    const wrapped = "Agent terminated early due to an API error: "
+      + "You've hit your weekly limit · resets Aug 26 at 2pm (America/New_York)";
+    expect(detectUsageLimit(wrapped, undefined, NOW)).not.toBeNull();
+  });
+
+  test('catches a limit with no qualifier and a status-line reset', () => {
+    expect(detectUsageLimit("You've hit your limit", undefined, NOW)).not.toBeNull();
+    expect(detectUsageLimit('5-hour limit · resets 9pm', undefined, NOW)).not.toBeNull();
+  });
+
   test('ignores ordinary agent output', () => {
     const lines = [
       'Rate limiting the relay to 100 requests per minute',
@@ -57,6 +90,11 @@ describe('detectUsageLimit', () => {
       '+ Claude usage limit reached',
       "42: 'Claude usage limit reached',",
       "const message = 'Claude usage limit reached';",
+      // The new "hit your <x> limit" and bullet-form patterns, quoted.
+      "  /(?:usage|weekly|5-hour|session) limit\\b[^\\n]{0,24}?\\bresets?\\b/i,",
+      "  // You've hit your weekly limit — the message we match on",
+      "+ You've hit your weekly limit",
+      "const msg = \"You've hit your weekly limit\";",
     ];
     for (const line of quoted) {
       expect(detectUsageLimit(line, undefined, NOW), line).toBeNull();

--- a/src/main/usage-limit.ts
+++ b/src/main/usage-limit.ts
@@ -20,8 +20,17 @@
  */
 export const CLAUDE_USAGE_LIMIT_PATTERNS: readonly RegExp[] = [
   /Claude (?:AI )?usage limit reached/i,
-  /(?:You['’]ve|You have) reached your (?:usage|weekly|5-hour) limit/i,
+  // "You've hit your weekly limit" / "You have reached your usage limit".
+  // The verb is the part that varies and the part the first version of this
+  // got wrong: it required "reached", and the message a real weekly limit
+  // produces says "hit". The qualifier is optional too — "You've hit your
+  // limit" carries no adjective at all.
+  /(?:You['’]ve|You have) (?:hit|reached|used(?: up)?) your (?:[a-z0-9-]+ )?limit/i,
   /(?:usage|weekly|5-hour|session) limit reached/i,
+  // "Weekly limit · resets Aug 26 at 2pm" — the status-line form, where the
+  // limit and its reset are joined by a bullet rather than a sentence, so
+  // neither "reached" nor "will reset at" appears anywhere in it.
+  /(?:usage|weekly|5-hour|session) limit\b[^\n]{0,24}?\bresets?\b/i,
   /Your limit will reset at/i,
 ] as const;
 

--- a/src/main/usage-limit.ts
+++ b/src/main/usage-limit.ts
@@ -25,7 +25,16 @@ export const CLAUDE_USAGE_LIMIT_PATTERNS: readonly RegExp[] = [
   // got wrong: it required "reached", and the message a real weekly limit
   // produces says "hit". The qualifier is optional too — "You've hit your
   // limit" carries no adjective at all.
-  /(?:You['’]ve|You have) (?:hit|reached|used(?: up)?) your (?:[a-z0-9-]+ )?limit/i,
+  //
+  // The qualifier is an enumerated set rather than "any word", which is the
+  // narrower of two defensible choices. Any-word also matches "You've hit your
+  // credit limit" and "You've reached your spending limit" — sentences another
+  // API's error can put on this terminal — and a false positive here is not
+  // inert: it restarts live sessions and benches a healthy account for hours.
+  // The set covers the windows Anthropic actually meters on, so a wording this
+  // misses would have to be a new one, which is a smaller bet than trusting
+  // that no other service ever says "limit" in the second person.
+  /(?:You['’]ve|You have) (?:hit|reached|used(?: up)?) your (?:(?:usage|weekly|monthly|daily|session|hourly|5-hour) )?limit/i,
   /(?:usage|weekly|5-hour|session) limit reached/i,
   // "Weekly limit · resets Aug 26 at 2pm" — the status-line form, where the
   // limit and its reset are joined by a bullet rather than a sentence, so


### PR DESCRIPTION
Closes #209. Follow-up to #208.

A real weekly limit fired today:

```
You've hit your weekly limit · resets Aug 26 at 2pm (America/New_York)
```

`detectUsageLimit()` returned **null** for it. #207's failover never fires for this message — silently, with no error and no log line. Two live sessions were sitting on the exhausted account when it was found.

## The gap was one verb

Every pattern in #207 required **"reached"**. The message says **"hit"**. It also joins the reset to the limit with a bullet rather than a sentence, so neither `limit reached` nor `Your limit will reset at` appears in it either.

I confirmed this by running the merged code against the string rather than by reading the regexes — and the same way after fixing it. Reset parsing was never at fault: `parseResetAt` read `Aug 26 at 2pm` correctly the whole time.

This is the risk the #208 description called out as unverifiable, now observed. Worth being blunt about the lesson: those patterns were written from what the message plausibly says rather than what it does say, and a one-word difference is not something more careful paraphrasing would have caught. The real message is pinned verbatim now, because only a literal would have failed.

## Changes

- verb broadened — `hit` / `reached` / `used up`
- qualifier made optional — `You've hit your limit` carries no adjective
- status-line form added — `weekly limit · resets Aug 26 at 2pm`

## False positives

Broadening detection is exactly where a hole opens, so the quoting guard is re-checked against the new patterns quoted as source, as a comment, as a diff line, and as a string literal. All still refused.

## Verification

- The verbatim message detected, reset parsed to Aug 26 14:00
- The same message wrapped in an agent's error line detected
- `bun test` — 1106 pass, only the two pre-existing `preload`/`account-auth` collisions that are present on base `development` as well
- `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mhGTwSfD2uEAZfhZoYU2B