### PR TITLE
217 — Drop pr-title: a public repo cannot call an internal repo's workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,4 @@ updates:
       actions:
         patterns:
           - '*'
-    ignore:
-      # Private org repo hosting the reusable workflows (pr-title).
-      # Dependabot has no access to it — without this ignore the
-      # whole github-actions job fails with git_dependencies_not_reachable.
-      # Versioning of those workflows is managed upstream in org-standards.
-      - dependency-name: Software-Development-LLC/org-standards
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,9 +1,0 @@
-name: pr-title
-on:
-  pull_request:
-    types: [opened, edited]
-jobs:
-  title:
-    uses: Software-Development-LLC/org-standards/.github/workflows/pr-title.yml@v1
-    with:
-      key: B


### PR DESCRIPTION
Closes #217. Companion to #212.

`pr-title.yml` has failed on **every** PR in this repo — #185, #196, #200, #208, #210, #216 — at 0s, with zero jobs and "This run likely failed because of a workflow file issue". It is not about titles:

```
Bodhilander    public
org-standards  internal (private: true)
```

A public repository cannot consume a reusable workflow from a private or internal one. `org-standards` sets `access_level: organization`, which grants org repos access but does not extend to public callers — GitHub can't resolve the workflow, so the run dies before scheduling a job.

## Ruled out first

Each against evidence, not inspection:

| Hypothesis | Finding |
|---|---|
| input contract mismatch | callee wants `key` (required, string); caller passes `key: B` ✓ |
| permission intersection | `default_workflow_permissions` on this repo is `write` ✓ |
| bad or missing `v1` tag | tag exists, byte-identical to default branch ✓ |
| malformed YAML | both caller and callee parse ✓ |

## Consequence

It has **never worked here**. Its job is to stamp `[B-<issue#>][<Type>] <title>`; every title in this repo is `<issue#> — <title>`, written by hand. The only output it has ever produced is a red X on the checks list.

The `org-standards` ignore in `dependabot.yml` goes with it — it existed solely to stop Dependabot choking on the reusable-workflow references, and there are none left.

## Alternatives not taken

- **Inline the ~65 lines** — the right move if `[B-<issue>]` stamping is wanted. It isn't today.
- **Make `org-standards` public** — fixes every consumer at once, but publishes org tooling, and that isn't this repo's call.

Both stay available; this just stops a check that cannot pass from failing on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mhGTwSfD2uEAZfhZoYU2B