### PR TITLE
Cut v3.5.1-beta.12 so the relay default fix ships

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.5.1-beta.11",
+  "version": "3.5.1-beta.12",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {


### PR DESCRIPTION
Closes #250

Bumps `package.json` to `3.5.1-beta.12`. Nothing else changes.

`beta.11` was cut at `2ef4ecc`. #249 merged after it at `2935e5f`, so `DEFAULT_RELAY_URL` now points at `bodhilander.bodhilabs.dev` in the branch and at the NXDOMAIN `cl-relay.sytanek.tech` in every installer. This makes them match.

Same release mechanics as #246, and the same one that actually bites: **no `--tags`.** The local tag `npm version` created has been deleted, and `git ls-remote --tags origin v3.5.1-beta.12` returns nothing, so `release.yml` cuts the tag itself instead of finding one and skipping the build.

**Merge order matters here.** The `beta.11` run is still building. Two release workflows in flight would race on the beta channel manifest, and the loser is whichever finishes first — if `beta.11` finished second it would hand beta users the older build. This waits for that run to complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NH6mNrBb78jz3fFT7XeGjS