### PR TITLE
Say what deleting a Claude account destroys

### DIFF
--- a/src/main/__tests__/account-auth.test.ts
+++ b/src/main/__tests__/account-auth.test.ts
@@ -451,3 +451,76 @@ describe('cancelLoginFlow', () => {
     expect(kills).toBe(1);
   });
 });
+
+/**
+ * accountRemovalCost is what the delete confirmation quotes, and both halves
+ * are measured rather than declared: the sessions come from the same predicate
+ * deleteAccount() unsets, and the conversations are counted off disk. A count
+ * that silently reads zero would turn the warning into a reassurance.
+ */
+describe('accountRemovalCost', () => {
+  function writeTranscripts(accountId: string, slug: string, names: string[]): void {
+    const dir = path.join(userDataDir, 'claude-accounts', accountId, '.claude', 'projects', slug);
+    fs.mkdirSync(dir, { recursive: true });
+    for (const name of names) fs.writeFileSync(path.join(dir, name), '{}');
+  }
+
+  function insertAccount(id: string): void {
+    db.prepare('INSERT INTO claude_accounts (id, label, config_dir) VALUES (?, ?, ?)')
+      .run(id, id, path.join(userDataDir, 'claude-accounts', id, '.claude'));
+  }
+
+  function bindSession(id: string, accountId: string | null): void {
+    db.prepare('INSERT INTO sessions (id, name, working_dir, claude_account_id) VALUES (?, ?, ?, ?)')
+      .run(id, id, userDataDir, accountId);
+  }
+
+  test('counts transcripts across slugs and only the sessions on this account', () => {
+    insertAccount('a1');
+    writeTranscripts('a1', 'proj-one', ['x.jsonl', 'y.jsonl']);
+    writeTranscripts('a1', 'proj-two', ['z.jsonl']);
+    bindSession('s1', 'a1');
+    bindSession('s2', 'a1');
+    bindSession('s3', 'other');
+    bindSession('s4', null);
+
+    expect(accountAuth.accountRemovalCost('a1')).toEqual({ sessions: 2, conversations: 3 });
+  });
+
+  test('ignores files that are not transcripts', () => {
+    insertAccount('a1');
+    writeTranscripts('a1', 'proj', ['keep.jsonl', 'notes.md', 'settings.json']);
+
+    expect(accountAuth.accountRemovalCost('a1').conversations).toBe(1);
+  });
+
+  // An account that never ran has no projects/ at all. That is the ordinary
+  // case, not a failure, and it has to report zero rather than throw — the
+  // confirmation is built from this before the user sees it.
+  test('an account that never ran costs nothing and does not throw', () => {
+    insertAccount('a1');
+    fs.mkdirSync(path.join(userDataDir, 'claude-accounts', 'a1', '.claude'), { recursive: true });
+
+    expect(accountAuth.accountRemovalCost('a1')).toEqual({ sessions: 0, conversations: 0 });
+  });
+
+  test('a config dir that was never created at all still answers', () => {
+    insertAccount('a1');
+
+    expect(accountAuth.accountRemovalCost('a1')).toEqual({ sessions: 0, conversations: 0 });
+  });
+
+  // projects/ holds a directory per working dir, but nothing stops a stray file
+  // landing beside them. It contributes nothing and must not take the
+  // surrounding count down with it. The inner catch guards the narrower case of
+  // a directory that stops being readable after it was listed, which needs a
+  // race to reach and is not covered here.
+  test('a plain file among the slugs is skipped, and the slugs beside it still count', () => {
+    insertAccount('a1');
+    writeTranscripts('a1', 'good', ['x.jsonl']);
+    const projects = path.join(userDataDir, 'claude-accounts', 'a1', '.claude', 'projects');
+    fs.writeFileSync(path.join(projects, 'not-a-dir'), 'plain file');
+
+    expect(accountAuth.accountRemovalCost('a1').conversations).toBe(1);
+  });
+});

--- a/src/main/account-auth.ts
+++ b/src/main/account-auth.ts
@@ -21,7 +21,7 @@ import * as accountsRepo from './repositories/accounts';
 import { AccountIdentity, LOGIN_ARTIFACTS, resolveAccountIdentity } from './account-identity';
 import { registerHooks } from './mcp-config';
 import { seedLegacyConversations } from './legacy-claude-seed';
