### PR TITLE
Cut v3.5.1-beta.13 so the Windows Settings menu fix ships

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.5.1-beta.12",
+  "version": "3.5.1-beta.13",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {


### PR DESCRIPTION
Closes #255

Bumps `package.json` to `3.5.1-beta.13`. Nothing else changes.

`beta.12` was cut at `9227ceb`. #253 merged after it at `b5d2461`, so Windows and Linux users still have no visible menu path to Settings in any installer — which on those platforms is the only route to Remote Hosting, Updates and the Export/Import handoff controls. This makes the installers match the branch.

Same release mechanics as #246 and #251, and the same one that actually bites: **no `--tags`.** The local tag `npm version` created has been deleted, and `git ls-remote --tags origin v3.5.1-beta.13` returns nothing, so `release.yml` cuts the tag itself instead of finding one and skipping the build.

Unlike #251 this needs no merge hold — `beta.12` finished, and no release run is in flight to race on the beta channel manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NH6mNrBb78jz3fFT7XeGjS
