### PR TITLE
233 — Give the real-corpus regression a ceiling it cannot miss

### DIFF
--- a/src/main/api/chat-parser/__tests__/parser.test.ts
+++ b/src/main/api/chat-parser/__tests__/parser.test.ts
@@ -424,6 +424,23 @@ describe('ChatParser wrap-space recovery (BDHLNDR-73 #40)', () => {
   });
 });
 
+/**
+ * Ceiling for the real-corpus test (#233).
+ *
+ * bun's default is 5000ms, and this test overran it in the full-repo run under
+ * coverage instrumentation — `5016.05ms`, i.e. it did not assert wrong, it ran
+ * out of clock. Measured: ~2s wall in isolation under `--coverage` with every
+ * core saturated, so the default left only about 2x headroom, which an 88-file
+ * parallel run consumes.
+ *
+ * Raised rather than making the test cheaper on purpose. It parses a 340KB real
+ * PTY capture, and the size of that corpus is the point of the regression —
+ * trimming it to fit a timeout would quietly weaken the only test that has ever
+ * caught this class of parser bug. This number is a backstop against a hang,
+ * not a performance budget: if it is ever reached, something is genuinely wrong.
+ */
+const REAL_CORPUS_TIMEOUT_MS = 30_000;
+
 describe('ChatParser real-corpus regression (BDHLNDR-72)', () => {
   test('5-min real Claude session captures: extracts real content, suppresses noise', async () => {
     // Real PTY capture from one of @Will Long's Bodhilander sessions on
@@ -502,5 +519,5 @@ describe('ChatParser real-corpus regression (BDHLNDR-72)', () => {
     expect(allText).toContain('memory usage');
     expect(allText).toContain('concerns (windows');
     expect(allText).toContain('Slack, and Figma');
-  });
+  }, REAL_CORPUS_TIMEOUT_MS);
 });


### PR DESCRIPTION
Closes #233

The last known member of the flake family from #228. Filed during that work with one observation and no diagnosis; this is the diagnosis.

## Measured, and my first hypothesis was wrong

The obvious suspect was the test's chunking loop — 340KB at 4096 bytes is ~83 iterations, each doing `await new Promise((r) => setTimeout(r, 1))`. A per-chunk event-loop yield under contention looked like an easy answer.

It isn't the cause:

| | 83 × `setTimeout(1)` |
|---|---|
| idle | ~95ms |
| all 16 cores saturated | ~140ms |

Nowhere near the budget. The time is the **parsing itself**: ~2s wall in isolation under `--coverage` on a loaded machine. That leaves bun's 5000ms default only about 2× headroom, and an 88-file parallel run consumes it — which is exactly why this only ever appeared in the full-repo coverage run and never in isolation.

## Raised the ceiling rather than making the test cheaper

The issue asked for this call to be made deliberately, so: the test parses a 340KB real PTY capture, and **the size of that corpus is the regression**. It's the test that caught a parser producing 1572 events with a longest payload of one character. Trimming it to fit a timeout would quietly weaken the only thing standing between that bug and a rerun of it.

`REAL_CORPUS_TIMEOUT_MS = 30_000` — roughly 15× the measured isolated cost. It's a backstop against a hang, not a performance budget; if it's ever reached, something is genuinely wrong.

This is different in kind from the four fixes in #232. Those were tests *waiting* on something with a sleep sized for an idle machine, and the fix was to wait on the condition. There is nothing to wait on here — it's real work that is simply slower than the default when the machine is busy and every line is instrumented.

## Siblings

Checked, as the issue asked. `real-corpus-bdhlndr-72.raw` is the **only test fixture in the repo over 50KB**, so nothing else has this exposure. The other 41 tests in the file share ~1.5s between them.

## Verification — the condition that actually reproduced it

3 consecutive full-repo runs with `bun test --coverage --coverage-reporter=lcov --isolate` under full core saturation — the exact combination that produced the original failure:

**1298 pass / 0 fail**, 153–166s per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGPAJHf4nggL377CBqtLgm