### PR TITLE
213/214 — An account switch that says what it did, and a default that names where it goes

### DIFF
--- a/src/main/__tests__/account-switch.test.ts
+++ b/src/main/__tests__/account-switch.test.ts
@@ -352,6 +352,17 @@ describe('switch outcome', () => {
     expect(result.affectedSessionIds).toEqual(['s1']);
   });
 
+  test('names no account rather than undefined when no default is configured', () => {
+    // AccountChip renders `account: ClaudeAccount | null`; an undefined
+    // leaking through the default lookup would be a different thing entirely.
+    addGroup('g1');
+    addSession('s1', 'g1');
+
+    const result = accountSwitch.assignGroupAccount('g1', null);
+
+    expect(result.outcome.account).toBeNull();
+  });
+
   test('an assignment to a deleted account falls through to the default', () => {
     addAccount('acct-a', true);
     addGroup('g1');

--- a/src/main/__tests__/account-switch.test.ts
+++ b/src/main/__tests__/account-switch.test.ts
@@ -287,3 +287,78 @@ describe('assignGroupAccount', () => {
     expect(result.affectedSessionIds).toEqual([]);
   });
 });
+
+/**
+ * The outcome (#214) exists so a switch that restarts nothing can still be
+ * explained. `affectedSessionIds: []` is returned both when nothing needed to
+ * move and when nothing could, and the renderer cannot tell those apart — nor
+ * could the user, which is the bug.
+ */
+describe('switch outcome', () => {
+  test('a session pick that changes nothing still names the account and the session', () => {
+    addAccount('acct-a', true);
+    addGroup('g1', 'acct-a');
+    addSession('s1', 'g1');
+
+    // Picking the account the session already inherits: no restart, but the
+    // row is now an override and the session has left group control.
+    const result = accountSwitch.assignSessionAccount('s1', 'acct-a');
+
+    expect(result.affectedSessionIds).toEqual([]);
+    expect(result.outcome.account?.id).toBe('acct-a');
+    expect(result.outcome.unchangedSessionIds).toEqual(['s1']);
+  });
+
+  test('a session that does move reports no unchanged sessions', () => {
+    addAccount('acct-a', true);
+    addAccount('acct-b');
+    addGroup('g1');
+    addSession('s1', 'g1');
+
+    const result = accountSwitch.assignSessionAccount('s1', 'acct-b');
+
+    expect(result.outcome.account?.id).toBe('acct-b');
+    expect(result.outcome.unchangedSessionIds).toEqual([]);
+  });
+
+  test('a group switch separates sessions it could not move from ones already there', () => {
+    addAccount('acct-a', true);
+    addAccount('acct-b');
+    addGroup('g1');
+    addSession('inherits', 'g1');
+    addSession('pinned', 'g1', { accountId: 'acct-a' });
+    addSession('already', 'g1', { accountId: 'acct-b' });
+
+    const result = accountSwitch.assignGroupAccount('g1', 'acct-b');
+
+    expect(result.affectedSessionIds).toEqual(['inherits']);
+    // Both stayed put, but for different reasons — and only one of them is
+    // something the user can act on from the group menu.
+    expect(result.outcome.unchangedSessionIds.sort()).toEqual(['already', 'pinned']);
+    expect(result.outcome.overriddenSessionIds.sort()).toEqual(['already', 'pinned']);
+  });
+
+  test('clearing a group assignment names the default account it falls back to', () => {
+    addAccount('acct-a', true);
+    addAccount('acct-b');
+    addGroup('g1', 'acct-b');
+    addSession('s1', 'g1');
+
+    const result = accountSwitch.assignGroupAccount('g1', null);
+
+    // #213: this is the item sitting one row above the account list, so what
+    // it resolves to has to be knowable rather than inferred.
+    expect(result.outcome.account?.id).toBe('acct-a');
+    expect(result.affectedSessionIds).toEqual(['s1']);
+  });
+
+  test('an assignment to a deleted account falls through to the default', () => {
+    addAccount('acct-a', true);
+    addGroup('g1');
+    addSession('s1', 'g1');
+
+    const result = accountSwitch.assignGroupAccount('g1', 'gone');
+
+    expect(result.outcome.account?.id).toBe('acct-a');
+  });
+});

--- a/src/main/account-switch.ts
+++ b/src/main/account-switch.ts
@@ -4,6 +4,7 @@ import { AccountSwitchResult, ClaudeAccount } from '../shared/types';
 import { getDatabase } from './database';
 import { resolveAccountForSession } from './account-resolver';
 import { carryTranscript, legacyClaudeConfigDir } from './conversation-transcript';
+import * as accountsRepo from './repositories/accounts';
 import * as groupsRepo from './repositories/groups';
 import * as sessionsRepo from './repositories/sessions';
 