-import { ClaudeAccount } from '../shared/types';
+import { AccountRemovalCost, ClaudeAccount } from '../shared/types';
 
 interface LoginFlow {
   accountId: string;
@@ -297,6 +297,41 @@ export function cancelLoginFlow(
   }
 
   activeFlows.delete(ptyId);
+}
+
+/**
+ * What removing an account costs, for a confirmation that can name it. The
+ * conversations are the part worth counting: they live under the config dir
+ * and go with it, and nothing else on disk records them.
+ */
+export function accountRemovalCost(accountId: string): AccountRemovalCost {
+  return {
+    sessions: accountsRepo.countSessionsUsingAccount(accountId),
+    conversations: countTranscripts(configDirFor(accountId)),
+  };
+}
+
+/** Transcripts live at <configDir>/projects/<cwd-slug>/<uuid>.jsonl. */
+function countTranscripts(configDir: string): number {
+  const projects = path.join(configDir, 'projects');
+  let slugs: fs.Dirent[];
+  try {
+    slugs = fs.readdirSync(projects, { withFileTypes: true });
+  } catch {
+    // No projects/ is the ordinary "never used" case, not a failure.
+    return 0;
+  }
+
+  let total = 0;
+  for (const slug of slugs) {
+    if (!slug.isDirectory()) continue;
+    try {
+      total += fs.readdirSync(path.join(projects, slug.name)).filter((f) => f.endsWith('.jsonl')).length;
+    } catch {
+      // A slug we cannot read contributes nothing and stops nothing.
+    }
+  }
+  return total;
 }
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -955,6 +955,8 @@ safeHandle('accounts:confirmLoginMacOS', (ptyId: string) => {
   accountAuth.confirmLoginMacOS(mainWindow, ptyId);
 });
 
+safeHandle('accounts:removalCost', (id: string) => accountAuth.accountRemovalCost(id));
+
 safeHandle('accounts:delete', (id: string) => {
   accountAuth.deleteAccountAndDir(id);
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, AccountFailoverEvent, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest, PortableExportResult, PortableImportResult, HandoffOfferState, HandoffPrepareResult, ArrivalReport } from '../shared/types';
+import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, AccountFailoverEvent, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest, PortableExportResult, PortableImportResult, HandoffOfferState, HandoffPrepareResult, ArrivalReport, AccountRemovalCost } from '../shared/types';
 
 // Get homedir from environment since os module isn't available in sandbox
 const homedir = process.env.HOME || process.env.USERPROFILE || '/';
@@ -375,6 +375,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('accounts:cancelLogin', ptyId, deleteAccount),
   confirmAccountLoginMacOS: (ptyId: string): Promise<void> =>
     ipcRenderer.invoke('accounts:confirmLoginMacOS', ptyId),
+  accountRemovalCost: (id: string): Promise<AccountRemovalCost> =>
+    ipcRenderer.invoke('accounts:removalCost', id),
   deleteAccount: (id: string): Promise<void> =>
     ipcRenderer.invoke('accounts:delete', id),
   updateAccount: (id: string, updates: { label?: string; color?: string; email?: string | null }): Promise<void> =>

--- a/src/main/repositories/accounts.ts
+++ b/src/main/repositories/accounts.ts
@@ -125,6 +125,14 @@ export function touchAccount(id: string): void {
   );
 }
 
+/** Counts what deleteAccount() is about to unset, using the same predicate. */
+export function countSessionsUsingAccount(id: string): number {
+  const row = getDatabase()
+    .prepare('SELECT COUNT(*) AS n FROM sessions WHERE claude_account_id = ?')
+    .get(id) as { n: number };
+  return row.n;
+}
+
 /**
  * Delete an account and NULL out any sessions/groups that referred to it.
  * SQLite ALTER TABLE can't add a real FK, so we enforce SET NULL semantics here.
@@ -137,14 +145,6 @@ export function touchAccount(id: string): void {
  * neither a live account nor an assigned one — so the user is told their
  * account was removed and offered nothing to move to.
  */
