### PR TITLE
Show Settings off macOS instead of hiding it behind a chord

### DIFF
--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -110,16 +110,12 @@ describe('reaching Settings without the macOS app menu', () => {
       // The bug was an item that existed only to register its accelerator, so
       // asserting it exists proves nothing on its own.
       expect((item as { visible?: boolean }).visible).not.toBe(false);
+
+      sent.length = 0;
+      item!.click!();
+      expect(sent).toContain('open-settings');
     });
   }
-
-  test('clicking it opens Settings', () => {
-    sent.length = 0;
-    const item = sessionMenuOn('win32').find((i) => i.label?.startsWith('Settings'));
-    item!.click!();
-
-    expect(sent).toContain('open-settings');
-  });
 
   test('macOS keeps it in the app menu and does not duplicate it into Session', () => {
     const labels = sessionMenuOn('darwin').map((i) => i.label);

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -35,9 +35,30 @@ mock.module('electron', () => ({
 
 const { createApplicationMenu } = await import('./menu');
 
+const sent: string[] = [];
+
 function buildMenu(): void {
-  const fakeWindow = { webContents: { send: () => {} } } as never;
+  const fakeWindow = {
+    isDestroyed: () => false,
+    webContents: { send: (channel: string) => { sent.push(channel); } },
+  } as never;
   createApplicationMenu(fakeWindow);
+}
+
+/**
+ * The app menu is macOS-only, so everything it holds has to be mirrored
+ * elsewhere off macOS. Building under a forced platform is the only way to see
+ * that other branch from here.
+ */
+function sessionMenuOn(platform: string): MenuItem[] {
+  const real = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    buildMenu();
+    return template.find((m) => m.label === 'Session')?.submenu ?? [];
+  } finally {
+    Object.defineProperty(process, 'platform', { value: real, configurable: true });
+  }
 }
 
 function sessionMenu(): MenuItem[] {
@@ -77,5 +98,34 @@ describe('the Session menu', () => {
     for (const label of ['Export…', 'Import…']) {
       expect((itemLabelled(label) as { accelerator?: string }).accelerator).toBeUndefined();
     }
+  });
+});
+
+describe('reaching Settings without the macOS app menu', () => {
+  for (const platform of ['win32', 'linux']) {
+    test(`${platform} shows Settings in a menu rather than hiding it behind a chord`, () => {
+      const item = sessionMenuOn(platform).find((i) => i.label?.startsWith('Settings'));
+
+      expect(item).toBeDefined();
+      // The bug was an item that existed only to register its accelerator, so
+      // asserting it exists proves nothing on its own.
+      expect((item as { visible?: boolean }).visible).not.toBe(false);
+    });
+  }
+
+  test('clicking it opens Settings', () => {
+    sent.length = 0;
+    const item = sessionMenuOn('win32').find((i) => i.label?.startsWith('Settings'));
+    item!.click!();
+
+    expect(sent).toContain('open-settings');
+  });
+
+  test('macOS keeps it in the app menu and does not duplicate it into Session', () => {
+    const labels = sessionMenuOn('darwin').map((i) => i.label);
+    expect(labels.filter((l) => l?.startsWith('Settings'))).toHaveLength(0);
+
+    const appMenu = template.find((m) => m.label === 'Bodhilander')?.submenu ?? [];
+    expect(appMenu.map((i) => i.label)).toContain('Preferences...');
   });
 });

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -179,10 +179,10 @@ export function createApplicationMenu(mainWindow: BrowserWindow): void {
         ...(isMac ? [] : [
           { type: 'separator' as const },
           {
-            // Hidden menu item to register Ctrl+, accelerator on Windows/Linux
-            label: 'Settings',
+            // Mirrors the macOS app menu's Preferences, which has no menu bar to live in
+            // off macOS. ',' is not a terminal key, so CmdOrCtrl is safe here.
+            label: 'Settings...',
             accelerator: 'CmdOrCtrl+,',
-            visible: false,
             click: () => {
               if (mainWindow && !mainWindow.isDestroyed()) {
                 mainWindow.webContents.send('open-settings');


### PR DESCRIPTION
Closes #252

Drops `visible: false` from the non-mac Settings item and names it `Settings...`, matching its sibling `Claude Accounts...`.

The macOS app menu does not exist on Windows or Linux, so the non-mac branch mirrors its entries into the Session menu. Settings was mirrored as an invisible item — added to register `CmdOrCtrl+,`, per its own comment, not to be reachable. The result was that Windows and Linux had **no visible path to Settings anywhere**: not Session, not Edit, not View. Reported from `beta.10` on Windows, and the code is unchanged on `development`, so it has been true of every build.

That matters more than a missing menu entry usually would, because Settings is where Remote Hosting, Updates and the Export/Import handoff controls live. A user who did not already know `Ctrl+,` could not reach any of them.

Scope is this one item. Everything else in the app menu is already accounted for off macOS — `About Bodhilander` sits in Help on every platform, `Quit` and `Claude Accounts...` are mirrored and visible, and `services`/`hide`/`unhide` are macOS-only roles with nothing to mirror.

**On the tests.** `isMac` is read per call, so forcing `process.platform` around `createApplicationMenu` is enough to build the other branch — the platform is restored in a `finally` so a failure cannot leak it into later tests.

The assertion is `visible !== false`, not "the item exists". Existence is precisely what the old tests checked and precisely what an invisible item satisfies, which is how this survived. A macOS case is included so the fix cannot drift into duplicating Settings into Session on the platform that already has it in the app menu.

Control-verified: with `visible: false` restored, the win32 and linux cases fail and the other six still pass.

Verified: `bun test --isolate` 1490 pass / 0 fail; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NH6mNrBb78jz3fFT7XeGjS