### PR TITLE
225 — Clear the remaining Sonar findings, and take the gate to zero

### DIFF
--- a/relay/src/db/index.ts
+++ b/relay/src/db/index.ts
@@ -16,8 +16,8 @@ export function openDb(dbPath: string): RelayDb {
     fs.mkdirSync(path.dirname(path.resolve(dbPath)), { recursive: true });
   }
   const db = new Database(dbPath, { create: true });
-  db.exec('PRAGMA journal_mode = WAL;');
-  db.exec('PRAGMA foreign_keys = ON;');
+  db.run('PRAGMA journal_mode = WAL;');
+  db.run('PRAGMA foreign_keys = ON;');
   runMigrations(db);
   return db;
 }
@@ -45,10 +45,10 @@ export function runMigrations(db: RelayDb): void {
 
     const sql = fs.readFileSync(path.join(dir, file), 'utf8');
     db.transaction(() => {
-      db.exec(sql);
+      db.run(sql);
       // user_version does not accept bound parameters; `version` is a validated
       // integer parsed from the filename above, so interpolation is safe here.
-      db.exec(`PRAGMA user_version = ${version};`);
+      db.run(`PRAGMA user_version = ${version};`);
     })();
   }
 }

--- a/relay/src/http.ts
+++ b/relay/src/http.ts
@@ -424,7 +424,7 @@ export function createRouter(ctx: RelayContext) {
 
     const { invite, code } = repos.createShareInvite({
       machineId,
-      expectedGithubLogin: (expectedGithubLogin as string | null) ?? null,
+      expectedGithubLogin: expectedGithubLogin ?? null,
       role: role as 'viewer' | 'operator',
       label: (label as string | undefined) ?? null,
       grantTtlSeconds,
@@ -597,7 +597,7 @@ function publicMachine(m: Machine) {
   };
 }
 
-async function readJson(req: Request): Promise<unknown | null> {
+async function readJson(req: Request): Promise<unknown> {
   try {
     return await req.json();
   } catch {

--- a/relay/src/ws.ts
+++ b/relay/src/ws.ts
@@ -122,31 +122,38 @@ export function createGateway(ctx: WsGatewayContext) {
     notifyGrantRevoked,
 
     close(ws: ServerWebSocket<SocketData>) {
-      if (ws.data.role === 'agent') {
-        const { machineId, authTimer } = ws.data;
-        if (authTimer) {
-          clearTimeout(authTimer);
-          ws.data.authTimer = null;
-        }
-        if (machineId && agents.get(machineId) === ws) {
-          agents.delete(machineId);
-          logger.info('agent offline', { machineId });
-          // Tell any clients bound to this machine that their agent dropped.
-          for (const client of clients.values()) {
-            if ((client.data as ClientSocketData).machineId === machineId) send(client, { type: 'agent:offline' });
-          }
-        }
-      } else {
-        const { clientId, machineId } = ws.data;
-        if (clients.get(clientId) === ws) clients.delete(clientId);
-        // Tell the agent this client went away so it can tear down the session.
-        if (machineId) {
-          const agent = agents.get(machineId);
-          if (agent) send(agent, { type: 'client:closed', clientId });
-        }
-      }
+      // Narrow here and hand the result down: the role check is what tells the
+      // compiler which shape ws.data has, and it does not survive a call.
+      const data = ws.data;
+      if (data.role === 'agent') closeAgent(ws, data);
+      else closeClient(ws, data);
     },
   };
+
+  function closeAgent(ws: ServerWebSocket<SocketData>, data: AgentSocketData): void {
+    const { machineId, authTimer } = data;
+    if (authTimer) {
+      clearTimeout(authTimer);
+      data.authTimer = null;
+    }
+    if (!machineId || agents.get(machineId) !== ws) return;
+
+    agents.delete(machineId);
+    logger.info('agent offline', { machineId });
+    // Tell any clients bound to this machine that their agent dropped.
+    for (const client of clients.values()) {
+      if ((client.data as ClientSocketData).machineId === machineId) send(client, { type: 'agent:offline' });
+    }
+  }
+
+  function closeClient(ws: ServerWebSocket<SocketData>, data: ClientSocketData): void {
+    const { clientId, machineId } = data;
+    if (clients.get(clientId) === ws) clients.delete(clientId);
+    // Tell the agent this client went away so it can tear down the session.
+    if (!machineId) return;
+    const agent = agents.get(machineId);
+    if (agent) send(agent, { type: 'client:closed', clientId });
+  }
 
   async function handleAgent(ws: ServerWebSocket<SocketData>, data: AgentSocketData, msg: Record<string, unknown>) {
     if (!data.authed) {

--- a/relay/web/src/crypto.ts
+++ b/relay/web/src/crypto.ts
@@ -15,7 +15,7 @@ const dec = (u: ArrayBuffer | Uint8Array) => new TextDecoder().decode(u);
 
 function toB64(u: Uint8Array): string {
   let s = '';
-  for (let i = 0; i < u.length; i++) s += String.fromCharCode(u[i]!);
+  for (const byte of u) s += String.fromCharCode(byte);
   return btoa(s);
 }
 function fromB64(s: string): Uint8Array {

--- a/relay/web/src/shares.ts
+++ b/relay/web/src/shares.ts
@@ -132,15 +132,17 @@ export function guestShareRows(shares: WireMyShare[], now: number): ShareRow[] {
             : (g.machineName ?? g.ownerName ?? 'A shared session'),
         roleWord: roleWord(g.role),
         pending: g.status === 'pending',
-        detail:
-          g.status === 'pending'
-            ? "Waiting to be let in — they'll get a prompt on their machine"
-            : untilRevoked(g, now)
-              ? 'Until you leave, or they stop sharing'
-              : `Ends in ${timeLeft(g.expiresAt! - now)}`,
+        detail: guestDetail(g, now),
         action: 'Leave',
       }),
     );
+}
+
+/** What a guest's row says about how long they have. */
+function guestDetail(g: WireShareGrant, now: number): string {
+  if (g.status === 'pending') return "Waiting to be let in — they'll get a prompt on their machine";
+  if (untilRevoked(g, now)) return 'Until you leave, or they stop sharing';
+  return `Ends in ${timeLeft(g.expiresAt! - now)}`;
 }
 
 /** The question a revoke action asks, honest about what saying yes does. */

--- a/relay/web/src/styles.css
+++ b/relay/web/src/styles.css
@@ -39,8 +39,7 @@
   --shadow: 0 1px 2px rgba(0,0,0,.4), 0 12px 34px rgba(0,0,0,.45);
 }
 
-* { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
-* { scrollbar-width: thin; scrollbar-color: color-mix(in srgb, var(--muted) 40%, transparent) transparent; }
+* { box-sizing: border-box; -webkit-tap-highlight-color: transparent; scrollbar-width: thin; scrollbar-color: color-mix(in srgb, var(--muted) 40%, transparent) transparent; }
 ::-webkit-scrollbar { width: 10px; height: 10px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: color-mix(in srgb, var(--muted) 38%, transparent); border-radius: 8px; border: 2px solid transparent; background-clip: padding-box; }

--- a/src/main/api/__tests__/ws-message.test.ts
+++ b/src/main/api/__tests__/ws-message.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Turning a websocket payload into text.
+ *
+ * This exists because `data.toString()` — the idiom it replaced — is correct
+ * for only one of the three shapes `RawData` can take. It decodes the pairing
+ * handshake and every post-auth frame, so it reads untrusted network input,
+ * and the two shapes the old code got wrong are the ones with no natural
+ * coverage: nothing in ordinary local use produces a fragmented frame or an
+ * ArrayBuffer, which is how the bug survived.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { RawData } from 'ws';
+import { messageText } from '../ws-message';
+
+const FRAME = JSON.stringify({ type: 'auth', token: 'abc', nested: { n: 1 } });
+
+/** Split a payload the way a fragmented frame arrives. */
+function fragmentsOf(buf: Buffer, cut: number): RawData {
+  return [buf.subarray(0, cut), buf.subarray(cut)] as unknown as RawData;
+}
+
+describe('messageText', () => {
+  test('decodes a Buffer — the shape that always worked', () => {
+    expect(messageText(Buffer.from(FRAME, 'utf8'))).toBe(FRAME);
+  });
+
+  /**
+   * A fragmented frame arrives as an array of Buffers, and Array.toString()
+   * joins with commas — so a payload split mid-token gained a stray comma at
+   * the seam and stopped parsing.
+   */
+  test('rejoins a fragmented frame without inventing a separator', () => {
+    const whole = Buffer.from(FRAME, 'utf8');
+    const cut = Math.floor(whole.length / 2);
+
+    expect(messageText(fragmentsOf(whole, cut))).toBe(FRAME);
+    expect(JSON.parse(messageText(fragmentsOf(whole, cut)))).toEqual(JSON.parse(FRAME));
+    // What the replaced idiom produced from the same input.
+    expect([whole.subarray(0, cut), whole.subarray(cut)].toString()).not.toBe(FRAME);
+  });
+
+  /** An ArrayBuffer stringifies to '[object ArrayBuffer]' — the message is
+   *  lost outright rather than mangled. */
+  test('decodes an ArrayBuffer instead of stringifying the object', () => {
+    const bytes = new TextEncoder().encode(FRAME);
+    const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+
+    expect(messageText(ab)).toBe(FRAME);
+    expect(String(ab)).toBe('[object ArrayBuffer]');
+  });
+
+  /** Concatenating bytes before decoding, rather than decoding each fragment,
+   *  is what keeps a character split across the seam intact. */
+  test('survives a multi-byte character split across fragments', () => {
+    const text = 'auth: café — ☕';
+    const whole = Buffer.from(text, 'utf8');
+    const cut = whole.indexOf(Buffer.from('é', 'utf8')) + 1;
+
+    expect(messageText(fragmentsOf(whole, cut))).toBe(text);
+  });
+
+  test('an empty payload is empty text, not a throw', () => {
+    expect(messageText(Buffer.alloc(0))).toBe('');
+    expect(messageText([] as unknown as RawData)).toBe('');
+  });
+});

--- a/src/main/api/relay/relay-client.ts
+++ b/src/main/api/relay/relay-client.ts
@@ -39,6 +39,7 @@ import {
 import { getInviteScope, recordInviteScope } from './grant-sql';
 import type { GrantRole } from './grants';
 import { getAllSessions } from '../../repositories/sessions';
+import { messageText } from '../ws-message';
 
 /** Session name for the approval prompt, or null if it has since gone. */
 function getSessionName(sessionId: string): string | null {
@@ -337,7 +338,7 @@ export class RelayClient extends EventEmitter {
     });
 
     ws.on('message', (data) => {
-      void this.handleMessage(data.toString());
+      void this.handleMessage(messageText(data));
     });
 
     ws.on('close', (code) => {

--- a/src/main/api/ws-message.ts
+++ b/src/main/api/ws-message.ts
@@ -1,0 +1,17 @@
+import type { RawData } from 'ws';
+
+/**
+ * A websocket payload as text.
+ *
+ * `RawData` is `Buffer | ArrayBuffer | Buffer[]`, and only the first of those
+ * has a `toString()` that yields the message: an ArrayBuffer stringifies to
+ * '[object ArrayBuffer]' and a fragment array to comma-joined halves. Which
+ * arrives depends on `binaryType` and on whether the frame was fragmented, so
+ * the common `data.toString()` is right for the case that usually happens
+ * rather than for the type.
+ */
+export function messageText(data: RawData): string {
+  if (Buffer.isBuffer(data)) return data.toString('utf8');
+  if (Array.isArray(data)) return Buffer.concat(data).toString('utf8');
+  return Buffer.from(data).toString('utf8');
+}

--- a/src/main/api/ws-server.ts
+++ b/src/main/api/ws-server.ts
@@ -34,6 +34,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import log from 'electron-log';
 import { PairingManager, PairedDevice } from './pairing/pairing-manager';
 import { ptyManager } from '../pty-manager';
+import { messageText } from './ws-message';
 
 export interface WsMessage {
   type: string;
@@ -112,7 +113,7 @@ export function createWsServer(httpServer: HttpServer, pairingManager: PairingMa
       // If still pending, treat the message as an auth attempt.
       const pendingState = pending.get(ws);
       if (pendingState) {
-        handleAuthMessage(ws, data.toString(), pendingState, pending, clients, pairingManager);
+        handleAuthMessage(ws, messageText(data), pendingState, pending, clients, pairingManager);
         return;
       }
 
@@ -130,7 +131,7 @@ export function createWsServer(httpServer: HttpServer, pairingManager: PairingMa
       }
 
       try {
-        const message = JSON.parse(data.toString()) as WsMessage;
+        const message = JSON.parse(messageText(data)) as WsMessage;
         // Ignore (but log) any post-auth `auth` frames — clients should not
         // re-authenticate on an already-authenticated socket.
         if (message.type === 'auth') {

--- a/src/main/arena/engine.ts
+++ b/src/main/arena/engine.ts
@@ -336,7 +336,7 @@ export class ArenaEngine extends EventEmitter {
       stderrTail = (stderrTail + data.toString()).slice(-2000);
     });
 
-    const rl = readline.createInterface({ input: child.stdout! });
+    const rl = readline.createInterface({ input: child.stdout });
     rl.on('line', (line) => {
       this.appendChunk(responseId, parser.onLine(line));
     });

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -348,14 +348,14 @@ export function createApplicationMenu(mainWindow: BrowserWindow): void {
         { type: 'separator' },
         {
           label: 'Documentation',
-          click: async () => {
-            await shell.openExternal('https://github.com/Software-Development-LLC/Bodhilander');
+          click: () => {
+            void shell.openExternal('https://github.com/Software-Development-LLC/Bodhilander');
           },
         },
         {
           label: 'Report Issue',
-          click: async () => {
-            await shell.openExternal('https://github.com/Software-Development-LLC/Bodhilander/issues');
+          click: () => {
+            void shell.openExternal('https://github.com/Software-Development-LLC/Bodhilander/issues');
           },
         },
         {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -969,9 +969,9 @@ const App: React.FC = () => {
     }
   }, [sessions, activeSessionId, setActiveSessionId]);
 
-  const handleCloseSession = useCallback(async () => {
+  const handleCloseSession = useCallback(() => {
     if (activeSessionId) {
-      await handleRemoveSession(activeSessionId);
+      handleRemoveSession(activeSessionId);
     }
   }, [activeSessionId, handleRemoveSession]);
 

--- a/src/renderer/components/ClaudeAccountsModal.tsx
+++ b/src/renderer/components/ClaudeAccountsModal.tsx
@@ -429,7 +429,7 @@ const AddAccountButton: React.FC<{ onAdd: (label: string) => Promise<void>; disa
   const [label, setLabel] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
-  const submit = async (e: React.FormEvent) => {
+  const submit = async (e: React.SyntheticEvent) => {
     e.preventDefault();
     const trimmed = label.trim();
     if (!trimmed || submitting) return;

--- a/src/renderer/components/NamePromptModal.tsx
+++ b/src/renderer/components/NamePromptModal.tsx
@@ -73,7 +73,7 @@ export const NamePromptModal: React.FC<NamePromptModalProps> = ({
     }
   }, [isOpen, defaultValue, accountPicker?.initialAccountId, providerPicker]);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.SyntheticEvent) => {
     e.preventDefault();
     const trimmed = value.trim();
     const finalName = trimmed || defaultValue;

--- a/src/renderer/components/ShareSessionModal.tsx
+++ b/src/renderer/components/ShareSessionModal.tsx
@@ -83,7 +83,7 @@ export const ShareSessionModal: React.FC<ShareSessionModalProps> = ({ sessionId,
   );
 
   const submit = useCallback(
-    async (e: React.FormEvent) => {
+    async (e: React.SyntheticEvent) => {
       e.preventDefault();
       if (!sessionId || busy) return;
       setBusy(true);

--- a/src/renderer/store/analytics.ts
+++ b/src/renderer/store/analytics.ts
@@ -59,8 +59,8 @@ export function useAnalytics(timeRange: TimeRange): UseAnalyticsResult {
   }, [timeRange]);
 
   useEffect(() => {
-    loadStats();
+    void loadStats();
   }, [loadStats]);
 
-  return { globalStats, recentEvents, loading, error, refresh: loadStats };
+  return { globalStats, recentEvents, loading, error, refresh: () => { void loadStats(); } };
 }


### PR DESCRIPTION
Closes #225. Completes the sweep started in #221.

## One latent bug

Three sites called `data.toString()` on a websocket payload. `RawData` is `Buffer | ArrayBuffer | Buffer[]`, and **only the first stringifies to the message** — an ArrayBuffer yields `'[object ArrayBuffer]'`, a fragment array comma-joins its halves. Which arrives depends on `binaryType` and on whether the frame was fragmented, so the common idiom is right for the case that usually happens rather than for the type. A shared `messageText()` handles all three.

## One lesson, from the one complexity finding I took

`ws.ts` `close()` (complexity 21) had two independent branches and split cleanly — except the `ws.data.role` check was **narrowing** `SocketData` to the agent or client shape, and narrowing doesn't survive a call. The compiler caught it instantly, and the data is now passed down explicitly.

That is exactly why the other three dispatchers (complexity 24–60) are **not** split here. They carry live traffic between agent, relay and client, and the same mistake there surfaces as a dropped frame, not a type error.

## Also fixed

`db.exec` → `db.run` ×4 (deprecated overload) · `React.FormEvent` → `SyntheticEvent` ×3 (the types deprecate it with *"FormEvent doesn't actually exist"*) · two promise-where-void handlers · two unnecessary assertions, including a `child.stdout!` the compiler confirms was never needed · `Promise<unknown | null>` collapsed to what it always was · an `await` on a non-promise · a nested ternary · an indexed loop over an iterable · a duplicated `*` selector.

## Accepted as *wrong* (5)

Every remaining `||` → `??`. All are deliberate empty-string-means-absent:

```ts
githubClientId:   env.GITHUB_CLIENT_ID || null,            // GITHUB_CLIENT_ID= is not a client id
allowedGithubOrg: env.ALLOWED_GITHUB_ORG?.trim() || null,  // whitespace-only is absent
vapidSubject:     env.VAPID_SUBJECT ?? 'mailto:...',       // ?? where empty IS meaningful
```

`config.ts` uses both operators three lines apart, chosen per case — the codebase answering the rule.

**Across this whole sweep, 8 of ~25 `||` findings would have introduced bugs** if applied as suggested. One in three. That is the argument for reading each rather than bulk-applying, and it's why a fourth site that *looked* identical (`sel.parentId || sel.id`) was fixed rather than accepted after checking that `repositories/groups.ts` normalises it to null upstream.

## Accepted as *deferred* (7)

Distinguished deliberately from the above — here **Sonar is right** and the work is real:

- **#223** — recharts `Cell` ×4. A genuine API migration whose correctness is visual, not testable.
- **#224** — the three protocol dispatchers.

Each carries that reasoning on the finding itself, so nobody later reads an Accept as "we decided this was nonsense".

## On `FormEvent` → `SyntheticEvent`

Not because the handler is shared. The React types deprecate `FormEvent` with the note *"FormEvent doesn't actually exist"* — there is no such DOM event, and `SyntheticEvent` is the honest supertype. Only `preventDefault()` is used at all three sites.

## Verification

- `tsc` clean on both root projects, `relay` and `relay/web`
- `build:web` builds; relay suite 268 pass; root suite 1109 pass (two pre-existing `preload`/`account-auth` collisions, present on base `development`)
- no behaviour change intended outside the websocket-payload fix, which is a correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mhGTwSfD2uEAZfhZoYU2B