### PR TITLE
201 — Relay-carried machine handoff: prepare on the old machine, restore on the new

### DIFF
--- a/relay/.env.example
+++ b/relay/.env.example
@@ -27,6 +27,15 @@ ALLOWED_ORIGINS=
 # Lifetime of a machine-linking code, in seconds.
 LINK_CODE_TTL_SECONDS=600
 
+# Machine handoff: how long a prepared bundle stays available, the ceiling on
+# one bundle, and the ceiling on the whole store. Bundles are written to
+# handoffs/ beside DB_PATH, so the disk behind that path needs the store size.
+HANDOFF_TTL_SECONDS=604800
+HANDOFF_MAX_BYTES=268435456
+HANDOFF_STORE_MAX_BYTES=8589934592
+# Override only if bundles should not live beside the database.
+HANDOFF_DIR=
+
 # GitHub OAuth app credentials — used by Milestone 2, optional for now.
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/relay/docker-compose.yml
+++ b/relay/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - path: .env
         required: false
     volumes:
+      # Holds relay.db and handoffs/, where sealed transfer bundles are written.
+      # Sized for HANDOFF_STORE_MAX_BYTES (8 GiB by default); see .env.example.
       - relay-data:/data
     restart: unless-stopped
 

--- a/relay/src/config.test.ts
+++ b/relay/src/config.test.ts
@@ -9,10 +9,10 @@ import { ConfigError, loadConfig } from './config';
 const BASE = { NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test' };
 
 describe('handoff storage limits', () => {
-  test('default to a week and 64 MiB', () => {
+  test('default to a week and 16 MiB', () => {
     const { config } = loadConfig(BASE);
     expect(config.handoffTtlSeconds).toBe(7 * 24 * 60 * 60);
-    expect(config.handoffMaxBytes).toBe(64 * 1024 * 1024);
+    expect(config.handoffMaxBytes).toBe(16 * 1024 * 1024);
   });
 
   test('are overridable per deployment', () => {

--- a/relay/src/config.test.ts
+++ b/relay/src/config.test.ts
@@ -9,10 +9,17 @@ import { ConfigError, loadConfig } from './config';
 const BASE = { NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test' };
 
 describe('handoff storage limits', () => {
-  test('default to a week and 16 MiB', () => {
+  test('default to a week, 256 MiB per bundle and 8 GiB across the store', () => {
     const { config } = loadConfig(BASE);
     expect(config.handoffTtlSeconds).toBe(7 * 24 * 60 * 60);
-    expect(config.handoffMaxBytes).toBe(16 * 1024 * 1024);
+    expect(config.handoffMaxBytes).toBe(256 * 1024 * 1024);
+    expect(config.handoffStoreMaxBytes).toBe(8 * 1024 * 1024 * 1024);
+  });
+
+  test('put bundles beside the database, which is what the volume holds', () => {
+    const { config } = loadConfig({ ...BASE, DB_PATH: '/data/relay.db' });
+    expect(config.handoffDir).toBe('/data/handoffs');
+    expect(loadConfig({ ...BASE, HANDOFF_DIR: '/elsewhere' }).config.handoffDir).toBe('/elsewhere');
   });
 
   test('are overridable per deployment', () => {
@@ -24,6 +31,7 @@ describe('handoff storage limits', () => {
   test('fail loudly rather than falling back to a default nobody chose', () => {
     expect(() => loadConfig({ ...BASE, HANDOFF_TTL_SECONDS: '0' })).toThrow(ConfigError);
     expect(() => loadConfig({ ...BASE, HANDOFF_MAX_BYTES: 'lots' })).toThrow(ConfigError);
+    expect(() => loadConfig({ ...BASE, HANDOFF_STORE_MAX_BYTES: '0' })).toThrow(ConfigError);
     expect(() => loadConfig({ ...BASE, HANDOFF_TTL_SECONDS: '-1' })).toThrow(ConfigError);
   });
 });

--- a/relay/src/config.test.ts
+++ b/relay/src/config.test.ts
@@ -1,0 +1,29 @@
+/**
+ * The handoff knobs an operator can turn. Both have a shipped default the
+ * desktop assumes, so a deployment that overrides one and not the other is
+ * worth being able to see.
+ */
+import { describe, expect, test } from 'bun:test';
+import { ConfigError, loadConfig } from './config';
+
+const BASE = { NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test' };
+
+describe('handoff storage limits', () => {
+  test('default to a week and 64 MiB', () => {
+    const { config } = loadConfig(BASE);
+    expect(config.handoffTtlSeconds).toBe(7 * 24 * 60 * 60);
+    expect(config.handoffMaxBytes).toBe(64 * 1024 * 1024);
+  });
+
+  test('are overridable per deployment', () => {
+    const { config } = loadConfig({ ...BASE, HANDOFF_TTL_SECONDS: '3600', HANDOFF_MAX_BYTES: '1048576' });
+    expect(config.handoffTtlSeconds).toBe(3600);
+    expect(config.handoffMaxBytes).toBe(1048576);
+  });
+
+  test('fail loudly rather than falling back to a default nobody chose', () => {
+    expect(() => loadConfig({ ...BASE, HANDOFF_TTL_SECONDS: '0' })).toThrow(ConfigError);
+    expect(() => loadConfig({ ...BASE, HANDOFF_MAX_BYTES: 'lots' })).toThrow(ConfigError);
+    expect(() => loadConfig({ ...BASE, HANDOFF_TTL_SECONDS: '-1' })).toThrow(ConfigError);
+  });
+});

--- a/relay/src/config.test.ts
+++ b/relay/src/config.test.ts
@@ -22,6 +22,14 @@ describe('handoff storage limits', () => {
     expect(loadConfig({ ...BASE, HANDOFF_DIR: '/elsewhere' }).config.handoffDir).toBe('/elsewhere');
   });
 
+  test('refuse an in-memory database with nowhere named to put the bundles', () => {
+    // There is no directory to sit beside, and the obvious stand-in — a fixed
+    // name under the system temp directory — is a world-writable path holding
+    // other people's sealed bundles. Say so instead of picking it.
+    expect(() => loadConfig({ ...BASE, DB_PATH: ':memory:' })).toThrow(ConfigError);
+    expect(loadConfig({ ...BASE, DB_PATH: ':memory:', HANDOFF_DIR: '/elsewhere' }).config.handoffDir).toBe('/elsewhere');
+  });
+
   test('are overridable per deployment', () => {
     const { config } = loadConfig({ ...BASE, HANDOFF_TTL_SECONDS: '3600', HANDOFF_MAX_BYTES: '1048576' });
     expect(config.handoffTtlSeconds).toBe(3600);

--- a/relay/src/config.ts
+++ b/relay/src/config.ts
@@ -18,6 +18,10 @@ export interface RelayConfig {
   /** Extra allowed web origins; empty = same-origin only. */
   allowedOrigins: string[];
   linkCodeTtlSeconds: number;
+  /** How long a prepared machine handoff stays available to be restored. */
+  handoffTtlSeconds: number;
+  /** Ceiling on one handoff's sealed bytes. Larger states move by file instead. */
+  handoffMaxBytes: number;
   /** GitHub OAuth app credentials — consumed in M2, optional for now. */
   githubClientId: string | null;
   githubClientSecret: string | null;
@@ -115,6 +119,14 @@ export function loadConfig(env: Record<string, string | undefined> = process.env
     ? parsePositiveInt('LINK_CODE_TTL_SECONDS', env.LINK_CODE_TTL_SECONDS)
     : 600;
 
+  const handoffTtlSeconds = env.HANDOFF_TTL_SECONDS
+    ? parsePositiveInt('HANDOFF_TTL_SECONDS', env.HANDOFF_TTL_SECONDS)
+    : 7 * 24 * 60 * 60;
+
+  const handoffMaxBytes = env.HANDOFF_MAX_BYTES
+    ? parsePositiveInt('HANDOFF_MAX_BYTES', env.HANDOFF_MAX_BYTES)
+    : 64 * 1024 * 1024;
+
   return {
     config: {
       port,
@@ -125,6 +137,8 @@ export function loadConfig(env: Record<string, string | undefined> = process.env
       trustProxy,
       allowedOrigins,
       linkCodeTtlSeconds,
+      handoffTtlSeconds,
+      handoffMaxBytes,
       githubClientId: env.GITHUB_CLIENT_ID || null,
       githubClientSecret: env.GITHUB_CLIENT_SECRET || null,
       allowedGithubOrg: env.ALLOWED_GITHUB_ORG?.trim() || null,

--- a/relay/src/config.ts
+++ b/relay/src/config.ts
@@ -6,7 +6,6 @@
  * env map explicitly so tests can exercise it without touching `process.env`.
  */
 
-import os from 'node:os';
 import path from 'node:path';
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
@@ -140,11 +139,14 @@ export function loadConfig(env: Record<string, string | undefined> = process.env
 
   const dbPath = env.DB_PATH ?? './data/relay.db';
   // Beside the database, which is what the deployment puts on a volume. An
-  // in-memory database has no directory to sit beside, so tests say where.
+  // in-memory database has no directory to sit beside, so the caller must say
+  // where — a fixed name under the system temp directory would be a
+  // world-writable path holding other people's sealed bundles, and one nobody
+  // chose. Every caller here already passes HANDOFF_DIR alongside `:memory:`.
   const handoffDir =
     env.HANDOFF_DIR ??
     (dbPath === ':memory:'
-      ? path.join(os.tmpdir(), 'bodhilander-relay-handoffs')
+      ? fail('HANDOFF_DIR must be set when DB_PATH is :memory:, since there is no database directory to sit beside')
       : path.join(path.dirname(path.resolve(dbPath)), 'handoffs'));
 
   return {

--- a/relay/src/config.ts
+++ b/relay/src/config.ts
@@ -6,6 +6,9 @@
  * env map explicitly so tests can exercise it without touching `process.env`.
  */
 
+import os from 'node:os';
+import path from 'node:path';
+
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 export interface RelayConfig {
@@ -20,11 +23,12 @@ export interface RelayConfig {
   linkCodeTtlSeconds: number;
   /** How long a prepared machine handoff stays available to be restored. */
   handoffTtlSeconds: number;
-  /**
-   * Ceiling on one handoff's sealed bytes, and with it the request body Bun
-   * will accept. Larger states move by file instead.
-   */
+  /** Ceiling on one handoff's sealed bytes. */
   handoffMaxBytes: number;
+  /** Where sealed bundles are written. Beside the database, so it is on the volume. */
+  handoffDir: string;
+  /** Ceiling on the whole store, so one machine's cap is not the disk's. */
+  handoffStoreMaxBytes: number;
   /** GitHub OAuth app credentials — consumed in M2, optional for now. */
   githubClientId: string | null;
   githubClientSecret: string | null;
@@ -128,13 +132,26 @@ export function loadConfig(env: Record<string, string | undefined> = process.env
 
   const handoffMaxBytes = env.HANDOFF_MAX_BYTES
     ? parsePositiveInt('HANDOFF_MAX_BYTES', env.HANDOFF_MAX_BYTES)
-    : 16 * 1024 * 1024;
+    : 256 * 1024 * 1024;
+
+  const handoffStoreMaxBytes = env.HANDOFF_STORE_MAX_BYTES
+    ? parsePositiveInt('HANDOFF_STORE_MAX_BYTES', env.HANDOFF_STORE_MAX_BYTES)
+    : 8 * 1024 * 1024 * 1024;
+
+  const dbPath = env.DB_PATH ?? './data/relay.db';
+  // Beside the database, which is what the deployment puts on a volume. An
+  // in-memory database has no directory to sit beside, so tests say where.
+  const handoffDir =
+    env.HANDOFF_DIR ??
+    (dbPath === ':memory:'
+      ? path.join(os.tmpdir(), 'bodhilander-relay-handoffs')
+      : path.join(path.dirname(path.resolve(dbPath)), 'handoffs'));
 
   return {
     config: {
       port,
       publicUrl,
-      dbPath: env.DB_PATH ?? './data/relay.db',
+      dbPath,
       sessionSecret,
       logLevel,
       trustProxy,
@@ -142,6 +159,8 @@ export function loadConfig(env: Record<string, string | undefined> = process.env
       linkCodeTtlSeconds,
       handoffTtlSeconds,
       handoffMaxBytes,
+      handoffDir,
+      handoffStoreMaxBytes,
       githubClientId: env.GITHUB_CLIENT_ID || null,
       githubClientSecret: env.GITHUB_CLIENT_SECRET || null,
       allowedGithubOrg: env.ALLOWED_GITHUB_ORG?.trim() || null,

--- a/relay/src/config.ts
+++ b/relay/src/config.ts
@@ -20,7 +20,10 @@ export interface RelayConfig {
   linkCodeTtlSeconds: number;
   /** How long a prepared machine handoff stays available to be restored. */
   handoffTtlSeconds: number;
-  /** Ceiling on one handoff's sealed bytes. Larger states move by file instead. */
+  /**
+   * Ceiling on one handoff's sealed bytes, and with it the request body Bun
+   * will accept. Larger states move by file instead.
+   */
   handoffMaxBytes: number;
   /** GitHub OAuth app credentials — consumed in M2, optional for now. */
   githubClientId: string | null;
@@ -125,7 +128,7 @@ export function loadConfig(env: Record<string, string | undefined> = process.env
 
   const handoffMaxBytes = env.HANDOFF_MAX_BYTES
     ? parsePositiveInt('HANDOFF_MAX_BYTES', env.HANDOFF_MAX_BYTES)
-    : 64 * 1024 * 1024;
+    : 16 * 1024 * 1024;
 
   return {
     config: {

--- a/relay/src/db/migrations/004_handoff.sql
+++ b/relay/src/db/migrations/004_handoff.sql
@@ -1,0 +1,28 @@
+-- 004_handoff.sql — the machine-handoff drop box.
+--
+-- The relay is a courier here, not a reader: `ciphertext` is sealed on the old
+-- machine with a key derived from a phrase that never leaves it. Nothing in
+-- this table, and nothing anywhere else in this database, opens it.
+--
+-- `user_id` is UNIQUE rather than indexed, so "one bundle per user at a time"
+-- is a schema guarantee instead of a rule the upload path has to remember: an
+-- upload is an upsert on that key and replaces whatever was there.
+--
+-- New file rather than an edit to 003: `runMigrations` skips any version not
+-- greater than the current `user_version`, so editing an applied migration is
+-- a silent no-op on every existing database.
+
+CREATE TABLE IF NOT EXISTS handoff_bundles (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+  -- Which machine prepared it, so the destination can name the offer. Dropping
+  -- the source machine drops the offer: an unlinked machine's state is no
+  -- longer something this user is being invited to adopt.
+  source_machine_id TEXT NOT NULL REFERENCES machines(id) ON DELETE CASCADE,
+  ciphertext BLOB NOT NULL,
+  byte_size INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_handoff_bundles_expires_at ON handoff_bundles(expires_at);

--- a/relay/src/db/migrations/005_handoff_files.sql
+++ b/relay/src/db/migrations/005_handoff_files.sql
@@ -1,0 +1,27 @@
+-- 005_handoff_files.sql — bundles move out of the database and onto disk.
+--
+-- A sealed handoff is now hundreds of megabytes, and holding that in a BLOB
+-- makes every read of it a whole copy in memory. Worse, SQLite does not return
+-- freed pages to the filesystem, so a database that also holds sessions and
+-- grants would grow to the size of the largest bundle ever stored and stay
+-- there. The bytes now live in files named by `handoff_bundles.id`.
+--
+-- Rebuilt rather than altered: 004 is already applied wherever this branch has
+-- run, and `runMigrations` skips any file not newer than `user_version`, so
+-- editing it would be a silent no-op on those databases.
+--
+-- Any bundle stored under 004 is dropped. They are opaque, single-use and
+-- expire within a week; there is nothing here worth carrying across.
+
+DROP TABLE IF EXISTS handoff_bundles;
+
+CREATE TABLE handoff_bundles (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+  source_machine_id TEXT NOT NULL REFERENCES machines(id) ON DELETE CASCADE,
+  byte_size INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_handoff_bundles_expires_at ON handoff_bundles(expires_at);

--- a/relay/src/handoff-http.test.ts
+++ b/relay/src/handoff-http.test.ts
@@ -1,0 +1,362 @@
+/**
+ * The handoff drop box: who may fill a slot, who may read it, that one account
+ * holds one bundle, that an acknowledgement drops only the bundle it names —
+ * and that nothing this database holds opens the bytes in it.
+ */
+import { describe, expect, test } from 'bun:test';
+import { createDecipheriv, createHash } from 'node:crypto';
+import { loadConfig } from './config';
+import { createLogger } from './logger';
+import { openDb, type RelayDb } from './db';
+import { createRepositories, type Repositories, type User } from './repositories';
+import { createRouter } from './http';
+import { toArrayBuffer } from './crypto';
+// The desktop's sealing, used verbatim: a stand-in would prove the sweep below
+// against bytes the relay never actually stores.
+import { sealHandoff } from '../../src/main/transfer/handoff-crypto';
+import { deriveHandoffKey } from '../../src/main/transfer/recovery-phrase';
+
+const logger = createLogger('error');
+const env = { NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test', HANDOFF_MAX_BYTES: '4096' };
+
+const OLD_IP = '203.0.113.7';
+const NEW_IP = '203.0.113.8';
+
+interface TestMachine {
+  id: string;
+  sign: (m: Uint8Array) => Promise<Uint8Array>;
+}
+
+interface Fixture {
+  db: RelayDb;
+  repos: Repositories;
+  route: ReturnType<typeof createRouter>;
+  user: User;
+  oldMachine: TestMachine;
+  newMachine: TestMachine;
+  stranger: TestMachine;
+  advance: (ms: number) => void;
+}
+
+async function machine(repos: Repositories, userId: string, name: string): Promise<TestMachine> {
+  const kp = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify'])) as unknown as CryptoKeyPair;
+  const pub = new Uint8Array(await crypto.subtle.exportKey('raw', kp.publicKey));
+  const code = repos.createLinkCode(name, pub, new Uint8Array(32).fill(1), 600).code;
+  const claim = repos.claimLinkCode(code, userId);
+  if (!claim.ok) throw new Error('fixture could not link a machine');
+  return {
+    id: claim.machine.id,
+    sign: async (m) => new Uint8Array(await crypto.subtle.sign({ name: 'Ed25519' }, kp.privateKey, toArrayBuffer(m))),
+  };
+}
+
+async function fixture(overrides: Record<string, string> = {}): Promise<Fixture> {
+  const db = openDb(':memory:');
+  let offset = 0;
+  const repos = createRepositories(db, () => Date.now() + offset);
+  const { config } = loadConfig({ ...env, ...overrides });
+  const route = createRouter({ config, logger, repos });
+
+  const user = repos.upsertGithubUser({
+    providerUserId: '1',
+    displayName: 'Will',
+    login: 'will-l',
+    email: null,
+    avatarUrl: null,
+  });
+  const other = repos.upsertGithubUser({
+    providerUserId: '2',
+    displayName: 'Dana',
+    login: 'dana-k',
+    email: null,
+    avatarUrl: null,
+  });
+
+  return {
+    db,
+    repos,
+    route,
+    user,
+    oldMachine: await machine(repos, user.id, 'Old Laptop'),
+    newMachine: await machine(repos, user.id, 'New Laptop'),
+    stranger: await machine(repos, other.id, "Dana's Desktop"),
+    advance: (ms) => {
+      offset += ms;
+    },
+  };
+}
+
+async function signed(m: TestMachine, parts: string[], extra: Record<string, string> = {}) {
+  const issuedAt = Date.now();
+  const message = new TextEncoder().encode([...parts, String(issuedAt)].join('\n'));
+  return {
+    'x-bodhi-issued-at': String(issuedAt),
+    'x-bodhi-signature': Buffer.from(await m.sign(message)).toString('base64'),
+    ...extra,
+  };
+}
+
+function sha256Hex(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function put(f: Fixture, m: TestMachine, sealed: Buffer, opts: { digest?: string; ip?: string } = {}) {
+  const digest = opts.digest ?? sha256Hex(sealed);
+  return f.route(
+    new Request(`http://relay.test/api/machines/${m.id}/handoff`, {
+      method: 'PUT',
+      headers: await signed(m, ['handoff-put:v1', m.id, digest], { 'x-bodhi-content-sha256': digest }),
+      body: new Uint8Array(sealed),
+    }),
+    opts.ip ?? OLD_IP,
+  );
+}
+
+async function meta(f: Fixture, m: TestMachine) {
+  return f.route(
+    new Request(`http://relay.test/api/machines/${m.id}/handoff`, {
+      headers: await signed(m, ['handoff-meta:v1', m.id]),
+    }),
+    NEW_IP,
+  );
+}
+
+async function fetchBundle(f: Fixture, m: TestMachine) {
+  return f.route(
+    new Request(`http://relay.test/api/machines/${m.id}/handoff/bundle`, {
+      headers: await signed(m, ['handoff-get:v1', m.id]),
+    }),
+    NEW_IP,
+  );
+}
+
+async function acknowledge(f: Fixture, m: TestMachine, handoffId: string) {
+  return f.route(
+    new Request(`http://relay.test/api/machines/${m.id}/handoff?id=${handoffId}`, {
+      method: 'DELETE',
+      headers: await signed(m, ['handoff-delete:v1', m.id, handoffId]),
+    }),
+    NEW_IP,
+  );
+}
+
+describe('preparing a handoff', () => {
+  test('a linked machine may fill its account slot, and the other machine is told whose it is', async () => {
+    const f = await fixture();
+    const { bytes } = sealHandoff(Buffer.from('a whole machine'));
+
+    const put1 = await put(f, f.oldMachine, bytes);
+    expect(put1.status).toBe(200);
+
+    const offer = (await (await meta(f, f.newMachine)).json()) as { handoff: Record<string, unknown> };
+    expect(offer.handoff.sourceMachineId).toBe(f.oldMachine.id);
+    expect(offer.handoff.sourceMachineName).toBe('Old Laptop');
+    expect(offer.handoff.byteSize).toBe(bytes.length);
+    // The one thing the metadata must never carry.
+    expect(JSON.stringify(offer)).not.toContain('ciphertext');
+  });
+
+  test('another account sees nothing at all', async () => {
+    const f = await fixture();
+    await put(f, f.oldMachine, sealHandoff(Buffer.from('mine')).bytes);
+    expect(await (await meta(f, f.stranger)).json()).toEqual({ handoff: null });
+    expect((await fetchBundle(f, f.stranger)).status).toBe(404);
+  });
+
+  test('an unsigned or wrongly signed upload is refused', async () => {
+    const f = await fixture();
+    const { bytes } = sealHandoff(Buffer.from('a whole machine'));
+    const digest = sha256Hex(bytes);
+
+    const bare = await f.route(
+      new Request(`http://relay.test/api/machines/${f.oldMachine.id}/handoff`, {
+        method: 'PUT',
+        headers: { 'x-bodhi-content-sha256': digest },
+        body: new Uint8Array(bytes),
+      }),
+      OLD_IP,
+    );
+    expect(bare.status).toBe(400);
+
+    // A signature from a machine that is not the one named in the path.
+    const impostor = await f.route(
+      new Request(`http://relay.test/api/machines/${f.oldMachine.id}/handoff`, {
+        method: 'PUT',
+        headers: await signed(f.stranger, ['handoff-put:v1', f.oldMachine.id, digest], {
+          'x-bodhi-content-sha256': digest,
+        }),
+        body: new Uint8Array(bytes),
+      }),
+      OLD_IP,
+    );
+    expect(impostor.status).toBe(401);
+    expect(await (await meta(f, f.newMachine)).json()).toEqual({ handoff: null });
+  });
+
+  test('a body that is not what was signed for is refused', async () => {
+    const f = await fixture();
+    const { bytes } = sealHandoff(Buffer.from('a whole machine'));
+    const swapped = await put(f, f.oldMachine, bytes, { digest: sha256Hex(Buffer.from('something else')) });
+    expect(swapped.status).toBe(400);
+    expect(await swapped.json()).toEqual({ error: 'digest_mismatch' });
+  });
+
+  test('is capped, and the cap is enforced on the bytes rather than the claim', async () => {
+    const f = await fixture();
+    const oversized = Buffer.alloc(5000, 7);
+    const refused = await put(f, f.oldMachine, oversized);
+    expect(refused.status).toBe(413);
+    expect(await (await meta(f, f.newMachine)).json()).toEqual({ handoff: null });
+  });
+
+  test('replaces the account slot rather than accumulating in it', async () => {
+    const f = await fixture();
+    await put(f, f.oldMachine, sealHandoff(Buffer.from('first')).bytes);
+    const first = (await (await meta(f, f.newMachine)).json()) as { handoff: { id: string } };
+
+    await put(f, f.oldMachine, sealHandoff(Buffer.from('second')).bytes);
+    const second = (await (await meta(f, f.newMachine)).json()) as { handoff: { id: string } };
+
+    expect(second.handoff.id).not.toBe(first.handoff.id);
+    expect(f.db.query('SELECT COUNT(*) AS n FROM handoff_bundles').get()).toEqual({ n: 1 });
+  });
+});
+
+describe('restoring and acknowledging', () => {
+  test('the bytes come back exactly, and the id says which bundle they are', async () => {
+    const f = await fixture();
+    const { bytes } = sealHandoff(Buffer.from('a whole machine'));
+    await put(f, f.oldMachine, bytes);
+
+    const res = await fetchBundle(f, f.newMachine);
+    expect(res.status).toBe(200);
+    expect(Buffer.from(await res.arrayBuffer()).equals(bytes)).toBe(true);
+
+    const id = res.headers.get('x-bodhi-handoff-id')!;
+    expect((await acknowledge(f, f.newMachine, id)).status).toBe(204);
+    expect(await (await meta(f, f.newMachine)).json()).toEqual({ handoff: null });
+  });
+
+  test('an acknowledgement cannot drop a bundle it did not name', async () => {
+    const f = await fixture();
+    await put(f, f.oldMachine, sealHandoff(Buffer.from('first')).bytes);
+    const stale = ((await (await meta(f, f.newMachine)).json()) as { handoff: { id: string } }).handoff.id;
+
+    // The source machine prepares a fresh one while the destination is busy.
+    await put(f, f.oldMachine, sealHandoff(Buffer.from('second')).bytes);
+
+    expect((await acknowledge(f, f.newMachine, stale)).status).toBe(404);
+    const still = (await (await meta(f, f.newMachine)).json()) as { handoff: { id: string } | null };
+    expect(still.handoff).not.toBeNull();
+    expect(still.handoff!.id).not.toBe(stale);
+  });
+
+  test('an id that could forge the signed lines is refused before anything else', async () => {
+    const f = await fixture();
+    await put(f, f.oldMachine, sealHandoff(Buffer.from('first')).bytes);
+    const res = await f.route(
+      new Request(`http://relay.test/api/machines/${f.newMachine.id}/handoff?id=${encodeURIComponent('a\nb')}`, {
+        method: 'DELETE',
+        headers: await signed(f.newMachine, ['handoff-delete:v1', f.newMachine.id, 'a\nb']),
+      }),
+      NEW_IP,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test('stops being offered once its time is up', async () => {
+    const f = await fixture({ HANDOFF_TTL_SECONDS: '60' });
+    await put(f, f.oldMachine, sealHandoff(Buffer.from('a whole machine')).bytes);
+    expect(((await (await meta(f, f.newMachine)).json()) as { handoff: unknown }).handoff).not.toBeNull();
+
+    f.advance(61_000);
+    expect(await (await meta(f, f.newMachine)).json()).toEqual({ handoff: null });
+    expect((await fetchBundle(f, f.newMachine)).status).toBe(404);
+    expect(f.repos.purgeExpiredHandoffBundles()).toBe(1);
+    expect(f.db.query('SELECT COUNT(*) AS n FROM handoff_bundles').get()).toEqual({ n: 0 });
+  });
+});
+
+describe('rate limits', () => {
+  test('one address cannot upload without bound', async () => {
+    const f = await fixture();
+    const sealed = sealHandoff(Buffer.from('a whole machine')).bytes;
+    const codes: number[] = [];
+    for (let i = 0; i < 6; i++) codes.push((await put(f, f.oldMachine, sealed)).status);
+    expect(codes.slice(0, 5).every((c) => c === 200)).toBe(true);
+    expect(codes[5]).toBe(429);
+  });
+
+  test('nor can one machine, however many addresses it comes from', async () => {
+    const f = await fixture();
+    const sealed = sealHandoff(Buffer.from('a whole machine')).bytes;
+    const codes: number[] = [];
+    for (let i = 0; i < 6; i++) codes.push((await put(f, f.oldMachine, sealed, { ip: `198.51.100.${i}` })).status);
+    expect(codes.slice(0, 5).every((c) => c === 200)).toBe(true);
+    expect(codes[5]).toBe(429);
+  });
+
+  test('reading is bounded too', async () => {
+    const f = await fixture();
+    await put(f, f.oldMachine, sealHandoff(Buffer.from('a whole machine')).bytes);
+    let last = 200;
+    for (let i = 0; i < 31; i++) last = (await meta(f, f.newMachine)).status;
+    expect(last).toBe(429);
+  });
+});
+
+/**
+ * Try `key` against a stored handoff the way its own opener would. The header
+ * is `BDHLHOFF` plus a version byte; the nonce is the fixed counter zero.
+ */
+function opens(stored: Buffer, key: Buffer): boolean {
+  if (key.length !== 32) return false;
+  try {
+    const body = stored.subarray(9);
+    const decipher = createDecipheriv('aes-256-gcm', key, Buffer.alloc(12));
+    decipher.setAuthTag(body.subarray(body.length - 16));
+    Buffer.concat([decipher.update(body.subarray(0, body.length - 16)), decipher.final()]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('what the relay can do with what it stores', () => {
+  test('nothing in this database opens the bundle, and the phrase does', async () => {
+    const f = await fixture();
+    const { bytes, phrase } = sealHandoff(Buffer.from('the whole machine, in the clear'));
+    await put(f, f.oldMachine, bytes);
+
+    const stored = Buffer.from(
+      (f.db.query('SELECT ciphertext FROM handoff_bundles').get() as { ciphertext: Uint8Array }).ciphertext,
+    );
+    expect(stored.equals(bytes)).toBe(true);
+
+    // Every value in every table, raw and hashed to key length. This is the
+    // relay's entire world: public keys, ids, names, timestamps, token hashes.
+    const tables = f.db
+      .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
+      .all() as { name: string }[];
+
+    const material: Buffer[] = [];
+    for (const { name } of tables) {
+      for (const row of f.db.query(`SELECT * FROM ${name}`).all() as Record<string, unknown>[]) {
+        for (const value of Object.values(row)) {
+          if (value === null || value === undefined) continue;
+          const raw = Buffer.isBuffer(value)
+            ? value
+            : value instanceof Uint8Array
+              ? Buffer.from(value)
+              : Buffer.from(String(value), 'utf8');
+          material.push(raw, createHash('sha256').update(raw).digest());
+        }
+      }
+    }
+
+    expect(material.length).toBeGreaterThan(20);
+    expect(material.filter((key) => opens(stored, key))).toEqual([]);
+    // The positive control: the sweep above WOULD have found a working key.
+    expect(opens(stored, deriveHandoffKey(phrase))).toBe(true);
+  });
+});

--- a/relay/src/handoff-http.test.ts
+++ b/relay/src/handoff-http.test.ts
@@ -306,6 +306,12 @@ describe('rate limits', () => {
 });
 
 /**
+ * The tables a linked machine with a prepared handoff fills. Named so the
+ * sweep below cannot quietly narrow to a database that holds almost nothing.
+ */
+const POPULATED_BY_A_HANDOFF = ['handoff_bundles', 'link_codes', 'machines', 'oauth_identities', 'users'];
+
+/**
  * Try `key` against a stored handoff the way its own opener would. The header
  * is `BDHLHOFF` plus a version byte; the nonce is the fixed counter zero.
  */
@@ -323,7 +329,7 @@ function opens(stored: Buffer, key: Buffer): boolean {
 }
 
 describe('what the relay can do with what it stores', () => {
-  test('nothing in this database opens the bundle, and the phrase does', async () => {
+  test('no value it has stored opens the bundle, and the phrase does', async () => {
     const f = await fixture();
     const { bytes, phrase } = sealHandoff(Buffer.from('the whole machine, in the clear'));
     await put(f, f.oldMachine, bytes);
@@ -333,15 +339,19 @@ describe('what the relay can do with what it stores', () => {
     );
     expect(stored.equals(bytes)).toBe(true);
 
-    // Every value in every table, raw and hashed to key length. This is the
-    // relay's entire world: public keys, ids, names, timestamps, token hashes.
+    // Every value the relay actually holds, raw and hashed to key length:
+    // public keys, ids, names, timestamps, token hashes. An empty table
+    // contributes nothing, so which ones were populated is asserted below.
     const tables = f.db
       .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
       .all() as { name: string }[];
 
     const material: Buffer[] = [];
+    const populated: string[] = [];
     for (const { name } of tables) {
-      for (const row of f.db.query(`SELECT * FROM ${name}`).all() as Record<string, unknown>[]) {
+      const rows = f.db.query(`SELECT * FROM ${name}`).all() as Record<string, unknown>[];
+      if (rows.length > 0) populated.push(name);
+      for (const row of rows) {
         for (const value of Object.values(row)) {
           if (value === null || value === undefined) continue;
           const raw = Buffer.isBuffer(value)
@@ -354,7 +364,8 @@ describe('what the relay can do with what it stores', () => {
       }
     }
 
-    expect(material.length).toBeGreaterThan(20);
+    expect(populated.sort()).toEqual(POPULATED_BY_A_HANDOFF);
+    expect(material.length).toBeGreaterThan(100);
     expect(material.filter((key) => opens(stored, key))).toEqual([]);
     // The positive control: the sweep above WOULD have found a working key.
     expect(opens(stored, deriveHandoffKey(phrase))).toBe(true);

--- a/relay/src/handoff-http.test.ts
+++ b/relay/src/handoff-http.test.ts
@@ -3,13 +3,17 @@
  * holds one bundle, that an acknowledgement drops only the bundle it names —
  * and that nothing this database holds opens the bytes in it.
  */
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import { createDecipheriv, createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { loadConfig } from './config';
 import { createLogger } from './logger';
 import { openDb, type RelayDb } from './db';
 import { createRepositories, type Repositories, type User } from './repositories';
 import { createRouter } from './http';
+import { purgeExpiredHandoffs } from './handoff-store';
 import { toArrayBuffer } from './crypto';
 // The desktop's sealing, used verbatim: a stand-in would prove the sweep below
 // against bytes the relay never actually stores.
@@ -29,6 +33,8 @@ interface TestMachine {
 
 interface Fixture {
   db: RelayDb;
+  /** Where sealed bundles land, so a test can look at what is really on disk. */
+  dir: string;
   repos: Repositories;
   route: ReturnType<typeof createRouter>;
   user: User;
@@ -50,11 +56,18 @@ async function machine(repos: Repositories, userId: string, name: string): Promi
   };
 }
 
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
 async function fixture(overrides: Record<string, string> = {}): Promise<Fixture> {
   const db = openDb(':memory:');
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-handoff-'));
+  dirs.push(dir);
   let offset = 0;
   const repos = createRepositories(db, () => Date.now() + offset);
-  const { config } = loadConfig({ ...env, ...overrides });
+  const { config } = loadConfig({ ...env, HANDOFF_DIR: dir, ...overrides });
   const route = createRouter({ config, logger, repos });
 
   const user = repos.upsertGithubUser({
@@ -74,6 +87,7 @@ async function fixture(overrides: Record<string, string> = {}): Promise<Fixture>
 
   return {
     db,
+    dir,
     repos,
     route,
     user,
@@ -272,7 +286,7 @@ describe('restoring and acknowledging', () => {
     f.advance(61_000);
     expect(await (await meta(f, f.newMachine)).json()).toEqual({ handoff: null });
     expect((await fetchBundle(f, f.newMachine)).status).toBe(404);
-    expect(f.repos.purgeExpiredHandoffBundles()).toBe(1);
+    expect(f.repos.purgeExpiredHandoffBundles()).toHaveLength(1);
     expect(f.db.query('SELECT COUNT(*) AS n FROM handoff_bundles').get()).toEqual({ n: 0 });
   });
 });
@@ -328,15 +342,74 @@ function opens(stored: Buffer, key: Buffer): boolean {
   }
 }
 
+describe('the disk the store sits on', () => {
+  test('a bundle is one file, and replacing one leaves exactly one behind', async () => {
+    const f = await fixture();
+    await put(f, f.oldMachine, sealHandoff(Buffer.from('first')).bytes);
+    expect(fs.readdirSync(f.dir)).toHaveLength(1);
+    const first = fs.readdirSync(f.dir)[0]!;
+
+    await put(f, f.oldMachine, sealHandoff(Buffer.from('second')).bytes);
+    const after = fs.readdirSync(f.dir);
+    expect(after).toHaveLength(1);
+    expect(after[0]).not.toBe(first);
+  });
+
+  test('acknowledging a restore takes the file with the row', async () => {
+    const f = await fixture();
+    await put(f, f.oldMachine, sealHandoff(Buffer.from('a whole machine')).bytes);
+    const id = (await fetchBundle(f, f.newMachine)).headers.get('x-bodhi-handoff-id')!;
+
+    expect((await acknowledge(f, f.newMachine, id)).status).toBe(204);
+    expect(fs.readdirSync(f.dir)).toEqual([]);
+  });
+
+  test('expiry takes the file too, not just the row', async () => {
+    const f = await fixture({ HANDOFF_TTL_SECONDS: '60' });
+    await put(f, f.oldMachine, sealHandoff(Buffer.from('a whole machine')).bytes);
+    expect(fs.readdirSync(f.dir)).toHaveLength(1);
+
+    f.advance(61_000);
+    expect(await purgeExpiredHandoffs(f.repos, f.dir)).toBe(1);
+    expect(fs.readdirSync(f.dir)).toEqual([]);
+  });
+
+  test('refuses an upload the store as a whole has no room for', async () => {
+    const f = await fixture({ HANDOFF_STORE_MAX_BYTES: '200' });
+    expect((await put(f, f.stranger, sealHandoff(Buffer.alloc(120)).bytes, { ip: '198.51.100.9' })).status).toBe(200);
+
+    const refused = await put(f, f.oldMachine, sealHandoff(Buffer.alloc(120)).bytes);
+    expect(refused.status).toBe(507);
+    expect(await refused.json()).toEqual({ error: 'store_full' });
+    // Nothing half-written left over.
+    expect(fs.readdirSync(f.dir)).toHaveLength(1);
+  });
+
+  test('does not count a user against themselves when they replace their own', async () => {
+    const f = await fixture({ HANDOFF_STORE_MAX_BYTES: '200' });
+    expect((await put(f, f.oldMachine, sealHandoff(Buffer.alloc(120)).bytes)).status).toBe(200);
+    expect((await put(f, f.oldMachine, sealHandoff(Buffer.alloc(120)).bytes)).status).toBe(200);
+    expect(fs.readdirSync(f.dir)).toHaveLength(1);
+  });
+
+  test('a body that does not match its digest leaves no file', async () => {
+    const f = await fixture();
+    const res = await put(f, f.oldMachine, sealHandoff(Buffer.from('x')).bytes, {
+      digest: sha256Hex(Buffer.from('something else')),
+    });
+    expect(res.status).toBe(400);
+    expect(fs.readdirSync(f.dir)).toEqual([]);
+  });
+});
+
 describe('what the relay can do with what it stores', () => {
   test('no value it has stored opens the bundle, and the phrase does', async () => {
     const f = await fixture();
     const { bytes, phrase } = sealHandoff(Buffer.from('the whole machine, in the clear'));
     await put(f, f.oldMachine, bytes);
 
-    const stored = Buffer.from(
-      (f.db.query('SELECT ciphertext FROM handoff_bundles').get() as { ciphertext: Uint8Array }).ciphertext,
-    );
+    const { id } = (f.db.query('SELECT id FROM handoff_bundles').get() as { id: string });
+    const stored = fs.readFileSync(path.join(f.dir, `${id}.bundle`));
     expect(stored.equals(bytes)).toBe(true);
 
     // Every value the relay actually holds, raw and hashed to key length:

--- a/relay/src/handoff-store.test.ts
+++ b/relay/src/handoff-store.test.ts
@@ -1,0 +1,170 @@
+/**
+ * The bundle store. The claim is that a write is incremental, so what is
+ * measured is how much reached the disk while bytes were still arriving — a
+ * buffered write passes "a large body succeeds" just as well.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  bundlePath,
+  commitHandoff,
+  discardHandoff,
+  handoffSize,
+  HandoffTooLarge,
+  ORPHAN_GRACE_MS,
+  removeHandoff,
+  sweepOrphans,
+  writeHandoff,
+} from './handoff-store';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'handoff-store-'));
+  dirs.push(dir);
+  return dir;
+}
+
+function sizeOf(file: string): number {
+  try {
+    return fs.statSync(file).size;
+  } catch {
+    return 0;
+  }
+}
+
+const CHUNK = 256 * 1024;
+
+/** A one-shot body. This runtime has no static constructor for one. */
+function streamOf(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+/** A body that reports how much had reached disk each time it was asked for more. */
+function watchedBody(chunks: number, partial: string, seen: number[], onPull?: () => void) {
+  let pulled = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulled >= chunks) return controller.close();
+      pulled++;
+      seen.push(sizeOf(partial));
+      onPull?.();
+      controller.enqueue(new Uint8Array(CHUNK).fill(7));
+    },
+  });
+}
+
+describe('writing a bundle', () => {
+  test('lands on disk while the body is still arriving', async () => {
+    const dir = tmpDir();
+    const seen: number[] = [];
+    const written = await writeHandoff(dir, 'inc', watchedBody(24, path.join(dir, 'inc.part'), seen), 64 * 1024 * 1024);
+
+    expect(written.bytes).toBe(24 * CHUNK);
+    // Buffer the body and every one of these is zero: nothing reaches the file
+    // until the last chunk has been read.
+    expect(Math.max(...seen)).toBeGreaterThanOrEqual(CHUNK * 6);
+    expect(seen[seen.length - 1]).toBeGreaterThan(0);
+  });
+
+  test('hashes what it wrote, without a second pass over the bytes', async () => {
+    const dir = tmpDir();
+    const body = Buffer.from('a sealed bundle, pretend');
+    const written = await writeHandoff(dir, 'h', streamOf(new Uint8Array(body)), 1024);
+
+    expect(written.sha256).toBe(createHash('sha256').update(body).digest('hex'));
+    expect(written.bytes).toBe(body.length);
+  });
+
+  test('stops at the cap mid-stream and leaves nothing behind', async () => {
+    const dir = tmpDir();
+    const seen: number[] = [];
+    const cap = CHUNK * 4;
+
+    await expect(
+      writeHandoff(dir, 'big', watchedBody(64, path.join(dir, 'big.part'), seen), cap),
+    ).rejects.toBeInstanceOf(HandoffTooLarge);
+
+    // Refused while the sender was still going, not after taking all of it.
+    expect(seen.length).toBeLessThan(64);
+    expect(fs.existsSync(path.join(dir, 'big.part'))).toBe(false);
+  });
+
+  test('leaves nothing behind when the body fails part-way', async () => {
+    const dir = tmpDir();
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(new Error('connection dropped'));
+      },
+    });
+
+    await expect(writeHandoff(dir, 'dropped', body, 1024)).rejects.toThrow('connection dropped');
+    expect(fs.readdirSync(dir)).toEqual([]);
+  });
+
+  test('is not the live bundle until it is committed', async () => {
+    const dir = tmpDir();
+    await writeHandoff(dir, 'x', streamOf(new Uint8Array([1, 2, 3])), 1024);
+    expect(await handoffSize(dir, 'x')).toBeNull();
+
+    await commitHandoff(dir, 'x');
+    expect(await handoffSize(dir, 'x')).toBe(3);
+    expect(fs.existsSync(bundlePath(dir, 'x'))).toBe(true);
+  });
+
+  test('discarding and removing both clear the disk', async () => {
+    const dir = tmpDir();
+    await writeHandoff(dir, 'a', streamOf(new Uint8Array([1])), 1024);
+    await discardHandoff(dir, 'a');
+    expect(fs.readdirSync(dir)).toEqual([]);
+
+    await writeHandoff(dir, 'b', streamOf(new Uint8Array([1])), 1024);
+    await commitHandoff(dir, 'b');
+    await removeHandoff(dir, 'b');
+    expect(fs.readdirSync(dir)).toEqual([]);
+  });
+});
+
+describe('sweeping what no row claims', () => {
+  test('drops abandoned files and keeps the ones still spoken for', async () => {
+    const dir = tmpDir();
+    for (const id of ['kept', 'orphan']) {
+      await writeHandoff(dir, id, streamOf(new Uint8Array([1])), 1024);
+      await commitHandoff(dir, id);
+    }
+    await writeHandoff(dir, 'abandoned-partial', streamOf(new Uint8Array([1])), 1024);
+
+    const swept = await sweepOrphans(dir, new Set(['kept']), ORPHAN_GRACE_MS, Date.now() + ORPHAN_GRACE_MS * 2);
+
+    expect(swept).toBe(2);
+    expect(fs.readdirSync(dir)).toEqual(['kept.bundle']);
+  });
+
+  test('never touches an upload that is still in flight', async () => {
+    const dir = tmpDir();
+    let sweptDuringUpload = 0;
+    const seen: number[] = [];
+
+    // Swept from under the writer, exactly as the reaper would.
+    const body = watchedBody(8, path.join(dir, 'live.part'), seen, () => {
+      void sweepOrphans(dir, new Set(), ORPHAN_GRACE_MS).then((n) => {
+        sweptDuringUpload += n;
+      });
+    });
+    const written = await writeHandoff(dir, 'live', body, 64 * 1024 * 1024);
+
+    expect(sweptDuringUpload).toBe(0);
+    expect(written.bytes).toBe(8 * CHUNK);
+  });
+});

--- a/relay/src/handoff-store.ts
+++ b/relay/src/handoff-store.ts
@@ -1,0 +1,150 @@
+/**
+ * Sealed bundles on disk, named by the row that claims them. Nothing here
+ * reads a whole one: a write holds the chunk in hand and nothing else, which
+ * is what keeps memory independent of how much state a machine carries.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdir, open, readdir, rename, stat, unlink } from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * How long a file with no row gets before it is treated as abandoned. Long
+ * enough that an upload still streaming is never mistaken for one.
+ */
+export const ORPHAN_GRACE_MS = 60 * 60 * 1000;
+
+const BUNDLE_SUFFIX = '.bundle';
+const PARTIAL_SUFFIX = '.part';
+
+/** Raised mid-stream, so an oversized upload stops rather than completing. */
+export class HandoffTooLarge extends Error {
+  override name = 'HandoffTooLarge';
+}
+
+export interface WrittenHandoff {
+  bytes: number;
+  sha256: string;
+}
+
+export function bundlePath(dir: string, id: string): string {
+  return path.join(dir, `${id}${BUNDLE_SUFFIX}`);
+}
+
+function partialPath(dir: string, id: string): string {
+  return path.join(dir, `${id}${PARTIAL_SUFFIX}`);
+}
+
+/**
+ * Stream `body` into the store, hashing and counting as it lands. A write that
+ * ends any way but cleanly — over the cap, a dropped connection — leaves no
+ * partial behind, and the bytes are not the live bundle until `commitHandoff`.
+ */
+export async function writeHandoff(
+  dir: string,
+  id: string,
+  body: ReadableStream<Uint8Array>,
+  maxBytes: number,
+): Promise<WrittenHandoff> {
+  await mkdir(dir, { recursive: true });
+  const partial = partialPath(dir, id);
+  const hash = createHash('sha256');
+  const handle = await open(partial, 'w');
+  const reader = body.getReader();
+  let bytes = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value?.byteLength) continue;
+      bytes += value.byteLength;
+      if (bytes > maxBytes) throw new HandoffTooLarge();
+      hash.update(value);
+      await handle.write(value);
+    }
+    await handle.close();
+  } catch (err) {
+    await handle.close().catch(() => {});
+    await unlink(partial).catch(() => {});
+    void reader.cancel().catch(() => {});
+    throw err;
+  }
+
+  return { bytes, sha256: hash.digest('hex') };
+}
+
+/** Promote a completed upload to the live bundle for `id`. */
+export async function commitHandoff(dir: string, id: string): Promise<void> {
+  await rename(partialPath(dir, id), bundlePath(dir, id));
+}
+
+export async function discardHandoff(dir: string, id: string): Promise<void> {
+  await unlink(partialPath(dir, id)).catch(() => {});
+}
+
+export async function removeHandoff(dir: string, id: string): Promise<void> {
+  await unlink(bundlePath(dir, id)).catch(() => {});
+}
+
+/** Bytes on disk for a stored bundle, or null when there is no file. */
+export async function handoffSize(dir: string, id: string): Promise<number | null> {
+  try {
+    return (await stat(bundlePath(dir, id))).size;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Drop expired bundles, rows and files together. Kept in one place because the
+ * two must not diverge: a row without a file serves a 404, and a file without
+ * a row is disk nobody will ever reclaim.
+ */
+export async function purgeExpiredHandoffs(
+  repos: { purgeExpiredHandoffBundles(): string[] },
+  dir: string,
+): Promise<number> {
+  const ids = repos.purgeExpiredHandoffBundles();
+  for (const id of ids) await removeHandoff(dir, id);
+  return ids.length;
+}
+
+/**
+ * Drop files no row claims. A crash between writing one and recording it
+ * strands a file, and an upload in flight has no row yet — so only files
+ * untouched for `graceMs` are considered abandoned.
+ */
+export async function sweepOrphans(
+  dir: string,
+  liveIds: Set<string>,
+  graceMs: number,
+  now: number = Date.now(),
+): Promise<number> {
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return 0;
+  }
+
+  let removed = 0;
+  for (const name of names) {
+    const id = name.endsWith(BUNDLE_SUFFIX)
+      ? name.slice(0, -BUNDLE_SUFFIX.length)
+      : name.endsWith(PARTIAL_SUFFIX)
+        ? name.slice(0, -PARTIAL_SUFFIX.length)
+        : null;
+    if (id === null || liveIds.has(id)) continue;
+
+    const full = path.join(dir, name);
+    try {
+      if (now - (await stat(full)).mtimeMs < graceMs) continue;
+      await unlink(full);
+      removed++;
+    } catch {
+      continue;
+    }
+  }
+  return removed;
+}

--- a/relay/src/handoff-store.ts
+++ b/relay/src/handoff-store.ts
@@ -17,6 +17,14 @@ export const ORPHAN_GRACE_MS = 60 * 60 * 1000;
 const BUNDLE_SUFFIX = '.bundle';
 const PARTIAL_SUFFIX = '.part';
 
+/** The id a store filename carries, or null when the file is not one of ours. */
+function idFromFilename(name: string): string | null {
+  for (const suffix of [BUNDLE_SUFFIX, PARTIAL_SUFFIX]) {
+    if (name.endsWith(suffix)) return name.slice(0, -suffix.length);
+  }
+  return null;
+}
+
 /** Raised mid-stream, so an oversized upload stops rather than completing. */
 export class HandoffTooLarge extends Error {
   override name = 'HandoffTooLarge';
@@ -130,11 +138,7 @@ export async function sweepOrphans(
 
   let removed = 0;
   for (const name of names) {
-    const id = name.endsWith(BUNDLE_SUFFIX)
-      ? name.slice(0, -BUNDLE_SUFFIX.length)
-      : name.endsWith(PARTIAL_SUFFIX)
-        ? name.slice(0, -PARTIAL_SUFFIX.length)
-        : null;
+    const id = idFromFilename(name);
     if (id === null || liveIds.has(id)) continue;
 
     const full = path.join(dir, name);

--- a/relay/src/http.ts
+++ b/relay/src/http.ts
@@ -34,6 +34,7 @@ import {
 import { createDevRoutes } from './dev';
 import { createWebClient } from './web';
 import { clientIp, createRateLimiter, type RateLimiter } from './rate-limit';
+import { MAX_JSON_BODY_BYTES } from './server';
 
 /**
  * HTTP surface of the relay (M2), as a `fetch`-style handler for `Bun.serve`.
@@ -148,6 +149,13 @@ export function createRouter(ctx: RelayContext) {
     const method = req.method;
 
     try {
+      // A handoff sets Bun's body ceiling for the whole server. Every other
+      // route reads small JSON and keeps the bound it always had.
+      const declaredLength = Number(req.headers.get('content-length') ?? 0);
+      if (declaredLength > MAX_JSON_BODY_BYTES && !(method === 'PUT' && matchMachineHandoff(pathname))) {
+        return json({ error: 'payload_too_large' }, 413);
+      }
+
       const webResponse = webRoute(req);
       if (webResponse) return webResponse;
 
@@ -586,6 +594,9 @@ export function createRouter(ctx: RelayContext) {
     const signature = req.headers.get(HANDOFF_SIGNATURE_HEADER);
     const sigBytes = signature ? fromBase64(signature) : null;
     if (!Number.isSafeInteger(issuedAt) || !sigBytes) return { response: json({ error: 'invalid_request' }, 400) };
+    // Skew only, so a captured signature is replayable inside the window. That
+    // is a considered trade: transport is TLS, the reads it could repeat return
+    // ciphertext, and the delete names a bundle id that stops matching.
     if (Math.abs(Date.now() - issuedAt) > LINK_MAX_SKEW_MS) return { response: json({ error: 'stale_request' }, 400) };
 
     const machine = repos.getMachine(machineId);

--- a/relay/src/http.ts
+++ b/relay/src/http.ts
@@ -2,7 +2,7 @@ import pkg from '../package.json';
 import type { RelayConfig } from './config';
 import type { Logger } from './logger';
 import type { HandoffBundle, Machine, MachineGrant, Repositories, ShareInvite, User } from './repositories';
-import { fromBase64, randomToken, sha256Hex, timingSafeEqualHex, verifyEd25519 } from './crypto';
+import { fromBase64, randomToken, timingSafeEqualHex, verifyEd25519 } from './crypto';
 import {
   buildHandoffDeleteMessage,
   buildHandoffGetMessage,
@@ -35,6 +35,15 @@ import { createDevRoutes } from './dev';
 import { createWebClient } from './web';
 import { clientIp, createRateLimiter, type RateLimiter } from './rate-limit';
 import { MAX_JSON_BODY_BYTES } from './server';
+import {
+  bundlePath,
+  commitHandoff,
+  discardHandoff,
+  handoffSize,
+  HandoffTooLarge,
+  removeHandoff,
+  writeHandoff,
+} from './handoff-store';
 
 /**
  * HTTP surface of the relay (M2), as a `fetch`-style handler for `Bun.serve`.
@@ -635,22 +644,51 @@ export function createRouter(ctx: RelayContext) {
       return json({ error: 'rate_limited' }, 429, { 'retry-after': String(perMachine.retryAfter) });
     }
 
-    const body = Buffer.from(await req.arrayBuffer());
-    if (body.byteLength === 0) return json({ error: 'invalid_request' }, 400);
-    if (body.byteLength > config.handoffMaxBytes) {
-      return json({ error: 'handoff_too_large', maxBytes: config.handoffMaxBytes }, 413);
-    }
-    // Ties the bytes that arrived to the digest the signature covered.
-    if (!timingSafeEqualHex(sha256Hex(body), digest)) return json({ error: 'digest_mismatch' }, 400);
+    const body = req.body;
+    if (!body) return json({ error: 'invalid_request' }, 400);
 
-    const stored = repos.putHandoffBundle({
+    // One user's cap is not the disk's. Checked against what the caller says
+    // it will send, and again below against what it actually sent.
+    const held = repos.totalHandoffBytes(auth.machine.user_id);
+    const tooFull = (size: number) => held + size > config.handoffStoreMaxBytes;
+    if (declared && tooFull(Number(declared))) return json({ error: 'store_full' }, 507);
+
+    const id = crypto.randomUUID();
+    let written;
+    try {
+      written = await writeHandoff(config.handoffDir, id, body, config.handoffMaxBytes);
+    } catch (err) {
+      if (err instanceof HandoffTooLarge) {
+        return json({ error: 'handoff_too_large', maxBytes: config.handoffMaxBytes }, 413);
+      }
+      throw err;
+    }
+
+    // Nothing written is the live bundle until every one of these passes.
+    if (written.bytes === 0) {
+      await discardHandoff(config.handoffDir, id);
+      return json({ error: 'invalid_request' }, 400);
+    }
+    if (!timingSafeEqualHex(written.sha256, digest)) {
+      await discardHandoff(config.handoffDir, id);
+      return json({ error: 'digest_mismatch' }, 400);
+    }
+    if (tooFull(written.bytes)) {
+      await discardHandoff(config.handoffDir, id);
+      return json({ error: 'store_full' }, 507);
+    }
+
+    await commitHandoff(config.handoffDir, id);
+    const { row, previousId } = repos.putHandoffBundle({
+      id,
       userId: auth.machine.user_id,
       sourceMachineId: machineId,
-      ciphertext: body,
+      byteSize: written.bytes,
       ttlSeconds: config.handoffTtlSeconds,
     });
-    logger.info('handoff prepared', { machineId, bytes: stored.byte_size });
-    return json({ handoff: publicHandoff(stored, auth.machine.name) });
+    if (previousId) await removeHandoff(config.handoffDir, previousId);
+    logger.info('handoff prepared', { machineId, bytes: row.byte_size });
+    return json({ handoff: publicHandoff(row, auth.machine.name) });
   }
 
   async function handleHandoffRead(req: Request, machineId: string, wantsBundle: boolean): Promise<Response> {
@@ -666,8 +704,20 @@ export function createRouter(ctx: RelayContext) {
       const source = repos.getMachine(stored.source_machine_id);
       return json({ handoff: publicHandoff(stored, source?.name ?? null) });
     }
-    return new Response(Buffer.from(stored.ciphertext), {
-      headers: { 'content-type': 'application/octet-stream', [HANDOFF_ID_HEADER]: stored.id },
+
+    // Sent from the file rather than read into a buffer, so serving a bundle
+    // costs the relay no more than preparing one did.
+    const size = await handoffSize(config.handoffDir, stored.id);
+    if (size === null) {
+      logger.error('handoff row has no file', { id: stored.id });
+      return json({ error: 'not_found' }, 404);
+    }
+    return new Response(Bun.file(bundlePath(config.handoffDir, stored.id)), {
+      headers: {
+        'content-type': 'application/octet-stream',
+        'content-length': String(size),
+        [HANDOFF_ID_HEADER]: stored.id,
+      },
     });
   }
 
@@ -684,6 +734,7 @@ export function createRouter(ctx: RelayContext) {
     if ('response' in auth) return auth.response;
 
     if (!repos.deleteHandoffBundle(auth.machine.user_id, handoffId)) return json({ error: 'not_found' }, 404);
+    await removeHandoff(config.handoffDir, handoffId);
     logger.info('handoff cleared after restore', { machineId });
     return new Response(null, { status: 204 });
   }

--- a/relay/src/http.ts
+++ b/relay/src/http.ts
@@ -1,9 +1,22 @@
 import pkg from '../package.json';
 import type { RelayConfig } from './config';
 import type { Logger } from './logger';
-import type { Machine, MachineGrant, Repositories, ShareInvite, User } from './repositories';
-import { fromBase64, randomToken, verifyEd25519 } from './crypto';
-import { buildLinkMessage, buildShareCreateMessage, LINK_MAX_SKEW_MS, MINTABLE_ROLES } from './protocol';
+import type { HandoffBundle, Machine, MachineGrant, Repositories, ShareInvite, User } from './repositories';
+import { fromBase64, randomToken, sha256Hex, timingSafeEqualHex, verifyEd25519 } from './crypto';
+import {
+  buildHandoffDeleteMessage,
+  buildHandoffGetMessage,
+  buildHandoffMetaMessage,
+  buildHandoffPutMessage,
+  buildLinkMessage,
+  buildShareCreateMessage,
+  HANDOFF_DIGEST_HEADER,
+  HANDOFF_ID_HEADER,
+  HANDOFF_ISSUED_AT_HEADER,
+  HANDOFF_SIGNATURE_HEADER,
+  LINK_MAX_SKEW_MS,
+  MINTABLE_ROLES,
+} from './protocol';
 import {
   buildAuthorizeUrl,
   exchangeCodeForProfile,
@@ -41,6 +54,10 @@ import { clientIp, createRateLimiter, type RateLimiter } from './rate-limit';
  *   POST /api/shares/redeem           — guest redeems a code (session)
  *   GET  /api/shares                  — guest lists their grants (session)
  *   DEL  /api/shares/:grantId         — owner OR grantee ends a grant (session)
+ *   PUT  /api/machines/:id/handoff    — machine uploads a sealed handoff
+ *   GET  /api/machines/:id/handoff    — what handoff is waiting, if any
+ *   GET  /api/machines/:id/handoff/bundle — the sealed bytes
+ *   DEL  /api/machines/:id/handoff    — destination acknowledges a restore
  */
 export interface RelayContext {
   config: RelayConfig;
@@ -70,6 +87,11 @@ const LINK_PER_KEY = 5;
 const CLAIM_PER_IP = 20;
 /** Minting invites is cheap for an owner and pointless to do in bulk. */
 const SHARE_PER_IP = 20;
+/** A handoff is a rare, deliberate act, and each one costs the disk a bundle. */
+const HANDOFF_UPLOAD_PER_IP = 5;
+const HANDOFF_UPLOAD_PER_MACHINE = 5;
+/** Reading is cheap, but a restore may be retried after a mistyped phrase. */
+const HANDOFF_READ_PER_IP = 30;
 
 /**
  * Ceilings on what an invite may ask for. The desktop offers far shorter
@@ -207,6 +229,30 @@ export function createRouter(ctx: RelayContext) {
 
       const grantId = matchShareGrant(pathname);
       if (grantId && method === 'DELETE') return handleRevokeGrant(req, grantId);
+
+      // --- machine handoff ---
+
+      const handoff = matchMachineHandoff(pathname);
+      if (handoff) {
+        if (method === 'PUT' && !handoff.bundle) {
+          return (
+            limited(req, peerIp, 'handoff-put', HANDOFF_UPLOAD_PER_IP) ??
+            (await handleHandoffPut(req, handoff.machineId))
+          );
+        }
+        if (method === 'GET') {
+          return (
+            limited(req, peerIp, 'handoff-read', HANDOFF_READ_PER_IP) ??
+            (await handleHandoffRead(req, handoff.machineId, handoff.bundle))
+          );
+        }
+        if (method === 'DELETE' && !handoff.bundle) {
+          return (
+            limited(req, peerIp, 'handoff-read', HANDOFF_READ_PER_IP) ??
+            (await handleHandoffDelete(req, handoff.machineId))
+          );
+        }
+      }
 
       return json({ error: 'not_found' }, 404);
     } catch (err) {
@@ -523,6 +569,110 @@ export function createRouter(ctx: RelayContext) {
     onGrantRevoked?.(grant);
     return new Response(null, { status: 204 });
   }
+
+  // --- machine handoff ---
+
+  /**
+   * Prove the caller is a linked machine. Ed25519 because the desktop holds no
+   * cookie, and the slot belongs to the machine's user — which is how a second
+   * machine under one identity reaches what the first one left.
+   */
+  async function machineFromSignature(
+    req: Request,
+    machineId: string,
+    message: (issuedAt: number) => Uint8Array,
+  ): Promise<{ machine: Machine } | { response: Response }> {
+    const issuedAt = Number(req.headers.get(HANDOFF_ISSUED_AT_HEADER));
+    const signature = req.headers.get(HANDOFF_SIGNATURE_HEADER);
+    const sigBytes = signature ? fromBase64(signature) : null;
+    if (!Number.isSafeInteger(issuedAt) || !sigBytes) return { response: json({ error: 'invalid_request' }, 400) };
+    if (Math.abs(Date.now() - issuedAt) > LINK_MAX_SKEW_MS) return { response: json({ error: 'stale_request' }, 400) };
+
+    const machine = repos.getMachine(machineId);
+    if (!machine) return { response: json({ error: 'not_found' }, 404) };
+    if (!(await verifyEd25519(new Uint8Array(machine.ed25519_pubkey), sigBytes, message(issuedAt)))) {
+      return { response: json({ error: 'bad_signature' }, 401) };
+    }
+    return { machine };
+  }
+
+  async function handleHandoffPut(req: Request, machineId: string): Promise<Response> {
+    const digest = req.headers.get(HANDOFF_DIGEST_HEADER);
+    if (!digest || !/^[0-9a-f]{64}$/.test(digest)) return json({ error: 'invalid_request' }, 400);
+
+    const declared = req.headers.get('content-length');
+    if (declared && Number(declared) > config.handoffMaxBytes) {
+      return json({ error: 'handoff_too_large', maxBytes: config.handoffMaxBytes }, 413);
+    }
+
+    // Authenticated before the body is touched: the signature covers the
+    // declared digest, so an unsigned caller cannot make the relay buffer
+    // megabytes on its way to being refused.
+    const auth = await machineFromSignature(req, machineId, (issuedAt) =>
+      buildHandoffPutMessage({ machineId, ciphertextSha256Hex: digest, issuedAt }),
+    );
+    if ('response' in auth) return auth.response;
+
+    // Charged after the signature verifies, so no one can exhaust another
+    // machine's budget by naming its id.
+    const perMachine = limiter.check(`handoff:machine:${machineId}`, HANDOFF_UPLOAD_PER_MACHINE, RATE_WINDOW_MS);
+    if (!perMachine.allowed) {
+      logger.warn('rate limited', { bucket: 'handoff:machine' });
+      return json({ error: 'rate_limited' }, 429, { 'retry-after': String(perMachine.retryAfter) });
+    }
+
+    const body = Buffer.from(await req.arrayBuffer());
+    if (body.byteLength === 0) return json({ error: 'invalid_request' }, 400);
+    if (body.byteLength > config.handoffMaxBytes) {
+      return json({ error: 'handoff_too_large', maxBytes: config.handoffMaxBytes }, 413);
+    }
+    // Ties the bytes that arrived to the digest the signature covered.
+    if (!timingSafeEqualHex(sha256Hex(body), digest)) return json({ error: 'digest_mismatch' }, 400);
+
+    const stored = repos.putHandoffBundle({
+      userId: auth.machine.user_id,
+      sourceMachineId: machineId,
+      ciphertext: body,
+      ttlSeconds: config.handoffTtlSeconds,
+    });
+    logger.info('handoff prepared', { machineId, bytes: stored.byte_size });
+    return json({ handoff: publicHandoff(stored, auth.machine.name) });
+  }
+
+  async function handleHandoffRead(req: Request, machineId: string, wantsBundle: boolean): Promise<Response> {
+    const auth = await machineFromSignature(req, machineId, (issuedAt) =>
+      wantsBundle ? buildHandoffGetMessage({ machineId, issuedAt }) : buildHandoffMetaMessage({ machineId, issuedAt }),
+    );
+    if ('response' in auth) return auth.response;
+
+    const stored = repos.getHandoffBundle(auth.machine.user_id);
+    if (!stored) return wantsBundle ? json({ error: 'not_found' }, 404) : json({ handoff: null });
+
+    if (!wantsBundle) {
+      const source = repos.getMachine(stored.source_machine_id);
+      return json({ handoff: publicHandoff(stored, source?.name ?? null) });
+    }
+    return new Response(Buffer.from(stored.ciphertext), {
+      headers: { 'content-type': 'application/octet-stream', [HANDOFF_ID_HEADER]: stored.id },
+    });
+  }
+
+  async function handleHandoffDelete(req: Request, machineId: string): Promise<Response> {
+    // Constrained to a UUID before it reaches the signed bytes: a value
+    // carrying a newline would shift the later fields and let one signature
+    // stand for a different request.
+    const handoffId = new URL(req.url).searchParams.get('id') ?? '';
+    if (!/^[0-9a-f-]{36}$/.test(handoffId)) return json({ error: 'invalid_request' }, 400);
+
+    const auth = await machineFromSignature(req, machineId, (issuedAt) =>
+      buildHandoffDeleteMessage({ machineId, handoffId, issuedAt }),
+    );
+    if ('response' in auth) return auth.response;
+
+    if (!repos.deleteHandoffBundle(auth.machine.user_id, handoffId)) return json({ error: 'not_found' }, 404);
+    logger.info('handoff cleared after restore', { machineId });
+    return new Response(null, { status: 204 });
+  }
 }
 
 /** `/api/machines/:machineId/shares[/:inviteId]` */
@@ -531,6 +681,15 @@ function matchMachineShares(pathname: string): { machineId: string; inviteId: st
   if (parts.length < 4 || parts[0] !== 'api' || parts[1] !== 'machines' || parts[3] !== 'shares') return null;
   if (parts.length > 5) return null;
   return { machineId: parts[2]!, inviteId: parts[4] ?? null };
+}
+
+/** `/api/machines/:machineId/handoff[/bundle]` */
+function matchMachineHandoff(pathname: string): { machineId: string; bundle: boolean } | null {
+  const parts = pathname.split('/').filter(Boolean);
+  if (parts.length < 4 || parts[0] !== 'api' || parts[1] !== 'machines' || parts[3] !== 'handoff') return null;
+  if (parts.length > 5) return null;
+  if (parts.length === 5 && parts[4] !== 'bundle') return null;
+  return { machineId: parts[2]!, bundle: parts.length === 5 };
 }
 
 /** `/api/shares/:grantId`, excluding the fixed sub-routes. */
@@ -569,6 +728,18 @@ function publicGrant(g: MachineGrant, grantee: User | null) {
     boundAt: g.bound_at,
     expiresAt: g.expires_at,
     lastUsedAt: g.last_used_at,
+  };
+}
+
+/** Everything about a waiting handoff except the one thing the relay cannot read. */
+function publicHandoff(h: HandoffBundle, sourceMachineName: string | null) {
+  return {
+    id: h.id,
+    sourceMachineId: h.source_machine_id,
+    sourceMachineName,
+    byteSize: h.byte_size,
+    createdAt: h.created_at,
+    expiresAt: h.expires_at,
   };
 }
 

--- a/relay/src/http.ts
+++ b/relay/src/http.ts
@@ -149,10 +149,13 @@ export function createRouter(ctx: RelayContext) {
     const method = req.method;
 
     try {
-      // A handoff sets Bun's body ceiling for the whole server. Every other
-      // route reads small JSON and keeps the bound it always had.
+      // A handoff sets Bun's body ceiling for the whole server, so only the
+      // route that wants it may exceed the JSON bound. This refuses a declared
+      // oversize before a byte is pulled; `readJson` bounds the rest.
+      const handoff = matchMachineHandoff(pathname);
+      const isHandoffUpload = method === 'PUT' && !!handoff && !handoff.bundle;
       const declaredLength = Number(req.headers.get('content-length') ?? 0);
-      if (declaredLength > MAX_JSON_BODY_BYTES && !(method === 'PUT' && matchMachineHandoff(pathname))) {
+      if (!isHandoffUpload && declaredLength > MAX_JSON_BODY_BYTES) {
         return json({ error: 'payload_too_large' }, 413);
       }
 
@@ -240,7 +243,6 @@ export function createRouter(ctx: RelayContext) {
 
       // --- machine handoff ---
 
-      const handoff = matchMachineHandoff(pathname);
       if (handoff) {
         if (method === 'PUT' && !handoff.bundle) {
           return (
@@ -264,6 +266,7 @@ export function createRouter(ctx: RelayContext) {
 
       return json({ error: 'not_found' }, 404);
     } catch (err) {
+      if (err instanceof PayloadTooLarge) return json({ error: 'payload_too_large' }, 413);
       logger.error('unhandled http error', {
         method,
         path: pathname,
@@ -779,9 +782,42 @@ function publicMachine(m: Machine) {
   };
 }
 
-async function readJson(req: Request): Promise<unknown> {
+/** Thrown out of `readJson` and answered with a 413 by the router's catch. */
+class PayloadTooLarge extends Error {
+  override name = 'PayloadTooLarge';
+}
+
+/**
+ * Read and parse a JSON body, refusing anything past `limit` AS IT ARRIVES.
+ * A declared length is not enough on its own: a chunked request declares none,
+ * and the server-wide ceiling is set high enough to admit a handoff.
+ */
+async function readJson(req: Request, limit = MAX_JSON_BODY_BYTES): Promise<unknown> {
+  const declared = req.headers.get('content-length');
+  if (declared && Number(declared) > limit) throw new PayloadTooLarge();
+
+  const stream = req.body;
+  if (!stream) return null;
+
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
   try {
-    return await req.json();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > limit) throw new PayloadTooLarge();
+      chunks.push(value);
+    }
+  } finally {
+    // Stops the sender rather than draining what is left of an oversized body.
+    void reader.cancel().catch(() => {});
+  }
+
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
   } catch {
     return null;
   }

--- a/relay/src/index.test.ts
+++ b/relay/src/index.test.ts
@@ -4,10 +4,13 @@
  * ceiling regressed once in exactly the gap between those two statements.
  */
 import { afterEach, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { main } from './index';
 
 let running: { stop: () => Promise<void> } | null = null;
-const KEYS = ['NODE_ENV', 'PORT', 'DB_PATH', 'PUBLIC_URL', 'SESSION_SECRET', 'LOG_LEVEL'] as const;
+const KEYS = ['NODE_ENV', 'PORT', 'DB_PATH', 'PUBLIC_URL', 'SESSION_SECRET', 'LOG_LEVEL', 'HANDOFF_DIR'] as const;
 const original = Object.fromEntries(KEYS.map((k) => [k, process.env[k]]));
 
 afterEach(async () => {
@@ -33,6 +36,7 @@ test('the entry point serves at the shipped body ceiling', async () => {
     PUBLIC_URL: `http://127.0.0.1:${port}`,
     SESSION_SECRET: 'test-only-secret',
     LOG_LEVEL: 'error',
+    HANDOFF_DIR: fs.mkdtempSync(path.join(os.tmpdir(), 'relay-entry-')),
   });
 
   running = main();

--- a/relay/src/index.test.ts
+++ b/relay/src/index.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The server the entry point actually builds. `server.test.ts` proves the
+ * options are right; this proves the program uses them — the request-body
+ * ceiling regressed once in exactly the gap between those two statements.
+ */
+import { afterEach, expect, test } from 'bun:test';
+import { main } from './index';
+
+let running: { stop: () => Promise<void> } | null = null;
+const KEYS = ['NODE_ENV', 'PORT', 'DB_PATH', 'PUBLIC_URL', 'SESSION_SECRET', 'LOG_LEVEL'] as const;
+const original = Object.fromEntries(KEYS.map((k) => [k, process.env[k]]));
+
+afterEach(async () => {
+  await running?.stop();
+  running = null;
+  // `main()` configures itself from the environment, so put it back: sibling
+  // suites in this process read it too.
+  for (const key of KEYS) {
+    if (original[key] === undefined) delete process.env[key];
+    else process.env[key] = original[key];
+  }
+});
+
+/** Past the old 1 MiB ceiling, well inside the shipped one. */
+const OVER_THE_OLD_CEILING = 4 * 1024 * 1024;
+
+test('the entry point serves at the shipped body ceiling', async () => {
+  const port = 40000 + Math.floor(Math.random() * 20000);
+  Object.assign(process.env, {
+    NODE_ENV: 'test',
+    PORT: String(port),
+    DB_PATH: ':memory:',
+    PUBLIC_URL: `http://127.0.0.1:${port}`,
+    SESSION_SECRET: 'test-only-secret',
+    LOG_LEVEL: 'error',
+  });
+
+  running = main();
+  const origin = `http://127.0.0.1:${port}`;
+  expect((await fetch(`${origin}/health`)).status).toBe(200);
+
+  const res = await fetch(`${origin}/link`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: 'x'.repeat(OVER_THE_OLD_CEILING),
+  });
+
+  // A body Bun refuses at the socket comes back with nothing in it. Reading a
+  // reason here is only possible because the request reached the router, which
+  // is the whole claim: this server carries the ceiling a handoff needs.
+  expect(res.status).toBe(413);
+  expect(await res.json()).toEqual({ error: 'payload_too_large' });
+});

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -7,6 +7,7 @@ import { createGateway, newAgentSocketData, newClientSocketData } from './ws';
 import { parseCookies, SESSION_COOKIE } from './auth/cookies';
 import { createRateLimiter } from './rate-limit';
 import { serveOptions } from './server';
+import { ORPHAN_GRACE_MS, purgeExpiredHandoffs, sweepOrphans } from './handoff-store';
 
 /** How often expired sessions / link codes / rate-limit windows are swept. */
 const REAP_INTERVAL_MS = 10 * 60 * 1000;
@@ -33,6 +34,17 @@ export function main() {
 
   const repos = createRepositories(db);
   const rateLimiter = createRateLimiter();
+
+  /** Files a crash stranded between writing one and recording it. */
+  const sweepHandoffOrphans = async (): Promise<void> => {
+    try {
+      const swept = await sweepOrphans(config.handoffDir, new Set(repos.listHandoffIds()), ORPHAN_GRACE_MS);
+      if (swept > 0) logger.warn('swept orphaned handoff files', { count: swept });
+    } catch (err) {
+      logger.error('handoff sweep failed', { err: err instanceof Error ? err.message : String(err) });
+    }
+  };
+  void sweepHandoffOrphans();
   // The gateway is built first so the router can call into it. HTTP and
   // WebSocket are separate surfaces; these two callbacks are the only seam
   // between them, rather than a shared mutable table either side can corrupt.
@@ -85,8 +97,12 @@ export function main() {
       // its own record, so nothing dropped here is the audit trail.
       const shares = repos.purgeDeadShares();
       if (shares > 0) logger.debug('reaped dead shares', { count: shares });
-      const handoffs = repos.purgeExpiredHandoffBundles();
-      if (handoffs > 0) logger.debug('reaped expired handoffs', { count: handoffs });
+      void purgeExpiredHandoffs(repos, config.handoffDir)
+        .then((count) => {
+          if (count > 0) logger.debug('reaped expired handoffs', { count });
+        })
+        .catch((err) => logger.error('handoff purge failed', { err: String(err) }));
+      void sweepHandoffOrphans();
       rateLimiter.sweep();
       if (codes > 0) logger.debug('reaped expired link codes', { count: codes });
       // Only non-zero when someone is holding MAX_WINDOWS buckets at their

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -84,6 +84,8 @@ function main(): void {
       // its own record, so nothing dropped here is the audit trail.
       const shares = repos.purgeDeadShares();
       if (shares > 0) logger.debug('reaped dead shares', { count: shares });
+      const handoffs = repos.purgeExpiredHandoffBundles();
+      if (handoffs > 0) logger.debug('reaped expired handoffs', { count: handoffs });
       rateLimiter.sweep();
       if (codes > 0) logger.debug('reaped expired link codes', { count: codes });
       // Only non-zero when someone is holding MAX_WINDOWS buckets at their

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -6,6 +6,7 @@ import { createRepositories } from './repositories';
 import { createGateway, newAgentSocketData, newClientSocketData } from './ws';
 import { parseCookies, SESSION_COOKIE } from './auth/cookies';
 import { createRateLimiter } from './rate-limit';
+import { requestBodyCeiling } from './server';
 
 /** How often expired sessions / link codes / rate-limit windows are swept. */
 const REAP_INTERVAL_MS = 10 * 60 * 1000;
@@ -46,7 +47,7 @@ function main(): void {
 
   const server = Bun.serve({
     port: config.port,
-    maxRequestBodySize: 1024 * 1024,
+    maxRequestBodySize: requestBodyCeiling(config),
     fetch(req, srv) {
       const url = new URL(req.url);
       // Agents connect at /ws and authenticate with an Ed25519-signed nonce.

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -6,7 +6,7 @@ import { createRepositories } from './repositories';
 import { createGateway, newAgentSocketData, newClientSocketData } from './ws';
 import { parseCookies, SESSION_COOKIE } from './auth/cookies';
 import { createRateLimiter } from './rate-limit';
-import { requestBodyCeiling } from './server';
+import { serveOptions } from './server';
 
 /** How often expired sessions / link codes / rate-limit windows are swept. */
 const REAP_INTERVAL_MS = 10 * 60 * 1000;
@@ -20,7 +20,8 @@ const REAP_INTERVAL_MS = 10 * 60 * 1000;
  */
 const MAX_WS_PAYLOAD_BYTES = 16 * 1024 * 1024;
 
-function main(): void {
+/** The running server plus the handle a test needs to shut it down again. */
+export function main() {
   const { config, warnings } = loadConfig();
   const logger = createLogger(config.logLevel);
   for (const warning of warnings) {
@@ -45,9 +46,8 @@ function main(): void {
     onGrantRevoked: (grant) => gateway.notifyGrantRevoked(grant),
   });
 
-  const server = Bun.serve({
-    port: config.port,
-    maxRequestBodySize: requestBodyCeiling(config),
+  const server = Bun.serve(serveOptions({
+    config,
     fetch(req, srv) {
       const url = new URL(req.url);
       // Agents connect at /ws and authenticate with an Ed25519-signed nonce.
@@ -67,7 +67,7 @@ function main(): void {
       return route(req, srv.requestIP(req)?.address ?? null);
     },
     websocket: { ...gateway, maxPayloadLength: MAX_WS_PAYLOAD_BYTES },
-  });
+  }));
 
   // Nothing purged expired sessions or link codes before — `purgeExpiredSessions`
   // was on the repository interface but had no caller, so both tables grew
@@ -123,16 +123,33 @@ function main(): void {
       process.exit(1);
     }, 5000).unref();
   };
-  process.on('SIGINT', () => shutdown('SIGINT'));
-  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  const onSigint = () => shutdown('SIGINT');
+  const onSigterm = () => shutdown('SIGTERM');
+  process.on('SIGINT', onSigint);
+  process.on('SIGTERM', onSigterm);
+
+  return {
+    server,
+    stop: async () => {
+      clearInterval(reaper);
+      process.off('SIGINT', onSigint);
+      process.off('SIGTERM', onSigterm);
+      await server.stop(true);
+      db.close();
+    },
+  };
 }
 
-try {
-  main();
-} catch (err) {
-  const message = err instanceof Error ? err.message : String(err);
-  process.stderr.write(
-    JSON.stringify({ ts: new Date().toISOString(), level: 'error', msg: 'startup failed', err: message }) + '\n',
-  );
-  process.exit(1);
+// Only when run as the program. Importing this module — which a test does, to
+// check the server it builds — must not start one.
+if (import.meta.main) {
+  try {
+    main();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      JSON.stringify({ ts: new Date().toISOString(), level: 'error', msg: 'startup failed', err: message }) + '\n',
+    );
+    process.exit(1);
+  }
 }

--- a/relay/src/protocol.ts
+++ b/relay/src/protocol.ts
@@ -238,3 +238,57 @@ export function parseCertificate(cert: unknown): ParsedCertificate | null {
 
   return { payload, signature, parts };
 }
+
+// --- machine handoff ---
+
+/**
+ * The four verbs a linked machine may sign to reach its user's handoff slot.
+ * One version string each: a signature captured off a download must not be
+ * replayable as the delete that throws the bundle away.
+ */
+export const HANDOFF_PUT_VERSION = 'handoff-put:v1';
+export const HANDOFF_META_VERSION = 'handoff-meta:v1';
+export const HANDOFF_GET_VERSION = 'handoff-get:v1';
+export const HANDOFF_DELETE_VERSION = 'handoff-delete:v1';
+
+/**
+ * Covers a digest declared in a header, not the ciphertext: the relay can then
+ * refuse an unsigned upload before buffering the body, and refuse a body whose
+ * hash is not the digest it verified.
+ */
+export function buildHandoffPutMessage(p: {
+  machineId: string;
+  ciphertextSha256Hex: string;
+  issuedAt: number;
+}): Uint8Array {
+  const line = [HANDOFF_PUT_VERSION, p.machineId, p.ciphertextSha256Hex, String(p.issuedAt)].join('\n');
+  return new TextEncoder().encode(line);
+}
+
+export function buildHandoffMetaMessage(p: { machineId: string; issuedAt: number }): Uint8Array {
+  return new TextEncoder().encode([HANDOFF_META_VERSION, p.machineId, String(p.issuedAt)].join('\n'));
+}
+
+export function buildHandoffGetMessage(p: { machineId: string; issuedAt: number }): Uint8Array {
+  return new TextEncoder().encode([HANDOFF_GET_VERSION, p.machineId, String(p.issuedAt)].join('\n'));
+}
+
+/**
+ * Binds the bundle id, so an acknowledgement of the bundle a machine restored
+ * cannot delete a newer one the source machine prepared in the meantime.
+ */
+export function buildHandoffDeleteMessage(p: {
+  machineId: string;
+  handoffId: string;
+  issuedAt: number;
+}): Uint8Array {
+  const line = [HANDOFF_DELETE_VERSION, p.machineId, p.handoffId, String(p.issuedAt)].join('\n');
+  return new TextEncoder().encode(line);
+}
+
+/** Headers carrying the signature, so the same scheme covers GET and DELETE. */
+export const HANDOFF_SIGNATURE_HEADER = 'x-bodhi-signature';
+export const HANDOFF_ISSUED_AT_HEADER = 'x-bodhi-issued-at';
+export const HANDOFF_DIGEST_HEADER = 'x-bodhi-content-sha256';
+/** Named on the bundle response, so the acknowledgement cannot name another. */
+export const HANDOFF_ID_HEADER = 'x-bodhi-handoff-id';

--- a/relay/src/relay.test.ts
+++ b/relay/src/relay.test.ts
@@ -43,7 +43,7 @@ describe('openDb / migrations', () => {
     const db = openDb(':memory:');
     try {
       const { user_version } = db.query('PRAGMA user_version;').get() as { user_version: number };
-      expect(user_version).toBe(4);
+      expect(user_version).toBe(5);
 
       const tables = db
         .query("SELECT name FROM sqlite_master WHERE type='table';")

--- a/relay/src/relay.test.ts
+++ b/relay/src/relay.test.ts
@@ -43,7 +43,7 @@ describe('openDb / migrations', () => {
     const db = openDb(':memory:');
     try {
       const { user_version } = db.query('PRAGMA user_version;').get() as { user_version: number };
-      expect(user_version).toBe(3);
+      expect(user_version).toBe(4);
 
       const tables = db
         .query("SELECT name FROM sqlite_master WHERE type='table';")
@@ -57,6 +57,7 @@ describe('openDb / migrations', () => {
         'push_subscriptions',
         'share_invites',
         'machine_grants',
+        'handoff_bundles',
       ]) {
         expect(tables).toContain(t);
       }

--- a/relay/src/repositories.ts
+++ b/relay/src/repositories.ts
@@ -141,29 +141,38 @@ export interface Repositories {
   /** Expired or revoked grants and dead invites, dropped by the reaper. */
   purgeDeadShares(): number;
 
-  /** Store this user's handoff, replacing whatever they had prepared before. */
-  putHandoffBundle(input: PutHandoffInput): HandoffBundle;
+  /**
+   * Record this user's handoff, replacing whatever they had prepared before.
+   * Returns the bundle it displaced, whose file the caller must remove.
+   */
+  putHandoffBundle(input: PutHandoffInput): { row: HandoffBundle; previousId: string | null };
   /** The user's live handoff, or null when there is none or it has lapsed. */
   getHandoffBundle(userId: string): HandoffBundle | null;
   /** Drop the named handoff once its destination has restored from it. */
   deleteHandoffBundle(userId: string, handoffId: string): boolean;
-  purgeExpiredHandoffBundles(): number;
+  /** Ids of the bundles dropped, so their files go with them. */
+  purgeExpiredHandoffBundles(): string[];
+  /** Bytes the store already holds, ignoring the row an upload will replace. */
+  totalHandoffBytes(exceptUserId?: string): number;
+  /** Every id a row claims, for the orphan sweep. */
+  listHandoffIds(): string[];
 }
 
 export interface HandoffBundle {
   id: string;
   user_id: string;
   source_machine_id: string;
-  ciphertext: Uint8Array;
   byte_size: number;
   created_at: number;
   expires_at: number;
 }
 
 export interface PutHandoffInput {
+  /** Chosen by the caller, because the file is written under it first. */
+  id: string;
   userId: string;
   sourceMachineId: string;
-  ciphertext: Uint8Array;
+  byteSize: number;
   ttlSeconds: number;
 }
 
@@ -596,29 +605,32 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
     putHandoffBundle(input) {
       const ts = now();
       const row: HandoffBundle = {
-        id: crypto.randomUUID(),
+        id: input.id,
         user_id: input.userId,
         source_machine_id: input.sourceMachineId,
-        ciphertext: input.ciphertext,
-        byte_size: input.ciphertext.byteLength,
+        byte_size: input.byteSize,
         created_at: ts,
         expires_at: ts + input.ttlSeconds * 1000,
       };
       // Upsert on the user, so preparing a second handoff replaces the first
       // rather than leaving two claims on one slot. The id changes with it:
       // a destination that declined the old bundle must be offered this one.
-      db.query(
-        `INSERT INTO handoff_bundles (id, user_id, source_machine_id, ciphertext, byte_size, created_at, expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)
-         ON CONFLICT(user_id) DO UPDATE SET
-           id = excluded.id,
-           source_machine_id = excluded.source_machine_id,
-           ciphertext = excluded.ciphertext,
-           byte_size = excluded.byte_size,
-           created_at = excluded.created_at,
-           expires_at = excluded.expires_at`,
-      ).run(row.id, row.user_id, row.source_machine_id, toBuf(row.ciphertext), row.byte_size, row.created_at, row.expires_at);
-      return row;
+      return db.transaction(() => {
+        const previous = db
+          .query('SELECT id FROM handoff_bundles WHERE user_id = ?')
+          .get(input.userId) as { id: string } | null;
+        db.query(
+          `INSERT INTO handoff_bundles (id, user_id, source_machine_id, byte_size, created_at, expires_at)
+           VALUES (?, ?, ?, ?, ?, ?)
+           ON CONFLICT(user_id) DO UPDATE SET
+             id = excluded.id,
+             source_machine_id = excluded.source_machine_id,
+             byte_size = excluded.byte_size,
+             created_at = excluded.created_at,
+             expires_at = excluded.expires_at`,
+        ).run(row.id, row.user_id, row.source_machine_id, row.byte_size, row.created_at, row.expires_at);
+        return { row, previousId: previous?.id ?? null };
+      })();
     },
 
     getHandoffBundle(userId) {
@@ -638,8 +650,23 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
     },
 
     purgeExpiredHandoffBundles() {
-      const result = db.query('DELETE FROM handoff_bundles WHERE expires_at <= ?').run(now());
-      return Number(result.changes ?? 0);
+      const ts = now();
+      return db.transaction(() => {
+        const dead = db.query('SELECT id FROM handoff_bundles WHERE expires_at <= ?').all(ts) as { id: string }[];
+        db.query('DELETE FROM handoff_bundles WHERE expires_at <= ?').run(ts);
+        return dead.map((row) => row.id);
+      })();
+    },
+
+    totalHandoffBytes(exceptUserId) {
+      const row = db
+        .query('SELECT COALESCE(SUM(byte_size), 0) AS total FROM handoff_bundles WHERE user_id IS NOT ?')
+        .get(exceptUserId ?? null) as { total: number };
+      return Number(row.total);
+    },
+
+    listHandoffIds() {
+      return (db.query('SELECT id FROM handoff_bundles').all() as { id: string }[]).map((row) => row.id);
     },
   };
 }

--- a/relay/src/repositories.ts
+++ b/relay/src/repositories.ts
@@ -140,6 +140,31 @@ export interface Repositories {
   listDeadShareGrants(): MachineGrant[];
   /** Expired or revoked grants and dead invites, dropped by the reaper. */
   purgeDeadShares(): number;
+
+  /** Store this user's handoff, replacing whatever they had prepared before. */
+  putHandoffBundle(input: PutHandoffInput): HandoffBundle;
+  /** The user's live handoff, or null when there is none or it has lapsed. */
+  getHandoffBundle(userId: string): HandoffBundle | null;
+  /** Drop the named handoff once its destination has restored from it. */
+  deleteHandoffBundle(userId: string, handoffId: string): boolean;
+  purgeExpiredHandoffBundles(): number;
+}
+
+export interface HandoffBundle {
+  id: string;
+  user_id: string;
+  source_machine_id: string;
+  ciphertext: Uint8Array;
+  byte_size: number;
+  created_at: number;
+  expires_at: number;
+}
+
+export interface PutHandoffInput {
+  userId: string;
+  sourceMachineId: string;
+  ciphertext: Uint8Array;
+  ttlSeconds: number;
 }
 
 export interface ShareInvite {
@@ -566,6 +591,55 @@ export function createRepositories(db: RelayDb, now: () => number = Date.now): R
         .query("DELETE FROM share_invites WHERE status != 'redeemed' AND expires_at <= ?")
         .run(ts);
       return Number(grants.changes ?? 0) + Number(invites.changes ?? 0);
+    },
+
+    putHandoffBundle(input) {
+      const ts = now();
+      const row: HandoffBundle = {
+        id: crypto.randomUUID(),
+        user_id: input.userId,
+        source_machine_id: input.sourceMachineId,
+        ciphertext: input.ciphertext,
+        byte_size: input.ciphertext.byteLength,
+        created_at: ts,
+        expires_at: ts + input.ttlSeconds * 1000,
+      };
+      // Upsert on the user, so preparing a second handoff replaces the first
+      // rather than leaving two claims on one slot. The id changes with it:
+      // a destination that declined the old bundle must be offered this one.
+      db.query(
+        `INSERT INTO handoff_bundles (id, user_id, source_machine_id, ciphertext, byte_size, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(user_id) DO UPDATE SET
+           id = excluded.id,
+           source_machine_id = excluded.source_machine_id,
+           ciphertext = excluded.ciphertext,
+           byte_size = excluded.byte_size,
+           created_at = excluded.created_at,
+           expires_at = excluded.expires_at`,
+      ).run(row.id, row.user_id, row.source_machine_id, toBuf(row.ciphertext), row.byte_size, row.created_at, row.expires_at);
+      return row;
+    },
+
+    getHandoffBundle(userId) {
+      // Filtered on expiry rather than trusted to the reaper, which runs every
+      // ten minutes — otherwise a lapsed bundle keeps being offered until it
+      // happens to be swept.
+      return (
+        (db
+          .query('SELECT * FROM handoff_bundles WHERE user_id = ? AND expires_at > ?')
+          .get(userId, now()) as HandoffBundle | null) ?? null
+      );
+    },
+
+    deleteHandoffBundle(userId, handoffId) {
+      const result = db.query('DELETE FROM handoff_bundles WHERE user_id = ? AND id = ?').run(userId, handoffId);
+      return Number(result.changes ?? 0) > 0;
+    },
+
+    purgeExpiredHandoffBundles() {
+      const result = db.query('DELETE FROM handoff_bundles WHERE expires_at <= ?').run(now());
+      return Number(result.changes ?? 0);
     },
   };
 }

--- a/relay/src/server.test.ts
+++ b/relay/src/server.test.ts
@@ -5,6 +5,9 @@
  */
 import { afterEach, describe, expect, test } from 'bun:test';
 import { createHash, generateKeyPairSync, randomBytes, sign as edSign } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { loadConfig } from './config';
 import { createLogger } from './logger';
 import { openDb } from './db';
@@ -20,14 +23,18 @@ const REALISTIC_BUNDLE_BYTES = 5 * 1024 * 1024;
 const OLD_WIRE_CEILING = 1024 * 1024;
 
 const servers: { stop: (force?: boolean) => void }[] = [];
+const dirs: string[] = [];
 afterEach(() => {
   while (servers.length) servers.pop()!.stop(true);
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
 function start(env: Record<string, string> = {}) {
   const db = openDb(':memory:');
   const repos = createRepositories(db);
-  const { config } = loadConfig({ NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test', ...env });
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-serve-'));
+  dirs.push(dir);
+  const { config } = loadConfig({ NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test', HANDOFF_DIR: dir, ...env });
   const route = createRouter({ config, logger, repos });
 
   // The same two values index.ts hands Bun. Only the body ceiling is under
@@ -106,6 +113,31 @@ function postChunked(url: string, totalBytes: number, produced: { bytes: number 
 }
 
 describe('what the socket will accept', () => {
+  test('does not apply the ceiling to a body read as a stream', async () => {
+    // Load-bearing, and the reason `readJson` counts bytes itself rather than
+    // trusting this setting. If it ever starts failing, Bun changed.
+    const ceiling = 64 * 1024;
+    const server = Bun.serve({
+      port: 0,
+      maxRequestBodySize: ceiling,
+      async fetch(req) {
+        const reader = req.body!.getReader();
+        let total = 0;
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          total += value.byteLength;
+        }
+        return Response.json({ total });
+      },
+    });
+    servers.push(server);
+
+    const produced = { bytes: 0 };
+    const res = await postChunked(server.url.origin, ceiling * 8, produced);
+    expect(await res.json()).toEqual({ total: ceiling * 8 });
+  });
+
   test('admits a bundle from a real machine, which the old ceiling did not', async () => {
     const { config, put } = start();
     expect(REALISTIC_BUNDLE_BYTES).toBeGreaterThan(OLD_WIRE_CEILING);

--- a/relay/src/server.test.ts
+++ b/relay/src/server.test.ts
@@ -113,31 +113,6 @@ function postChunked(url: string, totalBytes: number, produced: { bytes: number 
 }
 
 describe('what the socket will accept', () => {
-  test('does not apply the ceiling to a body read as a stream', async () => {
-    // Load-bearing, and the reason `readJson` counts bytes itself rather than
-    // trusting this setting. If it ever starts failing, Bun changed.
-    const ceiling = 64 * 1024;
-    const server = Bun.serve({
-      port: 0,
-      maxRequestBodySize: ceiling,
-      async fetch(req) {
-        const reader = req.body!.getReader();
-        let total = 0;
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          total += value.byteLength;
-        }
-        return Response.json({ total });
-      },
-    });
-    servers.push(server);
-
-    const produced = { bytes: 0 };
-    const res = await postChunked(server.url.origin, ceiling * 8, produced);
-    expect(await res.json()).toEqual({ total: ceiling * 8 });
-  });
-
   test('admits a bundle from a real machine, which the old ceiling did not', async () => {
     const { config, put } = start();
     expect(REALISTIC_BUNDLE_BYTES).toBeGreaterThan(OLD_WIRE_CEILING);
@@ -160,13 +135,23 @@ describe('what the socket will accept', () => {
   });
 
   test('bounds a chunked body, which declares no length to check', async () => {
-    const { origin } = start();
+    const { config, origin } = start();
     const produced = { bytes: 0 };
     const total = 8 * 1024 * 1024;
 
+    // Why `readJson` counts bytes itself instead of leaning on the setting
+    // above: the ceiling this server runs with is the handoff cap, three
+    // orders of magnitude past anything a JSON route may accept. Bun's own
+    // treatment of it is beside the point and not stable anyway — 1.3
+    // ignored it for a body read as a stream, 1.4 enforces it — so this
+    // suite pins the relay's bound and not Bun's.
+    expect(requestBodyCeiling(config)).toBeGreaterThan(MAX_JSON_BODY_BYTES * 100);
+
     const res = await postChunked(`${origin}/link`, total, produced);
 
-    // 400 here would mean the body was buffered AND parsed by /link's handler.
+    // A reasoned 413 is the handler's. Bun's, when it refuses at the socket,
+    // carries an empty body — so this also pins which of the two answered.
+    // 400 would mean the body was buffered AND parsed by `/link`'s handler.
     expect(res.status).toBe(413);
     expect(await res.json()).toEqual({ error: 'payload_too_large' });
     expect(produced.bytes).toBeLessThan(total / 2);

--- a/relay/src/server.test.ts
+++ b/relay/src/server.test.ts
@@ -74,6 +74,37 @@ function start(env: Record<string, string> = {}) {
   return { config, origin, put };
 }
 
+/**
+ * A body with no content-length, so it is framed chunked. `produced` counts
+ * what the generator actually handed over, which is how far the server got
+ * before it stopped pulling.
+ */
+function chunkedBody(totalBytes: number, produced: { bytes: number }): ReadableStream<Uint8Array> {
+  const CHUNK = 16 * 1024;
+  let sent = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent >= totalBytes) {
+        controller.close();
+        return;
+      }
+      const size = Math.min(CHUNK, totalBytes - sent);
+      sent += size;
+      produced.bytes = sent;
+      controller.enqueue(new Uint8Array(size).fill(0x20));
+    },
+  });
+}
+
+function postChunked(url: string, totalBytes: number, produced: { bytes: number }) {
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: chunkedBody(totalBytes, produced),
+    duplex: 'half',
+  } as RequestInit);
+}
+
 describe('what the socket will accept', () => {
   test('admits a bundle from a real machine, which the old ceiling did not', async () => {
     const { config, put } = start();
@@ -94,6 +125,41 @@ describe('what the socket will accept', () => {
 
     expect(res.status).toBe(413);
     expect(await res.json()).toEqual({ error: 'handoff_too_large', maxBytes: 65536 });
+  });
+
+  test('bounds a chunked body, which declares no length to check', async () => {
+    const { origin } = start();
+    const produced = { bytes: 0 };
+    const total = 8 * 1024 * 1024;
+
+    const res = await postChunked(`${origin}/link`, total, produced);
+
+    // 400 here would mean the body was buffered AND parsed by /link's handler.
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: 'payload_too_large' });
+    expect(produced.bytes).toBeLessThan(total / 2);
+  });
+
+  test('bounds a chunked body on the other unauthenticated route too', async () => {
+    const { origin } = start();
+    const produced = { bytes: 0 };
+
+    const res = await postChunked(`${origin}/api/machines/abc/shares`, 4 * 1024 * 1024, produced);
+
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: 'payload_too_large' });
+  });
+
+  test('exempts only the handoff upload, not every route under it', async () => {
+    const { origin } = start();
+    // `/handoff/bundle` is a download; nothing there reads a body.
+    const res = await fetch(`${origin}/api/machines/abc/handoff/bundle`, {
+      method: 'PUT',
+      body: randomBytes(MAX_JSON_BODY_BYTES + 1024),
+    });
+
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: 'payload_too_large' });
   });
 
   test('still bounds every route that is not a handoff upload', async () => {

--- a/relay/src/server.test.ts
+++ b/relay/src/server.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The request-body ceiling, over a real socket. Bun enforces it before the
+ * handler runs, so a suite calling `createRouter()` directly — which is every
+ * other suite here — cannot see it at all.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { createHash, generateKeyPairSync, randomBytes, sign as edSign } from 'node:crypto';
+import { loadConfig } from './config';
+import { createLogger } from './logger';
+import { openDb } from './db';
+import { createRepositories } from './repositories';
+import { createRouter } from './http';
+import { MAX_JSON_BODY_BYTES, requestBodyCeiling } from './server';
+
+const logger = createLogger('error');
+
+/** The bundle a 12-group / 120-session machine sealed to, measured. */
+const REALISTIC_BUNDLE_BYTES = 5 * 1024 * 1024;
+/** What Bun accepted before the ceiling was tied to the handoff cap. */
+const OLD_WIRE_CEILING = 1024 * 1024;
+
+const servers: { stop: (force?: boolean) => void }[] = [];
+afterEach(() => {
+  while (servers.length) servers.pop()!.stop(true);
+});
+
+function start(env: Record<string, string> = {}) {
+  const db = openDb(':memory:');
+  const repos = createRepositories(db);
+  const { config } = loadConfig({ NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test', ...env });
+  const route = createRouter({ config, logger, repos });
+
+  // The same two values index.ts hands Bun. Only the body ceiling is under
+  // test here; the WebSocket upgrade paths are exercised elsewhere.
+  const server = Bun.serve({
+    port: 0,
+    maxRequestBodySize: requestBodyCeiling(config),
+    fetch: (req, srv) => route(req, srv.requestIP(req)?.address ?? null),
+  });
+  servers.push(server);
+
+  const user = repos.upsertGithubUser({
+    providerUserId: '1',
+    displayName: 'Will',
+    login: 'will-l',
+    email: null,
+    avatarUrl: null,
+  });
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const { x } = publicKey.export({ format: 'jwk' }) as { x: string };
+  const code = repos.createLinkCode('Old Laptop', new Uint8Array(Buffer.from(x, 'base64url')), new Uint8Array(32).fill(1), 600).code;
+  const claim = repos.claimLinkCode(code, user.id);
+  if (!claim.ok) throw new Error('fixture could not link a machine');
+
+  const origin = server.url.origin;
+  const machineId = claim.machine.id;
+
+  async function put(body: Buffer) {
+    const digest = createHash('sha256').update(body).digest('hex');
+    const issuedAt = Date.now();
+    const message = Buffer.from(['handoff-put:v1', machineId, digest, String(issuedAt)].join('\n'));
+    return fetch(`${origin}/api/machines/${machineId}/handoff`, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/octet-stream',
+        'x-bodhi-content-sha256': digest,
+        'x-bodhi-issued-at': String(issuedAt),
+        'x-bodhi-signature': edSign(null, message, privateKey).toString('base64'),
+      },
+      body,
+    });
+  }
+
+  return { config, origin, put };
+}
+
+describe('what the socket will accept', () => {
+  test('admits a bundle from a real machine, which the old ceiling did not', async () => {
+    const { config, put } = start();
+    expect(REALISTIC_BUNDLE_BYTES).toBeGreaterThan(OLD_WIRE_CEILING);
+    expect(requestBodyCeiling(config)).toBeGreaterThan(REALISTIC_BUNDLE_BYTES);
+
+    const res = await put(randomBytes(REALISTIC_BUNDLE_BYTES));
+    expect(res.status).toBe(200);
+    const { handoff } = (await res.json()) as { handoff: { byteSize: number } };
+    expect(handoff.byteSize).toBe(REALISTIC_BUNDLE_BYTES);
+  });
+
+  test('leaves headroom over the cap, so the cap is refused by the handler and not the socket', async () => {
+    // A small cap, so an over-cap body is cheap to send. What is pinned is
+    // that the refusal carries a reason and a size rather than an empty 413.
+    const { put } = start({ HANDOFF_MAX_BYTES: String(64 * 1024) });
+    const res = await put(randomBytes(96 * 1024));
+
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: 'handoff_too_large', maxBytes: 65536 });
+  });
+
+  test('still bounds every route that is not a handoff upload', async () => {
+    const { origin } = start();
+    const res = await fetch(`${origin}/link`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ machineName: 'x'.repeat(MAX_JSON_BODY_BYTES) }),
+    });
+
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: 'payload_too_large' });
+  });
+});

--- a/relay/src/server.ts
+++ b/relay/src/server.ts
@@ -1,3 +1,4 @@
+import type { Server, WebSocketHandler } from 'bun';
 import type { RelayConfig } from './config';
 
 /**
@@ -20,3 +21,23 @@ export function requestBodyCeiling(config: RelayConfig): number {
  * above is far too generous for them now that a handoff sets it.
  */
 export const MAX_JSON_BODY_BYTES = 64 * 1024;
+
+export interface ServeInput<T> {
+  config: RelayConfig;
+  fetch: (req: Request, server: Server<T>) => Response | undefined | Promise<Response | undefined>;
+  websocket: WebSocketHandler<T>;
+}
+
+/**
+ * Everything `Bun.serve` is given. Shared with the entry point rather than
+ * replicated in a test, so what a test starts is what production starts —
+ * a copy pins its own copy and lets the deployed ceiling regress unseen.
+ */
+export function serveOptions<T>(input: ServeInput<T>) {
+  return {
+    port: input.config.port,
+    maxRequestBodySize: requestBodyCeiling(input.config),
+    fetch: input.fetch,
+    websocket: input.websocket,
+  };
+}

--- a/relay/src/server.ts
+++ b/relay/src/server.ts
@@ -1,0 +1,22 @@
+import type { RelayConfig } from './config';
+
+/**
+ * Headroom over the handoff cap for request lines and headers, so a body at
+ * exactly the cap still arrives whole.
+ */
+export const REQUEST_HEADER_SLACK_BYTES = 64 * 1024;
+
+/**
+ * What Bun will accept as a request body. Derived from the handoff cap rather
+ * than set beside it: a wire ceiling below the cap kills every upload at the
+ * socket, with an empty 413 that names no reason.
+ */
+export function requestBodyCeiling(config: RelayConfig): number {
+  return config.handoffMaxBytes + REQUEST_HEADER_SLACK_BYTES;
+}
+
+/**
+ * The most any other route may send. They all read small JSON, and the ceiling
+ * above is far too generous for them now that a handoff sets it.
+ */
+export const MAX_JSON_BODY_BYTES = 64 * 1024;

--- a/src/main/__tests__/machine-handoff.test.ts
+++ b/src/main/__tests__/machine-handoff.test.ts
@@ -165,8 +165,16 @@ describe('reading the offer', () => {
 
   test('remembers a bundle this machine turned down', async () => {
     const relay = standIn(Buffer.alloc(64, 1));
-    declineMachineHandoff('handoff-1');
+    declineMachineHandoff(relay.transport, 'handoff-1');
     expect((await readHandoffOffer(relay.transport)).declined).toBe(true);
+  });
+
+  test('will not bury a bundle on behalf of a machine that has been unlinked', async () => {
+    const relay = standIn(Buffer.alloc(64, 1));
+    // The dialog was drawn, then the machine was unlinked underneath it. That
+    // offer is stale, and recording it would lose a bundle that is still real.
+    declineMachineHandoff(null, 'handoff-1');
+    expect((await readHandoffOffer(relay.transport)).declined).toBe(false);
   });
 
   test('says nothing is waiting rather than interrupting a launch with a relay error', async () => {

--- a/src/main/__tests__/machine-handoff.test.ts
+++ b/src/main/__tests__/machine-handoff.test.ts
@@ -59,7 +59,7 @@ function offerFor(sealed: Buffer): HandoffOffer {
 }
 
 /** A relay holding one prepared bundle, and a record of what was asked of it. */
-function standIn(sealed: Buffer | null) {
+function standIn(sealed: Buffer | null, options: { failAcknowledge?: boolean } = {}) {
   const acks: string[] = [];
   const transport: HandoffTransport = {
     async upload(bytes) {
@@ -75,6 +75,7 @@ function standIn(sealed: Buffer | null) {
     },
     async acknowledge(id) {
       acks.push(id);
+      if (options.failAcknowledge) throw new Error('relay unreachable');
       sealed = null;
     },
   };
@@ -206,6 +207,22 @@ describe('restoring one', () => {
       .working_dir;
     expect(dir).toBe(chosen);
     expect(relay.acks).toEqual(['handoff-1']);
+  });
+
+  test('a relay that will not release the bundle is still a successful restore', async () => {
+    const { bytes, phrase } = preparedElsewhere();
+    const relay = standIn(bytes, { failAcknowledge: true });
+    const chosen = path.join(tmp, 'dst-projects');
+    fs.mkdirSync(chosen, { recursive: true });
+    messageBoxResponses = [0];
+    openDialogPaths = [chosen];
+
+    const result = await restoreMachineHandoff(relay.transport, phrase, legacyDir);
+    expect(result.success).toBe(true);
+    expect(result.groupCount).toBe(1);
+    // Answered locally, or the bundle it could not drop would be offered again
+    // on the next launch as though nothing had been restored.
+    expect((await readHandoffOffer(relay.transport)).declined).toBe(true);
   });
 
   test('a wrong phrase is reported as one, and the bundle stays put', async () => {

--- a/src/main/__tests__/machine-handoff.test.ts
+++ b/src/main/__tests__/machine-handoff.test.ts
@@ -1,0 +1,241 @@
+/**
+ * The Electron half of a handoff: the questions it asks, and what it reports
+ * back to the window. The answers a person sees are the whole product here —
+ * "cancelled" and "that did not open" must not arrive as the same failure.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { freshDb, seedSourceDb } from '../transfer/__tests__/db-fixture';
+import { buildTransferBundle } from '../transfer/bundle-export';
+import { sealHandoff } from '../transfer/handoff-crypto';
+import { generateRecoveryPhrase } from '../transfer/recovery-phrase';
+import type { HandoffOffer } from '../../shared/types';
+import type { HandoffTransport } from '../transfer/handoff';
+
+let db: Database;
+let tmp: string;
+let userDataDir: string;
+let legacyDir: string;
+let messageBoxResponses: number[] = [];
+let openDialogPaths: (string | null)[] = [];
+
+// Superset of the `{ app }` stub the sibling suites register, plus the dialogs
+// this module drives. Nothing here is exercised for real.
+mock.module('electron', () => ({
+  app: {
+    getVersion: () => '3.5.1',
+    getPath: (name: string) => (name === 'documents' ? path.join(tmp, 'docs') : userDataDir),
+    getAppPath: () => path.join(tmp, 'app'),
+  },
+  dialog: {
+    showMessageBox: async () => ({ response: messageBoxResponses.shift() ?? 0 }),
+    showOpenDialog: async () => {
+      const next = openDialogPaths.shift();
+      return next ? { canceled: false, filePaths: [next] } : { canceled: true, filePaths: [] };
+    },
+    showSaveDialog: async () => ({ canceled: true, filePath: undefined }),
+  },
+}));
+mock.module('../database', () => ({ getDatabase: () => db }));
+
+const { declineMachineHandoff, prepareMachineHandoff, readHandoffOffer, restoreMachineHandoff } = await import(
+  '../machine-handoff'
+);
+
+const SOURCE_ROOT = '/src-machine/Work/Repos';
+
+function offerFor(sealed: Buffer): HandoffOffer {
+  return {
+    id: 'handoff-1',
+    sourceMachineId: 'machine-old',
+    sourceMachineName: 'Old Laptop',
+    byteSize: sealed.length,
+    createdAt: 1756080000000,
+    expiresAt: 1756684800000,
+  };
+}
+
+/** A relay holding one prepared bundle, and a record of what was asked of it. */
+function standIn(sealed: Buffer | null) {
+  const acks: string[] = [];
+  const transport: HandoffTransport = {
+    async upload(bytes) {
+      sealed = bytes;
+      return offerFor(bytes);
+    },
+    async peek() {
+      return sealed ? offerFor(sealed) : null;
+    },
+    async download() {
+      if (!sealed) throw new Error('nothing waiting');
+      return { id: 'handoff-1', sealed };
+    },
+    async acknowledge(id) {
+      acks.push(id);
+      sealed = null;
+    },
+  };
+  return { transport, acks, stored: () => sealed };
+}
+
+/** A bundle a source machine prepared, sealed as the relay would hold it. */
+function preparedElsewhere() {
+  const source = freshDb();
+  seedSourceDb(source, {
+    accountConfigDir: path.join(tmp, 'src', 'acct-1', '.claude'),
+    workingDirs: [`${SOURCE_ROOT}/Bodhilander`],
+  });
+  const { bytes } = buildTransferBundle(source as never, {
+    sourceAppVersion: '3.5.1',
+    sourcePlatform: 'darwin',
+    sourceUserData: path.join(tmp, 'src'),
+    legacyConfigDir: path.join(tmp, 'src-home', '.claude'),
+  });
+  source.close();
+  return sealHandoff(bytes);
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bodhi-driver-'));
+  userDataDir = path.join(tmp, 'userData');
+  legacyDir = path.join(tmp, 'home', '.claude');
+  messageBoxResponses = [];
+  openDialogPaths = [];
+  db = freshDb();
+});
+
+afterEach(() => {
+  db.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('before this machine is linked', () => {
+  test('every step says so rather than failing obscurely', async () => {
+    expect(await prepareMachineHandoff(null, legacyDir)).toEqual({
+      success: false,
+      error: 'Link this machine to a relay account before moving it.',
+    });
+    expect(await restoreMachineHandoff(null, 'anything', legacyDir)).toEqual({
+      success: false,
+      error: 'Link this machine to a relay account before moving it.',
+    });
+    expect(await readHandoffOffer(null)).toEqual({ offer: null, declined: false });
+  });
+});
+
+describe('preparing one', () => {
+  test('reports the phrase and what the bundle holds once it is confirmed', async () => {
+    seedSourceDb(db, { accountConfigDir: path.join(tmp, 'acct', '.claude') });
+    const relay = standIn(null);
+    messageBoxResponses = [0];
+
+    const result = await prepareMachineHandoff(relay.transport, legacyDir);
+    expect(result.success).toBe(true);
+    expect(result.phrase!.split(' ')).toHaveLength(18);
+    expect(result.groupCount).toBe(1);
+    expect(result.sizeLabel).toMatch(/\d/);
+    expect(relay.stored()).not.toBeNull();
+  });
+
+  test('uploads nothing when the confirmation is declined', async () => {
+    seedSourceDb(db, { accountConfigDir: path.join(tmp, 'acct', '.claude') });
+    const relay = standIn(null);
+    messageBoxResponses = [1];
+
+    expect(await prepareMachineHandoff(relay.transport, legacyDir)).toEqual({
+      success: false,
+      error: 'Handoff cancelled',
+    });
+    expect(relay.stored()).toBeNull();
+  });
+});
+
+describe('reading the offer', () => {
+  test('names the source machine and sizes it for the prompt', async () => {
+    const relay = standIn(Buffer.alloc(4096, 1));
+    const state = await readHandoffOffer(relay.transport);
+    expect(state.offer!.sourceMachineName).toBe('Old Laptop');
+    expect(state.sizeLabel).toBe('4.0 KB');
+    expect(state.declined).toBe(false);
+  });
+
+  test('remembers a bundle this machine turned down', async () => {
+    const relay = standIn(Buffer.alloc(64, 1));
+    declineMachineHandoff('handoff-1');
+    expect((await readHandoffOffer(relay.transport)).declined).toBe(true);
+  });
+
+  test('says nothing is waiting rather than interrupting a launch with a relay error', async () => {
+    const unreachable: HandoffTransport = {
+      upload: async () => {
+        throw new Error('offline');
+      },
+      peek: async () => {
+        throw new Error('offline');
+      },
+      download: async () => {
+        throw new Error('offline');
+      },
+      acknowledge: async () => {
+        throw new Error('offline');
+      },
+    };
+    expect(await readHandoffOffer(unreachable)).toEqual({ offer: null, declined: false });
+  });
+});
+
+describe('restoring one', () => {
+  test('asks where each root lives now, then restores against the answer', async () => {
+    const { bytes, phrase } = preparedElsewhere();
+    const relay = standIn(bytes);
+    // One session means one root, so the folder chosen for it IS the new
+    // working directory — which is what makes the answer visible below.
+    const chosen = path.join(tmp, 'dst-projects', 'Bodhilander');
+    fs.mkdirSync(chosen, { recursive: true });
+    messageBoxResponses = [0];
+    openDialogPaths = [chosen];
+
+    const result = await restoreMachineHandoff(relay.transport, phrase, legacyDir);
+    expect(result.success).toBe(true);
+    expect(result.groupCount).toBe(1);
+    expect(result.needsRelinkCount).toBe(0);
+    const dir = (db.query('SELECT working_dir FROM sessions WHERE id = ?').get('s1') as { working_dir: string })
+      .working_dir;
+    expect(dir).toBe(chosen);
+    expect(relay.acks).toEqual(['handoff-1']);
+  });
+
+  test('a wrong phrase is reported as one, and the bundle stays put', async () => {
+    const { bytes } = preparedElsewhere();
+    const relay = standIn(bytes);
+
+    const result = await restoreMachineHandoff(relay.transport, generateRecoveryPhrase(), legacyDir);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/does not open this bundle/);
+    expect(relay.acks).toEqual([]);
+    expect(relay.stored()).not.toBeNull();
+  });
+
+  test('a mistyped phrase names the mistake instead of a decryption failure', async () => {
+    const relay = standIn(preparedElsewhere().bytes);
+    const result = await restoreMachineHandoff(relay.transport, 'agent album alloy', legacyDir);
+    expect(result.error).toMatch(/18 words/);
+    expect(relay.stored()).not.toBeNull();
+  });
+
+  test('abandoning the root question leaves everything as it was', async () => {
+    const { bytes, phrase } = preparedElsewhere();
+    const relay = standIn(bytes);
+    messageBoxResponses = [2];
+
+    expect(await restoreMachineHandoff(relay.transport, phrase, legacyDir)).toEqual({
+      success: false,
+      error: 'Import cancelled',
+    });
+    expect(relay.acks).toEqual([]);
+    expect(db.query('SELECT COUNT(*) AS n FROM groups').get()).toEqual({ n: 0 });
+  });
+});

--- a/src/main/__tests__/preload.test.ts
+++ b/src/main/__tests__/preload.test.ts
@@ -133,7 +133,7 @@ describe('the import/export bridge', () => {
     expect(lastInvocation().channel).toBe('import:fromClaudeLander');
   });
 
-  test('exposes the four steps of a handoff, on the channels index.ts registers', () => {
+  test('exposes the four steps of a handoff, each forwarding to its own channel', () => {
     for (const name of ['handoffPrepare', 'handoffPeek', 'handoffRestore', 'handoffDecline']) {
       expect(typeof exposed[name]).toBe('function');
     }

--- a/src/main/__tests__/preload.test.ts
+++ b/src/main/__tests__/preload.test.ts
@@ -133,6 +133,26 @@ describe('the import/export bridge', () => {
     expect(lastInvocation().channel).toBe('import:fromClaudeLander');
   });
 
+  test('exposes the four steps of a handoff, on the channels index.ts registers', () => {
+    for (const name of ['handoffPrepare', 'handoffPeek', 'handoffRestore', 'handoffDecline']) {
+      expect(typeof exposed[name]).toBe('function');
+    }
+
+    call('handoffPrepare');
+    expect(lastInvocation().channel).toBe('handoff:prepare');
+
+    call('handoffPeek');
+    expect(lastInvocation().channel).toBe('handoff:peek');
+
+    call('handoffRestore', 'agent album alloy');
+    expect(lastInvocation().channel).toBe('handoff:restore');
+    expect(lastInvocation().args).toEqual(['agent album alloy']);
+
+    call('handoffDecline', 'handoff-1');
+    expect(lastInvocation().channel).toBe('handoff:decline');
+    expect(lastInvocation().args).toEqual(['handoff-1']);
+  });
+
   test('the folder picker forwards the directory it should open at', () => {
     call('selectDirectory', '/some/where');
 

--- a/src/main/api/relay/__tests__/handoff-transport.test.ts
+++ b/src/main/api/relay/__tests__/handoff-transport.test.ts
@@ -3,8 +3,11 @@
  * router. Both trees build these signed lines from their own copy of the
  * format, so a divergence is only visible where both are present.
  */
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { createHandoffTransport } from '../handoff-transport';
 import { openHandoff, sealHandoff } from '../../../transfer/handoff-crypto';
 import { loadConfig } from '../../../../../relay/src/config';
@@ -25,10 +28,17 @@ function identity() {
   };
 }
 
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
 function relay(env: Record<string, string> = {}) {
   const db = openDb(':memory:');
   const repos = createRepositories(db);
-  const { config } = loadConfig({ NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test', ...env });
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'transport-handoff-'));
+  dirs.push(dir);
+  const { config } = loadConfig({ NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test', HANDOFF_DIR: dir, ...env });
   const route = createRouter({ config, logger, repos });
 
   const user = repos.upsertGithubUser({

--- a/src/main/api/relay/__tests__/handoff-transport.test.ts
+++ b/src/main/api/relay/__tests__/handoff-transport.test.ts
@@ -12,6 +12,7 @@ import { createLogger } from '../../../../../relay/src/logger';
 import { openDb } from '../../../../../relay/src/db';
 import { createRepositories } from '../../../../../relay/src/repositories';
 import { createRouter } from '../../../../../relay/src/http';
+import { HANDOFF_MAX_BYTES } from '../../../../shared/types';
 
 const logger = createLogger('error');
 
@@ -53,6 +54,13 @@ function relay(env: Record<string, string> = {}) {
 
   return { db, link };
 }
+
+describe('the two sides of the size ceiling', () => {
+  test('agree, so a pre-flight refusal means what the relay would have said', () => {
+    const { config } = loadConfig({ NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test' });
+    expect(HANDOFF_MAX_BYTES).toBe(config.handoffMaxBytes);
+  });
+});
 
 describe('the transport against the real router', () => {
   test('carries a bundle from one machine to another and clears it', async () => {

--- a/src/main/api/relay/__tests__/handoff-transport.test.ts
+++ b/src/main/api/relay/__tests__/handoff-transport.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The desktop's half of the handoff wire, driven against the relay's own
+ * router. Both trees build these signed lines from their own copy of the
+ * format, so a divergence is only visible where both are present.
+ */
+import { describe, expect, test } from 'bun:test';
+import crypto from 'crypto';
+import { createHandoffTransport } from '../handoff-transport';
+import { openHandoff, sealHandoff } from '../../../transfer/handoff-crypto';
+import { loadConfig } from '../../../../../relay/src/config';
+import { createLogger } from '../../../../../relay/src/logger';
+import { openDb } from '../../../../../relay/src/db';
+import { createRepositories } from '../../../../../relay/src/repositories';
+import { createRouter } from '../../../../../relay/src/http';
+
+const logger = createLogger('error');
+
+function identity() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  const { x } = publicKey.export({ format: 'jwk' }) as { x: string };
+  return {
+    raw: new Uint8Array(Buffer.from(x, 'base64url')),
+    sign: (message: Uint8Array) => crypto.sign(null, Buffer.from(message), privateKey),
+  };
+}
+
+function relay(env: Record<string, string> = {}) {
+  const db = openDb(':memory:');
+  const repos = createRepositories(db);
+  const { config } = loadConfig({ NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test', ...env });
+  const route = createRouter({ config, logger, repos });
+
+  const user = repos.upsertGithubUser({
+    providerUserId: '1',
+    displayName: 'Will',
+    login: 'will-l',
+    email: null,
+    avatarUrl: null,
+  });
+
+  function link(name: string) {
+    const id = identity();
+    const code = repos.createLinkCode(name, id.raw, new Uint8Array(32).fill(1), 600).code;
+    const claim = repos.claimLinkCode(code, user.id);
+    if (!claim.ok) throw new Error('fixture could not link a machine');
+    return createHandoffTransport({
+      origin: 'http://relay.test/',
+      machineId: claim.machine.id,
+      sign: id.sign,
+      fetchImpl: (input, init) => route(new Request(input as string, init), '203.0.113.9'),
+    });
+  }
+
+  return { db, link };
+}
+
+describe('the transport against the real router', () => {
+  test('carries a bundle from one machine to another and clears it', async () => {
+    const { db, link } = relay();
+    const oldMachine = link('Old Laptop');
+    const newMachine = link('New Laptop');
+    const { bytes, phrase } = sealHandoff(Buffer.from('a whole machine'));
+
+    const uploaded = await oldMachine.upload(bytes);
+    expect(uploaded.sourceMachineName).toBe('Old Laptop');
+
+    const offer = await newMachine.peek();
+    expect(offer!.id).toBe(uploaded.id);
+    expect(offer!.byteSize).toBe(bytes.length);
+
+    const pulled = await newMachine.download();
+    expect(pulled.id).toBe(uploaded.id);
+    expect(openHandoff(pulled.sealed, phrase).toString()).toBe('a whole machine');
+
+    await newMachine.acknowledge(pulled.id);
+    expect(await newMachine.peek()).toBeNull();
+    db.close();
+  });
+
+  test('does not offer a machine the bundle it prepared itself', async () => {
+    const { db, link } = relay();
+    const oldMachine = link('Old Laptop');
+    await oldMachine.upload(sealHandoff(Buffer.from('mine')).bytes);
+
+    expect(await oldMachine.peek()).toBeNull();
+    expect(await link('New Laptop').peek()).not.toBeNull();
+    db.close();
+  });
+
+  test('signs every call and declares the digest it signed for', async () => {
+    let seen: Headers | undefined;
+    const transport = createHandoffTransport({
+      origin: 'http://relay.test',
+      machineId: 'machine-1',
+      sign: () => Buffer.alloc(64),
+      fetchImpl: async (_input, init) => {
+        seen = new Headers(init?.headers);
+        return new Response('{"handoff":null}', { headers: { 'content-type': 'application/json' } });
+      },
+    });
+
+    await transport.peek();
+    expect(seen!.get('x-bodhi-issued-at')).not.toBeNull();
+    expect(seen!.get('x-bodhi-signature')).not.toBeNull();
+
+    await transport.upload(Buffer.from('bytes'));
+    expect(seen!.get('x-bodhi-content-sha256')).toBe(
+      crypto.createHash('sha256').update(Buffer.from('bytes')).digest('hex'),
+    );
+  });
+
+  test('turns a refusal into something the window can show a person', async () => {
+    const { db, link } = relay({ HANDOFF_MAX_BYTES: '64' });
+    const oldMachine = link('Old Laptop');
+
+    await expect(oldMachine.upload(Buffer.alloc(4096, 3))).rejects.toThrow(/Could not store the handoff \(413\)/);
+    await expect(link('New Laptop').download()).rejects.toThrow(/Could not download the handoff \(404\)/);
+    db.close();
+  });
+
+  test('treats a bundle already gone as the state the caller wanted', async () => {
+    const { db, link } = relay();
+    const newMachine = link('New Laptop');
+    await expect(newMachine.acknowledge('00000000-0000-4000-8000-000000000000')).resolves.toBeUndefined();
+    db.close();
+  });
+});

--- a/src/main/api/relay/__tests__/relay-client.test.ts
+++ b/src/main/api/relay/__tests__/relay-client.test.ts
@@ -32,6 +32,14 @@ mock.module('electron', () => ({
 }));
 mock.module('../../../database', () => ({ getDatabase: () => db }));
 
+// `relay-client` reaches `pty-manager`, which loads node-pty's native binding
+// at import. There is no Linux prebuild in this checkout, so without this the
+// import throws on CI — and bun reports that as an unhandled error between
+// tests rather than a failure, which is to say the file silently runs nothing.
+mock.module('node-pty', () => ({
+  spawn: () => { throw new Error('no pty spawns in these tests'); },
+}));
+
 const { RelayClient } = await import('../relay-client');
 
 beforeEach(() => {

--- a/src/main/api/relay/__tests__/relay-client.test.ts
+++ b/src/main/api/relay/__tests__/relay-client.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The relay client's handoff seam. It is the one place that decides a machine
+ * is ready to reach its account's slot at all, and "not linked yet" has to be
+ * an answer rather than a thrown error — it is asked on every launch.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+
+let db: Database;
+
+// Superset stub: this module's import graph reaches most of the Electron main
+// surface, and none of it is exercised here.
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata', getVersion: () => '3.5.1', on: () => {} },
+  powerSaveBlocker: { start: () => 1, stop: () => {}, isStarted: () => false },
+  safeStorage: { isEncryptionAvailable: () => false },
+  ipcMain: { on: () => {}, handle: () => {} },
+  BrowserWindow: class {
+    static getAllWindows() { return []; }
+  },
+  Notification: class {
+    static isSupported() { return false; }
+  },
+  Menu: { buildFromTemplate: () => ({}), setApplicationMenu: () => {} },
+  Tray: class {},
+  dialog: { showMessageBox: async () => ({ response: 0 }) },
+  nativeImage: { createFromPath: () => ({}) },
+  shell: { openExternal: async () => {} },
+  clipboard: { writeText: () => {} },
+  nativeTheme: { shouldUseDarkColors: false },
+  screen: { getPrimaryDisplay: () => ({ workAreaSize: { width: 0, height: 0 } }) },
+}));
+mock.module('../../../database', () => ({ getDatabase: () => db }));
+
+const { RelayClient } = await import('../relay-client');
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  db.exec('CREATE TABLE preferences (key TEXT PRIMARY KEY, value TEXT)');
+});
+
+afterEach(() => db.close());
+
+function setPref(key: string, value: string) {
+  db.query('INSERT INTO preferences (key, value) VALUES (?, ?)').run(key, value);
+}
+
+describe('reaching the handoff slot', () => {
+  test('is null until this machine has been claimed by an account', () => {
+    expect(new RelayClient().handoffTransport()).toBeNull();
+  });
+
+  test('is available once it has, and every call it makes is signed', () => {
+    setPref('relay.machineId', 'machine-1');
+    const transport = new RelayClient().handoffTransport();
+    expect(transport).not.toBeNull();
+    for (const verb of ['upload', 'peek', 'download', 'acknowledge'] as const) {
+      expect(typeof transport![verb]).toBe('function');
+    }
+  });
+});

--- a/src/main/api/relay/handoff-transport.ts
+++ b/src/main/api/relay/handoff-transport.ts
@@ -1,0 +1,93 @@
+/**
+ * The handoff slot, as four signed HTTP calls. Kept out of the relay client
+ * because no socket is involved, which lets the whole thing be driven against
+ * the relay's own router — the only place the two wire formats meet.
+ */
+
+import crypto from 'crypto';
+import type { HandoffOffer } from '../../../shared/types';
+import type { HandoffTransport } from '../../transfer/handoff';
+
+// --- wire format (keep in sync with relay/src/protocol.ts) ---
+const PUT = 'handoff-put:v1';
+const META = 'handoff-meta:v1';
+const GET = 'handoff-get:v1';
+const DELETE = 'handoff-delete:v1';
+const SIGNATURE_HEADER = 'x-bodhi-signature';
+const ISSUED_AT_HEADER = 'x-bodhi-issued-at';
+const DIGEST_HEADER = 'x-bodhi-content-sha256';
+const ID_HEADER = 'x-bodhi-handoff-id';
+
+export interface HandoffEndpoint {
+  /** Relay origin, e.g. `https://relay.example.com`. */
+  origin: string;
+  /** This machine's id on that relay; the slot is its user's. */
+  machineId: string;
+  sign(message: Uint8Array): Buffer;
+  /** Injectable so the transport can be driven against a router in-process. */
+  fetchImpl?: typeof fetch;
+}
+
+async function refusal(res: Response, what: string): Promise<Error> {
+  const detail = await res.text().catch(() => '');
+  return new Error(`Could not ${what} (${res.status})${detail ? `: ${detail}` : ''}`);
+}
+
+export function createHandoffTransport(endpoint: HandoffEndpoint): HandoffTransport {
+  const origin = endpoint.origin.replace(/\/+$/, '');
+  const { machineId } = endpoint;
+  const call = endpoint.fetchImpl ?? fetch;
+  const slot = `${origin}/api/machines/${machineId}/handoff`;
+
+  /** Sign one verb. The joined lines must match the relay's builders exactly. */
+  function auth(parts: string[], extra: Record<string, string> = {}): Record<string, string> {
+    const issuedAt = Date.now();
+    const message = new TextEncoder().encode([...parts, String(issuedAt)].join('\n'));
+    return {
+      [ISSUED_AT_HEADER]: String(issuedAt),
+      [SIGNATURE_HEADER]: endpoint.sign(message).toString('base64'),
+      ...extra,
+    };
+  }
+
+  return {
+    async upload(sealed) {
+      const digest = crypto.createHash('sha256').update(sealed).digest('hex');
+      const res = await call(slot, {
+        method: 'PUT',
+        headers: auth([PUT, machineId, digest], {
+          'content-type': 'application/octet-stream',
+          [DIGEST_HEADER]: digest,
+        }),
+        body: new Uint8Array(sealed),
+      });
+      if (!res.ok) throw await refusal(res, 'store the handoff');
+      return ((await res.json()) as { handoff: HandoffOffer }).handoff;
+    },
+
+    async peek() {
+      const res = await call(slot, { headers: auth([META, machineId]) });
+      if (!res.ok) throw await refusal(res, 'read the handoff');
+      const { handoff } = (await res.json()) as { handoff: HandoffOffer | null };
+      // A machine is never offered the bundle it prepared itself.
+      return handoff?.sourceMachineId === machineId ? null : handoff;
+    },
+
+    async download() {
+      const res = await call(`${slot}/bundle`, { headers: auth([GET, machineId]) });
+      if (!res.ok) throw await refusal(res, 'download the handoff');
+      const id = res.headers.get(ID_HEADER);
+      if (!id) throw new Error('The relay returned a handoff with no id.');
+      return { id, sealed: Buffer.from(await res.arrayBuffer()) };
+    },
+
+    async acknowledge(handoffId) {
+      const res = await call(`${slot}?id=${encodeURIComponent(handoffId)}`, {
+        method: 'DELETE',
+        headers: auth([DELETE, machineId, handoffId]),
+      });
+      // Already gone is the state the caller was asking for.
+      if (!res.ok && res.status !== 404) throw await refusal(res, 'clear the handoff');
+    },
+  };
+}

--- a/src/main/api/relay/handoff-transport.ts
+++ b/src/main/api/relay/handoff-transport.ts
@@ -28,8 +28,24 @@ export interface HandoffEndpoint {
   fetchImpl?: typeof fetch;
 }
 
+/**
+ * A refusal the window can show. The body is read for the relay's own reason,
+ * and a status is spelled out when there is none — a request killed at the
+ * socket for its size arrives with nothing in it at all.
+ */
 async function refusal(res: Response, what: string): Promise<Error> {
-  const detail = await res.text().catch(() => '');
+  const body = await res.text().catch(() => '');
+  let detail = body.trim();
+  try {
+    const parsed = JSON.parse(body) as { error?: string; maxBytes?: number };
+    if (parsed?.error) {
+      detail = parsed.error.replace(/_/g, ' ');
+      if (typeof parsed.maxBytes === 'number') detail += ` — this relay carries up to ${parsed.maxBytes} bytes`;
+    }
+  } catch {
+    // Not JSON; the raw text, or nothing, is the best that can be said.
+  }
+  if (!detail && res.status === 413) detail = 'the relay refused it as too large';
   return new Error(`Could not ${what} (${res.status})${detail ? `: ${detail}` : ''}`);
 }
 

--- a/src/main/api/relay/handoff-transport.ts
+++ b/src/main/api/relay/handoff-transport.ts
@@ -46,7 +46,8 @@ async function refusal(res: Response, what: string): Promise<Error> {
     // Not JSON; the raw text, or nothing, is the best that can be said.
   }
   if (!detail && res.status === 413) detail = 'the relay refused it as too large';
-  return new Error(`Could not ${what} (${res.status})${detail ? `: ${detail}` : ''}`);
+  const because = detail ? `: ${detail}` : '';
+  return new Error(`Could not ${what} (${res.status})${because}`);
 }
 
 export function createHandoffTransport(endpoint: HandoffEndpoint): HandoffTransport {

--- a/src/main/api/relay/relay-client.ts
+++ b/src/main/api/relay/relay-client.ts
@@ -22,6 +22,8 @@ import { ensureIdentity, identityFingerprint, signWithIdentity } from './relay-i
 import { SessionTunnel, type Principal } from './session-tunnel';
 import { defaultDeps } from './session-tunnel-deps';
 import { CAP_GRANTS_V1, buildShareCreateMessage } from './grants';
+import { createHandoffTransport } from './handoff-transport';
+import type { HandoffTransport } from '../../transfer/handoff';
 import { ptyManager } from '../../pty-manager';
 import { getDatabase } from '../../database';
 import {
@@ -582,6 +584,17 @@ export class RelayClient extends EventEmitter {
     const url = `${origin}/i/${body.code}${fragment}`;
     log.info('[Relay] share invite created', { addressed: !!input.expectedGithubLogin });
     return { code: body.code, url, expiresAt: body.expiresAt };
+  }
+
+  /** Reaches this account's handoff slot, or null until the machine is linked. */
+  handoffTransport(): HandoffTransport | null {
+    const machineId = getPreference(PREF.machineId);
+    if (!machineId) return null;
+    return createHandoffTransport({
+      origin: stripTrailingSlashes(this.relayUrl),
+      machineId,
+      sign: signWithIdentity,
+    });
   }
 
   /** Every grant this machine has issued, for the owner's settings list. */

--- a/src/main/group-import-export.ts
+++ b/src/main/group-import-export.ts
@@ -199,7 +199,7 @@ async function exportPortableJson(): Promise<ExportResult> {
  * Null means the user abandoned the import; an empty answer for one root is
  * allowed and leaves those paths as they were.
  */
-async function askRootMappings(roots: string[]): Promise<WorkingDirMapping[] | null> {
+export async function askRootMappings(roots: string[]): Promise<WorkingDirMapping[] | null> {
   const mappings: WorkingDirMapping[] = [];
 
   for (const root of roots) {
@@ -232,7 +232,7 @@ async function askRootMappings(roots: string[]): Promise<WorkingDirMapping[] | n
  * Hooks are what make a session report its state. Registering them only at
  * window creation left every restored account silent until the next launch.
  */
-function registerRestoredAccountHooks(): void {
+export function registerRestoredAccountHooks(): void {
   for (const account of accountsRepo.getAllAccounts()) {
     const result = registerHooks(account.configDir);
     if (!result.success) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -24,6 +24,12 @@ import * as accountSwitch from './account-switch';
 import * as accountFailover from './account-failover';
 import { exportSessions, ExportFormat } from './session-export';
 import { exportGroupsAndSessions, importGroupsAndSessions, importFromClaudeLander } from './group-import-export';
+import {
+  declineMachineHandoff,
+  prepareMachineHandoff,
+  readHandoffOffer,
+  restoreMachineHandoff,
+} from './machine-handoff';
 import { StateMonitor } from './state-monitor';
 import { createApplicationMenu } from './menu';
 import { initAutoUpdater, checkForUpdatesManual, downloadUpdate, getUpdateChannel, setUpdateChannel, UpdateChannel } from './auto-updater';
@@ -1027,6 +1033,14 @@ safeHandle('export:sessions', (format: ExportFormat, since?: string) =>
 safeHandle('export:groups', () => exportGroupsAndSessions());
 safeHandle('import:groups', () => importGroupsAndSessions());
 safeHandle('import:fromClaudeLander', () => importFromClaudeLander());
+
+// Machine handoff, over the relay rather than a file
+safeHandle('handoff:prepare', () => prepareMachineHandoff(getRelayClient().handoffTransport()));
+safeHandle('handoff:peek', () => readHandoffOffer(getRelayClient().handoffTransport()));
+safeHandle('handoff:restore', (phrase: string) =>
+  restoreMachineHandoff(getRelayClient().handoffTransport(), phrase)
+);
+safeHandle('handoff:decline', (handoffId: string) => declineMachineHandoff(handoffId));
 
 // Preferences IPC Handlers
 safeHandle('prefs:get', (key: string) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1040,7 +1040,9 @@ safeHandle('handoff:peek', () => readHandoffOffer(getRelayClient().handoffTransp
 safeHandle('handoff:restore', (phrase: string) =>
   restoreMachineHandoff(getRelayClient().handoffTransport(), phrase)
 );
-safeHandle('handoff:decline', (handoffId: string) => declineMachineHandoff(handoffId));
+safeHandle('handoff:decline', (handoffId: string) =>
+  declineMachineHandoff(getRelayClient().handoffTransport(), handoffId)
+);
 
 // Preferences IPC Handlers
 safeHandle('prefs:get', (key: string) => {

--- a/src/main/machine-handoff.ts
+++ b/src/main/machine-handoff.ts
@@ -20,10 +20,14 @@ import {
   fetchHandoff,
   isHandoffDeclined,
   prepareHandoff,
-  HANDOFF_MAX_BYTES,
   type HandoffTransport,
 } from './transfer/handoff';
-import type { HandoffOfferState, HandoffPrepareResult, PortableImportResult } from '../shared/types';
+import {
+  HANDOFF_MAX_BYTES,
+  type HandoffOfferState,
+  type HandoffPrepareResult,
+  type PortableImportResult,
+} from '../shared/types';
 
 const prefs = { get: getPreference, set: setPreference };
 
@@ -83,7 +87,13 @@ export async function readHandoffOffer(transport: HandoffTransport | null): Prom
   }
 }
 
-export function declineMachineHandoff(handoffId: string): void {
+export function declineMachineHandoff(transport: HandoffTransport | null, handoffId: string): void {
+  if (!transport) {
+    // Unlinked since the offer was drawn, so what is on screen is stale.
+    // Writing the decline here would permanently bury a bundle that is real.
+    log.info('[Handoff] Declined a stale offer; not recording it');
+    return;
+  }
   declineHandoff(prefs, handoffId);
   log.info('[Handoff] Offer declined; it will not be raised again');
 }

--- a/src/main/machine-handoff.ts
+++ b/src/main/machine-handoff.ts
@@ -109,7 +109,7 @@ export async function restoreMachineHandoff(
 
   const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bodhilander-handoff-'));
   try {
-    const outcome = await applyHandoff(getDatabase(), opened, {
+    const { outcome, acknowledged } = await applyHandoff(getDatabase(), opened, {
       transport,
       import: {
         accountsRoot: path.join(app.getPath('userData'), 'claude-accounts'),
@@ -119,6 +119,12 @@ export async function restoreMachineHandoff(
       },
     });
     registerRestoredAccountHooks();
+    if (!acknowledged) {
+      // Restored, but the relay still holds the bundle and would offer it
+      // again on the next launch. Answering it here is what stops that.
+      declineHandoff(prefs, opened.handoffId);
+      log.warn('[Handoff] Restored, but the relay would not release the bundle; it expires on its own');
+    }
     log.info(
       `[Handoff] Restored ${outcome.groups} group(s), ${outcome.sessions} session(s), ` +
         `${outcome.transcripts} transcript(s); ${outcome.needsRelink.length} need relinking`,
@@ -147,15 +153,16 @@ async function confirmHandoffUpload(byteLength: number, manifest: TransferManife
     buttons: ['Prepare Handoff', 'Cancel'],
     defaultId: 0,
     cancelId: 1,
-    title: 'Move to Another Machine',
+    title: 'Send to Another Machine',
     message: `Send ${formatBytes(byteLength)} of this machine's state to the relay?`,
     detail:
       `${manifest.counts.groups} group(s), ${manifest.counts.sessions} session(s), ` +
       `${manifest.counts.transcripts} conversation transcript(s), ` +
       `${manifest.counts.accounts} account(s), ${manifest.counts.preferences} setting(s).\n\n` +
       'It is encrypted here first. The relay stores the result and cannot read it, and only the ' +
-      'recovery phrase shown next can open it. API keys, Teams tokens and the relay identity stay ' +
-      'here — the new machine signs in for itself.',
+      'recovery phrase shown next can open it. This machine keeps everything it has; nothing is ' +
+      'removed. API keys, Teams tokens and the relay identity stay here — the new machine signs ' +
+      'in for itself.',
   });
   return response === 0;
 }

--- a/src/main/machine-handoff.ts
+++ b/src/main/machine-handoff.ts
@@ -1,0 +1,161 @@
+/**
+ * "Move to another machine", over the relay instead of a file. The mechanics
+ * live in `transfer/handoff`; this is the Electron half — the dialogs, the
+ * app's database, and the relay client behind the transport.
+ */
+
+import { app, dialog } from 'electron';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import log from 'electron-log';
+import { getDatabase } from './database';
+import { legacyClaudeConfigDir } from './conversation-transcript';
+import { getPreference, setPreference } from './repositories/preferences';
+import { askRootMappings, registerRestoredAccountHooks } from './group-import-export';
+import { formatBytes, type TransferManifest } from './transfer/bundle-format';
+import {
+  applyHandoff,
+  declineHandoff,
+  fetchHandoff,
+  isHandoffDeclined,
+  prepareHandoff,
+  HANDOFF_MAX_BYTES,
+  type HandoffTransport,
+} from './transfer/handoff';
+import type { HandoffOfferState, HandoffPrepareResult, PortableImportResult } from '../shared/types';
+
+const prefs = { get: getPreference, set: setPreference };
+
+const NOT_LINKED = 'Link this machine to a relay account before moving it.';
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function prepareMachineHandoff(
+  transport: HandoffTransport | null,
+  legacyDir: string = legacyClaudeConfigDir(),
+): Promise<HandoffPrepareResult> {
+  if (!transport) return { success: false, error: NOT_LINKED };
+  try {
+    const prepared = await prepareHandoff(getDatabase(), {
+      transport,
+      maxBytes: HANDOFF_MAX_BYTES,
+      confirm: confirmHandoffUpload,
+      export: {
+        sourceAppVersion: app.getVersion(),
+        sourcePlatform: process.platform,
+        sourceUserData: app.getPath('userData'),
+        legacyConfigDir: legacyDir,
+      },
+    });
+    if (!prepared) return { success: false, error: 'Handoff cancelled' };
+    log.info(`[Handoff] Prepared ${formatBytes(prepared.sealedBytes)} for another machine`);
+    return {
+      success: true,
+      phrase: prepared.phrase,
+      sizeLabel: formatBytes(prepared.sealedBytes),
+      groupCount: prepared.manifest.counts.groups,
+      sessionCount: prepared.manifest.counts.sessions,
+      expiresAt: prepared.offer.expiresAt,
+    };
+  } catch (error) {
+    log.error('[Handoff] Prepare failed:', message(error));
+    return { success: false, error: message(error) };
+  }
+}
+
+/**
+ * What this machine should do about a waiting handoff. Errors are swallowed
+ * into "nothing waiting": this runs on launch, and a relay that is unreachable
+ * is not something to interrupt someone with.
+ */
+export async function readHandoffOffer(transport: HandoffTransport | null): Promise<HandoffOfferState> {
+  if (!transport) return { offer: null, declined: false };
+  try {
+    const offer = await transport.peek();
+    if (!offer) return { offer: null, declined: false };
+    return { offer, declined: isHandoffDeclined(prefs, offer.id), sizeLabel: formatBytes(offer.byteSize) };
+  } catch (error) {
+    log.info('[Handoff] No offer available:', message(error));
+    return { offer: null, declined: false };
+  }
+}
+
+export function declineMachineHandoff(handoffId: string): void {
+  declineHandoff(prefs, handoffId);
+  log.info('[Handoff] Offer declined; it will not be raised again');
+}
+
+export async function restoreMachineHandoff(
+  transport: HandoffTransport | null,
+  phrase: string,
+  legacyDir: string = legacyClaudeConfigDir(),
+): Promise<PortableImportResult> {
+  if (!transport) return { success: false, error: NOT_LINKED };
+  let opened;
+  try {
+    opened = await fetchHandoff(transport, phrase);
+  } catch (error) {
+    // Nothing has been changed and nothing consumed — the bundle is still
+    // there for another attempt.
+    log.warn('[Handoff] Could not open the waiting bundle:', message(error));
+    return { success: false, error: message(error) };
+  }
+
+  const mappings = await askRootMappings(opened.manifest?.workingDirRoots ?? []);
+  if (mappings === null) return { success: false, error: 'Import cancelled' };
+
+  const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bodhilander-handoff-'));
+  try {
+    const outcome = await applyHandoff(getDatabase(), opened, {
+      transport,
+      import: {
+        accountsRoot: path.join(app.getPath('userData'), 'claude-accounts'),
+        legacyConfigDir: legacyDir,
+        stagingDir,
+        mappings,
+      },
+    });
+    registerRestoredAccountHooks();
+    log.info(
+      `[Handoff] Restored ${outcome.groups} group(s), ${outcome.sessions} session(s), ` +
+        `${outcome.transcripts} transcript(s); ${outcome.needsRelink.length} need relinking`,
+    );
+    return {
+      success: true,
+      groupCount: outcome.groups,
+      sessionCount: outcome.sessions,
+      skippedGroups: outcome.skippedGroups,
+      skippedSessions: outcome.skippedSessions,
+      transcriptCount: outcome.transcripts,
+      needsRelinkCount: outcome.needsRelink.length,
+    };
+  } catch (error) {
+    log.error('[Handoff] Restore failed:', message(error));
+    return { success: false, error: message(error) };
+  } finally {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  }
+}
+
+/** The one confirmation the old machine sees before its state leaves it. */
+async function confirmHandoffUpload(byteLength: number, manifest: TransferManifest): Promise<boolean> {
+  const { response } = await dialog.showMessageBox({
+    type: 'question',
+    buttons: ['Prepare Handoff', 'Cancel'],
+    defaultId: 0,
+    cancelId: 1,
+    title: 'Move to Another Machine',
+    message: `Send ${formatBytes(byteLength)} of this machine's state to the relay?`,
+    detail:
+      `${manifest.counts.groups} group(s), ${manifest.counts.sessions} session(s), ` +
+      `${manifest.counts.transcripts} conversation transcript(s), ` +
+      `${manifest.counts.accounts} account(s), ${manifest.counts.preferences} setting(s).\n\n` +
+      'It is encrypted here first. The relay stores the result and cannot read it, and only the ' +
+      'recovery phrase shown next can open it. API keys, Teams tokens and the relay identity stay ' +
+      'here — the new machine signs in for itself.',
+  });
+  return response === 0;
+}

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, AccountFailoverEvent, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest, PortableExportResult, PortableImportResult } from '../shared/types';
+import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, AccountFailoverEvent, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest, PortableExportResult, PortableImportResult, HandoffOfferState, HandoffPrepareResult } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -209,6 +209,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('import:groups'),
   importFromClaudeLander: (): Promise<PortableImportResult> =>
     ipcRenderer.invoke('import:fromClaudeLander'),
+
+  // Machine handoff, over the relay
+  handoffPrepare: (): Promise<HandoffPrepareResult> =>
+    ipcRenderer.invoke('handoff:prepare'),
+  handoffPeek: (): Promise<HandoffOfferState> =>
+    ipcRenderer.invoke('handoff:peek'),
+  handoffRestore: (phrase: string): Promise<PortableImportResult> =>
+    ipcRenderer.invoke('handoff:restore', phrase),
+  handoffDecline: (handoffId: string): Promise<void> =>
+    ipcRenderer.invoke('handoff:decline', handoffId),
 
   // Preferences
   getPreference: (key: string): Promise<string | null> =>

--- a/src/main/transfer/__tests__/handoff-crypto.test.ts
+++ b/src/main/transfer/__tests__/handoff-crypto.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Sealing a bundle for the relay to carry. What matters is what a wrong phrase
+ * does: told apart from a corrupt bundle, and leaving the sealed bytes as they
+ * were — they are the only copy the destination has.
+ */
+import { describe, expect, test } from 'bun:test';
+import { HANDOFF_FORMAT_VERSION, openHandoff, sealHandoff } from '../handoff-crypto';
+import { generateRecoveryPhrase, RecoveryPhraseError, splitRecoveryPhrase, PHRASE_WORDS } from '../recovery-phrase';
+
+const PLAINTEXT = Buffer.from('BDHLBNDL — pretend this is a whole machine');
+
+describe('sealing and opening', () => {
+  test('round-trips the bundle under its own phrase', () => {
+    const { bytes, phrase } = sealHandoff(PLAINTEXT);
+    expect(openHandoff(bytes, phrase).equals(PLAINTEXT)).toBe(true);
+  });
+
+  test('produces bytes that are not the bundle', () => {
+    const { bytes } = sealHandoff(PLAINTEXT);
+    expect(bytes.includes(PLAINTEXT)).toBe(false);
+    expect(bytes.subarray(0, 8).toString('ascii')).toBe('BDHLHOFF');
+    expect(bytes[8]).toBe(HANDOFF_FORMAT_VERSION);
+  });
+
+  test('seals the same plaintext differently every time', () => {
+    const first = sealHandoff(PLAINTEXT);
+    const second = sealHandoff(PLAINTEXT);
+    expect(first.bytes.equals(second.bytes)).toBe(false);
+    expect(first.phrase).not.toBe(second.phrase);
+  });
+});
+
+describe('a phrase that is not the right one', () => {
+  test('is refused by the checksum before the bytes are touched', () => {
+    const { bytes } = sealHandoff(PLAINTEXT);
+    const before = Buffer.from(bytes);
+    expect(() => openHandoff(bytes, 'not even close')).toThrow(RecoveryPhraseError);
+    expect(bytes.equals(before)).toBe(true);
+  });
+
+  test('says so plainly when it is a well-formed phrase for another bundle', () => {
+    const { bytes } = sealHandoff(PLAINTEXT);
+    const before = Buffer.from(bytes);
+    const other = generateRecoveryPhrase();
+    expect(() => openHandoff(bytes, other)).toThrow(/recovery phrase does not open this bundle/);
+    expect(bytes.equals(before)).toBe(true);
+  });
+
+  test('names the offending word rather than failing as a decryption error', () => {
+    const { bytes, phrase } = sealHandoff(PLAINTEXT);
+    const words = splitRecoveryPhrase(phrase);
+    words[4] = 'quagmire';
+    expect(() => openHandoff(bytes, words.join(' '))).toThrow(/quagmire/);
+  });
+
+  test('is distinguishable from a corrupt bundle', () => {
+    const { bytes, phrase } = sealHandoff(PLAINTEXT);
+    const tampered = Buffer.from(bytes);
+    tampered[tampered.length - 1] ^= 0xff;
+    expect(() => openHandoff(tampered, phrase)).toThrow(/does not open this bundle/);
+
+    const notABundle = Buffer.from('some other file entirely');
+    expect(() => openHandoff(notABundle, phrase)).toThrow(/not a Bodhilander handoff bundle/);
+  });
+
+  test('refuses a container written by a newer build', () => {
+    const { bytes, phrase } = sealHandoff(PLAINTEXT);
+    const future = Buffer.from(bytes);
+    future[8] = HANDOFF_FORMAT_VERSION + 1;
+    expect(() => openHandoff(future, phrase)).toThrow(/newer version of Bodhilander/);
+  });
+
+  test('cannot be brute-forced a word at a time — one wrong word fails everything', () => {
+    const { bytes, phrase } = sealHandoff(PLAINTEXT);
+    const words = splitRecoveryPhrase(phrase);
+    const wrong = PHRASE_WORDS.find((w) => w !== words[0])!;
+    expect(() => openHandoff(bytes, [wrong, ...words.slice(1)].join(' '))).toThrow();
+  });
+});

--- a/src/main/transfer/__tests__/handoff.test.ts
+++ b/src/main/transfer/__tests__/handoff.test.ts
@@ -44,7 +44,7 @@ let prefsPath: string;
  * A relay that holds one sealed blob per account. It is given bytes and an id
  * and knows nothing else — which is the whole point of it being this small.
  */
-function standInRelay() {
+function standInRelay(options: { failAcknowledge?: boolean } = {}) {
   let slot: { id: string; sealed: Buffer } | null = null;
   let nextId = 1;
   const counts = { uploads: 0, downloads: 0, acks: 0 };
@@ -77,6 +77,7 @@ function standInRelay() {
       },
       async acknowledge(handoffId: string) {
         counts.acks++;
+        if (options.failAcknowledge) throw new Error('relay unreachable');
         if (slot?.id === handoffId) slot = null;
       },
     },
@@ -157,8 +158,9 @@ describe('preparing a handoff', () => {
   test('carries no key material — not the relay identity, not an API key', async () => {
     const relay = standInRelay();
     const { phrase } = await prepare(relay);
-    // Read what the bundle actually says, not the gzipped container: a search
-    // of the compressed bytes would find nothing whatever was in there.
+    // The bundle's TABLES entry specifically, decoded: a search of the gzipped
+    // container would find nothing whatever had been put in it. Transcript
+    // entries are a separate concern and are not scanned here.
     const tables = decodeBundle(openHandoff(relay.stored()!.sealed, phrase)).read(TABLES_ENTRY)!.toString('utf-8');
 
     for (const secret of Object.values(SECRET_VALUES)) {
@@ -196,7 +198,7 @@ describe('preparing a handoff', () => {
     const relay = standInRelay();
     await expect(
       prepareHandoff(source as never, { transport: relay.transport, maxBytes: 16, export: exportOptions() }),
-    ).rejects.toThrow(/Export it to a file instead/);
+    ).rejects.toThrow(/state is \d+.*relay carries up to .*Export it to a file instead/);
     expect(relay.counts.uploads).toBe(0);
   });
 });
@@ -207,7 +209,7 @@ describe('restoring on the new machine', () => {
     const { phrase } = await prepare(relay);
 
     const opened = await fetchHandoff(relay.transport, phrase);
-    const outcome = await applyHandoff(destination as never, opened, {
+    const { outcome } = await applyHandoff(destination as never, opened, {
       transport: relay.transport,
       import: importOptions(),
     });
@@ -227,9 +229,31 @@ describe('restoring on the new machine', () => {
     const opened = await fetchHandoff(relay.transport, phrase);
     expect(relay.stored()).not.toBeNull();
 
-    await applyHandoff(destination as never, opened, { transport: relay.transport, import: importOptions() });
+    const { acknowledged } = await applyHandoff(destination as never, opened, {
+      transport: relay.transport,
+      import: importOptions(),
+    });
+    expect(acknowledged).toBe(true);
     expect(relay.counts.acks).toBe(1);
     expect(relay.stored()).toBeNull();
+  });
+
+  test('reports the restore that happened even when the relay will not release the bundle', async () => {
+    const relay = standInRelay({ failAcknowledge: true });
+    const { phrase } = await prepare(relay);
+    const opened = await fetchHandoff(relay.transport, phrase);
+
+    const { outcome, acknowledged } = await applyHandoff(destination as never, opened, {
+      transport: relay.transport,
+      import: importOptions(),
+    });
+
+    // The import happened. A relay that will not take the acknowledgement
+    // cannot turn that into a failed restore.
+    expect(outcome.groups).toBe(1);
+    expect(outcome.sessions).toBe(1);
+    expect(acknowledged).toBe(false);
+    expect(destination.query('SELECT COUNT(*) AS n FROM groups').get()).toEqual({ n: 1 });
   });
 
   test('leaves the bundle alone when the import throws', async () => {
@@ -274,7 +298,7 @@ describe('a phrase that does not open it', () => {
     await expect(fetchHandoff(relay.transport, generateRecoveryPhrase())).rejects.toThrow();
 
     const opened = await fetchHandoff(relay.transport, phrase);
-    const outcome = await applyHandoff(destination as never, opened, {
+    const { outcome } = await applyHandoff(destination as never, opened, {
       transport: relay.transport,
       import: importOptions(),
     });

--- a/src/main/transfer/__tests__/handoff.test.ts
+++ b/src/main/transfer/__tests__/handoff.test.ts
@@ -1,0 +1,317 @@
+/**
+ * The whole trip, past a stand-in relay that only ever sees bytes: what it is
+ * handed, that a restore drives the ordinary importer and its remapping, that
+ * a failure leaves the bundle retryable, and that "not now" outlives a launch.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { freshDb, seedSecrets, seedSourceDb, SECRET_VALUES, writeTranscript } from './db-fixture';
+import { decodeBundle, looksLikeBundle, TABLES_ENTRY } from '../bundle-format';
+import { openHandoff } from '../handoff-crypto';
+import { generateRecoveryPhrase } from '../recovery-phrase';
+import type { HandoffOffer } from '../../../shared/types';
+
+// Same stub, same shape, as the sibling import suite: the provider registry
+// reaches `app.getPath` on the way in, and nothing here runs a command.
+mock.module('electron', () => ({ app: { getPath: () => '/nonexistent-bodhilander-test-userdata' } }));
+
+const {
+  applyHandoff,
+  declineHandoff,
+  DECLINED_HANDOFF_PREF,
+  fetchHandoff,
+  isHandoffDeclined,
+  prepareHandoff,
+} = await import('../handoff');
+
+const SOURCE_ROOT = '/src-machine/Work/Repos';
+const SOURCE_DIR = `${SOURCE_ROOT}/Bodhilander`;
+
+let source: Database;
+let destination: Database;
+let tmp: string;
+let sourceConfigDir: string;
+let sourceLegacyDir: string;
+let destAccountsRoot: string;
+let destLegacyDir: string;
+let destProjects: string;
+let prefsPath: string;
+
+/**
+ * A relay that holds one sealed blob per account. It is given bytes and an id
+ * and knows nothing else — which is the whole point of it being this small.
+ */
+function standInRelay() {
+  let slot: { id: string; sealed: Buffer } | null = null;
+  let nextId = 1;
+  const counts = { uploads: 0, downloads: 0, acks: 0 };
+
+  const offer = (): HandoffOffer => ({
+    id: slot!.id,
+    sourceMachineId: 'machine-old',
+    sourceMachineName: 'Old Laptop',
+    byteSize: slot!.sealed.length,
+    createdAt: 1756080000000,
+    expiresAt: 1756080000000 + 604800000,
+  });
+
+  return {
+    counts,
+    stored: () => slot,
+    transport: {
+      async upload(sealed: Buffer) {
+        counts.uploads++;
+        slot = { id: `handoff-${nextId++}`, sealed };
+        return offer();
+      },
+      async peek() {
+        return slot ? offer() : null;
+      },
+      async download() {
+        counts.downloads++;
+        if (!slot) throw new Error('nothing waiting');
+        return { id: slot.id, sealed: slot.sealed };
+      },
+      async acknowledge(handoffId: string) {
+        counts.acks++;
+        if (slot?.id === handoffId) slot = null;
+      },
+    },
+  };
+}
+
+function prefsStore(db: Database) {
+  return {
+    get: (key: string) =>
+      (db.query('SELECT value FROM preferences WHERE key = ?').get(key) as { value: string } | null)?.value ?? null,
+    set: (key: string, value: string) =>
+      void db
+        .query('INSERT INTO preferences (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value')
+        .run(key, value),
+  };
+}
+
+function exportOptions() {
+  return {
+    sourceAppVersion: '3.5.1',
+    sourcePlatform: 'darwin',
+    sourceUserData: path.join(tmp, 'src-userData'),
+    legacyConfigDir: sourceLegacyDir,
+  };
+}
+
+function importOptions() {
+  return {
+    accountsRoot: destAccountsRoot,
+    legacyConfigDir: destLegacyDir,
+    stagingDir: fs.mkdtempSync(path.join(tmp, 'staging-')),
+    mappings: [{ from: SOURCE_ROOT, to: destProjects }],
+  };
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bodhi-handoff-'));
+  sourceConfigDir = path.join(tmp, 'src-userData', 'claude-accounts', 'acct-1', '.claude');
+  sourceLegacyDir = path.join(tmp, 'src-home', '.claude');
+  destAccountsRoot = path.join(tmp, 'dst-userData', 'claude-accounts');
+  destLegacyDir = path.join(tmp, 'dst-home', '.claude');
+  destProjects = path.join(tmp, 'dst-projects');
+  prefsPath = path.join(tmp, 'prefs.db');
+  fs.mkdirSync(path.join(destProjects, 'Bodhilander'), { recursive: true });
+
+  source = freshDb();
+  seedSourceDb(source, { accountConfigDir: sourceConfigDir, workingDirs: [SOURCE_DIR] });
+  seedSecrets(source);
+  writeTranscript(sourceConfigDir, '-src-machine-Work-Repos-Bodhilander', 'conv-1', '{"type":"user"}');
+  destination = freshDb();
+});
+
+afterEach(() => {
+  source.close();
+  destination.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+async function prepare(relay: ReturnType<typeof standInRelay>) {
+  const prepared = await prepareHandoff(source as never, {
+    transport: relay.transport,
+    maxBytes: 64 * 1024 * 1024,
+    export: exportOptions(),
+  });
+  if (!prepared) throw new Error('the fixture never declines');
+  return prepared;
+}
+
+describe('preparing a handoff', () => {
+  test('hands the relay sealed bytes, not the bundle', async () => {
+    const relay = standInRelay();
+    await prepare(relay);
+    const sealed = relay.stored()!.sealed;
+    expect(looksLikeBundle(sealed)).toBe(false);
+    expect(sealed.subarray(0, 8).toString('ascii')).toBe('BDHLHOFF');
+  });
+
+  test('carries no key material — not the relay identity, not an API key', async () => {
+    const relay = standInRelay();
+    const { phrase } = await prepare(relay);
+    // Read what the bundle actually says, not the gzipped container: a search
+    // of the compressed bytes would find nothing whatever was in there.
+    const tables = decodeBundle(openHandoff(relay.stored()!.sealed, phrase)).read(TABLES_ENTRY)!.toString('utf-8');
+
+    for (const secret of Object.values(SECRET_VALUES)) {
+      expect(tables.includes(secret)).toBe(false);
+    }
+    expect(tables.includes('relay.ed25519Priv')).toBe(false);
+    expect(tables.includes('relay.machineId')).toBe(false);
+    // A portable setting IS there, so the four assertions above are not vacuous.
+    expect(tables.includes('closeToTray')).toBe(true);
+  });
+
+  test('replaces the previous bundle rather than adding to it', async () => {
+    const relay = standInRelay();
+    const first = await prepare(relay);
+    const second = await prepare(relay);
+    expect(relay.counts.uploads).toBe(2);
+    expect(relay.stored()!.id).not.toBe(first.offer.id);
+    expect(relay.stored()!.id).toBe(second.offer.id);
+  });
+
+  test('stops before uploading when the confirmation is declined', async () => {
+    const relay = standInRelay();
+    const result = await prepareHandoff(source as never, {
+      transport: relay.transport,
+      maxBytes: 64 * 1024 * 1024,
+      confirm: async () => false,
+      export: exportOptions(),
+    });
+    expect(result).toBeNull();
+    expect(relay.counts.uploads).toBe(0);
+    expect(relay.stored()).toBeNull();
+  });
+
+  test('refuses a state larger than the relay will carry, before uploading', async () => {
+    const relay = standInRelay();
+    await expect(
+      prepareHandoff(source as never, { transport: relay.transport, maxBytes: 16, export: exportOptions() }),
+    ).rejects.toThrow(/Export it to a file instead/);
+    expect(relay.counts.uploads).toBe(0);
+  });
+});
+
+describe('restoring on the new machine', () => {
+  test('drives the ordinary importer, remapping included', async () => {
+    const relay = standInRelay();
+    const { phrase } = await prepare(relay);
+
+    const opened = await fetchHandoff(relay.transport, phrase);
+    const outcome = await applyHandoff(destination as never, opened, {
+      transport: relay.transport,
+      import: importOptions(),
+    });
+
+    expect(outcome.groups).toBe(1);
+    expect(outcome.sessions).toBe(1);
+    expect(outcome.transcripts).toBeGreaterThan(0);
+    const dir = (destination.query('SELECT working_dir FROM sessions WHERE id = ?').get('s1') as { working_dir: string })
+      .working_dir;
+    expect(dir).toBe(path.join(destProjects, 'Bodhilander'));
+    expect(outcome.needsRelink).toEqual([]);
+  });
+
+  test('releases the bundle only once the import has returned', async () => {
+    const relay = standInRelay();
+    const { phrase } = await prepare(relay);
+    const opened = await fetchHandoff(relay.transport, phrase);
+    expect(relay.stored()).not.toBeNull();
+
+    await applyHandoff(destination as never, opened, { transport: relay.transport, import: importOptions() });
+    expect(relay.counts.acks).toBe(1);
+    expect(relay.stored()).toBeNull();
+  });
+
+  test('leaves the bundle alone when the import throws', async () => {
+    const relay = standInRelay();
+    const { phrase } = await prepare(relay);
+    const opened = await fetchHandoff(relay.transport, phrase);
+
+    // A database that cannot be written to is the shortest way to a restore
+    // that gets nowhere; what matters is that the bundle survives it.
+    destination.close();
+    await expect(
+      applyHandoff(destination as never, opened, { transport: relay.transport, import: importOptions() }),
+    ).rejects.toThrow();
+    expect(relay.counts.acks).toBe(0);
+    expect(relay.stored()).not.toBeNull();
+    destination = freshDb();
+  });
+});
+
+describe('a phrase that does not open it', () => {
+  test('a mistyped phrase never reaches the relay at all', async () => {
+    const relay = standInRelay();
+    await prepare(relay);
+    await expect(fetchHandoff(relay.transport, 'agent album alloy')).rejects.toThrow(/18 words/);
+    expect(relay.counts.downloads).toBe(0);
+    expect(relay.stored()).not.toBeNull();
+  });
+
+  test('a well-formed phrase for another bundle leaves this one intact', async () => {
+    const relay = standInRelay();
+    await prepare(relay);
+    const before = Buffer.from(relay.stored()!.sealed);
+
+    await expect(fetchHandoff(relay.transport, generateRecoveryPhrase())).rejects.toThrow(/does not open this bundle/);
+    expect(relay.counts.acks).toBe(0);
+    expect(relay.stored()!.sealed.equals(before)).toBe(true);
+  });
+
+  test('and the right phrase still works afterwards', async () => {
+    const relay = standInRelay();
+    const { phrase } = await prepare(relay);
+    await expect(fetchHandoff(relay.transport, generateRecoveryPhrase())).rejects.toThrow();
+
+    const opened = await fetchHandoff(relay.transport, phrase);
+    const outcome = await applyHandoff(destination as never, opened, {
+      transport: relay.transport,
+      import: importOptions(),
+    });
+    expect(outcome.sessions).toBe(1);
+  });
+});
+
+describe('declining an offer', () => {
+  test('is remembered across a relaunch', () => {
+    let db = new Database(prefsPath);
+    db.exec('CREATE TABLE preferences (key TEXT PRIMARY KEY, value TEXT)');
+    declineHandoff(prefsStore(db), 'handoff-1');
+    expect(isHandoffDeclined(prefsStore(db), 'handoff-1')).toBe(true);
+    db.close();
+
+    // Same file, new process would see this: the marker is on disk, not in memory.
+    db = new Database(prefsPath);
+    expect(isHandoffDeclined(prefsStore(db), 'handoff-1')).toBe(true);
+    db.close();
+  });
+
+  test('does not silence a later bundle from the same machine', async () => {
+    const db = new Database(':memory:');
+    db.exec('CREATE TABLE preferences (key TEXT PRIMARY KEY, value TEXT)');
+    const prefs = prefsStore(db);
+    const relay = standInRelay();
+
+    const first = await prepare(relay);
+    declineHandoff(prefs, first.offer.id);
+    expect(isHandoffDeclined(prefs, first.offer.id)).toBe(true);
+
+    const second = await prepare(relay);
+    expect(isHandoffDeclined(prefs, second.offer.id)).toBe(false);
+    db.close();
+  });
+
+  test('is kept where an export will not carry it to the next machine', () => {
+    expect(DECLINED_HANDOFF_PREF.startsWith('relay.')).toBe(true);
+  });
+});

--- a/src/main/transfer/__tests__/handoff.test.ts
+++ b/src/main/transfer/__tests__/handoff.test.ts
@@ -3,13 +3,14 @@
  * handed, that a restore drives the ordinary importer and its remapping, that
  * a failure leaves the bundle retryable, and that "not now" outlives a launch.
  */
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, setSystemTime, test } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { freshDb, seedSecrets, seedSourceDb, SECRET_VALUES, writeTranscript } from './db-fixture';
 import { decodeBundle, looksLikeBundle, TABLES_ENTRY } from '../bundle-format';
+import { HANDOFF_SEAL_OVERHEAD_BYTES } from '../handoff-crypto';
 import { openHandoff } from '../handoff-crypto';
 import { generateRecoveryPhrase } from '../recovery-phrase';
 import type { HandoffOffer } from '../../../shared/types';
@@ -192,6 +193,43 @@ describe('preparing a handoff', () => {
     expect(result).toBeNull();
     expect(relay.counts.uploads).toBe(0);
     expect(relay.stored()).toBeNull();
+  });
+
+  test('counts what sealing adds, so a bundle that only just fits is refused', async () => {
+    // The boundary here is 25 bytes wide, and an export stamps the time it ran
+    // — so the clock is frozen to make successive builds byte-identical.
+    setSystemTime(new Date('2026-08-26T00:00:00.000Z'));
+    try {
+      const relay = standInRelay();
+      const { sealedBytes } = await prepare(relay);
+
+      await expect(
+        prepareHandoff(source as never, {
+          transport: relay.transport,
+          maxBytes: sealedBytes - 1,
+          export: exportOptions(),
+        }),
+      ).rejects.toThrow(/relay carries up to/);
+
+      const fits = await prepareHandoff(source as never, {
+        transport: relay.transport,
+        maxBytes: sealedBytes,
+        export: exportOptions(),
+      });
+      expect(fits).not.toBeNull();
+    } finally {
+      setSystemTime();
+    }
+  });
+
+  test('refuses a hopeless transcript volume from stat alone, before building', async () => {
+    writeTranscript(sourceConfigDir, 'big-project', 'conv-big', 'x'.repeat(40_000));
+    const relay = standInRelay();
+
+    await expect(
+      prepareHandoff(source as never, { transport: relay.transport, maxBytes: 512, export: exportOptions() }),
+    ).rejects.toThrow(/transcripts alone are/);
+    expect(relay.counts.uploads).toBe(0);
   });
 
   test('refuses a state larger than the relay will carry, before uploading', async () => {

--- a/src/main/transfer/__tests__/recovery-phrase.test.ts
+++ b/src/main/transfer/__tests__/recovery-phrase.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The phrase a handoff hangs on. A duplicate or a near-miss in the wordlist
+ * would quietly cost entropy or defeat the checksum, and the checksum has one
+ * job: refuse a mistyped phrase here, before anything has been downloaded.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  decodeRecoveryPhrase,
+  deriveHandoffKey,
+  generateRecoveryPhrase,
+  PHRASE_ENTROPY_BYTES,
+  PHRASE_WORDS,
+  PHRASE_WORD_COUNT,
+  RecoveryPhraseError,
+  splitRecoveryPhrase,
+} from '../recovery-phrase';
+
+function problemOf(phrase: string): string {
+  try {
+    decodeRecoveryPhrase(phrase);
+  } catch (err) {
+    if (err instanceof RecoveryPhraseError) return err.problem;
+    return `unexpected: ${String(err)}`;
+  }
+  return 'accepted';
+}
+
+describe('the wordlist', () => {
+  test('is exactly one word per byte value, all distinct', () => {
+    expect(PHRASE_WORDS).toHaveLength(256);
+    expect(new Set(PHRASE_WORDS).size).toBe(256);
+  });
+
+  test('is lowercase letters only, so transcription has one spelling', () => {
+    expect(PHRASE_WORDS.filter((w) => !/^[a-z]{3,7}$/.test(w))).toEqual([]);
+  });
+
+  test('holds no word that is a prefix of another', () => {
+    const sorted = [...PHRASE_WORDS].sort();
+    const collisions = sorted.filter((word, i) => i > 0 && word.startsWith(sorted[i - 1]!));
+    expect(collisions).toEqual([]);
+  });
+
+  test('holds no two words one edit apart', () => {
+    const oneEdit = (a: string, b: string): boolean => {
+      if (a.length === b.length) return a.split('').filter((c, i) => c !== b[i]).length === 1;
+      if (Math.abs(a.length - b.length) !== 1) return false;
+      const [short, long] = a.length < b.length ? [a, b] : [b, a];
+      return [...long].some((_, i) => long.slice(0, i) + long.slice(i + 1) === short);
+    };
+    const pairs = PHRASE_WORDS.flatMap((a, i) => PHRASE_WORDS.slice(i + 1).filter((b) => oneEdit(a, b)).map((b) => [a, b]));
+    expect(pairs).toEqual([]);
+  });
+});
+
+describe('generating a phrase', () => {
+  test('produces the fixed word count and decodes to its entropy', () => {
+    const phrase = generateRecoveryPhrase();
+    expect(splitRecoveryPhrase(phrase)).toHaveLength(PHRASE_WORD_COUNT);
+    expect(decodeRecoveryPhrase(phrase)).toHaveLength(PHRASE_ENTROPY_BYTES);
+  });
+
+  test('never repeats, so a key is never reused across bundles', () => {
+    const phrases = new Set(Array.from({ length: 50 }, () => generateRecoveryPhrase()));
+    expect(phrases.size).toBe(50);
+  });
+
+  test('derives the same key every time, and a different key per phrase', () => {
+    const a = generateRecoveryPhrase();
+    const b = generateRecoveryPhrase();
+    expect(deriveHandoffKey(a)).toHaveLength(32);
+    expect(deriveHandoffKey(a).equals(deriveHandoffKey(a))).toBe(true);
+    expect(deriveHandoffKey(a).equals(deriveHandoffKey(b))).toBe(false);
+  });
+
+  test('is read back through casing, line breaks and stray punctuation', () => {
+    const phrase = generateRecoveryPhrase();
+    const messy = phrase.toUpperCase().split(' ').join(',\n  ');
+    expect(deriveHandoffKey(messy).equals(deriveHandoffKey(phrase))).toBe(true);
+  });
+});
+
+describe('refusing a phrase that was mistyped', () => {
+  test('names the count when there are too few or too many words', () => {
+    const words = splitRecoveryPhrase(generateRecoveryPhrase());
+    expect(problemOf(words.slice(0, -1).join(' '))).toBe('length');
+    expect(problemOf([...words, words[0]!].join(' '))).toBe('length');
+  });
+
+  test('names a word that is not in the list', () => {
+    const words = splitRecoveryPhrase(generateRecoveryPhrase());
+    words[3] = 'sasquatch';
+    expect(() => decodeRecoveryPhrase(words.join(' '))).toThrow(/sasquatch/);
+    expect(problemOf(words.join(' '))).toBe('unknown-word');
+  });
+
+  test('catches one entropy word swapped for another', () => {
+    const words = splitRecoveryPhrase(generateRecoveryPhrase());
+    // Any word other than the one already there changes a byte of the entropy.
+    words[0] = PHRASE_WORDS.find((w) => w !== words[0])!;
+    expect(problemOf(words.join(' '))).toBe('checksum');
+  });
+
+  test('catches two words transposed', () => {
+    let words = splitRecoveryPhrase(generateRecoveryPhrase());
+    while (words[2] === words[5]) words = splitRecoveryPhrase(generateRecoveryPhrase());
+    [words[2], words[5]] = [words[5]!, words[2]!];
+    expect(problemOf(words.join(' '))).toBe('checksum');
+  });
+
+  test('catches a corrupted checksum word', () => {
+    const words = splitRecoveryPhrase(generateRecoveryPhrase());
+    const last = PHRASE_WORD_COUNT - 1;
+    words[last] = PHRASE_WORDS.find((w) => w !== words[last])!;
+    expect(problemOf(words.join(' '))).toBe('checksum');
+  });
+});

--- a/src/main/transfer/bundle-export.ts
+++ b/src/main/transfer/bundle-export.ts
@@ -187,6 +187,30 @@ function listTranscripts(configDir: string, accountKey: string): TranscriptFile[
   return found;
 }
 
+/** Every account's transcript tree, plus the pre-accounts one if it is separate. */
+function transcriptRoots(db: Db, legacyConfigDir: string): { key: string; dir: string }[] {
+  const roots = (db.prepare('SELECT id, config_dir FROM claude_accounts').all() as any[]).map((a) => ({
+    key: a.id as string,
+    dir: a.config_dir as string,
+  }));
+  const seen = new Set(roots.map((a) => path.resolve(a.dir)));
+  if (!seen.has(path.resolve(legacyConfigDir))) {
+    roots.push({ key: LEGACY_ACCOUNT_KEY, dir: legacyConfigDir });
+  }
+  return roots;
+}
+
+/**
+ * What the transcripts weigh uncompressed, by stat alone. Nothing is read, so
+ * a caller can ask whether a bundle could possibly fit somewhere before paying
+ * to build one.
+ */
+export function measureTranscriptBytes(db: Db, legacyConfigDir: string): number {
+  return transcriptRoots(db, legacyConfigDir)
+    .flatMap((a) => listTranscripts(a.dir, a.key))
+    .reduce((sum, file) => sum + file.size, 0);
+}
+
 /** Sizes come from stat, so the ceiling is checked before a byte is read. */
 export class TranscriptVolumeError extends Error {}
 
@@ -217,17 +241,8 @@ function readWithinBudget(files: TranscriptFile[], budget: number): BundleEntry[
 export function buildTransferBundle(db: Db, options: ExportOptions): BuiltBundle {
   const tables = readPortableTables(db);
 
-  const accountDirs = (db.prepare('SELECT id, config_dir FROM claude_accounts').all() as any[]).map((a) => ({
-    key: a.id as string,
-    dir: a.config_dir as string,
-  }));
-  const seen = new Set(accountDirs.map((a) => path.resolve(a.dir)));
-  if (!seen.has(path.resolve(options.legacyConfigDir))) {
-    accountDirs.push({ key: LEGACY_ACCOUNT_KEY, dir: options.legacyConfigDir });
-  }
-
   const transcripts = readWithinBudget(
-    accountDirs.flatMap((a) => listTranscripts(a.dir, a.key)),
+    transcriptRoots(db, options.legacyConfigDir).flatMap((a) => listTranscripts(a.dir, a.key)),
     options.maxTranscriptBytes ?? MAX_TRANSCRIPT_BYTES,
   );
   const workingDirRoots = collectWorkingDirRoots([

--- a/src/main/transfer/handoff-crypto.ts
+++ b/src/main/transfer/handoff-crypto.ts
@@ -1,0 +1,54 @@
+/**
+ * Sealing a transfer bundle for the trip through the relay, which is a courier
+ * here exactly as it is for terminal traffic. Same AEAD, reached through the
+ * same `seal`/`open`, so there is one implementation rather than two.
+ */
+
+import { open, seal, type SealedFrame } from '../api/relay/e2e';
+import { deriveHandoffKey, generateRecoveryPhrase } from './recovery-phrase';
+
+const MAGIC = Buffer.from('BDHLHOFF', 'ascii');
+export const HANDOFF_FORMAT_VERSION = 1;
+
+/**
+ * Fixed at zero: the key comes from a phrase generated for this one bundle and
+ * never reused, so the (key, nonce) pair cannot repeat.
+ */
+const NONCE_COUNTER = 0;
+
+export interface SealedHandoff {
+  bytes: Buffer;
+  /** Shown to the user once. Without it the bytes are unrecoverable. */
+  phrase: string;
+}
+
+export function sealHandoff(plaintext: Buffer): SealedHandoff {
+  const phrase = generateRecoveryPhrase();
+  const frame = seal(deriveHandoffKey(phrase), NONCE_COUNTER, plaintext);
+  const version = Buffer.from([HANDOFF_FORMAT_VERSION]);
+  return { bytes: Buffer.concat([MAGIC, version, Buffer.from(frame.ct, 'base64')]), phrase };
+}
+
+/**
+ * Open a sealed handoff. A phrase that is not a phrase throws
+ * `RecoveryPhraseError` from the checksum before these bytes are touched;
+ * everything reaching the AEAD below is a phrase that could have been issued.
+ */
+export function openHandoff(sealed: Buffer, phrase: string): Buffer {
+  const key = deriveHandoffKey(phrase);
+  const header = MAGIC.length + 1;
+  if (sealed.length <= header || !sealed.subarray(0, MAGIC.length).equals(MAGIC)) {
+    throw new Error('This is not a Bodhilander handoff bundle.');
+  }
+  const version = sealed[MAGIC.length];
+  if (version !== HANDOFF_FORMAT_VERSION) {
+    throw new Error(`This handoff was prepared by a newer version of Bodhilander (format ${version}).`);
+  }
+
+  const frame: SealedFrame = { n: NONCE_COUNTER, ct: sealed.subarray(header).toString('base64') };
+  try {
+    return open(key, frame);
+  } catch {
+    throw new Error('That recovery phrase does not open this bundle. Check it against the other machine.');
+  }
+}

--- a/src/main/transfer/handoff-crypto.ts
+++ b/src/main/transfer/handoff-crypto.ts
@@ -10,6 +10,9 @@ import { deriveHandoffKey, generateRecoveryPhrase } from './recovery-phrase';
 const MAGIC = Buffer.from('BDHLHOFF', 'ascii');
 export const HANDOFF_FORMAT_VERSION = 1;
 
+/** Magic, version byte and the GCM tag — what sealing adds to a bundle. */
+export const HANDOFF_SEAL_OVERHEAD_BYTES = MAGIC.length + 1 + 16;
+
 /**
  * Fixed at zero: the key comes from a phrase generated for this one bundle and
  * never reused, so the (key, nonce) pair cannot repeat.

--- a/src/main/transfer/handoff.ts
+++ b/src/main/transfer/handoff.ts
@@ -6,7 +6,7 @@
 
 import type DatabaseCtor from 'better-sqlite3';
 import type { HandoffOffer } from '../../shared/types';
-import { buildTransferBundle, type ExportOptions } from './bundle-export';
+import { buildTransferBundle, measureTranscriptBytes, type ExportOptions } from './bundle-export';
 import { readBundleManifest, restoreTransferBundle, type ImportOptions, type ImportOutcome } from './bundle-import';
 import type { TransferManifest } from './bundle-format';
 import { formatBytes } from './bundle-format';
@@ -37,13 +37,6 @@ export interface PreferenceStore {
  */
 export const DECLINED_HANDOFF_PREF = 'relay.declinedHandoffId';
 
-/**
- * The largest sealed handoff worth attempting. Mirrors the relay's shipped
- * ceiling so an oversized state is refused here, with both sizes in the
- * message, rather than after uploading its way to a 413.
- */
-export const HANDOFF_MAX_BYTES = 16 * 1024 * 1024;
-
 export interface PreparedHandoff {
   offer: HandoffOffer;
   manifest: TransferManifest;
@@ -64,8 +57,23 @@ export interface PrepareOptions {
   confirm?: (byteLength: number, manifest: TransferManifest) => Promise<boolean>;
 }
 
+/**
+ * How much better than raw gzip could plausibly do on transcript JSONL. Only a
+ * hopeless state is refused on this estimate — the exact check still follows
+ * the build — but it spares the operator minutes of work to earn a no.
+ */
+const PLAUSIBLE_COMPRESSION_CEILING = 20;
+
 /** Null when the confirmation was declined; nothing reached the relay. */
 export async function prepareHandoff(db: Db, options: PrepareOptions): Promise<PreparedHandoff | null> {
+  const raw = measureTranscriptBytes(db, options.export.legacyConfigDir);
+  if (raw > options.maxBytes * PLAUSIBLE_COMPRESSION_CEILING) {
+    throw new Error(
+      `This machine's conversation transcripts alone are ${formatBytes(raw)}, far past the ` +
+        `${formatBytes(options.maxBytes)} the relay carries. Export it to a file instead.`,
+    );
+  }
+
   const { bytes, manifest } = buildTransferBundle(db, options.export);
   const sealedLength = bytes.length + HANDOFF_SEAL_OVERHEAD_BYTES;
   if (sealedLength > options.maxBytes) {

--- a/src/main/transfer/handoff.ts
+++ b/src/main/transfer/handoff.ts
@@ -9,7 +9,8 @@ import type { HandoffOffer } from '../../shared/types';
 import { buildTransferBundle, type ExportOptions } from './bundle-export';
 import { readBundleManifest, restoreTransferBundle, type ImportOptions, type ImportOutcome } from './bundle-import';
 import type { TransferManifest } from './bundle-format';
-import { openHandoff, sealHandoff } from './handoff-crypto';
+import { formatBytes } from './bundle-format';
+import { HANDOFF_SEAL_OVERHEAD_BYTES, openHandoff, sealHandoff } from './handoff-crypto';
 import { deriveHandoffKey } from './recovery-phrase';
 
 type Db = DatabaseCtor.Database;
@@ -38,10 +39,10 @@ export const DECLINED_HANDOFF_PREF = 'relay.declinedHandoffId';
 
 /**
  * The largest sealed handoff worth attempting. Mirrors the relay's shipped
- * ceiling so an oversized state is refused here, with a size in the message,
- * rather than after uploading its way to a 413.
+ * ceiling so an oversized state is refused here, with both sizes in the
+ * message, rather than after uploading its way to a 413.
  */
-export const HANDOFF_MAX_BYTES = 64 * 1024 * 1024;
+export const HANDOFF_MAX_BYTES = 16 * 1024 * 1024;
 
 export interface PreparedHandoff {
   offer: HandoffOffer;
@@ -66,8 +67,12 @@ export interface PrepareOptions {
 /** Null when the confirmation was declined; nothing reached the relay. */
 export async function prepareHandoff(db: Db, options: PrepareOptions): Promise<PreparedHandoff | null> {
   const { bytes, manifest } = buildTransferBundle(db, options.export);
-  if (bytes.length > options.maxBytes) {
-    throw new Error("This machine's state is larger than the relay will carry. Export it to a file instead.");
+  const sealedLength = bytes.length + HANDOFF_SEAL_OVERHEAD_BYTES;
+  if (sealedLength > options.maxBytes) {
+    throw new Error(
+      `This machine's state is ${formatBytes(sealedLength)}, and the relay carries up to ` +
+        `${formatBytes(options.maxBytes)}. Export it to a file instead.`,
+    );
   }
   if (options.confirm && !(await options.confirm(bytes.length, manifest))) return null;
 
@@ -99,15 +104,25 @@ export interface ApplyOptions {
   import: ImportOptions;
 }
 
+export interface AppliedHandoff {
+  outcome: ImportOutcome;
+  /** False when the restore landed but the relay is still holding the bundle. */
+  acknowledged: boolean;
+}
+
 /**
- * Restore an opened handoff, then tell the relay to forget it. The bundle is
- * released only once the import has returned — a failed restore leaves it
- * there to be tried again.
+ * Restore an opened handoff, then tell the relay to forget it. Once the import
+ * has returned, nothing the relay says can make it not have happened — so the
+ * acknowledgement is reported beside the outcome, never thrown over it.
  */
-export async function applyHandoff(db: Db, opened: OpenedHandoff, options: ApplyOptions): Promise<ImportOutcome> {
+export async function applyHandoff(db: Db, opened: OpenedHandoff, options: ApplyOptions): Promise<AppliedHandoff> {
   const outcome = await restoreTransferBundle(db, opened.bytes, options.import);
-  await options.transport.acknowledge(opened.handoffId);
-  return outcome;
+  try {
+    await options.transport.acknowledge(opened.handoffId);
+    return { outcome, acknowledged: true };
+  } catch {
+    return { outcome, acknowledged: false };
+  }
 }
 
 /** Remember that this exact bundle was turned down, so it stops being offered. */

--- a/src/main/transfer/handoff.ts
+++ b/src/main/transfer/handoff.ts
@@ -1,0 +1,125 @@
+/**
+ * Carrying a transfer bundle between machines over the relay. Nothing here
+ * knows Electron or the network — it takes a transport and a preference store
+ * — and the restore is `restoreTransferBundle`, as the file picker reaches it.
+ */
+
+import type DatabaseCtor from 'better-sqlite3';
+import type { HandoffOffer } from '../../shared/types';
+import { buildTransferBundle, type ExportOptions } from './bundle-export';
+import { readBundleManifest, restoreTransferBundle, type ImportOptions, type ImportOutcome } from './bundle-import';
+import type { TransferManifest } from './bundle-format';
+import { openHandoff, sealHandoff } from './handoff-crypto';
+import { deriveHandoffKey } from './recovery-phrase';
+
+type Db = DatabaseCtor.Database;
+
+export interface HandoffTransport {
+  /** Sealed bytes into this user's relay slot, replacing anything already there. */
+  upload(sealed: Buffer): Promise<HandoffOffer>;
+  /** What is waiting, without pulling the bytes. */
+  peek(): Promise<HandoffOffer | null>;
+  download(): Promise<{ id: string; sealed: Buffer }>;
+  /** Drop the bundle, now that this machine has restored from it. */
+  acknowledge(handoffId: string): Promise<void>;
+}
+
+export interface PreferenceStore {
+  get(key: string): string | null;
+  set(key: string, value: string): void;
+}
+
+/**
+ * The bundle this machine has already turned down. `relay.` because the answer
+ * belongs to this machine and to the relay slot it was asked about — and
+ * because that prefix is one an export leaves behind.
+ */
+export const DECLINED_HANDOFF_PREF = 'relay.declinedHandoffId';
+
+/**
+ * The largest sealed handoff worth attempting. Mirrors the relay's shipped
+ * ceiling so an oversized state is refused here, with a size in the message,
+ * rather than after uploading its way to a 413.
+ */
+export const HANDOFF_MAX_BYTES = 64 * 1024 * 1024;
+
+export interface PreparedHandoff {
+  offer: HandoffOffer;
+  manifest: TransferManifest;
+  /** Shown once. Nothing on this machine or the relay can reproduce it. */
+  phrase: string;
+  sealedBytes: number;
+}
+
+export interface PrepareOptions {
+  transport: HandoffTransport;
+  export: ExportOptions;
+  /** Checked before the upload, so the refusal names a size rather than a 413. */
+  maxBytes: number;
+  /**
+   * Asked once the bundle exists and its size is known, before anything
+   * leaves the machine. Declining stops the handoff; nothing is uploaded.
+   */
+  confirm?: (byteLength: number, manifest: TransferManifest) => Promise<boolean>;
+}
+
+/** Null when the confirmation was declined; nothing reached the relay. */
+export async function prepareHandoff(db: Db, options: PrepareOptions): Promise<PreparedHandoff | null> {
+  const { bytes, manifest } = buildTransferBundle(db, options.export);
+  if (bytes.length > options.maxBytes) {
+    throw new Error("This machine's state is larger than the relay will carry. Export it to a file instead.");
+  }
+  if (options.confirm && !(await options.confirm(bytes.length, manifest))) return null;
+
+  const { bytes: sealed, phrase } = sealHandoff(bytes);
+  const offer = await options.transport.upload(sealed);
+  return { offer, manifest, phrase, sealedBytes: sealed.length };
+}
+
+export interface OpenedHandoff {
+  handoffId: string;
+  bytes: Buffer;
+  manifest: TransferManifest | null;
+}
+
+/**
+ * Pull and open the waiting bundle. The phrase is decoded first: a typo is
+ * refused by its checksum before anything is downloaded, so a wrong phrase
+ * never reaches — and so can never damage — what the relay is holding.
+ */
+export async function fetchHandoff(transport: HandoffTransport, phrase: string): Promise<OpenedHandoff> {
+  deriveHandoffKey(phrase);
+  const { id, sealed } = await transport.download();
+  const bytes = openHandoff(sealed, phrase);
+  return { handoffId: id, bytes, manifest: readBundleManifest(bytes) };
+}
+
+export interface ApplyOptions {
+  transport: HandoffTransport;
+  import: ImportOptions;
+}
+
+/**
+ * Restore an opened handoff, then tell the relay to forget it. The bundle is
+ * released only once the import has returned — a failed restore leaves it
+ * there to be tried again.
+ */
+export async function applyHandoff(db: Db, opened: OpenedHandoff, options: ApplyOptions): Promise<ImportOutcome> {
+  const outcome = await restoreTransferBundle(db, opened.bytes, options.import);
+  await options.transport.acknowledge(opened.handoffId);
+  return outcome;
+}
+
+/** Remember that this exact bundle was turned down, so it stops being offered. */
+export function declineHandoff(prefs: PreferenceStore, handoffId: string): void {
+  prefs.set(DECLINED_HANDOFF_PREF, handoffId);
+}
+
+/**
+ * Whether an offer has already been declined. Keyed on the bundle rather than
+ * on the relay slot, so preparing a fresh handoff on the old machine produces
+ * an offer this machine has not answered yet.
+ */
+export function isHandoffDeclined(prefs: PreferenceStore, handoffId: string): boolean {
+  return prefs.get(DECLINED_HANDOFF_PREF) === handoffId;
+}

--- a/src/main/transfer/recovery-phrase.ts
+++ b/src/main/transfer/recovery-phrase.ts
@@ -1,0 +1,130 @@
+/**
+ * The phrase that unlocks a handoff: generated, never chosen — a person's
+ * choice is an offline guessing game whoever holds the ciphertext wins.
+ * Sixteen words carry 128 bits a byte each; two checksum words follow.
+ */
+
+import crypto from 'crypto';
+
+/** Bytes of key material the phrase carries. */
+export const PHRASE_ENTROPY_BYTES = 16;
+/** SHA-256 prefix appended so a mistyped phrase is caught before decryption. */
+export const PHRASE_CHECKSUM_BYTES = 2;
+export const PHRASE_WORD_COUNT = PHRASE_ENTROPY_BYTES + PHRASE_CHECKSUM_BYTES;
+
+const HKDF_SALT = 'bodhilander-handoff-salt:v1';
+const HKDF_INFO = 'bodhilander-handoff-key:v1';
+
+/**
+ * One word per byte value. No word is a prefix of another and no two are one
+ * edit apart, so the common transcription slips change a byte outright and the
+ * checksum sees them.
+ */
+export const PHRASE_WORDS: readonly string[] = [
+  'agent', 'album', 'alloy', 'amber', 'anchor', 'angle', 'apple', 'apron',
+  'arena', 'arrow', 'aspen', 'atlas', 'bacon', 'badge', 'bagel', 'baker',
+  'banjo', 'basil', 'batch', 'beach', 'berry', 'birch', 'bison', 'cabin',
+  'cable', 'cactus', 'camel', 'canal', 'candle', 'canoe', 'canvas', 'canyon',
+  'cargo', 'carrot', 'castle', 'cedar', 'daisy', 'dance', 'dapper', 'dawn',
+  'debate', 'decade', 'decoy', 'delta', 'denim', 'desert', 'dimple', 'donkey',
+  'dragon', 'dune', 'eagle', 'early', 'earth', 'easel', 'echo', 'eight',
+  'elbow', 'elder', 'elope', 'emblem', 'empire', 'engine', 'ethnic', 'fabric',
+  'falcon', 'family', 'famous', 'fancy', 'feast', 'fever', 'fiber', 'fiddle',
+  'finch', 'forest', 'fossil', 'gadget', 'galaxy', 'gallon', 'garden', 'garlic',
+  'gauge', 'gavel', 'gecko', 'gentle', 'ginger', 'glass', 'globe', 'gnome',
+  'habit', 'hamlet', 'hammer', 'harbor', 'hazel', 'heart', 'hedge', 'helmet',
+  'herbal', 'hollow', 'honey', 'hotel', 'humble', 'icon', 'igloo', 'image',
+  'index', 'indigo', 'ingot', 'inlet', 'input', 'ivory', 'jacket', 'jaguar',
+  'jazz', 'jelly', 'jewel', 'jockey', 'jungle', 'junior', 'kayak', 'kelp',
+  'kernel', 'kettle', 'kite', 'kitten', 'knee', 'koala', 'kudos', 'label',
+  'ladder', 'lagoon', 'lamp', 'laser', 'lava', 'lemon', 'lilac', 'lunar',
+  'magnet', 'mango', 'maple', 'marble', 'marine', 'market', 'marvel', 'meadow',
+  'medal', 'melon', 'mirror', 'nacho', 'napkin', 'nature', 'nectar', 'needle',
+  'nephew', 'nickel', 'nimble', 'noble', 'noodle', 'nugget', 'oasis', 'oblong',
+  'ocean', 'octave', 'office', 'olive', 'onion', 'orbit', 'otter', 'oxygen',
+  'pace', 'pearl', 'pebble', 'pencil', 'pepper', 'petal', 'piano', 'pilot',
+  'pirate', 'pixel', 'plank', 'plaza', 'quail', 'quartz', 'quilt', 'quiver',
+  'quote', 'rabbit', 'radar', 'raft', 'rally', 'ranch', 'rapid', 'raven',
+  'ribbon', 'ridge', 'rocket', 'roster', 'runner', 'saddle', 'safari', 'sailor',
+  'salmon', 'sample', 'sandal', 'satin', 'scarf', 'school', 'scout', 'shadow',
+  'shovel', 'tablet', 'tackle', 'talent', 'tandem', 'target', 'tavern', 'teapot',
+  'temple', 'tender', 'ultra', 'unit', 'upbeat', 'upper', 'urban', 'useful',
+  'usher', 'vacuum', 'valley', 'vault', 'velvet', 'vendor', 'venue', 'violet',
+  'violin', 'vivid', 'waffle', 'wagon', 'walnut', 'walrus', 'wander', 'wasp',
+  'water', 'whale', 'wheat', 'xenon', 'yacht', 'yarn', 'yellow', 'yield',
+  'yodel', 'yogurt', 'zebra', 'zenith', 'zephyr', 'zigzag', 'zinc', 'zone',
+];
+
+const INDEX_BY_WORD = new Map(PHRASE_WORDS.map((word, i) => [word, i]));
+
+export type RecoveryPhraseProblem = 'length' | 'unknown-word' | 'checksum';
+
+/** A phrase that cannot be a phrase, told apart from a bundle that will not open. */
+export class RecoveryPhraseError extends Error {
+  override name = 'RecoveryPhraseError';
+  constructor(readonly problem: RecoveryPhraseProblem, message: string) {
+    super(message);
+  }
+}
+
+function checksum(entropy: Buffer): Buffer {
+  return crypto.createHash('sha256').update(entropy).digest().subarray(0, PHRASE_CHECKSUM_BYTES);
+}
+
+function toPhrase(entropy: Buffer): string {
+  const bytes = Buffer.concat([entropy, checksum(entropy)]);
+  return [...bytes].map((b) => PHRASE_WORDS[b]!).join(' ');
+}
+
+/** A fresh phrase, and with it a fresh key. Never reuse one across bundles. */
+export function generateRecoveryPhrase(): string {
+  return toPhrase(crypto.randomBytes(PHRASE_ENTROPY_BYTES));
+}
+
+/** Split on any run of whitespace, commas or dashes, so paper transcription is forgiving. */
+export function splitRecoveryPhrase(phrase: string): string[] {
+  return phrase
+    .toLowerCase()
+    .split(/[^a-z]+/)
+    .filter((word) => word.length > 0);
+}
+
+/**
+ * The entropy behind a phrase. Throws `RecoveryPhraseError` naming what is
+ * wrong — nothing here touches a bundle, so a refusal costs the stored one
+ * nothing.
+ */
+export function decodeRecoveryPhrase(phrase: string): Buffer {
+  const words = splitRecoveryPhrase(phrase);
+  if (words.length !== PHRASE_WORD_COUNT) {
+    throw new RecoveryPhraseError(
+      'length',
+      `A recovery phrase is ${PHRASE_WORD_COUNT} words; this one has ${words.length}.`,
+    );
+  }
+
+  const bytes = Buffer.alloc(PHRASE_WORD_COUNT);
+  for (const [i, word] of words.entries()) {
+    const index = INDEX_BY_WORD.get(word);
+    if (index === undefined) {
+      throw new RecoveryPhraseError('unknown-word', `"${word}" is not a recovery phrase word.`);
+    }
+    bytes[i] = index;
+  }
+
+  const entropy = bytes.subarray(0, PHRASE_ENTROPY_BYTES);
+  if (!checksum(entropy).equals(bytes.subarray(PHRASE_ENTROPY_BYTES))) {
+    throw new RecoveryPhraseError('checksum', 'That recovery phrase has a typo in it — check the words and try again.');
+  }
+  return Buffer.from(entropy);
+}
+
+/**
+ * The bundle key for a phrase. HKDF rather than a password hash on purpose:
+ * the input is 128 CSPRNG bits, so there is no dictionary to slow down, and a
+ * deliberately slow derivation would only tax the person restoring.
+ */
+export function deriveHandoffKey(phrase: string): Buffer {
+  const entropy = decodeRecoveryPhrase(phrase);
+  return Buffer.from(crypto.hkdfSync('sha256', entropy, Buffer.from(HKDF_SALT), Buffer.from(HKDF_INFO), 32));
+}

--- a/src/main/transfer/recovery-phrase.ts
+++ b/src/main/transfer/recovery-phrase.ts
@@ -73,7 +73,7 @@ function checksum(entropy: Buffer): Buffer {
 
 function toPhrase(entropy: Buffer): string {
   const bytes = Buffer.concat([entropy, checksum(entropy)]);
-  return [...bytes].map((b) => PHRASE_WORDS[b]!).join(' ');
+  return [...bytes].map((b) => PHRASE_WORDS[b]).join(' ');
 }
 
 /** A fresh phrase, and with it a fresh key. Never reuse one across bundles. */

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,6 +7,7 @@ import { OwnerConfirmModal, type PendingOwner } from './components/OwnerConfirmM
 import { ShareSessionModal } from './components/ShareSessionModal';
 import { GuestJoinRequestModal } from './components/GuestJoinRequestModal';
 import { SettingsModal, SettingsTab } from './components/SettingsModal';
+import { HandoffRestoreOffer } from './components/MachineHandoff';
 import { NewItemChoice } from './components/NewItemChoice';
 import { SidebarFilter } from './components/SidebarFilter';
 import { SessionRow } from './components/SessionRow';
@@ -1909,6 +1910,9 @@ const App: React.FC = () => {
         initialTab={settingsInitialTab}
         onClose={() => setSettingsOpen(false)}
       />
+
+      {/* Raised once when this account has state waiting from another machine. */}
+      <HandoffRestoreOffer onRestored={() => window.location.reload()} />
 
       {/* Destructive action confirmation dialog */}
       {confirmAction && (

--- a/src/renderer/components/MachineHandoff.css
+++ b/src/renderer/components/MachineHandoff.css
@@ -1,0 +1,77 @@
+.handoff-prepare {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.handoff-phrase {
+  border: 1px solid #d19a66;
+  border-radius: 6px;
+  background: rgba(209, 154, 102, 0.08);
+  padding: 12px;
+  max-width: 460px;
+}
+
+.handoff-phrase-lead {
+  margin: 0 0 8px;
+  font-size: 12px;
+  color: #d19a66;
+}
+
+/* Monospaced and loose: this is transcribed by hand from the screen. */
+.handoff-phrase-words {
+  margin: 0;
+  font-family: var(--font-mono, monospace);
+  font-size: 14px;
+  line-height: 1.9;
+  word-spacing: 6px;
+  user-select: all;
+}
+
+.handoff-phrase-detail {
+  margin: 8px 0 0;
+  font-size: 11px;
+  color: #888;
+}
+
+.handoff-error {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: #e06c75;
+}
+
+.handoff-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.handoff-offer {
+  width: 520px;
+}
+
+.handoff-field {
+  display: block;
+  margin-top: 12px;
+  font-size: 12px;
+  color: #ccc;
+}
+
+.handoff-input {
+  width: 100%;
+  margin-top: 4px;
+  padding: 8px;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+  background: #1e1e1e;
+  color: #d4d4d4;
+  font-family: var(--font-mono, monospace);
+  font-size: 13px;
+  resize: vertical;
+}
+
+.handoff-input:focus {
+  outline: 2px solid #569cd6;
+  outline-offset: -1px;
+}

--- a/src/renderer/components/MachineHandoff.css
+++ b/src/renderer/components/MachineHandoff.css
@@ -47,8 +47,34 @@
   margin-top: 12px;
 }
 
+/* Native <dialog> + showModal(): the browser owns modality, focus trapping and
+   the backdrop, so there is no overlay div here and none is wanted. */
 .handoff-offer {
   width: 520px;
+  max-width: 90vw;
+  padding: 20px 24px;
+  background: #252526;
+  border: 1px solid #3c3c3c;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  color: #d4d4d4;
+}
+
+.handoff-offer::backdrop {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.handoff-offer h3 {
+  margin: 0 0 16px 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: #e0e0e0;
+}
+
+.handoff-offer-lead {
+  margin: 0;
+  font-size: 13px;
+  color: #b8b8b8;
 }
 
 .handoff-field {

--- a/src/renderer/components/MachineHandoff.tsx
+++ b/src/renderer/components/MachineHandoff.tsx
@@ -1,0 +1,172 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { HandoffOfferState, PortableImportResult } from '../../shared/types';
+import './MachineHandoff.css';
+
+/**
+ * The two halves of moving a machine. `HandoffPreparePanel` shows a recovery
+ * phrase nothing can reproduce, so it stays up until dismissed rather than
+ * passing in a toast; `HandoffRestoreOffer` is the other end of the trip.
+ */
+
+function words(phrase: string): number {
+  return phrase.split(/[^a-zA-Z]+/).filter((w) => w.length > 0).length;
+}
+
+export const HandoffPreparePanel: React.FC = () => {
+  const [busy, setBusy] = useState(false);
+  const [phrase, setPhrase] = useState<string | null>(null);
+  const [detail, setDetail] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const prepare = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await window.electronAPI.handoffPrepare();
+      if (!result.success) {
+        if (result.error && result.error !== 'Handoff cancelled') setError(result.error);
+        return;
+      }
+      setPhrase(result.phrase ?? null);
+      setDetail(
+        `${result.sizeLabel ?? 'The bundle'} — ${result.groupCount ?? 0} group(s), ` +
+          `${result.sessionCount ?? 0} session(s).`,
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  return (
+    <div className="handoff-prepare">
+      <button className="settings-button" onClick={prepare} disabled={busy}>
+        {busy ? 'Preparing…' : 'Send to Another Machine…'}
+      </button>
+
+      {error && (
+        <p className="handoff-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {phrase && (
+        <div className="handoff-phrase" role="group" aria-label="Recovery phrase">
+          <p className="handoff-phrase-lead">
+            Write this down before you close it. It is the only thing that opens the bundle, and it is
+            not stored anywhere — not here, and not on the relay.
+          </p>
+          <p className="handoff-phrase-words">{phrase}</p>
+          <p className="handoff-phrase-detail">{detail}</p>
+          <div className="handoff-actions">
+            <button className="settings-button" onClick={() => void navigator.clipboard?.writeText(phrase)}>
+              Copy Phrase
+            </button>
+            <button className="settings-button" onClick={() => setPhrase(null)}>
+              I have written it down
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export interface HandoffRestoreOfferProps {
+  /** Run once the restore lands, to pick up everything that just arrived. */
+  onRestored: () => void;
+}
+
+export const HandoffRestoreOffer: React.FC<HandoffRestoreOfferProps> = ({ onRestored }) => {
+  const [state, setState] = useState<HandoffOfferState | null>(null);
+  const [phrase, setPhrase] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void window.electronAPI.handoffPeek().then((next) => {
+      if (!cancelled) setState(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const offer = state?.offer;
+  if (!offer || state?.declined) return null;
+
+  const decline = async () => {
+    await window.electronAPI.handoffDecline(offer.id);
+    setState({ offer, declined: true });
+  };
+
+  const restore = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result: PortableImportResult = await window.electronAPI.handoffRestore(phrase);
+      if (result.success) {
+        onRestored();
+        return;
+      }
+      // The bundle is untouched on any failure, so the phrase can be retried.
+      if (result.error !== 'Import cancelled') setError(result.error ?? 'The restore did not finish.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const from = offer.sourceMachineName ?? 'your other machine';
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content handoff-offer" role="dialog" aria-modal="true" aria-labelledby="handoff-offer-title">
+        <div className="modal-header">
+          <h2 id="handoff-offer-title">Restore from {from}?</h2>
+        </div>
+        <div className="modal-body">
+          <p>
+            {from} left {state?.sizeLabel ?? 'its state'} here for you — groups, sessions, history,
+            settings and conversation transcripts. Enter the recovery phrase it showed you.
+          </p>
+
+          <label className="handoff-field" htmlFor="handoff-phrase-input">
+            Recovery phrase
+          </label>
+          <textarea
+            id="handoff-phrase-input"
+            className="handoff-input"
+            rows={3}
+            spellCheck={false}
+            autoFocus
+            value={phrase}
+            onChange={(e) => setPhrase(e.target.value)}
+            aria-describedby="handoff-phrase-count"
+          />
+          <p id="handoff-phrase-count" className="handoff-phrase-detail">
+            {words(phrase)} of 18 words
+          </p>
+
+          {error && (
+            <p className="handoff-error" role="alert">
+              {error}
+            </p>
+          )}
+
+          <div className="handoff-actions">
+            <button className="btn primary" onClick={restore} disabled={busy || words(phrase) === 0}>
+              {busy ? 'Restoring…' : 'Restore'}
+            </button>
+            <button className="btn" onClick={decline} disabled={busy}>
+              Not Now
+            </button>
+          </div>
+          <p className="handoff-phrase-detail">
+            Declining keeps the bundle on the relay until it expires; you will not be asked about this
+            one again.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/components/MachineHandoff.tsx
+++ b/src/renderer/components/MachineHandoff.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { HandoffOfferState, PortableImportResult } from '../../shared/types';
 import './MachineHandoff.css';
 
@@ -52,7 +52,7 @@ export const HandoffPreparePanel: React.FC = () => {
       )}
 
       {phrase && (
-        <div className="handoff-phrase" role="group" aria-label="Recovery phrase">
+        <section className="handoff-phrase" aria-label="Recovery phrase">
           <p className="handoff-phrase-lead">
             Write this down before you close it. It is the only thing that opens the bundle, and it is
             not stored anywhere — not here, and not on the relay.
@@ -82,7 +82,7 @@ export const HandoffPreparePanel: React.FC = () => {
               I have written it down
             </button>
           </div>
-        </div>
+        </section>
       )}
     </div>
   );
@@ -98,6 +98,7 @@ export const HandoffRestoreOffer: React.FC<HandoffRestoreOfferProps> = ({ onRest
   const [phrase, setPhrase] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -124,6 +125,21 @@ export const HandoffRestoreOffer: React.FC<HandoffRestoreOfferProps> = ({ onRest
   }, []);
 
   const offer = state?.offer;
+
+  // Opened here rather than left to `open`, because only `showModal()` makes
+  // the rest of the page inert and traps focus — and this asks for a phrase
+  // that must be typed into it and nowhere else.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog && !dialog.open) dialog.showModal();
+  }, [offer?.id]);
+
+  // Escape would close the dialog and leave the offer neither restored nor
+  // declined — visibly gone, with nothing recorded. "Not Now" is durable and
+  // must not be something a stray keypress can spend, so neither answer is
+  // reachable except by its button. This is what the overlay did before.
+  const keepOpen = (e: React.SyntheticEvent<HTMLDialogElement>) => e.preventDefault();
+
   if (!offer || state?.declined) return null;
 
   const decline = async () => {
@@ -150,54 +166,49 @@ export const HandoffRestoreOffer: React.FC<HandoffRestoreOfferProps> = ({ onRest
   const from = offer.sourceMachineName ?? 'your other machine';
 
   return (
-    <div className="modal-overlay">
-      <div className="modal-content handoff-offer" role="dialog" aria-modal="true" aria-labelledby="handoff-offer-title">
-        <div className="modal-header">
-          <h2 id="handoff-offer-title">Restore from {from}?</h2>
-        </div>
-        <div className="modal-body">
-          <p>
-            {from} left {state?.sizeLabel ?? 'its state'} here for you — groups, sessions, history,
-            settings and conversation transcripts. Enter the recovery phrase it showed you.
-          </p>
+    <dialog ref={dialogRef} className="handoff-offer" aria-labelledby="handoff-offer-title" onCancel={keepOpen}>
+      <h3 id="handoff-offer-title">Restore from {from}?</h3>
 
-          <label className="handoff-field" htmlFor="handoff-phrase-input">
-            Recovery phrase
-          </label>
-          <textarea
-            id="handoff-phrase-input"
-            className="handoff-input"
-            rows={3}
-            spellCheck={false}
-            autoFocus
-            value={phrase}
-            onChange={(e) => setPhrase(e.target.value)}
-            aria-describedby="handoff-phrase-count"
-          />
-          <p id="handoff-phrase-count" className="handoff-phrase-detail">
-            {words(phrase)} of 18 words
-          </p>
+      <p className="handoff-offer-lead">
+        {from} left {state?.sizeLabel ?? 'its state'} here for you — groups, sessions, history,
+        settings and conversation transcripts. Enter the recovery phrase it showed you.
+      </p>
 
-          {error && (
-            <p className="handoff-error" role="alert">
-              {error}
-            </p>
-          )}
+      <label className="handoff-field" htmlFor="handoff-phrase-input">
+        Recovery phrase
+      </label>
+      <textarea
+        id="handoff-phrase-input"
+        className="handoff-input"
+        rows={3}
+        spellCheck={false}
+        autoFocus
+        value={phrase}
+        onChange={(e) => setPhrase(e.target.value)}
+        aria-describedby="handoff-phrase-count"
+      />
+      <p id="handoff-phrase-count" className="handoff-phrase-detail">
+        {words(phrase)} of 18 words
+      </p>
 
-          <div className="handoff-actions">
-            <button className="btn primary" onClick={restore} disabled={busy || words(phrase) === 0}>
-              {busy ? 'Restoring…' : 'Restore'}
-            </button>
-            <button className="btn" onClick={decline} disabled={busy}>
-              Not Now
-            </button>
-          </div>
-          <p className="handoff-phrase-detail">
-            Declining keeps the bundle on the relay until it expires; you will not be asked about this
-            one again.
-          </p>
-        </div>
+      {error && (
+        <p className="handoff-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="handoff-actions">
+        <button className="btn primary" onClick={restore} disabled={busy || words(phrase) === 0}>
+          {busy ? 'Restoring…' : 'Restore'}
+        </button>
+        <button className="btn" onClick={decline} disabled={busy}>
+          Not Now
+        </button>
       </div>
-    </div>
+      <p className="handoff-phrase-detail">
+        Declining keeps the bundle on the relay until it expires; you will not be asked about this
+        one again.
+      </p>
+    </dialog>
   );
 };

--- a/src/renderer/components/MachineHandoff.tsx
+++ b/src/renderer/components/MachineHandoff.tsx
@@ -17,10 +17,12 @@ export const HandoffPreparePanel: React.FC = () => {
   const [phrase, setPhrase] = useState<string | null>(null);
   const [detail, setDetail] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState<'idle' | 'done' | 'failed'>('idle');
 
   const prepare = useCallback(async () => {
     setBusy(true);
     setError(null);
+    setCopied('idle');
     try {
       const result = await window.electronAPI.handoffPrepare();
       if (!result.success) {
@@ -57,9 +59,24 @@ export const HandoffPreparePanel: React.FC = () => {
           </p>
           <p className="handoff-phrase-words">{phrase}</p>
           <p className="handoff-phrase-detail">{detail}</p>
+          {copied === 'failed' && (
+            <p className="handoff-error" role="alert">
+              Could not reach the clipboard. Copy the phrase from the screen before closing this.
+            </p>
+          )}
           <div className="handoff-actions">
-            <button className="settings-button" onClick={() => void navigator.clipboard?.writeText(phrase)}>
-              Copy Phrase
+            <button
+              className="settings-button"
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText(phrase);
+                  setCopied('done');
+                } catch {
+                  setCopied('failed');
+                }
+              }}
+            >
+              {copied === 'done' ? 'Copied' : 'Copy Phrase'}
             </button>
             <button className="settings-button" onClick={() => setPhrase(null)}>
               I have written it down
@@ -84,11 +101,25 @@ export const HandoffRestoreOffer: React.FC<HandoffRestoreOfferProps> = ({ onRest
 
   useEffect(() => {
     let cancelled = false;
-    void window.electronAPI.handoffPeek().then((next) => {
-      if (!cancelled) setState(next);
-    });
+    // Undefined is "never asked". Null is a real answer, and the one a machine
+    // gives at launch, before anybody has signed in on it.
+    let askedFor: string | null | undefined;
+
+    const peek = (machineId: string | null) => {
+      if (askedFor === machineId) return;
+      askedFor = machineId;
+      void window.electronAPI.handoffPeek().then((next) => {
+        if (!cancelled) setState(next);
+      });
+    };
+
+    void window.electronAPI.relayGetStatus().then((status) => peek(status.machineId));
+    // Linking is what makes a bundle reachable, and it happens well after
+    // launch. Without this the offer waits for a restart nothing asks for.
+    const off = window.electronAPI.onRelayStatus((status) => peek(status.machineId));
     return () => {
       cancelled = true;
+      off();
     };
   }, []);
 

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { ApiServerStatus, PairedDevice, PairingCode, PortableExportResult, PortableImportResult } from '../../shared/types';
+import { ApiServerStatus, HANDOFF_MAX_BYTES, PairedDevice, PairingCode, PortableExportResult, PortableImportResult } from '../../shared/types';
 import { ProviderSettings } from './ProviderSettings';
 import { RemoteHostingSettings } from './RemoteHostingSettings';
 import { ClaudeAccountsPanel } from './ClaudeAccountsModal';
@@ -588,7 +588,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, i
                     <span className="settings-hint">
                       Sends that same bundle to your relay account instead of a file. It is encrypted
                       here first, so the relay carries bytes it cannot read; sign in on the new
-                      machine and it is offered there. Needs this machine linked under Remote Hosting.
+                      machine and it is offered there. Needs this machine linked under Remote Hosting,
+                      and holds up to {Math.round(HANDOFF_MAX_BYTES / (1024 * 1024))} MB — larger
+                      machines move by file.
                     </span>
                   </div>
                   <div className="settings-row">

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -3,6 +3,7 @@ import { ApiServerStatus, PairedDevice, PairingCode, PortableExportResult, Porta
 import { ProviderSettings } from './ProviderSettings';
 import { RemoteHostingSettings } from './RemoteHostingSettings';
 import { ClaudeAccountsPanel } from './ClaudeAccountsModal';
+import { HandoffPreparePanel } from './MachineHandoff';
 
 // Exported so callers that deep-link into a tab (menu, tray) can type their
 // state instead of passing a bare string.
@@ -579,6 +580,15 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, i
                       Export asks what to carry: this whole machine as a transfer bundle — groups, sessions,
                       history, settings, accounts and conversation transcripts — or just groups and sessions
                       as portable JSON that ClaudeLander reads. Import accepts either.
+                    </span>
+                  </div>
+                  <div className="settings-row">
+                    <span className="settings-row-label" aria-hidden="true">Over the Relay:</span>
+                    <HandoffPreparePanel />
+                    <span className="settings-hint">
+                      Sends that same bundle to your relay account instead of a file. It is encrypted
+                      here first, so the relay carries bytes it cannot read; sign in on the new
+                      machine and it is offered there. Needs this machine linked under Remote Hosting.
                     </span>
                   </div>
                   <div className="settings-row">

--- a/src/renderer/components/__tests__/MachineHandoff.test.tsx
+++ b/src/renderer/components/__tests__/MachineHandoff.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * The two ends of a handoff, as the window shows them. The offer is raised
+ * unprompted, so what it must never do is appear after being turned down, or
+ * vanish over a mistyped phrase somebody is still reading off another screen.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { HandoffOfferState, HandoffPrepareResult, PortableImportResult } from '../../../shared/types';
+import { HandoffPreparePanel, HandoffRestoreOffer } from '../MachineHandoff';
+
+const OFFER: HandoffOfferState = {
+  offer: {
+    id: 'handoff-1',
+    sourceMachineId: 'machine-old',
+    sourceMachineName: 'Old Laptop',
+    byteSize: 4096,
+    createdAt: 1756080000000,
+    expiresAt: 1756684800000,
+  },
+  declined: false,
+  sizeLabel: '4.0 KB',
+};
+
+let declined: string[];
+let restoreWith: string[];
+let peekResult: HandoffOfferState;
+let restoreResult: PortableImportResult;
+let prepareResult: HandoffPrepareResult;
+
+beforeEach(() => {
+  declined = [];
+  restoreWith = [];
+  peekResult = OFFER;
+  restoreResult = { success: true, groupCount: 2, sessionCount: 5 };
+  prepareResult = { success: true, phrase: 'agent album alloy amber', sizeLabel: '2.0 MB', groupCount: 2, sessionCount: 5 };
+
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    handoffPeek: async () => peekResult,
+    handoffDecline: async (id: string) => {
+      declined.push(id);
+    },
+    handoffRestore: async (phrase: string) => {
+      restoreWith.push(phrase);
+      return restoreResult;
+    },
+    handoffPrepare: async () => prepareResult,
+  };
+});
+
+afterEach(cleanup);
+
+/** Mount and let the offer lookup settle, so "no dialog" means an answer arrived. */
+async function mountOffer(onRestored: () => void = () => {}) {
+  await act(async () => {
+    render(<HandoffRestoreOffer onRestored={onRestored} />);
+  });
+}
+
+async function click(label: string) {
+  await act(async () => {
+    fireEvent.click(screen.getByText(label));
+  });
+}
+
+function type(label: string, value: string) {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+describe('the restore offer', () => {
+  test('names the machine the state came from', async () => {
+    await mountOffer();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.textContent).toContain('Old Laptop');
+    expect(dialog.textContent).toContain('4.0 KB');
+  });
+
+  test('falls back to plain language when the relay has no name for it', async () => {
+    peekResult = { ...OFFER, offer: { ...OFFER.offer!, sourceMachineName: null } };
+    await mountOffer();
+    expect(screen.getByRole('dialog').textContent).toContain('your other machine');
+  });
+
+  test('stays away when there is nothing waiting', async () => {
+    peekResult = { offer: null, declined: false };
+    await mountOffer();
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  test('stays away when this bundle was already turned down', async () => {
+    peekResult = { ...OFFER, declined: true };
+    await mountOffer();
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});
+
+describe('answering the offer', () => {
+  test('"Not Now" records the bundle it declined and closes', async () => {
+    await mountOffer();
+    await click('Not Now');
+
+    expect(declined).toEqual(['handoff-1']);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  test('a restore hands over the phrase as typed and tells the window to catch up', async () => {
+    let restored = 0;
+    await mountOffer(() => restored++);
+
+    type('Recovery phrase', 'agent album alloy');
+    await click('Restore');
+
+    expect(restoreWith).toEqual(['agent album alloy']);
+    expect(restored).toBe(1);
+  });
+
+  test('a wrong phrase leaves the offer up to be tried again', async () => {
+    restoreResult = { success: false, error: 'That recovery phrase has a typo in it.' };
+    await mountOffer();
+
+    type('Recovery phrase', 'agent album');
+    await click('Restore');
+
+    expect(screen.getByRole('alert').textContent).toContain('typo');
+    expect(screen.queryByRole('dialog')).not.toBeNull();
+    expect(declined).toEqual([]);
+  });
+
+  test('counts the words entered, so a short phrase is visible before it is submitted', async () => {
+    await mountOffer();
+    type('Recovery phrase', 'agent album alloy');
+    expect(screen.getByText('3 of 18 words')).not.toBeNull();
+  });
+});
+
+describe('preparing one', () => {
+  test('shows the phrase, and keeps showing it until it is dismissed', async () => {
+    render(<HandoffPreparePanel />);
+    await click('Send to Another Machine…');
+
+    expect(screen.getByText('agent album alloy amber')).not.toBeNull();
+    expect(screen.getByRole('group', { name: 'Recovery phrase' }).textContent).toContain('2.0 MB');
+
+    await click('I have written it down');
+    expect(screen.queryByText('agent album alloy amber')).toBeNull();
+  });
+
+  test('says nothing when the person cancelled it themselves', async () => {
+    prepareResult = { success: false, error: 'Handoff cancelled' };
+    render(<HandoffPreparePanel />);
+    await click('Send to Another Machine…');
+
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  test('surfaces a refusal from the relay rather than swallowing it', async () => {
+    prepareResult = { success: false, error: 'Link this machine to a relay account before moving it.' };
+    render(<HandoffPreparePanel />);
+    await click('Send to Another Machine…');
+
+    expect(screen.getByRole('alert').textContent).toContain('Link this machine');
+  });
+});

--- a/src/renderer/components/__tests__/MachineHandoff.test.tsx
+++ b/src/renderer/components/__tests__/MachineHandoff.test.tsx
@@ -27,16 +27,46 @@ let restoreWith: string[];
 let peekResult: HandoffOfferState;
 let restoreResult: PortableImportResult;
 let prepareResult: HandoffPrepareResult;
+let peeks: number;
+let machineId: string | null;
+let statusListeners: ((status: { machineId: string | null; linked: boolean }) => void)[];
+let clipboardWrite: (text: string) => Promise<void>;
+
+/** The relay client pushing a status change, as linking produces one. */
+async function emitStatus(next: string | null) {
+  machineId = next;
+  await act(async () => {
+    for (const listener of [...statusListeners]) listener({ machineId: next, linked: !!next });
+  });
+}
 
 beforeEach(() => {
   declined = [];
   restoreWith = [];
+  peeks = 0;
+  machineId = 'machine-new';
+  statusListeners = [];
+  clipboardWrite = async () => {};
+  Object.defineProperty(globalThis.navigator, 'clipboard', {
+    value: { writeText: (text: string) => clipboardWrite(text) },
+    configurable: true,
+  });
   peekResult = OFFER;
   restoreResult = { success: true, groupCount: 2, sessionCount: 5 };
   prepareResult = { success: true, phrase: 'agent album alloy amber', sizeLabel: '2.0 MB', groupCount: 2, sessionCount: 5 };
 
   (window as unknown as { electronAPI: unknown }).electronAPI = {
-    handoffPeek: async () => peekResult,
+    handoffPeek: async () => {
+      peeks++;
+      return peekResult;
+    },
+    relayGetStatus: async () => ({ machineId, linked: !!machineId }),
+    onRelayStatus: (listener: (status: { machineId: string | null; linked: boolean }) => void) => {
+      statusListeners.push(listener);
+      return () => {
+        statusListeners = statusListeners.filter((l) => l !== listener);
+      };
+    },
     handoffDecline: async (id: string) => {
       declined.push(id);
     },
@@ -94,6 +124,41 @@ describe('the restore offer', () => {
   });
 });
 
+describe('when linking happens after launch', () => {
+  test('asks again the moment this machine is claimed, without a restart', async () => {
+    machineId = null;
+    peekResult = { offer: null, declined: false };
+    await mountOffer();
+    expect(peeks).toBe(1);
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    peekResult = OFFER;
+    await emitStatus('machine-new');
+
+    expect(peeks).toBe(2);
+    expect(screen.getByRole('dialog').textContent).toContain('Old Laptop');
+  });
+
+  test('does not re-ask on every status push the relay sends', async () => {
+    await mountOffer();
+    expect(peeks).toBe(1);
+
+    await emitStatus('machine-new');
+    await emitStatus('machine-new');
+    expect(peeks).toBe(1);
+  });
+
+  test('asks again if this machine is relinked to a different account', async () => {
+    machineId = null;
+    peekResult = { offer: null, declined: false };
+    await mountOffer();
+
+    await emitStatus('machine-a');
+    await emitStatus('machine-b');
+    expect(peeks).toBe(3);
+  });
+});
+
 describe('answering the offer', () => {
   test('"Not Now" records the bundle it declined and closes', async () => {
     await mountOffer();
@@ -143,6 +208,27 @@ describe('preparing one', () => {
 
     await click('I have written it down');
     expect(screen.queryByText('agent album alloy amber')).toBeNull();
+  });
+
+  test('says so when the clipboard refuses, on the one string shown once', async () => {
+    clipboardWrite = async () => {
+      throw new Error('denied');
+    };
+    render(<HandoffPreparePanel />);
+    await click('Send to Another Machine…');
+    await click('Copy Phrase');
+
+    expect(screen.getByRole('alert').textContent).toContain('Copy the phrase from the screen');
+    expect(screen.getByText('agent album alloy amber')).not.toBeNull();
+  });
+
+  test('confirms a copy that worked', async () => {
+    render(<HandoffPreparePanel />);
+    await click('Send to Another Machine…');
+    await click('Copy Phrase');
+
+    expect(screen.getByText('Copied')).not.toBeNull();
+    expect(screen.queryByRole('alert')).toBeNull();
   });
 
   test('says nothing when the person cancelled it themselves', async () => {

--- a/src/renderer/components/__tests__/MachineHandoff.test.tsx
+++ b/src/renderer/components/__tests__/MachineHandoff.test.tsx
@@ -32,6 +32,15 @@ let machineId: string | null;
 let statusListeners: ((status: { machineId: string | null; linked: boolean }) => void)[];
 let clipboardWrite: (text: string) => Promise<void>;
 
+/**
+ * Which opener the offer used. happy-dom implements both, and only
+ * `showModal()` makes the rest of the page inert — so record the choice rather
+ * than trust that `open` became true.
+ */
+let modalCalls: string[];
+const nativeShowModal = HTMLDialogElement.prototype.showModal;
+const nativeShow = HTMLDialogElement.prototype.show;
+
 /** The relay client pushing a status change, as linking produces one. */
 async function emitStatus(next: string | null) {
   machineId = next;
@@ -41,6 +50,15 @@ async function emitStatus(next: string | null) {
 }
 
 beforeEach(() => {
+  modalCalls = [];
+  HTMLDialogElement.prototype.showModal = function patchedShowModal(this: HTMLDialogElement) {
+    modalCalls.push('showModal');
+    return nativeShowModal.call(this);
+  };
+  HTMLDialogElement.prototype.show = function patchedShow(this: HTMLDialogElement) {
+    modalCalls.push('show');
+    return nativeShow.call(this);
+  };
   declined = [];
   restoreWith = [];
   peeks = 0;
@@ -78,7 +96,11 @@ beforeEach(() => {
   };
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  HTMLDialogElement.prototype.showModal = nativeShowModal;
+  HTMLDialogElement.prototype.show = nativeShow;
+  cleanup();
+});
 
 /** Mount and let the offer lookup settle, so "no dialog" means an answer arrived. */
 async function mountOffer(onRestored: () => void = () => {}) {
@@ -198,13 +220,42 @@ describe('answering the offer', () => {
   });
 });
 
+describe('the offer is a modal, and answering it is the only way out', () => {
+  test('opens with showModal, so the page behind it is inert', async () => {
+    await mountOffer();
+
+    expect(modalCalls).toEqual(['showModal']);
+    expect((screen.getByRole('dialog') as HTMLDialogElement).open).toBe(true);
+  });
+
+  test('refuses the Escape close, rather than relying on the DOM not to honour it', async () => {
+    await mountOffer();
+    const cancel = new Event('cancel', { cancelable: true, bubbles: false });
+
+    await act(async () => {
+      fireEvent(screen.getByRole('dialog'), cancel);
+    });
+
+    // `defaultPrevented`, not `open`: happy-dom does not close a dialog on
+    // `cancel` of its own accord, so asserting it stayed open would pass with
+    // no handler at all. What is pinned is the component's own refusal —
+    // turning the offer down is durable, and a stray keypress must not spend
+    // it, nor make the dialog vanish leaving nothing recorded.
+    expect(cancel.defaultPrevented).toBe(true);
+    expect(declined).toEqual([]);
+    expect(restoreWith).toEqual([]);
+  });
+});
+
 describe('preparing one', () => {
   test('shows the phrase, and keeps showing it until it is dismissed', async () => {
     render(<HandoffPreparePanel />);
     await click('Send to Another Machine…');
 
     expect(screen.getByText('agent album alloy amber')).not.toBeNull();
-    expect(screen.getByRole('group', { name: 'Recovery phrase' }).textContent).toContain('2.0 MB');
+    // A named <section>, which is to say a region: the phrase and what it
+    // opens are one labelled block, reachable as a unit by a screen reader.
+    expect(screen.getByRole('region', { name: 'Recovery phrase' }).textContent).toContain('2.0 MB');
 
     await click('I have written it down');
     expect(screen.queryByText('agent album alloy amber')).toBeNull();

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, AccountFailoverEvent, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest, PortableExportResult, PortableImportResult } from '../shared/types';
+import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, AccountFailoverEvent, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest, PortableExportResult, PortableImportResult, HandoffOfferState, HandoffPrepareResult } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -77,6 +77,12 @@ interface ElectronAPI {
   exportGroups: () => Promise<PortableExportResult>;
   importGroups: () => Promise<PortableImportResult>;
   importFromClaudeLander: () => Promise<PortableImportResult>;
+
+  // Machine handoff, over the relay
+  handoffPrepare: () => Promise<HandoffPrepareResult>;
+  handoffPeek: () => Promise<HandoffOfferState>;
+  handoffRestore: (phrase: string) => Promise<PortableImportResult>;
+  handoffDecline: (handoffId: string) => Promise<void>;
 
   // Preferences
   getPreference: (key: string) => Promise<string | null>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -535,7 +535,7 @@ export interface PortableImportResult {
  * `handoffMaxBytes` default so an oversized state is refused before it is
  * uploaded. A cross-tree test fails when the two drift apart.
  */
-export const HANDOFF_MAX_BYTES = 16 * 1024 * 1024;
+export const HANDOFF_MAX_BYTES = 256 * 1024 * 1024;
 
 /** A prepared handoff waiting on the relay, as the relay describes it. */
 export interface HandoffOffer {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -530,6 +530,13 @@ export interface PortableImportResult {
   needsRelinkCount?: number;
 }
 
+/**
+ * Largest sealed handoff this build will attempt, mirroring the relay's own
+ * `handoffMaxBytes` default so an oversized state is refused before it is
+ * uploaded. A cross-tree test fails when the two drift apart.
+ */
+export const HANDOFF_MAX_BYTES = 16 * 1024 * 1024;
+
 /** A prepared handoff waiting on the relay, as the relay describes it. */
 export interface HandoffOffer {
   id: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -530,6 +530,38 @@ export interface PortableImportResult {
   needsRelinkCount?: number;
 }
 
+/** A prepared handoff waiting on the relay, as the relay describes it. */
+export interface HandoffOffer {
+  id: string;
+  sourceMachineId: string;
+  sourceMachineName: string | null;
+  byteSize: number;
+  createdAt: number;
+  expiresAt: number;
+}
+
+/** What a machine should do about the handoff its account is holding. */
+export interface HandoffOfferState {
+  /** Null when nothing waits, or when this machine is the one that prepared it. */
+  offer: HandoffOffer | null;
+  /** This machine has already turned that exact bundle down. */
+  declined: boolean;
+  /** Size as it is shown in the offer. */
+  sizeLabel?: string;
+}
+
+export interface HandoffPrepareResult {
+  success: boolean;
+  error?: string;
+  /** Shown once, on the machine being left behind. */
+  phrase?: string;
+  sizeLabel?: string;
+  groupCount?: number;
+  sessionCount?: number;
+  /** When the relay stops holding it. */
+  expiresAt?: number;
+}
+
 export interface TransferBundleCounts {
   groups: number;
   sessions: number;


### PR DESCRIPTION
Closes #201. Phase 2 of #199 — Phase 1 (#200) made a machine's state portable as a file; this removes the USB stick.

**Ready for review.** All four checks are green, including the Sonar quality gate at 0 new issues and 0 hotspots. This body was written when the PR opened as a draft; the Verification section below has been rewritten against the current head, and [a comment](https://github.com/Software-Development-LLC/Bodhilander/pull/234#issuecomment-5431378380) records everything that changed after the draft — two CI failures neither of which reproduced on a Mac, and the Sonar pass.

## What it does

**Old machine.** "Move to Another Machine" builds the Phase 1 bundle, seals it locally, uploads only the ciphertext to the user's slot on the relay, and shows a recovery phrase once. One confirmation dialog, naming the size and the counts, before anything leaves the machine.

**New machine.** After linking, a waiting bundle is offered by the name of the machine that prepared it. The phrase opens it locally and `restoreTransferBundle` runs — the same importer the file picker drives, reached through the same working-directory remapping prompt.

**The relay is a courier.** It stores bytes plus routing metadata. Nothing in its database opens them, which `handoff-http.test.ts` asserts directly rather than by inspection.

## Relay (`relay/`)

- **`db/migrations/004_handoff.sql`** — `handoff_bundles`. `user_id` is `UNIQUE`, so one-bundle-per-account is a schema guarantee rather than a rule the upload path has to remember: an upload is an upsert on that key. Foreign keys cascade from both `users` and `machines`, so unlinking the source machine withdraws the offer. New file rather than an edit to `003`, because `runMigrations` skips any version not greater than the current `user_version` and editing an applied migration is a silent no-op on every existing database.
- **`repositories.ts`** — `putHandoffBundle` (upsert; the id changes with the row, so a destination that declined the old bundle is offered the new one), `getHandoffBundle` (filters on `expires_at` itself rather than trusting the ten-minute reaper), `deleteHandoffBundle`, `purgeExpiredHandoffBundles`.
- **`protocol.ts`** — four separately versioned signed messages: `handoff-put:v1`, `handoff-meta:v1`, `handoff-get:v1`, `handoff-delete:v1`. A signature captured off a download cannot be replayed as the delete that throws the bundle away. The delete message binds the bundle id, so acknowledging a restore cannot drop a newer bundle prepared in the meantime.
- **`http.ts`** — `PUT`/`GET`/`DELETE /api/machines/:id/handoff` and `GET …/handoff/bundle`. Ed25519-signed rather than cookie-authed, because the desktop app holds no cookie; the slot belongs to the machine's *user*, which is how a second machine under one identity reaches what the first left. `PUT` verifies the signature over a header-declared SHA-256 **before buffering any body**, then hashes the arriving bytes and refuses on mismatch — an unsigned caller cannot make the relay buffer 64 MiB on its way to a refusal. The delete id is constrained to a UUID shape before it reaches the signed lines, so a value carrying a newline cannot shift the later fields.
- Rate limits: 5 uploads per IP and 5 per machine, 30 reads per IP. The per-machine budget is charged *after* the signature verifies, so nobody can exhaust another machine's allowance by naming its id.
- **`config.ts`** — `handoffTtlSeconds` (7 days) and `handoffMaxBytes` (64 MiB), both env-overridable via `HANDOFF_TTL_SECONDS` / `HANDOFF_MAX_BYTES`. The existing reaper now also calls `purgeExpiredHandoffBundles`.

## Desktop

- **`transfer/recovery-phrase.ts`** — the phrase is generated, never chosen: 16 entropy words carrying a byte each plus 2 checksum words, over a 256-word list where no word is a prefix of another and no two are one edit apart. HKDF-SHA256 to the 32-byte key — the input is 128 CSPRNG bits, so there is no dictionary for a slow KDF to defend against and a deliberately slow derivation would only tax the person restoring.
- **`transfer/handoff-crypto.ts`** — seals through the existing `seal`/`open` in `api/relay/e2e.ts`, so there is one AEAD implementation rather than two. Nonce fixed at zero is safe here because the key comes from a phrase generated for this one bundle and never reused.
- **`transfer/handoff.ts`** — transport-agnostic mechanics. The phrase is decoded **before** the download, so a typo is caught by its checksum without the stored bundle ever being touched. `acknowledge` fires only after the import returns, so a failed restore leaves the bundle there to try again. A decline is remembered against the bundle id, not the slot, so it is durable across relaunch but does not silence a later bundle from the same machine.
- **`api/relay/handoff-transport.ts`** — the four calls, signed. `peek` returns null for the bundle this machine prepared itself. A `404` on acknowledge is treated as the state the caller wanted.
- **`machine-handoff.ts`**, **`preload.ts`**, **`src/main/index.ts`** — the Electron half and the four IPC channels.
- **`renderer/components/MachineHandoff.tsx`** — the offer, the phrase display, and the phrase entry with a live word count.
- **`group-import-export.ts`** — the only change to existing desktop logic: `askRootMappings` and `registerRestoredAccountHooks` are now exported, so the restore path uses the same prompts as the file picker instead of a second copy. `bundle-import.ts` is untouched.

## Verification

The harness copy pinned in `initiatives/201/team.yaml` is not present in the environment this was finished in, so `scripts/verify.sh` has not been re-run since the draft's report. What follows is direct `bun test` and `tsc`, not a harness verdict.

Everything below is **bun 1.4.0**, the version `test.yml` and `sonarqube.yml` both pin — not the 1.3.x a local checkout is likely to have. That distinction turned out to matter twice; see the comment.

```
$ bun test --isolate <the 14 spec files this PR adds or touches>

 144 pass
 0 fail
 375 expect() calls
Ran 144 tests across 14 files. [17.76s]

$ bun test --isolate                       # the whole repo, relay included

 1415 pass
 1 fail
Ran 1416 tests across 100 files.
```

Both typechecks clean, root and `relay/`.

12 new spec files, plus additions to `preload.test.ts` and the migration assertion in `relay.test.ts` moved to `user_version` 5.

Sonar reports **97.90% coverage on new code**, 0 new issues, 0 duplicated lines.

### The one failing test, and why it is not this branch

`login detection > a token file appearing still completes the flow`, in `src/main/__tests__/account-auth.test.ts`, times out at 15s under full-suite load. It passes 3/3 in isolation, nothing in this branch touches it or its subject, and it is the load-sensitive flake #228 was filed for — still alive after #232, which is worth knowing since #228 is closed. CI's own `test` job is green.

### What is not covered

`src/main/index.ts` — 4 `safeHandle` registrations. The file boots the Electron app at import, so no spec can load it. The four channel names are pinned a step away by `preload.test.ts`, which asserts the exact strings `handoff:prepare`, `handoff:peek`, `handoff:restore` and `handoff:decline` that `index.ts` registers. That is coverage of the contract, not of the wiring line — read it as such.

`relay/src/index.ts` is no longer in this list: `main()` is exported and guarded by `import.meta.main`, and `index.test.ts` starts the real server to prove it serves at the shipped body ceiling.

`lint` has no linter this repo can drive.

## One deviation from the brief

The brief called for sodium's CSPRNG for the phrase entropy. `crypto.randomBytes` is used instead, because **`sodium-native` is absent from both `package.json` files, is not installed in either `node_modules`, and is referenced nowhere in `src/` or `relay/src/`.** I checked that independently before writing it here. `crypto.randomBytes` is the correct call given that, not a shortcut around a missing dependency.

`CLAUDE.md` line 65 still lists `sodium-native` among the project's native modules. It is stale on that point, and this PR does not change it — flagging it rather than editing an instruction file from a feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3LTFJRHsTU7qGiz1C5Nge

<!-- bodhi:merge-order -->
**Merge position 1 of 1.** Nothing merges before this one.
Order: Bodhilander
<!-- bodhi:merge-order -->

