### PR TITLE
Point the default relay URL at a relay that exists

### DIFF
--- a/src/main/api/relay/relay-client.ts
+++ b/src/main/api/relay/relay-client.ts
@@ -100,7 +100,7 @@ export interface AssertedOwner {
 
 export type { RelayStatus } from '../../../shared/types';
 
-const DEFAULT_RELAY_URL = 'https://cl-relay.sytanek.tech';
+const DEFAULT_RELAY_URL = 'https://bodhilander.bodhilabs.dev';
 
 const PREF = {
   enabled: 'relay.enabled',


### PR DESCRIPTION
Closes #247

`DEFAULT_RELAY_URL` becomes `https://bodhilander.bodhilabs.dev`. One line; it was the only reference in `src/`.

The old value, `https://cl-relay.sytanek.tech`, was NXDOMAIN — verified against 1.1.1.1, with the parent `sytanek.tech` resolving fine, so the record genuinely did not exist rather than a resolver having a bad day. The new one resolves to `20.127.80.85` and answers `/health` with 200.

This matters most on a clean install. `relay.url` sits under `LOCAL_PREFERENCE_PREFIXES`, so it deliberately does not travel in a transfer bundle — meaning the machine being handed *to*, which is the one that most needs a working relay, is exactly the one that fell back to the dead name and got a DNS error instead of a usable default.

**Not fixed here:** that relay is still running a pre-handoff build and 404s on `/api/machines/:id/handoff`. Pointing at it is correct regardless; #248 covers the redeploy.

No test pins the constant. One would assert a hostname rather than a behaviour, and would have to be edited by hand every time the relay moves — the check that would actually have caught this is DNS, not the suite.

Verified: `tsc --noEmit` clean; `bun test src/main/api/relay` 161 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NH6mNrBb78jz3fFT7XeGjS