@@ -44,11 +45,21 @@ export function assignSessionAccount(
   const after = resolveAccountForSession(sessionId);
 
   if ((before?.id ?? null) === (after?.id ?? null)) {
-    return { affectedSessionIds: [] };
+    // The write still happened and still means something — the session is now
+    // pinned to this account instead of inheriting it, so a later group switch
+    // will leave it behind. Nothing restarts, so the caller is the only thing
+    // that can say so (#214).
+    return {
+      affectedSessionIds: [],
+      outcome: { account: after, unchangedSessionIds: [sessionId], overriddenSessionIds: [] },
+    };
   }
 
   rehomeConversation(sessionId, before, after);
-  return { affectedSessionIds: [sessionId] };
+  return {
+    affectedSessionIds: [sessionId],
+    outcome: { account: after, unchangedSessionIds: [], overriddenSessionIds: [] },
+  };
 }
 
 /**
@@ -61,22 +72,51 @@ export function assignGroupAccount(
   accountId: string | null,
 ): AccountSwitchResult {
   const db = getDatabase();
-  const ids = (db.prepare('SELECT id FROM sessions WHERE group_id = ?').all(groupId) as
-    { id: string }[]).map(row => row.id);
+  const rows = db.prepare(
+    'SELECT id, claude_account_id FROM sessions WHERE group_id = ?'
+  ).all(groupId) as { id: string; claude_account_id: string | null }[];
+  const ids = rows.map(row => row.id);
 
   const before = new Map(ids.map(id => [id, resolveAccountForSession(id)]));
   groupsRepo.updateGroup(groupId, { claudeAccountId: accountId });
 
   const affectedSessionIds: string[] = [];
+  const unchangedSessionIds: string[] = [];
   for (const id of ids) {
     const prev = before.get(id) ?? null;
     const next = resolveAccountForSession(id);
-    if ((prev?.id ?? null) === (next?.id ?? null)) continue;
+    if ((prev?.id ?? null) === (next?.id ?? null)) {
+      unchangedSessionIds.push(id);
+      continue;
+    }
     rehomeConversation(id, prev, next);
     affectedSessionIds.push(id);
   }
 
-  return { affectedSessionIds };
+  return {
+    affectedSessionIds,
+    outcome: {
+      account: groupAccount(accountId),
+      unchangedSessionIds,
+      // Read from the pre-write rows: a group switch never touches a session's
+      // own column, so these are the sessions it was structurally unable to
+      // move — a different fact from "already there", and the one that
+      // explains a group switch that appears to do nothing (#214).
+      overriddenSessionIds: rows.filter(row => row.claude_account_id !== null).map(row => row.id),
+    },
+  };
+}
+
+/**
+ * The account a group resolves to after being pointed at `accountId`.
+ *
+ * Mirrors resolveAccountForSession's tail: null means "use the default", and a
+ * reference to an account that no longer exists falls through to the default
+ * the same way a missing assignment does.
+ */
+function groupAccount(accountId: string | null): ClaudeAccount | null {
+  const picked = accountId ? accountsRepo.getAccount(accountId) : null;
+  return picked ?? accountsRepo.getDefaultAccount();
 }
 
 /**

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -16,6 +16,8 @@ import { ArenaPanel } from './components/ArenaPanel';
 import { ViewSwitcher, type ContentView } from './components/ViewSwitcher';
 import { isSwitchPending, type SessionAccountIndicatorProps } from './components/SessionAccountIndicator';
 import { FailoverNotice } from './components/FailoverNotice';
+import { AccountSwitchNotice } from './components/AccountSwitchNotice';
+import { AccountSwitchReport, reportGroupSwitch, reportSessionSwitch } from './accountSwitchReport';
 import { AccountFailoverEvent, ClaudeAccount, Session } from '../shared/types';
 import type { LiveAccountBinding, LiveAccountBindings, RelayAttachedGuest, RelayPendingShare, RelayStatus } from '../shared/types';
 import { useSessions } from './store/sessions';
@@ -77,6 +79,21 @@ export function accountMenuLabel(acc: ClaudeAccount, isCurrent: boolean): string
   return `${isCurrent ? '✓ ' : '   '}Use "${acc.label}"`
     + tail
     + (acc.isDefault ? ' (default)' : '');
+}
+
+/**
+ * How the group menu's "use the default" item is named (#213).
+ *
+ * It used to say only "Use default account", sitting one row above the account
+ * list — so during a usage limit, when the whole reason for opening this menu
+ * is to get off the default, a single-row miss put the group back on the
+ * account it was escaping and said nothing. Naming the destination makes the
+ * consequence readable before the click rather than hours later.
+ */
+export function defaultAccountMenuLabel(accounts: ClaudeAccount[], isCurrent: boolean): string {
+  const fallback = accounts.find(acc => acc.isDefault) ?? null;
+  const tail = fallback ? ` (${fallback.label})` : '';
+  return `${isCurrent ? '✓ ' : '   '}Use default account${tail}`;
 }
 
 /**
@@ -196,6 +213,8 @@ const App: React.FC = () => {
    * a stack of banners would push the terminal off screen.
    */
   const [failoverNotice, setFailoverNotice] = useState<AccountFailoverEvent | null>(null);
+  // What the last manual account switch did, when it restarted nothing (#214).
+  const [switchNotice, setSwitchNotice] = useState<AccountSwitchReport | null>(null);
   // Which account each running pty ACTUALLY spawned under (#165), keyed by
   // session id. Absent id = no pty running for that session.
   const [liveAccounts, setLiveAccounts] = useState<LiveAccountBindings>({});
