### PR TITLE
228/204 — Wait on the condition, not the clock, in the load-sensitive suites

### DIFF
--- a/relay/src/ws.test.ts
+++ b/relay/src/ws.test.ts
@@ -10,6 +10,15 @@ import { toArrayBuffer } from './crypto';
 const logger = createLogger('error');
 const b64 = (b: Uint8Array) => Buffer.from(b).toString('base64');
 
+/**
+ * Auth window for the reaper tests. Large enough that a loaded machine can
+ * finish a real handshake inside it, since a window the handshake cannot meet
+ * tests the machine's speed rather than the reaper.
+ */
+const REAPER_WINDOW_MS = 500;
+/** How far past the window a disarmed socket must survive to prove the point. */
+const REAPER_MARGIN_MS = 300;
+
 function startServer(repos: Repositories, authTimeoutMs?: number) {
   const gateway = createGateway({ repos, logger, authTimeoutMs });
   return Bun.serve({
@@ -213,12 +222,14 @@ describe('agent WebSocket handshake', () => {
   });
 
   test('answering the challenge disarms the reaper', async () => {
-    // The mirror of the test above: with a 50ms timeout, an authenticated
-    // socket that stays quiet well past it must still be alive. Without the
-    // clearTimeout in the auth path this fails.
+    // The mirror of the test above: an authenticated socket that stays quiet
+    // well past the timeout must still be alive. Without the clearTimeout in
+    // the auth path this fails. The window has to outlast the handshake it is
+    // disarmed by — a connect, a challenge round-trip and a signature — or the
+    // reaper fires first and the test measures the machine, not the reaper.
     const repos = freshRepos();
     const { pub, sign, machineId } = await registerMachine(repos);
-    const server = startServer(repos, 50);
+    const server = startServer(repos, REAPER_WINDOW_MS);
     try {
       const c = connect(`ws://127.0.0.1:${server.port}/ws`);
       await c.opened;
@@ -229,7 +240,7 @@ describe('agent WebSocket handshake', () => {
 
       // Prove liveness after the window rather than sleeping blind: a ping
       // round-trip that completes can only happen on an open socket.
-      await Bun.sleep(120);
+      await Bun.sleep(REAPER_WINDOW_MS + REAPER_MARGIN_MS);
       c.ws.send(JSON.stringify({ type: 'ping' }));
       expect(await c.nextOfType('pong')).toMatchObject({ type: 'pong' });
     } finally {

--- a/relay/web/src/connection.test.ts
+++ b/relay/web/src/connection.test.ts
@@ -37,6 +37,18 @@ function ab(u: Uint8Array): ArrayBuffer {
   return b;
 }
 
+/**
+ * Wait until `predicate` holds rather than for a fixed number of milliseconds.
+ * Every assertion below waits on an async settle — a WebCrypto unseal, a state
+ * push. The deadline is a backstop, not a wait: it returns as soon as the
+ * condition holds, and missing it fails on the assertion that follows, which
+ * says far more about what went wrong than a bare timeout would.
+ */
+async function until(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) await Bun.sleep(1);
+}
+
 /** A stand-in for the browser WebSocket the connection opens. */
 class FakeSocket {
   static last: FakeSocket | null = null;
@@ -129,8 +141,8 @@ async function connected(): Promise<Session> {
     agentX25519Pub: agentXPubB64,
     signature: toB64(sig),
   });
-  // Let the async handshake settle.
-  await Bun.sleep(20);
+  // Let the async handshake settle — it is done when the state lands.
+  await until(() => states.some((x) => x.state === 'ready'));
 
   // Mirror the client's key derivation from the agent side.
   const clientPub = await subtle.importKey('raw', ab(fromB64(clientPubB64)), algo({ name: 'X25519' }), false, []);
@@ -184,7 +196,7 @@ describe('a refused command must not end the session', () => {
     const before = s.states.length;
 
     s.socket.deliver(await s.seal(0, { type: 'command:denied', reason: 'not_permitted', command: 'terminal:input' }));
-    await Bun.sleep(20);
+    await until(() => s.refusals.length > 0);
 
     expect(s.refusals).toEqual(['terminal:input']);
     // No new state at all — the session is untouched.
@@ -199,7 +211,7 @@ describe('a refused command must not end the session', () => {
     const before = s.states.length;
 
     s.socket.deliver(await s.seal(0, { type: 'denied', reason: 'not_permitted', command: 'terminal:resize' }));
-    await Bun.sleep(20);
+    await until(() => s.refusals.length > 0);
 
     expect(s.refusals).toEqual(['terminal:resize']);
     expect(s.states.length).toBe(before);
@@ -210,7 +222,7 @@ describe('a refused command must not end the session', () => {
     const s = await connected();
     s.socket.deliver(await s.seal(0, { type: 'command:denied', command: 'terminal:input' }));
     s.socket.deliver(await s.seal(1, { type: 'sessions', sessions: [] }));
-    await Bun.sleep(20);
+    await until(() => s.messages.length > 0);
 
     expect(s.messages.map((m) => m.type)).toEqual(['sessions']);
   });
@@ -220,7 +232,7 @@ describe('losing access still ends the session', () => {
   test.each([...ENDING_REASONS])('reason %s ends it, with that reason preserved', async (reason) => {
     const s = await connected();
     s.socket.deliver(await s.seal(0, { type: 'denied', reason }));
-    await Bun.sleep(20);
+    await until(() => s.states.some((x) => x.state === 'denied'));
 
     const denied = s.states.filter((x) => x.state === 'denied');
     expect(denied).toHaveLength(1);
@@ -234,7 +246,7 @@ describe('losing access still ends the session', () => {
     // already closed — silence is the worse error.
     const s = await connected();
     s.socket.deliver(await s.seal(0, { type: 'denied' }));
-    await Bun.sleep(20);
+    await until(() => s.states.some((x) => x.state === 'denied'));
 
     expect(s.states.some((x) => x.state === 'denied')).toBe(true);
     expect(s.refusals).toEqual([]);
@@ -251,7 +263,7 @@ describe('losing access still ends the session', () => {
     await socket.onopen!();
 
     socket.deliver({ type: 'denied', reason: 'revoked' });
-    await Bun.sleep(20);
+    await until(() => states.some((x) => x.state === 'denied'));
 
     const denied = states.find((x) => x.state === 'denied');
     expect(denied?.detail).toBe('not_authorized');

--- a/src/main/__tests__/account-auth.test.ts
+++ b/src/main/__tests__/account-auth.test.ts
@@ -219,8 +219,17 @@ function writeConfigFile(configDir: string, name: string, contents: unknown): vo
   fs.writeFileSync(path.join(configDir, name), JSON.stringify(contents));
 }
 
-/** fs.watch delivers asynchronously, so the assertion has to outlast it. */
-async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+/**
+ * fs.watch delivers asynchronously, so the assertion has to outlast it. This
+ * ceiling must stay below the per-test timeout the watch-driven tests declare,
+ * or the two race and a real failure reports a bare timeout instead of the
+ * message below, which says what was actually being waited on.
+ */
+const WATCH_TIMEOUT_MS = 15_000;
+/** Per-test ceiling for the watch-driven tests; must exceed WATCH_TIMEOUT_MS. */
+const WATCH_TEST_TIMEOUT_MS = 20_000;
+
+async function waitFor(predicate: () => boolean, timeoutMs = WATCH_TIMEOUT_MS): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (predicate()) return;
@@ -273,7 +282,7 @@ describe('login detection', () => {
     expect(fs.existsSync(path.join(account.configDir, '.credentials.json'))).toBe(false);
 
     accountAuth.cancelLoginFlow(pty, ptyId, false);
-  });
+  }, WATCH_TEST_TIMEOUT_MS);
 
   test('a token file appearing still completes the flow', async () => {
     const pty = fakePtyManager();
@@ -285,7 +294,7 @@ describe('login detection', () => {
     await waitFor(() => storedEmail(account.id) === 'will@linux.test');
 
     accountAuth.cancelLoginFlow(pty, ptyId, false);
-  });
+  }, WATCH_TEST_TIMEOUT_MS);
 
   test('the manual confirmation records the email the watch would have', async () => {
     const pty = fakePtyManager();

--- a/src/main/api/routes/__tests__/sessions.test.ts
+++ b/src/main/api/routes/__tests__/sessions.test.ts
@@ -78,6 +78,19 @@ function insertSession(id: string, workingDir = '/tmp'): void {
   `).run(id, workingDir);
 }
 
+/**
+ * Wait until `predicate` holds rather than for a fixed number of milliseconds.
+ * This one waits for an in-flight fetch to reach the route. The deadline is a
+ * backstop; it returns as soon as the condition holds, and missing it fails on
+ * the assertion that follows rather than on a bare timeout.
+ */
+async function until(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 1));
+  }
+}
+
 function sessionRowCount(id: string): number {
   return (db.prepare('SELECT COUNT(*) AS c FROM sessions WHERE id = ?').get(id) as { c: number }).c;
 }
@@ -137,7 +150,8 @@ describe('POST /sessions/:id/stop', () => {
     const pending = fetch(`${baseUrl}/sessions/${id}/stop`, { method: 'POST' });
     let settled = false;
     const tracked = pending.then((r) => { settled = true; return r; });
-    await new Promise((r) => setTimeout(r, 25));
+    // Wait for the route to actually ask for the kill, not for 25ms and hope.
+    await until(() => killCalls.length > 0);
     // The kill has been asked for but has not settled: no response yet, so
     // success can only ever mean the process is really gone.
     expect(killCalls).toEqual([id]);


### PR DESCRIPTION
Closes #204
Closes #228

## Reproduced first

The issues describe flakes that never appear on an idle machine, so the first job was a harness that fails on demand:

| condition | result |
|---|---|
| idle, `bun test --isolate` ×5 | **5/5 clean**, ~29s per run |
| all 16 cores saturated, ×3 | **3/3 failed**, ~50s per run |

Each loaded failure hit one of the tests #228 names — `POST /sessions/:id/stop`, `losing access still ends the session`, `the handshake still works`. That harness is what makes the fix checkable rather than hopeful.

## Four wall-clock dependencies, each replaced with the thing it was waiting for

**`relay/web/src/connection.test.ts`** — seven `Bun.sleep(20)` calls waiting on a WebCrypto unseal or a state push. Enough on an idle machine, not under an 83-file parallel run — exactly why these passed 5/5 in isolation and failed in CI (#204). Each now polls the specific condition it was sleeping for, with a generous backstop deadline. A genuine hang still fails on the assertion that follows, which says far more than a bare timeout.

**`src/main/api/routes/__tests__/sessions.test.ts`** — a 25ms sleep waiting for an in-flight `fetch` to reach the route. Under load it hadn't arrived and the assertion read an empty array. Now waits for the kill to actually be requested; the real assertion — that the response has *not* settled — is untouched.

**`src/main/__tests__/account-auth.test.ts`** — `waitFor`'s 5000ms ceiling was also bun's default per-test timeout, so the two raced and the test could die either way (`condition was never met` at 5002ms against a 5000ms limit). The ceiling now sits under a raised per-test timeout, so a real failure reports *what it was waiting on*.

**`relay/src/ws.test.ts`** — the reaper's 50ms auth window had to contain a connect, a challenge round-trip and an Ed25519 signature. Loaded, the reaper fired before the auth meant to disarm it and the test died with `ws error`. The window is now about the reaper rather than about how busy the machine is.

## Deliberately left alone

The 10ms and 150ms grace periods before **negative** assertions in those same files. Under load those can only make a test weaker, never redder — they are not flake sources, and tightening them is a different piece of work with a different justification.

## Verification — #228's own acceptance bar

> 10 consecutive full-repo `bun test --isolate` runs with 0 failures on an otherwise loaded machine.

**10/10, 1291 pass / 0 fail**, every core saturated throughout, at 124–128s per run — roughly 4× the idle baseline and well past the ~50s runs that were failing before the change.

## Not addressed

**#206** (`Terminal.resizeRequest` under coverage instrumentation on Linux) is a distinct mechanism on a platform I can't reproduce on here, and it stays open. Worth noting its premise is now stale in one respect: it says the failure reddens `development`'s Sonar gate, and that gate is currently green at `new_violations: 0`.

## A note on this branch

The commit on it carries another session's message and trailers — a second Claude Code session working in this same checkout committed my uncommitted edits before I did. The code in it is the work described above (verified: the identifiers are ones coined here), but that commit message lacks the `Closes` trailers and the evidence, which is why both are stated in full here. I did not rewrite the shared branch's history to fix the message, since another session may be working on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGPAJHf4nggL377CBqtLgm