### PR TITLE
229 — The last Sonar violation: a nested template literal in the OAuth error

### DIFF
--- a/relay/src/auth/github.ts
+++ b/relay/src/auth/github.ts
@@ -58,7 +58,8 @@ export async function exchangeCodeForProfile(
   if (!tokenRes.ok) throw new GithubOAuthError(`token endpoint returned ${tokenRes.status}`);
   const tokenJson = (await tokenRes.json()) as { access_token?: string; error?: string };
   if (!tokenJson.access_token) {
-    throw new GithubOAuthError(`no access_token in response${tokenJson.error ? `: ${tokenJson.error}` : ''}`);
+    const detail = tokenJson.error ? `: ${tokenJson.error}` : '';
+    throw new GithubOAuthError(`no access_token in response${detail}`);
   }
   const token = tokenJson.access_token;
 


### PR DESCRIPTION
Closes #229. Tail of #225.

After that merged, the `development` gate came back with exactly one failing condition:

```
new_violations: 1 (threshold 0)                   <- this
new_software_quality_maintainability_issues: 1    ok (was 51)
new_security_hotspots_reviewed: 100%              ok (was 50%)
```

`relay/src/auth/github.ts:61`. It was on the list for #225 — I accepted its sibling on line 101 as a deliberate falsy fallback and never came back to this one.

```ts
const detail = tokenJson.error ? `: ${tokenJson.error}` : '';
throw new GithubOAuthError(`no access_token in response${detail}`);
```

Same message, same conditional, one fewer literal inside a literal.

## Verification

- relay typechecks; suite 268 pass
- this should take `new_violations` to 0 and the gate green — I'll confirm from the post-merge branch analysis rather than assume it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mhGTwSfD2uEAZfhZoYU2B