### PR TITLE
215 — Stop the test suite writing into the installed app's log

### DIFF
--- a/test-setup/happydom.ts
+++ b/test-setup/happydom.ts
@@ -11,6 +11,30 @@
  * globals back. Component tests only need document/window/HTMLElement.
  */
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import log from 'electron-log';
+
+/**
+ * Stop the suite writing into the installed app's log file.
+ *
+ * electron-log's file transport resolves a default path per platform — on macOS
+ * `~/Library/Logs/<appName>/main.log`, which is the same file a running
+ * Bodhilander is appending to. Any module under test that imports electron-log
+ * therefore logs into it, at an offset of its own, while the app writes at its
+ * own: the two interleave and overwrite, and the result is a log that is not a
+ * record of either.
+ *
+ * That is not a tidiness problem. It was found while reading that log to
+ * diagnose a real account-switch bug (#213), where the file contained fixture
+ * accounts from `account-auth.test.ts` — labels "Work" and "Doomed",
+ * will@acme.test, "teardown glitched" — interleaved with, and in places on top
+ * of, the app's own entries. Tests corrupting the evidence you debug with is
+ * worse than tests being noisy.
+ *
+ * Disabling the transport rather than redirecting it: nothing asserts on log
+ * FILES, so a temp path would only move the litter somewhere else. Console
+ * output is untouched, so a test that needs to see a log line still can.
+ */
+log.transports.file.level = false;
 
 // Capture Bun's natives before happy-dom replaces them.
 // Network/crypto only. DOM-side globals (Event, EventTarget, MessageEvent, …)


### PR DESCRIPTION
Closes #215.

`bun test` was writing into `~/Library/Logs/bodhilander/main.log` — the file a running Bodhilander appends to. electron-log's file transport resolves a default per-platform path, so every module under test that imports it logged into the live app's file, at an independent offset. The two interleave and overwrite.

## How it was found

Reading that log to diagnose #213 — a real account switch that reverted. The file contained fixture accounts from `account-auth.test.ts` (`label="Work"`, `label="Doomed"`, `will@acme.test`, `teardown glitched`) timestamped 17:33 but sitting *before* the app's own 14:11 entries, with real lines partly overwritten.

Sixty fake account logins in the record someone is using to work out why their account switch reverted. That is worse than noise: the fixtures are plausible enough to send you chasing a login flow that never happened.

## Fix

One line in `test-setup/happydom.ts`:

```ts
log.transports.file.level = false;
```

`bunfig.toml` preloads that file for every test in the repo, so this covers the whole suite — including suites not yet written — at a single point.

**Disabled rather than redirected to a temp path.** Nothing asserts on log *files*, so redirecting would only relocate the litter. Console output is untouched, so a test that needs to see a log line still can.

## Verified

| | |
|---|---|
| `account-auth.test.ts` alone (previously the biggest writer) | log size unchanged |
| full suite, 1105 tests | log delta **0 bytes** |

Existing pollution is historical and not cleaned up here; it just stops growing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mhGTwSfD2uEAZfhZoYU2B