### PR TITLE
211 — Drop the Jira key-prefix workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -36,7 +36,7 @@ body:
     id: scope
     attributes:
       label: Scope
-      description: Maps to the Jira Major/Minor/New Feature distinction.
+      description: How large a change this is.
       options:
         - Major feature
         - Minor feature

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,8 @@ updates:
         patterns:
           - '*'
     ignore:
-      # Private org repo hosting the reusable workflows (jira-key-prefix,
-      # pr-title). Dependabot has no access to it — without this ignore the
+      # Private org repo hosting the reusable workflows (pr-title).
+      # Dependabot has no access to it — without this ignore the
       # whole github-actions job fails with git_dependencies_not_reachable.
       # Versioning of those workflows is managed upstream in org-standards.
       - dependency-name: Software-Development-LLC/org-standards

--- a/.github/workflows/jira-key-prefix.yml
+++ b/.github/workflows/jira-key-prefix.yml
@@ -1,9 +1,0 @@
-name: jira-key-prefix
-on:
-  issues:
-    types: [opened]
-jobs:
-  prefix:
-    uses: Software-Development-LLC/org-standards/.github/workflows/jira-key-prefix.yml@v1
-    with:
-      key: B


### PR DESCRIPTION
Closes #211.

`.github/workflows/jira-key-prefix.yml` runs on every `issues: opened` event and fails every time — it failed on both issues I opened today (#207, #209) and on others before that. We track work in GitHub issues now, so it is prefixing titles with a key for a system nobody reads: a red X on every new issue, for a job whose *success* would be undesirable anyway.

Two collateral references go with it, since both describe things that stop being true when the file is deleted:

- `dependabot.yml` names the workflow in the comment explaining the `org-standards` ignore. **The ignore stays** — it still covers `pr-title`, and removing it would break the github-actions job with `git_dependencies_not_reachable`. Only the dead name goes.
- `ISSUE_TEMPLATE/feature.yml` described its Scope dropdown as mapping to "the Jira Major/Minor/New Feature distinction". Same options, minus the explanation-by-reference to a system we left.

## Noted, not changed

`pr-title.yml` — the other `org-standards` reusable workflow — **also fails on every PR**, at 0s, and has on every recent one (#185, #196, #200, #210), not just mine. Same 0s no-jobs signature as the Jira workflow, which points at how the `@v1` reusable workflow resolves rather than at anything about titles.

I've left it alone deliberately: it isn't Jira, it's failing for everyone rather than because of anything here, and it may be something you want repaired rather than removed. Written down in #211 so it isn't lost.

No source changes; nothing to test beyond CI continuing to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mhGTwSfD2uEAZfhZoYU2B