-/** Counts what deleteAccount() is about to unset, using the same predicate. */
-export function countSessionsUsingAccount(id: string): number {
-  const row = getDatabase()
-    .prepare('SELECT COUNT(*) AS n FROM sessions WHERE claude_account_id = ?')
-    .get(id) as { n: number };
-  return row.n;
-}
-
 export function deleteAccount(id: string): void {
   const db = getDatabase();
   const tx = db.transaction(() => {

--- a/src/main/repositories/accounts.ts
+++ b/src/main/repositories/accounts.ts
@@ -137,6 +137,14 @@ export function touchAccount(id: string): void {
  * neither a live account nor an assigned one — so the user is told their
  * account was removed and offered nothing to move to.
  */
+/** Counts what deleteAccount() is about to unset, using the same predicate. */
+export function countSessionsUsingAccount(id: string): number {
+  const row = getDatabase()
+    .prepare('SELECT COUNT(*) AS n FROM sessions WHERE claude_account_id = ?')
+    .get(id) as { n: number };
+  return row.n;
+}
+
 export function deleteAccount(id: string): void {
   const db = getDatabase();
   const tx = db.transaction(() => {

--- a/src/renderer/components/ClaudeAccountsModal.tsx
+++ b/src/renderer/components/ClaudeAccountsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ClaudeAccount, LiveAccountBindings } from '../../shared/types';
+import { AccountRemovalCost, ClaudeAccount, LiveAccountBindings } from '../../shared/types';
 import Terminal from './Terminal';
 import { AccountChip } from './AccountChip';
 import './ClaudeAccountsModal.css';
@@ -12,6 +12,41 @@ import './ClaudeAccountsModal.css';
 // isOpen plumbing needed. Reached from the app menu's "Claude Accounts…" item
 // (menu:open-accounts), which deep-links Settings to this tab.
 // -----------------------------------------------------------------------------
+
+/**
+ * What the delete costs. The transcripts live in the config directory this
+ * removes and nothing else on disk records them, so the confirmation names
+ * them rather than only listing what it unsets. A null cost means we could not
+ * measure it, and silence beats a number we do not have.
+ */
+export function removalWarning(cost: AccountRemovalCost | null): string {
+  if (!cost) return '';
+  if (cost.conversations === 0) return '\n\nIt has no saved conversations, so nothing is lost.';
+
+  const conversations = cost.conversations === 1
+    ? '1 saved conversation'
+    : `${cost.conversations} saved conversations`;
+  const deletes = `\n\nThis permanently deletes ${conversations}.`;
+
+  if (cost.sessions === 0) return deletes;
+  if (cost.sessions === 1) {
+    return `${deletes} The session bound to this account stays in the sidebar, but its `
+      + 'history is gone and it cannot be resumed.';
+  }
+  return `${deletes} The ${cost.sessions} sessions bound to this account stay in the sidebar, `
+    + 'but their history is gone and they cannot be resumed.';
+}
+
+/** Live ptys lose the directory underneath them, which is a different loss. */
+export function runningWarning(runningSessions: number): string {
+  if (runningSessions === 0) return '';
+  if (runningSessions === 1) {
+    return '\n\n1 session is using it right now. It keeps running, but its account directory '
+      + 'goes away underneath it.';
+  }
+  return `\n\n${runningSessions} sessions are using it right now. They keep running, but their `
+    + 'account directory goes away underneath them.';
+}
 
 export const ClaudeAccountsPanel: React.FC = () => {
   const [accounts, setAccounts] = useState<ClaudeAccount[]>([]);
@@ -96,31 +131,20 @@ export const ClaudeAccountsPanel: React.FC = () => {
     await refresh();
   }, [refresh]);
 
-  // Deleting removes the on-disk config dir, which is where the transcripts
-  // live, so the confirmation has to name what that costs rather than only
-  // what it unsets.
   const handleDelete = useCallback(async (id: string, label: string, runningSessions: number) => {
-    const cost = await window.electronAPI.accountRemovalCost(id);
-
-    // The conversations are the part that does not come back, and counting them
-    // is the whole point of asking main first: the transcripts live in the
-    // config directory this deletes, and nothing else on disk records them.
-    const loss = cost.conversations > 0
-      ? `\n\nThis permanently deletes ${cost.conversations} saved `
-        + `${cost.conversations === 1 ? 'conversation' : 'conversations'}. `
-        + `${cost.sessions === 1 ? 'The session' : `The ${cost.sessions} sessions`} bound to this `
-        + `account ${cost.sessions === 1 ? 'stays' : 'stay'} in the sidebar, but ${cost.sessions === 1 ? 'its' : 'their'} `
-        + `history is gone and ${cost.sessions === 1 ? 'it' : 'they'} cannot be resumed.`
-      : '\n\nIt has no saved conversations, so nothing is lost.';
-
-    const running = runningSessions > 0
-      ? `\n\n${runningSessions} ${runningSessions === 1 ? 'session is' : 'sessions are'} using it right `
-        + `now. They keep running, but their account directory goes away underneath them.`
-      : '';
+    // A cost we could not compute must not block the delete, so a failure here
+    // falls through to a confirmation that claims no number rather than one
+    // that claims a wrong one.
+    let cost: AccountRemovalCost | null = null;
+    try {
+      cost = await window.electronAPI.accountRemovalCost(id);
+    } catch (err) {
+      console.error('Could not measure what deleting this account costs', err);
+    }
 
     const confirmed = window.confirm(
       `Delete account "${label}"?\n\nThis removes its saved credentials and unsets any sessions or `
-      + `groups that were bound to it.${loss}${running}`
+      + `groups that were bound to it.${removalWarning(cost)}${runningWarning(runningSessions)}`
     );
     if (!confirmed) return;
     await window.electronAPI.deleteAccount(id);

--- a/src/renderer/components/ClaudeAccountsModal.tsx
+++ b/src/renderer/components/ClaudeAccountsModal.tsx
@@ -96,21 +96,31 @@ export const ClaudeAccountsPanel: React.FC = () => {
     await refresh();
   }, [refresh]);
 
-  // The panel computes "N sessions are running on this account" two inches
-  // above this button, and deleting removes the on-disk config dir out from
-  // under those live ptys (#165). Withholding the number here while the dialog
-  // reassures the user that "sessions themselves are kept" is the one place
-  // that count actually had a job to do.
+  // Deleting removes the on-disk config dir, which is where the transcripts
+  // live, so the confirmation has to name what that costs rather than only
+  // what it unsets.
   const handleDelete = useCallback(async (id: string, label: string, runningSessions: number) => {
-    const subject = runningSessions === 1 ? 'session is' : 'sessions are';
-    const warning = runningSessions > 0
-      ? `\n\n${runningSessions} running ${subject} `
-        + `using this account right now. They keep running, but their account directory goes away `
-        + `with it — restart them onto another account first if you need their conversations.`
+    const cost = await window.electronAPI.accountRemovalCost(id);
+
+    // The conversations are the part that does not come back, and counting them
+    // is the whole point of asking main first: the transcripts live in the
+    // config directory this deletes, and nothing else on disk records them.
+    const loss = cost.conversations > 0
+      ? `\n\nThis permanently deletes ${cost.conversations} saved `
+        + `${cost.conversations === 1 ? 'conversation' : 'conversations'}. `
+        + `${cost.sessions === 1 ? 'The session' : `The ${cost.sessions} sessions`} bound to this `
+        + `account ${cost.sessions === 1 ? 'stays' : 'stay'} in the sidebar, but ${cost.sessions === 1 ? 'its' : 'their'} `
+        + `history is gone and ${cost.sessions === 1 ? 'it' : 'they'} cannot be resumed.`
+      : '\n\nIt has no saved conversations, so nothing is lost.';
+
+    const running = runningSessions > 0
+      ? `\n\n${runningSessions} ${runningSessions === 1 ? 'session is' : 'sessions are'} using it right `
+        + `now. They keep running, but their account directory goes away underneath them.`
       : '';
+
     const confirmed = window.confirm(
       `Delete account "${label}"?\n\nThis removes its saved credentials and unsets any sessions or `
-      + `groups that were bound to it. Sessions themselves are kept.${warning}`
+      + `groups that were bound to it.${loss}${running}`
     );
     if (!confirmed) return;
     await window.electronAPI.deleteAccount(id);

--- a/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
+++ b/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { describe, expect, test, afterEach } from 'bun:test';
 import { act, render, screen, cleanup, fireEvent } from '@testing-library/react';
-import { AccountRow, ClaudeAccountsPanel, LoginBanner, LoginHint } from '../ClaudeAccountsModal';
+import { AccountRow, ClaudeAccountsPanel, LoginBanner, LoginHint, removalWarning, runningWarning } from '../ClaudeAccountsModal';
 import { ClaudeAccount } from '../../../shared/types';
 
 afterEach(cleanup);
@@ -220,23 +220,28 @@ describe('ClaudeAccountsPanel delete confirmation', () => {
     expect(messages[0]).toContain('cannot be resumed');
   });
 
-  test('speaks of one conversation and one session in the singular', async () => {
-    const { messages } = await openPanel({}, { sessions: 1, conversations: 1 });
+  /**
+   * Measuring the cost is a new round-trip standing between the button and the
+   * dialog. If it can reject, it can take the whole delete with it and leave a
+   * button that does nothing when clicked.
+   */
+  test('still offers the delete when the cost cannot be measured', async () => {
+    const deleted = stubApi({});
+    (window as unknown as { electronAPI: { accountRemovalCost: () => Promise<never> } })
+      .electronAPI.accountRemovalCost = () => Promise.reject(new Error('database is locked'));
+    const messages: string[] = [];
+    (window as unknown as { confirm: (m: string) => boolean }).confirm = (m: string) => {
+      messages.push(m);
+      return true;
+    };
+    await act(async () => { render(<ClaudeAccountsPanel />); });
 
     await clickDelete();
 
-    expect(messages[0]).toContain('permanently deletes 1 saved conversation.');
-    expect(messages[0]).toContain('The session bound to this account stays in the sidebar');
-    expect(messages[0]).toContain('its history is gone');
-  });
-
-  test('says plainly when there is nothing to lose', async () => {
-    const { messages } = await openPanel({}, { sessions: 0, conversations: 0 });
-
-    await clickDelete();
-
-    expect(messages[0]).toContain('no saved conversations, so nothing is lost');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('removes its saved credentials');
     expect(messages[0]).not.toContain('permanently deletes');
+    expect(deleted).toEqual(['a1']);
   });
 });
 
@@ -322,5 +327,67 @@ describe('LoginBanner', () => {
   test('an unstarted login claims nothing either', () => {
     render(<LoginBanner completed={false} verified={false} />);
     expect(banner()).toBeNull();
+  });
+});
+
+/**
+ * The confirmation's wording, tested where it is decided rather than through
+ * the panel. Both counts have a singular the plural branch never exercises,
+ * and a zero that has to read as reassurance rather than a warning about
+ * nothing.
+ */
+describe('removalWarning', () => {
+  test('names conversations and sessions in the plural', () => {
+    const text = removalWarning({ sessions: 3, conversations: 12 });
+    expect(text).toContain('permanently deletes 12 saved conversations');
+    expect(text).toContain('The 3 sessions bound to this account stay in the sidebar');
+    expect(text).toContain('they cannot be resumed');
+  });
+
+  test('speaks of one conversation and one session in the singular', () => {
+    const text = removalWarning({ sessions: 1, conversations: 1 });
+    expect(text).toContain('permanently deletes 1 saved conversation.');
+    expect(text).toContain('The session bound to this account stays in the sidebar');
+    expect(text).toContain('its history is gone');
+  });
+
+  // Conversations with nothing bound to them is reachable: the sessions were
+  // deleted, or the transcripts arrived in a bundle. Saying "The 0 sessions"
+  // is the failure this guards.
+  test('reports conversations with no sessions without inventing a session count', () => {
+    const text = removalWarning({ sessions: 0, conversations: 4 });
+    expect(text).toContain('permanently deletes 4 saved conversations.');
+    expect(text).not.toContain('0 sessions');
+    expect(text).not.toContain('bound to this account');
+  });
+
+  test('says plainly when there is nothing to lose', () => {
+    const text = removalWarning({ sessions: 0, conversations: 0 });
+    expect(text).toContain('no saved conversations, so nothing is lost');
+    expect(text).not.toContain('permanently deletes');
+  });
+
+  // A cost we could not measure must not be reported as a cost of zero, which
+  // is the one wrong answer that reads as safe.
+  test('claims nothing when the cost could not be measured', () => {
+    expect(removalWarning(null)).toBe('');
+  });
+});
+
+describe('runningWarning', () => {
+  test('is silent when nothing is running', () => {
+    expect(runningWarning(0)).toBe('');
+  });
+
+  test('agrees with itself in the singular', () => {
+    const text = runningWarning(1);
+    expect(text).toContain('1 session is using it right now');
+    expect(text).toContain('It keeps running, but its account directory goes away underneath it');
+  });
+
+  test('agrees with itself in the plural', () => {
+    const text = runningWarning(2);
+    expect(text).toContain('2 sessions are using it right now');
+    expect(text).toContain('They keep running, but their account directory goes away underneath them');
   });
 });

--- a/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
+++ b/src/renderer/components/__tests__/ClaudeAccountsModal.test.tsx
@@ -139,13 +139,17 @@ describe('AccountRow', () => {
 describe('ClaudeAccountsPanel delete confirmation', () => {
   const listed: ClaudeAccount[] = [account({ id: 'a1', label: 'Personal' })];
 
-  function stubApi(live: Record<string, { accountId: string | null }>) {
+  function stubApi(
+    live: Record<string, { accountId: string | null }>,
+    cost: { sessions: number; conversations: number } = { sessions: 0, conversations: 0 },
+  ) {
     const deleted: string[] = [];
     (window as unknown as { electronAPI: unknown }).electronAPI = {
       listAccounts: async () => listed,
       getLiveAccounts: async () => live,
       onPtyLiveAccount: () => () => {},
       onAccountLoginCompleted: () => () => {},
+      accountRemovalCost: async () => cost,
       deleteAccount: async (id: string) => { deleted.push(id); },
       setDefaultAccount: async () => true,
       startAccountLogin: async () => ({ account: listed[0], ptyId: 'p' }),
@@ -162,8 +166,11 @@ describe('ClaudeAccountsPanel delete confirmation', () => {
     return deleted;
   }
 
-  async function openPanel(live: Record<string, { accountId: string | null }>) {
-    const deleted = stubApi(live);
+  async function openPanel(
+    live: Record<string, { accountId: string | null }>,
+    cost?: { sessions: number; conversations: number },
+  ) {
+    const deleted = stubApi(live, cost);
     const messages: string[] = [];
     (window as unknown as { confirm: (m: string) => boolean }).confirm = (m: string) => {
       messages.push(m);
@@ -173,6 +180,8 @@ describe('ClaudeAccountsPanel delete confirmation', () => {
     return { deleted, messages };
   }
 
+  const clickDelete = () => act(async () => { fireEvent.click(screen.getByText('Delete')); });
+
   test('names the sessions that will lose their account directory', async () => {
     const { deleted, messages } = await openPanel({
       s1: { accountId: 'a1' },
@@ -180,19 +189,54 @@ describe('ClaudeAccountsPanel delete confirmation', () => {
       s3: { accountId: 'other' },
     });
 
-    await act(async () => { fireEvent.click(screen.getByText('Delete')); });
+    await clickDelete();
 
-    expect(messages[0]).toContain('2 running sessions are using this account right now');
-    expect(messages[0]).toContain('their account directory goes away');
+    expect(messages[0]).toContain('2 sessions are using it right now');
+    expect(messages[0]).toContain('their account directory goes away underneath them');
     expect(deleted).toEqual(['a1']);
   });
 
   test('says nothing about running sessions when there are none', async () => {
     const { messages } = await openPanel({ s3: { accountId: 'other' } });
 
-    await act(async () => { fireEvent.click(screen.getByText('Delete')); });
+    await clickDelete();
 
-    expect(messages[0]).not.toContain('running session');
+    expect(messages[0]).not.toContain('using it right now');
+  });
+
+  /**
+   * The transcripts go with the config directory, and nothing else on disk
+   * records them. A confirmation that only lists what it unsets reads as
+   * reversible, which is how a machine handoff's carried history gets thrown
+   * away by someone tidying up stale accounts.
+   */
+  test('counts the conversations the delete destroys', async () => {
+    const { messages } = await openPanel({}, { sessions: 3, conversations: 12 });
+
+    await clickDelete();
+
+    expect(messages[0]).toContain('permanently deletes 12 saved conversations');
+    expect(messages[0]).toContain('The 3 sessions bound to this account stay in the sidebar');
+    expect(messages[0]).toContain('cannot be resumed');
+  });
+
+  test('speaks of one conversation and one session in the singular', async () => {
+    const { messages } = await openPanel({}, { sessions: 1, conversations: 1 });
+
+    await clickDelete();
+
+    expect(messages[0]).toContain('permanently deletes 1 saved conversation.');
+    expect(messages[0]).toContain('The session bound to this account stays in the sidebar');
+    expect(messages[0]).toContain('its history is gone');
+  });
+
+  test('says plainly when there is nothing to lose', async () => {
+    const { messages } = await openPanel({}, { sessions: 0, conversations: 0 });
+
+    await clickDelete();
+
+    expect(messages[0]).toContain('no saved conversations, so nothing is lost');
+    expect(messages[0]).not.toContain('permanently deletes');
   });
 });
 

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, AccountFailoverEvent, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest, PortableExportResult, PortableImportResult, HandoffOfferState, HandoffPrepareResult, ArrivalReport } from '../shared/types';
+import { Group, Session, SessionEvent, SessionStats, GlobalStats, ClaudeAccount, AccountSwitchResult, AccountFailoverEvent, LiveAccountBinding, LiveAccountBindings, ProviderStatus, ProviderInstallHint, ArenaRun, ArenaUpdate, KeyVaultStatus, RelayStatus, RelayShare, RelayResizeRequest, PortableExportResult, PortableImportResult, HandoffOfferState, HandoffPrepareResult, ArrivalReport, AccountRemovalCost } from '../shared/types';
 
 interface ElectronAPI {
   platform: string;
@@ -184,6 +184,7 @@ interface ElectronAPI {
   startAccountLogin: (label: string) => Promise<{ account: ClaudeAccount; ptyId: string }>;
   cancelAccountLogin: (ptyId: string, deleteAccount: boolean) => Promise<void>;
   confirmAccountLoginMacOS: (ptyId: string) => Promise<void>;
+  accountRemovalCost: (id: string) => Promise<AccountRemovalCost>;
   deleteAccount: (id: string) => Promise<void>;
   updateAccount: (id: string, updates: { label?: string; color?: string; email?: string | null }) => Promise<void>;
   setDefaultAccount: (id: string) => Promise<boolean>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -648,3 +648,11 @@ export interface TransferBundleManifest {
   providersWithApiKeys?: string[];
   counts: TransferBundleCounts;
 }
+
+/** What removing a Claude account destroys, so the confirmation can say it. */
+export interface AccountRemovalCost {
+  /** Sessions bound to the account, running or not. */
+  sessions: number;
+  /** Conversation transcripts stored under the account's config dir. */
+  conversations: number;
+}


### PR DESCRIPTION
Closes #257

The delete confirmation said `Sessions themselves are kept.` and listed what it unsets. Meanwhile `deleteAccountAndDir` runs `fs.rmSync(root, { recursive: true, force: true })` over the config directory, which holds `projects/**/*.jsonl` — every transcript. The one sentence that came close to the truth ("their account directory goes away with it") lived in a branch that fires only when sessions are *running*, so the quiet case said nothing at all.

Sessions keep their `claude_session_id`, so starting one afterwards asks the CLI to resume a conversation with no transcript and surfaces `session id not found` — a message naming neither the account nor the deletion.

Found on a real Mac -> Windows handoff. The source had 432 transcripts; after removing the carried accounts on the destination, 10 remained. The arrival report lists carried accounts as needing sign-in, and removing them instead is a reasonable misreading of "these are stale" — which destroys exactly what the handoff just carried.

**What changes.** A new `accounts:removalCost` IPC returns the sessions bound to the account and the transcripts under its config dir; the dialog names both:

> This permanently deletes 12 saved conversations. The 3 sessions bound to this account stay in the sidebar, but their history is gone and they cannot be resumed.

and when there is nothing to lose it says so, rather than warning about a cost that does not exist.

The count is computed in main because the renderer cannot stat the disk. `countSessionsUsingAccount` uses the same predicate as the `UPDATE` in `deleteAccount`, so the number cannot drift from what actually gets unset.

**Deliberately not changed.** The delete still removes the directory. Keeping `projects/` while dropping credentials would preserve the history, but leaves an orphaned tree with no owner and no UI to manage it — a design change that deserves its own issue rather than riding in on a confirmation-copy fix. This makes the destruction visible; it does not make it optional.

Also removed a comment that named a ticket and described the copy it no longer matches.

**Tests.** Control-verified: with the old dialog restored, the four assertions on the new copy fail and the rest pass. Both plural and singular are pinned, since the singular branch is the one nobody exercises by hand.

**Verification.** `tsc --noEmit` clean. Full suite on this Windows machine: **1484 pass / 6 fail**, and the same **6 fail on a clean tree at `2de2d8b`** — pre-existing, Windows-only, none in files this touches. CI runs ubuntu, so they are invisible there; filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CRgFEZ7jErTVJ8SHii9Ee
