### PR TITLE
227 — Export preferences by allowlist, and make a new key impossible to forget

### DIFF
--- a/src/main/transfer/__tests__/bundle-export.test.ts
+++ b/src/main/transfer/__tests__/bundle-export.test.ts
@@ -160,7 +160,7 @@ describe('what must never reach the archive', () => {
     const tables = JSON.parse(bundle.read(TABLES_ENTRY)!.toString('utf-8'));
     const keys = tables.preferences.map((p: { key: string }) => p.key);
 
-    expect(keys).toContain('theme');
+    expect(keys).toContain('fontSize');
     expect(keys).toContain('closeToTray');
     expect(keys).toHaveLength(2);
   });

--- a/src/main/transfer/__tests__/bundle-format.test.ts
+++ b/src/main/transfer/__tests__/bundle-format.test.ts
@@ -78,11 +78,19 @@ describe('the container', () => {
   });
 });
 
-describe('the preference exclusion policy', () => {
+describe('the preference portability policy', () => {
+  // These used to be 'theme', 'soundEnabled', 'betaChannel' and 'apiPort' —
+  // none of which this app has ever written. The assertion passed under the
+  // old denylist for the same reason any unknown string did, so it proved
+  // nothing about real settings. They are real keys now (#227).
   test('keeps the ordinary settings a user would want back', () => {
-    for (const key of ['theme', 'closeToTray', 'soundEnabled', 'betaChannel', 'apiPort']) {
+    for (const key of ['fontSize', 'closeToTray', 'soundVolume', 'updateChannel', 'webglRenderer']) {
       expect(isPortablePreferenceKey(key)).toBe(true);
     }
+  });
+
+  test('a key nobody has classified stays home instead of travelling', () => {
+    expect(isPortablePreferenceKey('somePreferenceAddedLater')).toBe(false);
   });
 
   test('refuses every safeStorage-sealed key', () => {

--- a/src/main/transfer/__tests__/bundle-import.test.ts
+++ b/src/main/transfer/__tests__/bundle-import.test.ts
@@ -103,7 +103,7 @@ describe('what comes back', () => {
     await restore(exportBytes(), mappedToDest());
 
     const keys = (destination.prepare('SELECT key FROM preferences').all() as { key: string }[]).map((r) => r.key);
-    expect(keys).toContain('theme');
+    expect(keys).toContain('fontSize');
     expect(keys).not.toContain('teamsTokens');
     expect(keys).not.toContain('windowBounds');
   });
@@ -218,7 +218,7 @@ describe('transactional', () => {
       arenaRuns: [],
       // No matching run, so the foreign key fires after the rows above landed.
       arenaResponses: [{ id: 'r1', runId: 'missing-run', provider: 'claude', status: 'done', responseText: '', ttftMs: null, totalMs: null, inputTokens: null, outputTokens: null, costUsd: null, error: null, round: 0, prompt: null, sessionRef: null }],
-      preferences: [{ key: 'theme', value: 'dark' }],
+      preferences: [{ key: 'fontSize', value: '14' }],
       accounts: [],
     };
     const manifest: TransferManifest = {
@@ -295,12 +295,12 @@ describe('idempotence', () => {
     seedSecrets(source);
     const bytes = exportBytes();
     await restore(bytes, mappedToDest());
-    destination.prepare("UPDATE preferences SET value = 'light' WHERE key = 'theme'").run();
+    destination.prepare("UPDATE preferences SET value = '18' WHERE key = 'fontSize'").run();
 
     await restore(bytes, mappedToDest());
 
-    const row = destination.prepare('SELECT value FROM preferences WHERE key = ?').get('theme') as any;
-    expect(row.value).toBe('light');
+    const row = destination.prepare('SELECT value FROM preferences WHERE key = ?').get('fontSize') as any;
+    expect(row.value).toBe('18');
   });
 
   test('re-importing the same bundle duplicates nothing', async () => {

--- a/src/main/transfer/__tests__/bundle-preference-policy.test.ts
+++ b/src/main/transfer/__tests__/bundle-preference-policy.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The forcing function behind the export allowlist (#227).
+ *
+ * Switching to an allowlist makes an unclassified preference stay home, which
+ * is the safe default but a silent one: a legitimate new setting would quietly
+ * stop travelling between machines and nobody would find out until a user
+ * noticed their choice had not followed them.
+ *
+ * So this test reads the source for preference keys and fails on any key that
+ * is on neither list. It is a lint rather than a unit test, and that is the
+ * point — it makes "I added a preference" a decision someone has to write
+ * down, in the file where the consequence lives.
+ *
+ * It can only see keys written as literals. Computed ones
+ * (`providerApiKey.${id}`) live under namespaces covered by the prefix list,
+ * which is why prefixes count as a classification here.
+ *
+ * Run with: bun test src/main/transfer/__tests__
+ */
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { isClassifiedPreferenceKey, isPortablePreferenceKey } from '../bundle-format';
+
+const SRC = path.resolve(import.meta.dir, '../../..');
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      sourceFiles(full, out);
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Every preference key the source names as a literal, whether through a direct
+ * get/setPreference call or through a `const SOMETHING_PREF = '...'` binding.
+ */
+function declaredPreferenceKeys(): Map<string, string> {
+  const found = new Map<string, string>();
+  const patterns = [
+    /(?:get|set)Preference\(\s*'([^']+)'/g,
+    // Name must END in PREF / PREF_KEY. A `*_PREFIX` constant is a namespace,
+    // not a key — those are covered by the prefix list, and matching them here
+    // dragged in unrelated things like TRANSCRIPT_PREFIX.
+    /(?:const|readonly)\s+[A-Za-z0-9_]*PREF(?:_KEY)?\s*(?::[^=]+)?=\s*'([^']+)'/g,
+  ];
+
+  for (const file of sourceFiles(SRC)) {
+    const text = fs.readFileSync(file, 'utf8');
+    for (const pattern of patterns) {
+      pattern.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = pattern.exec(text)) !== null) {
+        const key = m[1]!;
+        // A prefix constant is a namespace, not a key; the prefix list covers it.
+        if (key.endsWith('.')) continue;
+        if (!found.has(key)) found.set(key, path.relative(SRC, file));
+      }
+    }
+  }
+  return found;
+}
+
+describe('every preference key is classified for export', () => {
+  test('the scan finds the keys it is supposed to be guarding', () => {
+    // Guards the guard: a regex that silently matched nothing would make this
+    // whole file pass forever while classifying nothing.
+    const keys = declaredPreferenceKeys();
+    expect(keys.size).toBeGreaterThan(10);
+    expect([...keys.keys()]).toContain('fontSize');
+    expect([...keys.keys()]).toContain('teamsTokens');
+  });
+
+  test('no preference key is left undecided', () => {
+    const unclassified = [...declaredPreferenceKeys()]
+      .filter(([key]) => !isClassifiedPreferenceKey(key))
+      .map(([key, file]) => `${key}  (${file})`);
+
+    expect(unclassified).toEqual([]);
+  });
+});
+
+describe('the allowlist itself', () => {
+  test('an unknown key stays home rather than travelling by default', () => {
+    expect(isPortablePreferenceKey('somethingAddedNextYear')).toBe(false);
+    expect(isPortablePreferenceKey('')).toBe(false);
+  });
+
+  test('the settings a user chose still travel', () => {
+    for (const key of ['fontSize', 'soundVolume', 'enableNotifications', 'updateChannel']) {
+      expect(isPortablePreferenceKey(key)).toBe(true);
+    }
+  });
+
+  test('secrets and machine-shaped settings do not', () => {
+    for (const key of [
+      'teamsTokens',
+      'windowBounds',
+      'customShellPath',
+      'soundErrorCustomPath',
+      'providerApiKey.anthropic',
+      'providerApiKeyUse.anthropic',
+      'relay.ed25519Priv',
+      'relay.ownerUserId',
+    ]) {
+      expect(isPortablePreferenceKey(key)).toBe(false);
+    }
+  });
+
+  test('a one-time migration marker never travels, including the one that used to', () => {
+    // quotaCooldownsCleared was exported under the denylist purely because
+    // nobody added it — the exact failure the allowlist exists to stop.
+    for (const key of [
+      'quotaCooldownsCleared',
+      'legacyCodeSearchCleanupDone',
+      'legacyMemoryCleanupDone',
+      'legacyMemoryMcpCleanupDone',
+    ]) {
+      expect(isPortablePreferenceKey(key)).toBe(false);
+      expect(isClassifiedPreferenceKey(key)).toBe(true);
+    }
+  });
+});

--- a/src/main/transfer/__tests__/db-fixture.ts
+++ b/src/main/transfer/__tests__/db-fixture.ts
@@ -214,7 +214,10 @@ export function seedSecrets(db: Database): void {
   pref.run('customShellPath', SECRET_VALUES.customShellPath);
   pref.run('preferredEditor', SECRET_VALUES.preferredEditor);
   pref.run('soundWaitingCustomPath', SECRET_VALUES.soundPath);
-  pref.run('theme', 'dark');
+  // A real portable key. This fixture used to seed 'theme', which is not a
+  // preference this app has ever written — so the tests asserting it travelled
+  // were asserting about a key that does not exist (#227).
+  pref.run('fontSize', '14');
   pref.run('closeToTray', 'true');
 
   db.prepare(

--- a/src/main/transfer/bundle-format.ts
+++ b/src/main/transfer/bundle-format.ts
@@ -131,19 +131,68 @@ export type TransferCounts = TransferBundleCounts;
 export type TransferManifest = TransferBundleManifest;
 
 // ---------------------------------------------------------------------------
-// Exclusion policy — enforced here, at export, never at import
+// Portability policy — enforced here, at export, never at import
 // ---------------------------------------------------------------------------
+
+/**
+ * Preferences that travel with a bundle.
+ *
+ * An ALLOWLIST, deliberately (#227). This used to be a denylist, which was
+ * correct for every key that existed but failed in the wrong direction: a
+ * preference added later was exported by default, and only stayed home if
+ * whoever added it remembered this file. A bundle is a portable file meant to
+ * be carried between machines and plausibly handed to someone else, so the
+ * default for an unclassified key has to be "stays home".
+ *
+ * That failure was not hypothetical. `quotaCooldownsCleared` — a one-time
+ * migration marker whose three siblings are all listed as local below — was
+ * added without a matching exclusion and was being exported. Under an
+ * allowlist it simply never shipped.
+ *
+ * Adding a preference means adding it here or to LOCAL_PREFERENCE_KEYS;
+ * `bundle-preference-policy.test.ts` fails until you do.
+ */
+const PORTABLE_PREFERENCE_KEYS = new Set([
+  // Appearance and behaviour the user chose, which they will want again.
+  'fontSize',
+  'webglRenderer',
+  'closeToTray',
+  'autoLaunchClaude',
+  'sidebar.showActiveOnly',
+  'updateChannel',
+  // Notification and sound settings — the ON/OFF choices travel; the custom
+  // FILE PATHS behind them do not, because they name this machine's disk.
+  'enableNotifications',
+  'notificationSound',
+  'soundVolume',
+  'soundDebouncePreset',
+  'soundWaitingEnabled',
+  'soundErrorEnabled',
+  'soundStartEnabled',
+  'soundCompleteEnabled',
+  // Account failover policy (BDHLNDR-31) — a user's choice about their own
+  // accounts, not a fact about this machine.
+  'accountFailoverEnabled',
+  'accountFailbackEnabled',
+]);
 
 /**
  * Preference namespaces sealed to the source machine's OS keychain, plus the
  * relay identity. Nothing under these can be decrypted anywhere else, and the
  * relay's machine model requires the destination to mint its own keypair.
  */
-const EXCLUDED_PREFERENCE_PREFIXES = ['providerApiKey.', 'providerApiKeyUse.', 'relay.'] as const;
+const LOCAL_PREFERENCE_PREFIXES = ['providerApiKey.', 'providerApiKeyUse.', 'relay.'] as const;
 
-/** Secrets and settings that describe this machine rather than this user. */
-const EXCLUDED_PREFERENCE_KEYS = new Set([
+/**
+ * Keys classified as staying home. Redundant for the filter now that the
+ * allowlist decides, and kept anyway: this is the written record of which
+ * keys were considered and rejected, and it is what lets the policy test tell
+ * "deliberately local" apart from "nobody has looked at this yet".
+ */
+const LOCAL_PREFERENCE_KEYS = new Set([
+  // Secrets.
   'teamsTokens',
+  // Facts about this machine's hardware, disk, or installed software.
   'windowBounds',
   'customShellPath',
   'preferredEditor',
@@ -151,14 +200,30 @@ const EXCLUDED_PREFERENCE_KEYS = new Set([
   'soundErrorCustomPath',
   'soundStartCustomPath',
   'soundCompleteCustomPath',
+  // One-time migration markers. Carrying one would tell the destination a
+  // cleanup had already run on a database where it had not.
   'legacyCodeSearchCleanupDone',
   'legacyMemoryCleanupDone',
   'legacyMemoryMcpCleanupDone',
+  'quotaCooldownsCleared',
 ]);
 
 export function isPortablePreferenceKey(key: string): boolean {
-  if (EXCLUDED_PREFERENCE_KEYS.has(key)) return false;
-  return !EXCLUDED_PREFERENCE_PREFIXES.some((prefix) => key.startsWith(prefix));
+  return PORTABLE_PREFERENCE_KEYS.has(key);
+}
+
+/**
+ * Whether anyone has decided what this key should do at export time.
+ *
+ * The allowlist alone makes an unclassified key stay home, which is the safe
+ * default but a silent one — a legitimate new setting would quietly stop
+ * travelling and nobody would hear about it. This is what the policy test uses
+ * to turn that silence into a failing build.
+ */
+export function isClassifiedPreferenceKey(key: string): boolean {
+  return PORTABLE_PREFERENCE_KEYS.has(key)
+    || LOCAL_PREFERENCE_KEYS.has(key)
+    || LOCAL_PREFERENCE_PREFIXES.some((prefix) => key.startsWith(prefix));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #227

Carried forward from review on #205, raised twice as non-blocking.

## The bug it predicted had already happened

The issue argues the denylist "fails in the wrong direction" — a preference added later ships in the bundle unless someone remembers this file. Enumerating the whole preferences surface to build the allowlist turned up exactly that, live on `development`:

**`quotaCooldownsCleared` was being exported.** It's a one-time migration marker. Its three siblings — `legacyCodeSearchCleanupDone`, `legacyMemoryCleanupDone`, `legacyMemoryMcpCleanupDone` — are all explicitly excluded, so the intent was never ambiguous; this one was simply missed when it was added (by me, earlier today). Carrying it tells a destination machine a cleanup already ran on a database where it hasn't.

Under an allowlist it never shipped in the first place. That is the whole argument for the change, and it didn't need a hypothetical.

## Shape — option 1 from the issue

`PORTABLE_PREFERENCE_KEYS` now decides; `LOCAL_PREFERENCE_KEYS` and `LOCAL_PREFERENCE_PREFIXES` are kept as the written record of what was considered and rejected, which is what lets the policy test tell "deliberately local" from "nobody has looked at this yet".

The safe default is silent on its own — a legitimate new setting would quietly stop travelling and nobody would find out until a user noticed. So `isClassifiedPreferenceKey` plus `bundle-preference-policy.test.ts` turn that silence into a failing build: the test scans source for preference literals and fails on any key on neither list.

It's a lint rather than a unit test, deliberately. It makes "I added a preference" a decision written down in the file where the consequence lives.

**It caught a bug in itself on the first run** — the constant regex matched `*_PREFIX` names (`TRANSCRIPT_PREFIX`, `INSTALL_PREFIX`) and dragged in three non-keys. Tightened to names ending `PREF`/`PREF_KEY`. There's now a guards-the-guard test asserting the scan finds a known-portable and a known-local key, so a regex that silently matched nothing can't make the whole file pass forever.

## The existing tests were asserting on keys that do not exist

`bundle-format.test.ts` checked that `theme`, `soundEnabled`, `betaChannel` and `apiPort` were portable. **None of those four appear anywhere in non-test source** — this app has never written them. Under a denylist they passed for the same reason any unknown string did, so "keeps the ordinary settings a user would want back" was verifying nothing at all. The `db-fixture` seeded `theme` too, which is why four tests failed the moment the default flipped.

Fixtures and assertions now use real keys (`fontSize`, `closeToTray`, `soundVolume`, `updateChannel`, `webglRenderer`). This is the part I'd most like a second opinion on — it's the change that alters what the existing suite covers, and it's worth confirming I classified the real surface correctly rather than plausibly.

## Acceptance, against the issue's own list

- **A new key cannot reach a bundle without classification** — allowlist decides; policy test fails the build on an unclassified key.
- **Every key currently exported still is** — full inventory below. The only behaviour change is `quotaCooldownsCleared`, which is the bug.
- **The canary test still passes** — a seeded secret absent from the raw bytes and from the decompressed text; untouched and green.

### Classification

**Portable (16):** `fontSize`, `webglRenderer`, `closeToTray`, `autoLaunchClaude`, `sidebar.showActiveOnly`, `updateChannel`, `enableNotifications`, `notificationSound`, `soundVolume`, `soundDebouncePreset`, `soundWaitingEnabled`, `soundErrorEnabled`, `soundStartEnabled`, `soundCompleteEnabled`, `accountFailoverEnabled`, `accountFailbackEnabled`

**Local:** `teamsTokens`; the machine-shaped ones (`windowBounds`, `customShellPath`, `preferredEditor`, the four `sound*CustomPath`); the four migration markers; and the `providerApiKey.` / `providerApiKeyUse.` / `relay.` namespaces.

Note the sound settings split deliberately: the on/off choice travels, the custom **file path** behind it does not, because it names this machine's disk.

## Testing

`bun test --isolate` — **1298 pass, 0 fail**. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGPAJHf4nggL377CBqtLgm