@@ -631,7 +650,16 @@ const App: React.FC = () => {
   // that session and picked an account, so the restart is the thing they asked
   // for.
   const handleAssignSessionAccount = async (sessionId: string, accountId: string | null) => {
-    restartSessions(liveSessionsAmong(await setSessionAccount(sessionId, accountId)));
+    const result = await setSessionAccount(sessionId, accountId);
+    if (!result) return; // The store already logged the failure; say nothing untrue.
+
+    const liveAffected = liveSessionsAmong(result.affectedSessionIds);
+    restartSessions(liveAffected);
+    setSwitchNotice(reportSessionSwitch(result, {
+      targetName: sessions.find(s => s.id === sessionId)?.name ?? 'This session',
+      pickedAccountId: accountId,
+      liveAffected,
+    }));
   };
 
   // A group switch can sweep several running sessions at once, which is a much
@@ -639,15 +667,30 @@ const App: React.FC = () => {
   // still persists the assignment; those sessions move over on their next
   // restart.
   const handleAssignGroupAccount = async (groupId: string, accountId: string | null) => {
-    const live = liveSessionsAmong(await setGroupAccount(groupId, accountId));
+    const result = await setGroupAccount(groupId, accountId);
+    if (!result) return; // The store already logged the failure; say nothing untrue.
+
+    const live = liveSessionsAmong(result.affectedSessionIds);
+    setSwitchNotice(reportGroupSwitch(result, {
+      targetName: groups.find(g => g.id === groupId)?.name ?? 'This group',
+      pickedAccountId: accountId,
+      liveAffected: live,
+    }));
     if (live.length === 0) return;
+
     const count = live.length === 1 ? '1 running session' : `${live.length} running sessions`;
     setConfirmAction({
       type: 'restartForAccountSwitch',
       id: groupId,
       sessionIds: live,
-      message: `${count} in this group ${live.length === 1 ? 'is' : 'are'} still on the previous `
-        + `account. Restart ${live.length === 1 ? 'it' : 'them'} now to apply the switch? `
+      // States the change as done, because it is: the row was written before
+      // this dialog existed and "Not now" declines only the restart. Read as a
+      // confirmation prompt — which is what a modal appearing straight after a
+      // click looks like — dismissing it feels like cancelling the switch, and
+      // the group silently stays moved (#213).
+      message: `This group now uses the new account. ${count} in it `
+        + `${live.length === 1 ? 'is' : 'are'} still running on the previous one. `
+        + `Restart ${live.length === 1 ? 'it' : 'them'} now to apply the switch? `
         + `Conversations resume where they left off. Skipping applies the switch on their next restart.`,
     });
   };
@@ -686,6 +729,7 @@ const App: React.FC = () => {
         // failures, so there's nothing for the caller to await.
         onClick: () => { void handleAssignSessionAccount(sessionId, null); },
       });
+      items.push({ label: 'separator', onClick: () => {}, separator: true });
       for (const acc of claudeAccounts) {
         items.push({
           label: accountMenuLabel(acc, currentAccountId === acc.id),
@@ -726,11 +770,16 @@ const App: React.FC = () => {
     if (claudeAccounts.length > 0) {
       items.push({ label: 'separator', onClick: () => {}, separator: true });
       items.push({
-        label: `${currentAccountId === null ? '✓ ' : '   '}Use default account`,
+        label: defaultAccountMenuLabel(claudeAccounts, currentAccountId === null),
         // Fire-and-forget, as above — the restart prompt is raised from inside
         // the handler once main reports which sessions moved.
         onClick: () => { void handleAssignGroupAccount(groupId, null); },
       });
+      // This item clears the assignment rather than setting one, and during a
+      // usage limit the account it resolves to is usually the one being fled.
+      // A separator so the row above the account list is not one slip away
+      // from undoing the switch the user came here to make (#213).
+      items.push({ label: 'separator', onClick: () => {}, separator: true });
       for (const acc of claudeAccounts) {
         items.push({
           label: accountMenuLabel(acc, currentAccountId === acc.id),
@@ -1657,6 +1706,9 @@ const App: React.FC = () => {
               setFailoverNotice(null);
             }}
           />
+        )}
+        {switchNotice && (
+          <AccountSwitchNotice report={switchNotice} onDismiss={() => setSwitchNotice(null)} />
         )}
         {contentView === 'analytics' && (
           <AnalyticsPanel

--- a/src/renderer/__tests__/App.accounts.test.ts
+++ b/src/renderer/__tests__/App.accounts.test.ts
@@ -16,7 +16,12 @@
  * Run with: bun test src/renderer/__tests__/App.accounts.test.ts
  */
 import { describe, expect, test } from 'bun:test';
-import { accountMenuLabel, resolveAccountIndicator, respawnable } from '../App';
+import {
+  accountMenuLabel,
+  defaultAccountMenuLabel,
+  resolveAccountIndicator,
+  respawnable,
+} from '../App';
 import type { ClaudeAccount, LiveAccountBinding, Session } from '../../shared/types';
 
 const work = {
@@ -135,6 +140,30 @@ describe('resolveAccountIndicator', () => {
     const renamed = { ...work, label: 'Acme Corp' } as ClaudeAccount;
     const props = resolve({ accounts: [renamed, personal], binding: bindingFor(work.id) })!;
     expect(props.liveAccount?.label).toBe('Acme Corp');
+  });
+});
+
+/**
+ * The group menu's "use the default" item (#213).
+ *
+ * It clears the assignment rather than setting one, and during a usage limit
+ * the account it resolves to is usually the one the user is trying to get off.
+ * An unnamed destination one row above the account list is what let a group
+ * silently go back onto a spent account.
+ */
+describe('defaultAccountMenuLabel', () => {
+  test('names the account the item actually resolves to', () => {
+    expect(defaultAccountMenuLabel([work, personal], false)).toContain('Personal');
+  });
+
+  test('says only what it knows when no account is marked default', () => {
+    const label = defaultAccountMenuLabel([{ ...work, isDefault: false } as ClaudeAccount], false);
+    expect(label).toContain('Use default account');
+    expect(label).not.toContain('(');
+  });
+
+  test('is ticked when the group is already on the default', () => {
+    expect(defaultAccountMenuLabel([work, personal], true).startsWith('✓ ')).toBe(true);
   });
 });
 

--- a/src/renderer/__tests__/accountSwitchReport.test.ts
+++ b/src/renderer/__tests__/accountSwitchReport.test.ts
@@ -1,0 +1,151 @@
+/**
+ * What an account switch says when it restarts nothing (#214).
+ *
+ * The bug these cover is silence, so the assertions are about a sentence
+ * existing and being true — not about its exact wording. Two things matter
+ * enough to pin down: that the one case which speaks for itself stays quiet,
+ * and that a session pinned in place is TOLD it is pinned, because that is the
+ * consequence the click has and cannot be seen anywhere in the UI.
+ *
+ * Run with: bun test src/renderer/__tests__
+ */
+import { describe, expect, test } from 'bun:test';
+import { reportGroupSwitch, reportSessionSwitch } from '../accountSwitchReport';
+import { AccountSwitchResult, ClaudeAccount } from '../../shared/types';
+
+function account(id: string, label: string): ClaudeAccount {
+  return {
+    id,
+    label,
+    configDir: `/tmp/${id}`,
+    email: null,
+    color: '#888888',
+    isDefault: false,
+    createdAt: new Date('2026-08-01T00:00:00Z'),
+    lastUsedAt: null,
+    fallbackRank: 0,
+    limitedUntil: null,
+    limitedAt: null,
+  };
+}
+
+const WORK = account('work', 'Work');
+
+function result(over: Partial<AccountSwitchResult> & {
+  outcome?: Partial<AccountSwitchResult['outcome']>;
+} = {}): AccountSwitchResult {
+  return {
+    affectedSessionIds: over.affectedSessionIds ?? [],
+    outcome: {
+      account: WORK,
+      unchangedSessionIds: [],
+      overriddenSessionIds: [],
+      ...over.outcome,
+    },
+  };
+}
+
+describe('reportSessionSwitch', () => {
+  test('says nothing when the session is about to restart in front of the user', () => {
+    const report = reportSessionSwitch(
+      result({ affectedSessionIds: ['s1'] }),
+      { targetName: 'Predicate Permissions', pickedAccountId: 'work', liveAffected: ['s1'] },
+    );
+
+    expect(report).toBeNull();
+  });
+
+  test('a stopped session is told when the account will take effect', () => {
+    const report = reportSessionSwitch(
+      result({ affectedSessionIds: ['s1'] }),
+      { targetName: 'Predicate Permissions', pickedAccountId: 'work', liveAffected: [] },
+    );
+
+    expect(report).not.toBeNull();
+    expect(report?.account).toBe(WORK);
+    expect(`${report?.prefix}${report?.suffix}`).toContain('Predicate Permissions');
+    expect(report?.suffix).toContain('start');
+  });
+
+  test('picking the account a session already inherits says it is now pinned', () => {
+    // The exact shape of #214: the click registered, the row was written, the
+    // effective account did not move — and the session quietly stopped
+    // following its group, which nothing else in the UI reveals.
+    const report = reportSessionSwitch(
+      result({ outcome: { unchangedSessionIds: ['s1'] } }),
+      { targetName: 'Session 1', pickedAccountId: 'work', liveAffected: [] },
+    );
+
+    expect(report?.tone).toBe('muted');
+    expect(report?.suffix).toContain('pinned');
+    expect(report?.suffix).toContain('group');
+  });
+
+  test('clearing an override that changed nothing does not claim a pin', () => {
+    const report = reportSessionSwitch(
+      result({ outcome: { unchangedSessionIds: ['s1'] } }),
+      { targetName: 'Session 1', pickedAccountId: null, liveAffected: [] },
+    );
+
+    expect(report?.suffix).not.toContain('pinned');
+    expect(report?.prefix).toContain('group');
+  });
+});
+
+describe('reportGroupSwitch', () => {
+  test('defers to the restart prompt when one is about to appear', () => {
+    const report = reportGroupSwitch(
+      result({ affectedSessionIds: ['a', 'b'] }),
+      { targetName: 'Api Service', pickedAccountId: 'work', liveAffected: ['a', 'b'] },
+    );
+
+    expect(report).toBeNull();
+  });
+
+  test('an empty group still confirms what it now uses', () => {
+    const report = reportGroupSwitch(
+      result(),
+      { targetName: 'Api Service', pickedAccountId: 'work', liveAffected: [] },
+    );
+
+    expect(report?.prefix).toContain('Api Service');
+    expect(report?.account).toBe(WORK);
+  });
+
+  test('sessions that moved but are stopped are reported, not silently dropped', () => {
+    const report = reportGroupSwitch(
+      result({ affectedSessionIds: ['a', 'b'] }),
+      { targetName: 'Api Service', pickedAccountId: 'work', liveAffected: [] },
+    );
+
+    expect(report?.suffix).toContain('2 sessions');
+    expect(report?.suffix).toContain('stopped');
+  });
+
+  test('distinguishes sessions already on the account from ones pinned elsewhere', () => {
+    const report = reportGroupSwitch(
+      result({ outcome: {
+        unchangedSessionIds: ['already', 'pinned-1', 'pinned-2'],
+        overriddenSessionIds: ['pinned-1', 'pinned-2'],
+      } }),
+      { targetName: 'Api Service', pickedAccountId: 'work', liveAffected: [] },
+    );
+
+    expect(report?.suffix).toContain('1 session was already on it');
+    expect(report?.suffix).toContain('2 sessions have their own account');
+    expect(report?.suffix).toContain('nothing moved');
+  });
+
+  test('reports only the reason that applies when every session is pinned', () => {
+    const report = reportGroupSwitch(
+      result({ outcome: {
+        unchangedSessionIds: ['p1'],
+        overriddenSessionIds: ['p1'],
+      } }),
+      { targetName: 'Api Service', pickedAccountId: 'work', liveAffected: [] },
+    );
+
+    expect(report?.suffix).not.toContain('already on it');
+    expect(report?.suffix).toContain('own account');
+  });
+});

--- a/src/renderer/__tests__/accountSwitchReport.test.ts
+++ b/src/renderer/__tests__/accountSwitchReport.test.ts
@@ -132,8 +132,50 @@ describe('reportGroupSwitch', () => {
     );
 
     expect(report?.suffix).toContain('1 session was already on it');
-    expect(report?.suffix).toContain('2 sessions have their own account');
-    expect(report?.suffix).toContain('nothing moved');
+    expect(report?.suffix).toContain('2 have their own account');
+    expect(report?.suffix).toContain('did not move');
+  });
+
+  /**
+   * The shape the data-layer tests already build: one session inherits and
+   * moves, two stay behind. Reporting only the movers reintroduces exactly the
+   * "why did nothing happen to those?" ambiguity this pair of issues is about,
+   * so both facts have to survive into one sentence.
+   */
+  test('a mixed group reports the sessions that moved AND the ones left behind', () => {
+    const report = reportGroupSwitch(
+      result({
+        affectedSessionIds: ['inherits'],
+        outcome: {
+          unchangedSessionIds: ['already', 'pinned'],
+          overriddenSessionIds: ['already', 'pinned'],
+        },
+      }),
+      { targetName: 'Api Service', pickedAccountId: 'work', liveAffected: [] },
+    );
+
+    expect(report?.suffix).toContain('stopped');
+    expect(report?.suffix).toContain('own account');
+  });
+
+  test('still reports sessions left behind when a restart prompt is covering the movers', () => {
+    // The prompt names only what it is about to restart, so the pinned
+    // sessions have no other way of being mentioned.
+    const report = reportGroupSwitch(
+      result({
+        affectedSessionIds: ['inherits'],
+        outcome: {
+          unchangedSessionIds: ['pinned'],
+          overriddenSessionIds: ['pinned'],
+        },
+      }),
+      { targetName: 'Api Service', pickedAccountId: 'work', liveAffected: ['inherits'] },
+    );
+
+    expect(report).not.toBeNull();
+    expect(report?.suffix).toContain('own account');
+    // The prompt is already saying this; the notice must not repeat it.
+    expect(report?.suffix).not.toContain('stopped');
   });
 
   test('reports only the reason that applies when every session is pinned', () => {

--- a/src/renderer/accountSwitchReport.ts
+++ b/src/renderer/accountSwitchReport.ts
@@ -1,0 +1,152 @@
+import { AccountSwitchResult, ClaudeAccount } from '../shared/types';
+
+/**
+ * A sentence about an account switch, split around the account it names.
+ *
+ * The chip is a React element and the rest is text, so the two halves travel
+ * separately; keeping this file free of JSX is what lets every branch below be
+ * asserted directly rather than through a render.
+ */
+export interface AccountSwitchReport {
+  /** 'muted' when nothing changed at all — a confirmation, not news. */
+  tone: 'info' | 'muted';
+  /** Text before the account chip. */
+  prefix: string;
+  /** The account the target now resolves to. */
+  account: ClaudeAccount | null;
+  /** Text after the account chip. */
+  suffix: string;
+}
+
+export interface SwitchContext {
+  /** The session or group the click was on, for naming it back. */
+  targetName: string;
+  /** The account id the user picked; null = "inherit"/"use default". */
+  pickedAccountId: string | null;
+  /** Of the sessions that changed account, those with a pty to replace. */
+  liveAffected: string[];
+}
+
+/**
+ * What to say after a session's account was switched (#214).
+ *
+ * Returns null in the one case that speaks for itself: a live session whose
+ * account moved is about to visibly restart, and a notice saying so would be
+ * narrating something the user can already see.
+ *
+ * Every other outcome reaches the user as an unchanged screen. The click did
+ * land, the row did get written, and saying nothing is indistinguishable from
+ * a menu that ignored the click — which is what sends someone back to the menu
+ * to try again, and is how a group ends up mis-clicked onto the default (#213).
+ */
+export function reportSessionSwitch(
+  result: AccountSwitchResult,
+  ctx: SwitchContext,
+): AccountSwitchReport | null {
+  const { account } = result.outcome;
+  const name = quoted(ctx.targetName);
+
+  if (result.affectedSessionIds.length > 0) {
+    if (ctx.liveAffected.length > 0) return null; // The restart is the report.
+    return {
+      tone: 'info',
+      prefix: `${name} will use `,
+      account,
+      suffix: ' when you start it.',
+    };
+  }
+
+  // Nothing moved, because it was already there. Which of the two ways the
+  // user got here matters: picking the account explicitly pins the session to
+  // it, and that has a consequence they did not ask for and cannot see.
+  if (ctx.pickedAccountId !== null) {
+    return {
+      tone: 'muted',
+      prefix: `${name} was already using `,
+      account,
+      suffix: ' — it is now pinned to that account, so changing the group’s'
+        + ' account will no longer move this session.',
+    };
+  }
+
+  return {
+    tone: 'muted',
+    prefix: `${name} now follows its group, which uses `,
+    account,
+    suffix: ' — the same account it was already on, so nothing moved.',
+  };
+}
+
+/**
+ * What to say after a group's account was switched (#214).
+ *
+ * Returns null when the restart prompt is about to appear: that prompt already
+ * names what happened, and two things saying it at once is worse than one.
+ */
+export function reportGroupSwitch(
+  result: AccountSwitchResult,
+  ctx: SwitchContext,
+): AccountSwitchReport | null {
+  if (ctx.liveAffected.length > 0) return null; // The restart prompt is the report.
+
+  const { account, unchangedSessionIds, overriddenSessionIds } = result.outcome;
+  const prefix = `${quoted(ctx.targetName)} now uses `;
+
+  // Sessions that moved but have no pty to replace: the assignment is real and
+  // takes effect the moment they start, which is worth saying precisely
+  // because there is nothing on screen to suggest it.
+  if (result.affectedSessionIds.length > 0) {
+    return {
+      tone: 'info',
+      prefix,
+      account,
+      suffix: `. ${count(result.affectedSessionIds.length)} in it `
+        + `${plural(result.affectedSessionIds.length, 'is', 'are')} stopped and will use it `
+        + 'when you start ' + plural(result.affectedSessionIds.length, 'it', 'them') + '.',
+    };
+  }
+
+  if (unchangedSessionIds.length === 0) {
+    return { tone: 'info', prefix, account, suffix: '.' };
+  }
+
+  // A group switch cannot move a session pinned to its own account. That is
+  // the design, but it is invisible from the group menu, so a switch that
+  // moves nothing looks broken rather than declined.
+  const pinned = overriddenSessionIds.length;
+  const already = unchangedSessionIds.length - pinned;
+
+  return {
+    tone: 'muted',
+    prefix,
+    account,
+    suffix: `. ${describeStuck(already, pinned)}, so nothing moved.`,
+  };
+}
+
+/** "2 sessions were already on it and 1 has its own account" */
+function describeStuck(already: number, pinned: number): string {
+  const parts: string[] = [];
+  if (already > 0) {
+    parts.push(`${count(already)} ${plural(already, 'was', 'were')} already on it`);
+  }
+  if (pinned > 0) {
+    parts.push(
+      `${count(pinned)} ${plural(pinned, 'has', 'have')} ${plural(pinned, 'its', 'their')} own account`,
+    );
+  }
+  return parts.join(' and ');
+}
+
+function count(n: number): string {
+  return n === 1 ? '1 session' : `${n} sessions`;
+}
+
+function plural(n: number, one: string, many: string): string {
+  return n === 1 ? one : many;
+}
+
+/** Curly quotes: these names are user-typed and land mid-sentence. */
+function quoted(name: string): string {
+  return `“${name}”`;
+}

--- a/src/renderer/accountSwitchReport.ts
+++ b/src/renderer/accountSwitchReport.ts
@@ -64,7 +64,7 @@ export function reportSessionSwitch(
       tone: 'muted',
       prefix: `${name} was already using `,
       account,
-      suffix: ' — it is now pinned to that account, so changing the group’s'
+      suffix: ' — it is pinned to that account, so changing the group’s'
         + ' account will no longer move this session.',
     };
   }
@@ -80,62 +80,75 @@ export function reportSessionSwitch(
 /**
  * What to say after a group's account was switched (#214).
  *
- * Returns null when the restart prompt is about to appear: that prompt already
- * names what happened, and two things saying it at once is worse than one.
+ * Composes rather than picks: a group switch can do several things at once —
+ * move some sessions, move others that have no pty to restart, and fail to
+ * move the ones pinned to their own account — and the user needs all of them,
+ * not the first one that happens to apply.
+ *
+ * The restart prompt covers only the sessions it is about to restart. Every
+ * other fact lands here, which is why this returns null in exactly one case:
+ * the prompt is showing and there is nothing left for it to have missed.
  */
 export function reportGroupSwitch(
   result: AccountSwitchResult,
   ctx: SwitchContext,
 ): AccountSwitchReport | null {
-  if (ctx.liveAffected.length > 0) return null; // The restart prompt is the report.
-
   const { account, unchangedSessionIds, overriddenSessionIds } = result.outcome;
-  const prefix = `${quoted(ctx.targetName)} now uses `;
 
-  // Sessions that moved but have no pty to replace: the assignment is real and
-  // takes effect the moment they start, which is worth saying precisely
-  // because there is nothing on screen to suggest it.
-  if (result.affectedSessionIds.length > 0) {
-    return {
-      tone: 'info',
-      prefix,
-      account,
-      suffix: `. ${count(result.affectedSessionIds.length)} in it `
-        + `${plural(result.affectedSessionIds.length, 'is', 'are')} stopped and will use it `
-        + 'when you start ' + plural(result.affectedSessionIds.length, 'it', 'them') + '.',
-    };
-  }
+  const clauses: string[] = [];
 
-  if (unchangedSessionIds.length === 0) {
-    return { tone: 'info', prefix, account, suffix: '.' };
+  // Sessions that moved but have no pty to replace. The assignment is real and
+  // takes effect the moment they start — worth saying precisely because there
+  // is nothing on screen to suggest it.
+  const stoppedMovers = result.affectedSessionIds.length - ctx.liveAffected.length;
+  if (stoppedMovers > 0) {
+    clauses.push(`${count(stoppedMovers)} in it ${plural(stoppedMovers, 'is', 'are')} stopped and `
+      + `will use it when you start ${plural(stoppedMovers, 'it', 'them')}`);
   }
 
   // A group switch cannot move a session pinned to its own account. That is
   // the design, but it is invisible from the group menu, so a switch that
-  // moves nothing looks broken rather than declined.
-  const pinned = overriddenSessionIds.length;
-  const already = unchangedSessionIds.length - pinned;
+  // leaves sessions behind looks broken rather than declined.
+  const stuck = describeStuck(unchangedSessionIds, overriddenSessionIds);
+  if (stuck) {
+    clauses.push(`${stuck}, so ${plural(unchangedSessionIds.length, 'it', 'they')} did not move`);
+  }
+
+  // The prompt about to appear already names what it is restarting. Only stay
+  // silent if that is genuinely the whole story.
+  if (ctx.liveAffected.length > 0 && clauses.length === 0) return null;
 
   return {
-    tone: 'muted',
-    prefix,
+    // Muted only when the switch moved nothing anywhere — a confirmation
+    // rather than news.
+    tone: result.affectedSessionIds.length === 0 ? 'muted' : 'info',
+    prefix: `${quoted(ctx.targetName)} now uses `,
     account,
-    suffix: `. ${describeStuck(already, pinned)}, so nothing moved.`,
+    suffix: clauses.length === 0 ? '.' : `. ${sentence(clauses)}.`,
   };
 }
 
-/** "2 sessions were already on it and 1 has its own account" */
-function describeStuck(already: number, pinned: number): string {
-  const parts: string[] = [];
-  if (already > 0) {
-    parts.push(`${count(already)} ${plural(already, 'was', 'were')} already on it`);
+/** "2 sessions were already on it and 1 has its own account", or '' if neither. */
+function describeStuck(unchanged: string[], overridden: string[]): string {
+  const pinned = overridden.length;
+  const already = unchanged.length - pinned;
+
+  const own = `${plural(pinned, 'has', 'have')} ${plural(pinned, 'its', 'their')} own account`;
+
+  // Both reasons: the first clause establishes "sessions", so the second says
+  // a bare number rather than repeating the noun.
+  if (already > 0 && pinned > 0) {
+    return `${count(already)} ${plural(already, 'was', 'were')} already on it and ${pinned} ${own}`;
   }
-  if (pinned > 0) {
-    parts.push(
-      `${count(pinned)} ${plural(pinned, 'has', 'have')} ${plural(pinned, 'its', 'their')} own account`,
-    );
-  }
-  return parts.join(' and ');
+  if (already > 0) return `${count(already)} ${plural(already, 'was', 'were')} already on it`;
+  if (pinned > 0) return `${count(pinned)} ${own}`;
+  return '';
+}
+
+/** Joins independent clauses into one sentence, capitalised. */
+function sentence(clauses: string[]): string {
+  const joined = clauses.join('; ');
+  return joined.charAt(0).toUpperCase() + joined.slice(1);
 }
 
 function count(n: number): string {

--- a/src/renderer/components/AccountSwitchNotice.tsx
+++ b/src/renderer/components/AccountSwitchNotice.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { AccountSwitchReport } from '../accountSwitchReport';
+import { AccountChip } from './AccountChip';
+import { Notice } from './Notice';
+
+export interface AccountSwitchNoticeProps {
+  report: AccountSwitchReport;
+  onDismiss: () => void;
+}
+
+/**
+ * What an account switch did, when it did not restart anything (#214).
+ *
+ * Wears the same shell as the failover notice on purpose: from the user's side
+ * these are one event — "your sessions are on a different account now" — and
+ * the only difference is who initiated it.
+ */
+export const AccountSwitchNotice: React.FC<AccountSwitchNoticeProps> = ({ report, onDismiss }) => (
+  <Notice tone={report.tone} icon={report.tone === 'muted' ? '=' : '⇄'} onDismiss={onDismiss}>
+    {report.prefix}
+    <AccountChip account={report.account} size="sm" />
+    {report.suffix}
+  </Notice>
+);

--- a/src/renderer/components/FailoverNotice.tsx
+++ b/src/renderer/components/FailoverNotice.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { AccountFailoverEvent } from '../../shared/types';
 import { AccountChip } from './AccountChip';
-import './FailoverNotice.css';
+import { Notice } from './Notice';
 
 export interface FailoverNoticeProps {
   event: AccountFailoverEvent;
@@ -30,37 +30,26 @@ export const FailoverNotice: React.FC<FailoverNoticeProps> = ({ event, onDismiss
     : `${event.sessionIds.length} sessions`;
 
   return (
-    <output className={`failover-notice ${blocked ? 'blocked' : ''}`} aria-live="polite">
-      <span className="failover-notice-icon" aria-hidden="true">{blocked ? '!' : '⇄'}</span>
-
-      <div className="failover-notice-body">
-        {event.reason === 'failback' ? (
-          <>
-            <strong>Back on your own account.</strong>{' '}
-            <AccountChip account={event.to} size="sm" />{' '}
-            is out of its usage limit, so {sessions} moved back.
-          </>
-        ) : (
-          <>
-            <AccountChip account={event.from} size="sm" />{' '}
-            {describeLimit(event)}{' '}
-            {renderOutcome(event, sessions)}
-          </>
-        )}
-      </div>
-
-      <button className="failover-notice-link" onClick={onOpenAccounts}>
-        Accounts
-      </button>
-      <button
-        className="failover-notice-dismiss"
-        onClick={onDismiss}
-        aria-label="Dismiss"
-        title="Dismiss"
-      >
-        ×
-      </button>
-    </output>
+    <Notice
+      tone={blocked ? 'warn' : 'info'}
+      icon={blocked ? '!' : '⇄'}
+      onDismiss={onDismiss}
+      action={{ label: 'Accounts', onClick: onOpenAccounts }}
+    >
+      {event.reason === 'failback' ? (
+        <>
+          <strong>Back on your own account.</strong>{' '}
+          <AccountChip account={event.to} size="sm" />{' '}
+          is out of its usage limit, so {sessions} moved back.
+        </>
+      ) : (
+        <>
+          <AccountChip account={event.from} size="sm" />{' '}
+          {describeLimit(event)}{' '}
+          {renderOutcome(event, sessions)}
+        </>
+      )}
+    </Notice>
   );
 };
 

--- a/src/renderer/components/Notice.css
+++ b/src/renderer/components/Notice.css
@@ -1,4 +1,10 @@
-.failover-notice {
+/*
+ * The shell shared by every "here is what just happened to your sessions"
+ * line (#214). Extracted from FailoverNotice so an automatic failover and a
+ * manual account switch — the same event with a different instigator — cannot
+ * drift into looking like different kinds of thing.
+ */
+.notice {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -16,23 +22,28 @@
 /* Nothing moved. Warmer border so the two outcomes are distinguishable at a
    glance, without the alarm colouring of an actual error — the app is not
    broken, the quota is. */
-.failover-notice.blocked {
+.notice.notice-warn {
   border-left-color: var(--warning-color, #d79c40);
 }
 
-.failover-notice-icon {
+/* Nothing needed to move. Quieter still: this is a confirmation, not news. */
+.notice.notice-muted {
+  border-left-color: var(--border-color, #3a3a3a);
+}
+
+.notice-icon {
   flex: 0 0 auto;
   font-weight: 700;
   opacity: 0.8;
 }
 
-.failover-notice-body {
+.notice-body {
   flex: 1 1 auto;
   min-width: 0;
 }
 
-.failover-notice-link,
-.failover-notice-dismiss {
+.notice-link,
+.notice-dismiss {
   flex: 0 0 auto;
   background: none;
   border: none;
@@ -43,13 +54,13 @@
   font-size: 12px;
 }
 
-.failover-notice-link:hover,
-.failover-notice-dismiss:hover {
+.notice-link:hover,
+.notice-dismiss:hover {
   color: var(--text-primary, #ddd);
   background: var(--bg-hover, #2f2f30);
 }
 
-.failover-notice-dismiss {
+.notice-dismiss {
   font-size: 16px;
   line-height: 1;
 }

--- a/src/renderer/components/Notice.tsx
+++ b/src/renderer/components/Notice.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import './Notice.css';
+
+export type NoticeTone = 'info' | 'warn' | 'muted';
+
+export interface NoticeProps {
+  tone?: NoticeTone;
+  /** Single glyph carrying the tone visually; decorative, so aria-hidden. */
+  icon: string;
+  children: React.ReactNode;
+  onDismiss: () => void;
+  /** Optional escape hatch to wherever the underlying setting lives. */
+  action?: { label: string; onClick: () => void };
+}
+
+const TONE_CLASS: Record<NoticeTone, string> = {
+  info: '',
+  warn: 'notice-warn',
+  muted: 'notice-muted',
+};
+
+/**
+ * One line in the window about something that just happened to your sessions.
+ *
+ * `<output>` rather than a styled div: it carries role="status" natively, so
+ * the text is announced to a screen reader when it appears without stealing
+ * focus — the right register for a report about work the app did on its own,
+ * which is exactly what both of its users are (#214, failover).
+ */
+export const Notice: React.FC<NoticeProps> = ({ tone = 'info', icon, children, onDismiss, action }) => (
+  <output className={`notice ${TONE_CLASS[tone]}`.trim()} aria-live="polite">
+    <span className="notice-icon" aria-hidden="true">{icon}</span>
+    <div className="notice-body">{children}</div>
+    {action && (
+      <button className="notice-link" onClick={action.onClick}>{action.label}</button>
+    )}
+    <button className="notice-dismiss" onClick={onDismiss} aria-label="Dismiss" title="Dismiss">×</button>
+  </output>
+);

--- a/src/renderer/components/__tests__/AccountSwitchNotice.test.tsx
+++ b/src/renderer/components/__tests__/AccountSwitchNotice.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * The in-window report of a manual account switch (#214).
+ *
+ * The shell is shared with the failover notice, so what is worth asserting
+ * here is the join: the account has to be named inside the sentence, and the
+ * whole thing has to reach a screen reader as one announcement rather than as
+ * a fragment either side of an unlabelled chip.
+ */
+import { describe, expect, test, afterEach } from 'bun:test';
+import { render, screen, cleanup } from '@testing-library/react';
+import React from 'react';
+import { AccountSwitchNotice } from '../AccountSwitchNotice';
+import { AccountSwitchReport } from '../../accountSwitchReport';
+import { ClaudeAccount } from '../../../shared/types';
+
+afterEach(cleanup);
+
+const work = {
+  id: 'a-work', label: 'Work', email: null, color: '#61afef',
+  configDir: '/cfg/work', isDefault: false,
+} as ClaudeAccount;
+
+function show(report: Partial<AccountSwitchReport> = {}): string {
+  render(
+    <AccountSwitchNotice
+      report={{
+        tone: 'muted',
+        prefix: '“Session 1” was already using ',
+        account: work,
+        suffix: ' — it is now pinned to that account.',
+        ...report,
+      }}
+      onDismiss={() => {}}
+    />,
+  );
+  return screen.getByRole('status').textContent ?? '';
+}
+
+describe('AccountSwitchNotice', () => {
+  test('reads as one sentence with the account named inside it', () => {
+    expect(show()).toContain('“Session 1” was already using Work — it is now pinned');
+  });
+
+  test('names the no-account case rather than leaving a gap mid-sentence', () => {
+    const text = show({ account: null, prefix: 'This group now uses ', suffix: '.' });
+    expect(text).toContain('This group now uses');
+    // AccountChip's own empty label — asserted as non-empty rather than
+    // verbatim, since which words it uses is that component's business.
+    expect(text.replace('This group now uses', '').replace('.', '').trim().length).toBeGreaterThan(0);
+  });
+
+  test('is dismissible', () => {
+    show();
+    expect(screen.getByLabelText('Dismiss')).toBeDefined();
+  });
+});

--- a/src/renderer/store/groups.ts
+++ b/src/renderer/store/groups.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { Group } from '../../shared/types';
+import { AccountSwitchResult, Group } from '../../shared/types';
 
 const DEFAULT_COLORS = ['#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2'];
 
@@ -91,16 +91,19 @@ export function useGroups() {
    * useSessions().setSessionAccount for why the plain updateGroup path isn't
    * enough.
    */
-  const setGroupAccount = useCallback(async (id: string, accountId: string | null): Promise<string[]> => {
+  const setGroupAccount = useCallback(async (
+    id: string,
+    accountId: string | null,
+  ): Promise<AccountSwitchResult | null> => {
     try {
-      const { affectedSessionIds } = await window.electronAPI.assignAccountToGroup(id, accountId);
+      const result = await window.electronAPI.assignAccountToGroup(id, accountId);
       setGroups(prev => prev.map(g =>
         g.id === id ? { ...g, claudeAccountId: accountId } : g
       ));
-      return affectedSessionIds;
+      return result;
     } catch (error) {
       console.error('Failed to assign account to group:', error);
-      return [];
+      return null; // See useSessions().setSessionAccount for why not an empty result.
     }
   }, []);
 

--- a/src/renderer/store/sessions.ts
+++ b/src/renderer/store/sessions.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { Session, SessionState, DEFAULT_SESSION_PROVIDER } from '../../shared/types';
+import { AccountSwitchResult, Session, SessionState, DEFAULT_SESSION_PROVIDER } from '../../shared/types';
 
 /**
  * Apply a hook's state change to the list. Lifted out of the effect because
@@ -162,16 +162,22 @@ export function useSessions() {
    * ptys need restarting — the column write alone leaves a live session on the
    * old account.
    */
-  const setSessionAccount = useCallback(async (id: string, accountId: string | null): Promise<string[]> => {
+  const setSessionAccount = useCallback(async (
+    id: string,
+    accountId: string | null,
+  ): Promise<AccountSwitchResult | null> => {
     try {
-      const { affectedSessionIds } = await window.electronAPI.assignAccountToSession(id, accountId);
+      const result = await window.electronAPI.assignAccountToSession(id, accountId);
       setSessions(prev => prev.map(s =>
         s.id === id ? { ...s, claudeAccountId: accountId } : s
       ));
-      return affectedSessionIds;
+      return result;
     } catch (error) {
       console.error('Failed to assign account to session:', error);
-      return [];
+      // null, not an empty result: the caller reports what the switch did, and
+      // a failed call did nothing at all — reporting it as "already on that
+      // account" would be the same lie in a new place (#214).
+      return null;
     }
   }, []);
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -354,6 +354,41 @@ export interface AccountFailoverEvent {
  */
 export interface AccountSwitchResult {
   affectedSessionIds: string[];
+  /**
+   * What the write did, beyond what needs restarting (#214).
+   *
+   * `affectedSessionIds` answers one question — which ptys to replace — and
+   * answers it with `[]` in two very different situations: nothing needed to
+   * move, and nothing could. Both reach the user as an unchanged screen,
+   * indistinguishable from a menu that never registered the click. This is
+   * what the renderer needs to say which one it was.
+   */
+  outcome: AccountSwitchOutcome;
+}
+
+/**
+ * Why an account switch moved what it moved (#214).
+ *
+ * Deliberately describes sessions rather than prescribing a message: "already
+ * on that account" and "pinned to its own account" are different facts about
+ * the user's setup, and only the renderer knows which of them is worth saying
+ * in the surface the click came from.
+ */
+export interface AccountSwitchOutcome {
+  /** The account the target resolves to after the write (null = legacy dir). */
+  account: ClaudeAccount | null;
+  /**
+   * Sessions whose effective account did not move. For a session switch this
+   * is the session itself, meaning the pick recorded an override to the
+   * account it was already inheriting.
+   */
+  unchangedSessionIds: string[];
+  /**
+   * Group switches only: sessions carrying their own account override, which
+   * a group-level change cannot move by design. Worth separating from the
+   * above because the reason is different and so is the remedy.
+   */
+  overriddenSessionIds: string[];
 }
 
 /**


### PR DESCRIPTION
Fixes the two bugs filed out of the failover work — the ones behind "I changed the group from my exhausted work account to Brannon" and finding it back on the exhausted account minutes later, with nothing on screen having said so.

They're one incident from two sides, so they're one PR.

## #214 — a switch that restarts nothing reports nothing

`affectedSessionIds` answers exactly one question — which ptys to replace — and answers it with `[]` in two very different situations: nothing *needed* to move, and nothing *could*. Both reach the user as an unchanged screen, indistinguishable from a menu that never registered the click.

`AccountSwitchResult` now carries an `outcome`: the account the target resolves to, the sessions that stayed put, and which of those were pinned to their own account. The renderer turns that into one line in the window.

The case that speaks for itself stays quiet — a live session about to visibly restart doesn't need a notice narrating it.

The case most worth naming is the one in the issue: picking the account a session **already inherits** writes an override, which silently opts that session out of group-level control. Nothing said so, and the consequence surfaced hours later when a group switch mysteriously left it behind. It now says so.

## #213 — the default that didn't name itself

`Use default account` sat one row above the account list and named no destination. During a usage limit the default is usually the account being fled, so a one-row miss put the group straight back onto it.

- the item now names where it resolves to — `Use default account (Work)`
- a separator keeps it off the account list, so a slip lands on nothing
- the same separator goes into the session menu, where `Inherit account from group` has the same shape
- the restart prompt no longer reads as a confirmation. The assignment is already written when it appears and `Not now` declines only the restart, so it now says so outright rather than leaving "dismiss = cancel" as the natural reading

## Shared shell

`FailoverNotice`'s markup moves to a `Notice` component. An automatic failover and a manual switch are the same event to the user — only the instigator differs — and they shouldn't drift into looking like different kinds of thing.

## What I did not do

The issues also suggest an undo path (#213) and *not* writing a pointless override (#214). I left both alone deliberately:

- **undo** is a real feature with its own design questions, not a bug fix
- **suppressing the override write** would invent new semantics — explicitly picking an account is a reasonable thing to mean "pin here". The bug was the silence, not the write, so the write stays and is now reported

Both are judgement calls rather than omissions; say the word if you'd rather have either.

## Testing

`bun test --isolate` — **1288 pass, 0 fail**. New coverage:

- `accountSwitchReport.test.ts` (9) — every reporting branch, including the two that must stay silent
- `account-switch.test.ts` (+5) — the outcome fields, incl. a group switch separating "already there" from "pinned elsewhere", and an assignment to a deleted account falling through to the default
- `App.accounts.test.ts` (+3) — `defaultAccountMenuLabel`, incl. the no-default-set case
- `AccountSwitchNotice.test.tsx` (3) — the sentence reads as one announcement with the account named inside it

One of my own assertions caught a plural bug while writing them (`2 sessions have its own account`); fixed the string, kept the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGPAJHf4nggL377CBqtLgm