### PR TITLE
CI: shorten dist-* artifact retention to 1 day

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-${{ matrix.platform }}
+          # The release job in this same run re-uploads everything to a GitHub
+          # Release immediately after; nothing downstream needs this copy.
+          retention-days: 1
           path: |
             release/*.AppImage
             release/*.deb


### PR DESCRIPTION
The `dist-${{ matrix.platform }}` artifacts uploaded in the `build` job exist only to hand build output to the `release` job in the same run, which immediately re-uploads everything to a GitHub Release (`softprops/action-gh-release`). Nothing downstream reads them after that.

With no `retention-days` set they defaulted to 90 days, and Bodhilander is currently the single largest Actions-storage line item in the org (33 GB of live artifacts, ~1.5 GB-hr-equivalent/day gross). Actual distribution to users is unaffected — that goes through Releases, not artifacts.

One-line change: adds `retention-days: 1`.