### PR TITLE
Cut v3.5.1-beta.11 so the arrival relink button ships

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.5.1-beta.10",
+  "version": "3.5.1-beta.11",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {


### PR DESCRIPTION
Closes #245

Bumps `package.json` to `3.5.1-beta.11`. Nothing else changes.

`beta.10` was cut at `ddd8d49`. Since then `development` has taken #242 (the arrival relink button) and #244 (artifact retention), so the handoff feature is complete in the branch and absent from every installer. This makes the two match.

**Why a PR for a version bump.** CLAUDE.md says `npm version prerelease` then `git push`. A `pull_request` ruleset now covers `development` and rejects that push, so the bump commit rides a branch instead. The rest of the rule still holds and still matters: **no `--tags`.** The local tag `npm version` created has been deleted; `release.yml` cuts `v3.5.1-beta.11` itself when this merges, and would skip the build entirely if it found the tag already on the remote.

Verified before pushing: `git ls-remote --tags origin v3.5.1-beta.11` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NH6mNrBb78jz3fFT7XeGjS