### PR TITLE
Report group roots that landed without their folder

### DIFF
--- a/src/main/__tests__/machine-handoff.test.ts
+++ b/src/main/__tests__/machine-handoff.test.ts
@@ -320,8 +320,13 @@ describe('restoring one', () => {
     // not one that can start — and the report says so rather than reporting
     // a restore of one session and leaving the rest to be discovered.
     expect(report!.resumable).toBe(0);
-    expect(report!.needsRelink.map((r) => r.sessionId)).toEqual(['s1']);
+    // The group root is missing too, and is listed beside the session: nothing
+    // fails until someone creates a session under it, which is precisely why
+    // waiting for a failure is no way to find out.
+    expect(report!.needsRelink.map((r) => `${r.kind}:${r.sessionId}`))
+      .toEqual(['session:s1', 'group:g1']);
   });
+
 
   test('reports only the accounts the bundle carried, not every account here', async () => {
     const { bytes, phrase } = preparedElsewhere();
@@ -347,16 +352,16 @@ describe('restoring one', () => {
     messageBoxResponses = [1];
     await restoreMachineHandoff(relay.transport, phrase, legacyDir, noSuggestions);
 
-    expect(readArrival()!.needsRelink.map((r) => r.sessionId)).toEqual(['s1']);
     const here = path.join(tmp, 'dst', 'api');
     fs.mkdirSync(here, { recursive: true });
 
     const report = resolveRelink('s1', here);
 
-    // Both halves, or the report is describing work that is already done.
-    expect(report!.needsRelink).toEqual([]);
+    // Both halves, or the report is describing work that is already done. The
+    // group row survives: resolving a session says nothing about a group root.
+    expect(report!.needsRelink.map((r) => r.kind)).toEqual(['group']);
     expect(report!.resumable).toBe(1);
-    expect(readArrival()!.needsRelink).toEqual([]);
+    expect(readArrival()!.needsRelink.map((r) => r.kind)).toEqual(['group']);
     // The directory is the whole fix: `workingDirMissing` is derived from the
     // filesystem on every read, so a session pointed at a real folder stops
     // being parked without anything touching its state.
@@ -365,6 +370,31 @@ describe('restoring one', () => {
     };
     expect(row.working_dir).toBe(here);
     expect(sessionsRepo.getSession('s1')!.workingDirMissing).toBe(false);
+  });
+
+  /**
+   * The same act on a group: it writes the group row, not a session row of the
+   * same id, and strikes only the group off. Fixing a root is worth more than
+   * fixing one session — every session made under it later inherits it.
+   */
+  test('relinking a group root writes the group and leaves the session listed', async () => {
+    const { bytes, phrase } = preparedElsewhere();
+    const relay = standIn(bytes);
+    messageBoxResponses = [1];
+    await restoreMachineHandoff(relay.transport, phrase, legacyDir, noSuggestions);
+
+    const here = path.join(tmp, 'dst', 'work');
+    fs.mkdirSync(here, { recursive: true });
+
+    const report = resolveRelink('g1', here, undefined, 'group');
+
+    expect(report!.needsRelink.map((r) => r.kind)).toEqual(['session']);
+    // The session was never touched, so nothing about it became resumable.
+    expect(report!.resumable).toBe(0);
+    const group = db.query('SELECT working_dir FROM groups WHERE id = ?').get('g1') as {
+      working_dir: string;
+    };
+    expect(group.working_dir).toBe(here);
   });
 
   test('resolving the same session twice cannot walk the resumable count past the truth', async () => {

--- a/src/main/arrival.ts
+++ b/src/main/arrival.ts
@@ -15,6 +15,7 @@ import * as os from 'os';
 import * as path from 'path';
 import log from 'electron-log';
 import * as accountsRepo from './repositories/accounts';
+import * as groupsRepo from './repositories/groups';
 import * as sessionsRepo from './repositories/sessions';
 import { deletePreference, getPreference, setPreference } from './repositories/preferences';
 import { resolveAccountIdentity } from './account-identity';
@@ -121,7 +122,23 @@ function relinkItems(sessionIds: string[]): ArrivalRelinkItem[] {
     // rather than reported as a session with no name.
     const session = sessionsRepo.getSession(sessionId);
     if (!session) continue;
-    items.push({ sessionId, name: session.name, workingDir: session.workingDir });
+    items.push({ kind: 'session', sessionId, name: session.name, workingDir: session.workingDir });
+  }
+  return items;
+}
+
+/**
+ * The same, for group roots. A group's directory is where its next session
+ * would be created, so a missing one fails nothing until someone tries — which
+ * is exactly why it has to be reported rather than waited for.
+ */
+function groupRelinkItems(groupIds: string[]): ArrivalRelinkItem[] {
+  const items: ArrivalRelinkItem[] = [];
+  const byId = new Map(groupsRepo.getAllGroups().map((group) => [group.id, group]));
+  for (const groupId of groupIds) {
+    const group = byId.get(groupId);
+    if (!group?.workingDir) continue;
+    items.push({ kind: 'group', sessionId: groupId, name: group.name, workingDir: group.workingDir });
   }
   return items;
 }
@@ -168,7 +185,10 @@ export function recordArrival(input: RecordArrivalInput): ArrivalReport | null {
       transcripts: input.outcome.transcripts,
       skippedGroups: input.outcome.skippedGroups,
       skippedSessions: input.outcome.skippedSessions,
-      needsRelink: relinkItems(input.outcome.needsRelink),
+      needsRelink: [
+        ...relinkItems(input.outcome.needsRelink),
+        ...groupRelinkItems(input.outcome.groupsNeedingRelink ?? []),
+      ],
       accounts: accountItems(input.outcome.accountIds),
       // The manifest names providers that had a key on the source. A bundle
       // written before that existed says nothing, and nothing is what gets
@@ -200,24 +220,30 @@ export function resolveRelink(
   sessionId: string,
   workingDir: string,
   store: ReportStore = preferenceStore,
+  kind: 'session' | 'group' = 'session',
 ): ArrivalReport | null {
   // The directory and nothing else. `workingDirMissing` — the parked marker —
   // is derived from the filesystem on every read, so a real directory is the
   // whole fix; a restored session is already `stopped`, which made writing the
   // state a no-op on the only path that reaches here and left this able to
   // stop a *running* session if it were ever called with another id.
-  sessionsRepo.updateSession(sessionId, { workingDir });
+  if (kind === 'group') groupsRepo.updateGroup(sessionId, { workingDir });
+  else sessionsRepo.updateSession(sessionId, { workingDir });
 
   const report = loadArrivalReport(store);
   if (!report) return null;
 
-  const needsRelink = report.needsRelink.filter((item) => item.sessionId !== sessionId);
+  // Matched on kind too: a group and a session are separate rows and could in
+  // principle carry the same id, and resolving one must not strike the other.
+  const needsRelink = report.needsRelink.filter(
+    (item) => item.sessionId !== sessionId || (item.kind ?? 'session') !== kind,
+  );
   const next: ArrivalReport = {
     ...report,
     needsRelink,
     // Recomputed rather than incremented, so a double-resolve of the same
     // session cannot walk the count past the number of sessions there are.
-    resumable: Math.max(0, report.sessions - needsRelink.length),
+    resumable: Math.max(0, report.sessions - needsRelink.filter((i) => i.kind !== 'group').length),
   };
   saveArrivalReport(store, next);
   return next;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1058,11 +1058,11 @@ safeHandle('handoff:decline', (handoffId: string) =>
 // What the last restore left outstanding, kept so it can be opened again
 safeHandle('arrival:read', () => readArrival());
 safeHandle('arrival:dismiss', () => dismissArrival());
-safeHandle('arrival:resolveRelink', (sessionId: string, workingDir: string) => {
+safeHandle('arrival:resolveRelink', (sessionId: string, workingDir: string, kind?: 'session' | 'group') => {
   const id = (sessionId ?? '').toString().trim();
   const dir = (workingDir ?? '').toString().trim();
   if (!id || !dir) throw new Error('A session id and a folder are both required');
-  const report = resolveRelink(id, dir);
+  const report = resolveRelink(id, dir, undefined, kind === 'group' ? 'group' : 'session');
   // Every renderer's session list derives `workingDirMissing` in main, so a
   // relink is only visible once they reload. This is the broadcast they
   // already listen to.

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -225,8 +225,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('arrival:read'),
   arrivalDismiss: (): Promise<void> =>
     ipcRenderer.invoke('arrival:dismiss'),
-  arrivalResolveRelink: (sessionId: string, workingDir: string): Promise<ArrivalReport | null> =>
-    ipcRenderer.invoke('arrival:resolveRelink', sessionId, workingDir),
+  arrivalResolveRelink: (
+    sessionId: string,
+    workingDir: string,
+    kind?: 'session' | 'group',
+  ): Promise<ArrivalReport | null> =>
+    ipcRenderer.invoke('arrival:resolveRelink', sessionId, workingDir, kind),
 
   // Preferences
   getPreference: (key: string): Promise<string | null> =>

--- a/src/main/transfer/__tests__/arrival-report.test.ts
+++ b/src/main/transfer/__tests__/arrival-report.test.ts
@@ -59,6 +59,39 @@ describe('building the report', () => {
     expect(report.needsRelink).toHaveLength(2);
   });
 
+  /**
+   * Group roots share the list but are not sessions, so counting the list
+   * length would report conversations as unrecoverable that came back fine.
+   * The session count has to exceed the relinked sessions for this to show at
+   * all — with one session of each, Math.max(0, …) clamps both answers to zero.
+   */
+  test('group roots are listed without being counted against resumable', () => {
+    const report = buildArrivalReport({
+      ...BASE,
+      sessions: 4,
+      needsRelink: [
+        { kind: 'session', sessionId: 's1', name: 'api', workingDir: '/Users/will/Work/api' },
+        { kind: 'group', sessionId: 'g1', name: 'Work', workingDir: '/Users/will/Work' },
+        { kind: 'group', sessionId: 'g2', name: 'Me', workingDir: '/Users/will/Me' },
+      ],
+    });
+
+    expect(report.needsRelink).toHaveLength(3);
+    expect(report.resumable).toBe(3);
+  });
+
+  // Reports written before `kind` existed listed sessions only, so an item
+  // without one is a session and must keep counting as it always did.
+  test('an item with no kind is treated as the session it used to be', () => {
+    const report = buildArrivalReport({
+      ...BASE,
+      sessions: 4,
+      needsRelink: [{ sessionId: 's1', name: 'api', workingDir: '/x' }] as BuildArrivalReportInput['needsRelink'],
+    });
+
+    expect(report.resumable).toBe(3);
+  });
+
   test('never reports a negative count, however wrong the inputs are', () => {
     // A number below zero here would read as a claim about the user's data
     // rather than as the bug it would be.

--- a/src/main/transfer/__tests__/arrival-report.test.ts
+++ b/src/main/transfer/__tests__/arrival-report.test.ts
@@ -86,7 +86,7 @@ describe('building the report', () => {
     const report = buildArrivalReport({
       ...BASE,
       sessions: 4,
-      needsRelink: [{ sessionId: 's1', name: 'api', workingDir: '/x' }] as BuildArrivalReportInput['needsRelink'],
+      needsRelink: [{ sessionId: 's1', name: 'api', workingDir: '/x' }],
     });
 
     expect(report.resumable).toBe(3);

--- a/src/main/transfer/arrival-report.ts
+++ b/src/main/transfer/arrival-report.ts
@@ -35,6 +35,14 @@ export interface BuildArrivalReportInput {
   providersNeedingKeys: string[];
 }
 
+/**
+ * Items written before `kind` existed carry none, and every one of those was a
+ * session — so an absent kind counts as one rather than being dropped.
+ */
+function countSessions(items: ArrivalRelinkItem[]): number {
+  return items.filter((item) => item.kind !== 'group').length;
+}
+
 export function buildArrivalReport(input: BuildArrivalReportInput): ArrivalReport {
   return {
     restoredAt: input.restoredAt,
@@ -43,10 +51,11 @@ export function buildArrivalReport(input: BuildArrivalReportInput): ArrivalRepor
     sourcePlatform: input.manifest?.sourcePlatform ?? null,
     groups: input.groups,
     sessions: input.sessions,
-    // Never negative, even if a caller hands in a relink list longer than the
-    // session count — a wrong number here would read as a fact about the user's
-    // data rather than as the bug it is.
-    resumable: Math.max(0, input.sessions - input.needsRelink.length),
+    // Sessions only: the list also carries group roots, and a group is not a
+    // conversation that could have resumed. Never negative, even if a caller
+    // hands in a longer list than the session count — a wrong number here would
+    // read as a fact about the user's data rather than as the bug it is.
+    resumable: Math.max(0, input.sessions - countSessions(input.needsRelink)),
     transcripts: input.transcripts,
     skippedGroups: input.skippedGroups,
     skippedSessions: input.skippedSessions,

--- a/src/main/transfer/bundle-import.ts
+++ b/src/main/transfer/bundle-import.ts
@@ -62,6 +62,12 @@ export interface ImportOutcome {
   skippedSessions: number;
   /** Restored sessions whose working directory is not on this machine. */
   needsRelink: string[];
+  /**
+   * Restored groups whose working directory is not on this machine. Kept apart
+   * from the sessions because only sessions bear on how many conversations are
+   * resumable — a group root is where the NEXT session would be created.
+   */
+  groupsNeedingRelink: string[];
 }
 
 interface ParsedBundle {
@@ -140,6 +146,7 @@ interface RowCounts {
   skippedGroups: number;
   skippedSessions: number;
   needsRelink: string[];
+  groupsNeedingRelink: string[];
 }
 
 /**
@@ -171,6 +178,7 @@ function knownAccountIds(db: Db, tables: PortableTables): Set<string> {
 }
 
 function restoreGroups(db: Db, tables: PortableTables, options: ImportOptions, groupIds: Set<string>) {
+  const exists = options.directoryExists ?? ((dir: string) => fs.existsSync(dir));
   const accounts = knownAccountIds(db, tables);
   const insert = db.prepare(`
     INSERT INTO groups (id, name, color, working_dir, "order", created_at, parent_id, collapsed, claude_account_id)
@@ -179,17 +187,25 @@ function restoreGroups(db: Db, tables: PortableTables, options: ImportOptions, g
 
   let inserted = 0;
   let skipped = 0;
+  const needsRelink: string[] = [];
+
   for (const group of tables.groups) {
     if (groupIds.has(group.id)) {
       skipped++;
       continue;
     }
+    const workingDir = remapWorkingDir(group.workingDir ?? '', options.mappings);
+    // A group with no directory at all is not broken — it is a plain folder in
+    // the sidebar. Only one that names a directory this machine does not have
+    // is something the arrival report has to raise.
+    if (workingDir !== '' && !exists(workingDir)) needsRelink.push(group.id);
+
     const accountId = (group as { claudeAccountId?: string | null }).claudeAccountId;
     insert.run(
       group.id,
       group.name,
       group.color ?? '#888888',
-      remapWorkingDir(group.workingDir ?? '', options.mappings),
+      workingDir,
       group.order ?? 0,
       group.createdAt,
       group.parentId ?? null,
@@ -199,7 +215,7 @@ function restoreGroups(db: Db, tables: PortableTables, options: ImportOptions, g
     groupIds.add(group.id);
     inserted++;
   }
-  return { inserted, skipped };
+  return { inserted, skipped, needsRelink };
 }
 
 function restoreSessions(
@@ -389,6 +405,7 @@ function restoreRows(db: Db, tables: PortableTables, options: ImportOptions): Ro
     skippedGroups: groups.skipped,
     skippedSessions: sessions.skipped,
     needsRelink: sessions.needsRelink,
+    groupsNeedingRelink: groups.needsRelink,
   };
 }
 

--- a/src/renderer/components/ArrivalReport.css
+++ b/src/renderer/components/ArrivalReport.css
@@ -108,3 +108,8 @@
   gap: 8px;
   margin-top: 20px;
 }
+
+.arrival-kind {
+  opacity: 0.65;
+  font-weight: normal;
+}

--- a/src/renderer/components/ArrivalReport.tsx
+++ b/src/renderer/components/ArrivalReport.tsx
@@ -39,7 +39,10 @@ export interface ArrivalReportViewProps {
  */
 function relinkLabel(items: ArrivalRelinkItem[]): string {
   const groups = items.filter((item) => item.kind === 'group').length;
-  const noun = groups === 0 ? 'session' : (groups === items.length ? 'group' : 'item');
+  let noun = 'item';
+  if (groups === 0) noun = 'session';
+  else if (groups === items.length) noun = 'group';
+
   return items.length === 1
     ? `1 ${noun} needs its folder`
     : `${items.length} ${noun}s need their folder`;

--- a/src/renderer/components/ArrivalReport.tsx
+++ b/src/renderer/components/ArrivalReport.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import type { ArrivalReport, ClaudeAccount } from '../../shared/types';
+import type { ArrivalRelinkItem, ArrivalReport, ClaudeAccount } from '../../shared/types';
 import { ClaudeAccountLoginModal } from './ClaudeAccountsModal';
 import { accountsNeedingSignIn } from '../../shared/arrival';
 import './ArrivalReport.css';
@@ -27,13 +27,27 @@ export interface ArrivalReportViewProps {
   /** Run the sign-in flow for one restored account. */
   onSignIn: (accountId: string) => Promise<void> | void;
   /** Point one session at a folder on this machine. */
-  onRelink: (sessionId: string, currentDir: string) => Promise<void> | void;
+  onRelink: (sessionId: string, currentDir: string, kind: 'session' | 'group') => Promise<void> | void;
   /** Surfaced above the actions when something the report tried did not work. */
   error?: string | null;
 }
 
-function relinkLabel(count: number): string {
-  return count === 1 ? '1 session needs its folder' : `${count} sessions need their folder`;
+/**
+ * Sessions and group roots are both listed, so the heading counts "items"
+ * unless they are all of one kind — where naming the kind is more use than
+ * being uniformly vague.
+ */
+function relinkLabel(items: ArrivalRelinkItem[]): string {
+  const groups = items.filter((item) => item.kind === 'group').length;
+  const noun = groups === 0 ? 'session' : (groups === items.length ? 'group' : 'item');
+  return items.length === 1
+    ? `1 ${noun} needs its folder`
+    : `${items.length} ${noun}s need their folder`;
+}
+
+/** A group row has to say it is one: the fix is the same, the stakes are not. */
+function relinkKey(item: ArrivalRelinkItem): string {
+  return `${item.kind ?? 'session'}:${item.sessionId}`;
 }
 
 export const ArrivalReportView: React.FC<ArrivalReportViewProps> = ({
@@ -91,30 +105,34 @@ export const ArrivalReportView: React.FC<ArrivalReportViewProps> = ({
       </section>
 
       {report.needsRelink.length > 0 && (
-        <section className="arrival-section" aria-label="Sessions needing a folder">
-          <h4>{relinkLabel(report.needsRelink.length)}</h4>
+        <section className="arrival-section" aria-label="Sessions and groups needing a folder">
+          <h4>{relinkLabel(report.needsRelink)}</h4>
           <p className="arrival-muted">
             These arrived pointing at a folder that is not on this machine. Point each one at its
-            folder here and it becomes launchable again.
+            folder here. A session becomes launchable again; a group is where its next session
+            would start, so fixing the root fixes every session made under it later.
           </p>
           <ul className="arrival-list">
             {report.needsRelink.map((item) => (
-              <li key={item.sessionId}>
-                <span className="arrival-name">{item.name}</span>
+              <li key={relinkKey(item)}>
+                <span className="arrival-name">
+                  {item.name}
+                  {item.kind === 'group' && <span className="arrival-kind"> (group)</span>}
+                </span>
                 <span className="arrival-path">{item.workingDir}</span>
                 <button
                   className="btn"
                   disabled={relinking !== null}
                   onClick={async () => {
-                    setRelinking(item.sessionId);
+                    setRelinking(relinkKey(item));
                     try {
-                      await onRelink(item.sessionId, item.workingDir);
+                      await onRelink(item.sessionId, item.workingDir, item.kind ?? 'session');
                     } finally {
                       setRelinking(null);
                     }
                   }}
                 >
-                  {relinking === item.sessionId ? 'Setting…' : 'Set Folder…'}
+                  {relinking === relinkKey(item) ? 'Setting…' : 'Set Folder…'}
                 </button>
               </li>
             ))}
@@ -239,7 +257,7 @@ export const ArrivalReportModal: React.FC<ArrivalReportProps> = ({ report, onClo
           setLoginFlow(await window.electronAPI.resumeAccountLogin(accountId));
         }}
         error={error}
-        onRelink={async (sessionId, currentDir) => {
+        onRelink={async (sessionId, currentDir, kind) => {
           setError(null);
           try {
             // Opened at the folder the session is looking for. On a restore
@@ -251,7 +269,7 @@ export const ArrivalReportModal: React.FC<ArrivalReportProps> = ({ report, onClo
             // when the last one is resolved: the counts are still worth
             // reading, and a dialog that vanishes as you finish with it reads
             // as a crash. It stops being *raised* on the next launch instead.
-            const next = await window.electronAPI.arrivalResolveRelink(sessionId, chosen);
+            const next = await window.electronAPI.arrivalResolveRelink(sessionId, chosen, kind);
             if (next) setLive(next);
           } catch (err) {
             // Without this the rejection is unhandled, the button quietly

--- a/src/renderer/components/__tests__/ArrivalReport.test.tsx
+++ b/src/renderer/components/__tests__/ArrivalReport.test.tsx
@@ -136,7 +136,7 @@ describe('what it says', () => {
 
   test('lists each session that cannot start, with the folder it looked for', () => {
     view();
-    const section = screen.getByRole('region', { name: 'Sessions needing a folder' });
+    const section = screen.getByRole('region', { name: 'Sessions and groups needing a folder' });
 
     expect(section.textContent).toContain('api');
     expect(section.textContent).toContain('/Users/will/Work/api');
@@ -166,7 +166,7 @@ describe('what it says', () => {
   test('a restore with nothing outstanding shows no job lists at all', () => {
     view({ ...REPORT, needsRelink: [], accounts: [{ accountId: 'a2', label: 'p', loggedIn: true }], providersNeedingKeys: [] });
 
-    expect(screen.queryByRole('region', { name: 'Sessions needing a folder' })).toBeNull();
+    expect(screen.queryByRole('region', { name: 'Sessions and groups needing a folder' })).toBeNull();
     expect(screen.queryByRole('region', { name: 'Accounts needing a sign-in' })).toBeNull();
     expect(screen.queryByRole('region', { name: 'Provider keys to re-enter' })).toBeNull();
     // The counts still stand: this is a report, not only a to-do list.
@@ -243,12 +243,12 @@ describe('relinking a session from the report', () => {
 
   test('drops the row, and follows the count in the heading', async () => {
     render(<ArrivalReportModal report={REPORT} onClosed={() => {}} />);
-    expect(screen.getByRole('region', { name: 'Sessions needing a folder' }).textContent)
+    expect(screen.getByRole('region', { name: 'Sessions and groups needing a folder' }).textContent)
       .toContain('2 sessions need their folder');
 
     await clickRelink();
 
-    const section = screen.getByRole('region', { name: 'Sessions needing a folder' });
+    const section = screen.getByRole('region', { name: 'Sessions and groups needing a folder' });
     // Redrawn from what main stored, not from a local guess at it.
     expect(section.textContent).toContain('1 session needs its folder');
     expect(section.textContent).not.toContain('api');
@@ -262,7 +262,7 @@ describe('relinking a session from the report', () => {
     pickedDir = '/home/will/Work/web';
     await clickRelink();
 
-    expect(screen.queryByRole('region', { name: 'Sessions needing a folder' })).toBeNull();
+    expect(screen.queryByRole('region', { name: 'Sessions and groups needing a folder' })).toBeNull();
     // Deliberately still open: the counts are worth reading, and a dialog that
     // vanishes as you finish with it reads as a crash. It stops being *raised*
     // on the next launch instead, which is the launch check's job.
@@ -282,7 +282,7 @@ describe('relinking a session from the report', () => {
     // re-enabling and the row still sitting there — which reads as the button
     // not working rather than as the folder being unusable.
     expect(screen.getByRole('alert').textContent).toContain('EACCES');
-    expect(screen.getByRole('region', { name: 'Sessions needing a folder' }).textContent)
+    expect(screen.getByRole('region', { name: 'Sessions and groups needing a folder' }).textContent)
       .toContain('2 sessions need their folder');
   });
 
@@ -311,7 +311,7 @@ describe('relinking a session from the report', () => {
     await clickRelink();
 
     expect(relinked).toEqual([]);
-    expect(screen.getByRole('region', { name: 'Sessions needing a folder' }).textContent)
+    expect(screen.getByRole('region', { name: 'Sessions and groups needing a folder' }).textContent)
       .toContain('2 sessions need their folder');
   });
 });
@@ -358,5 +358,77 @@ describe('signing in from the report', () => {
     render(<ArrivalReportModal report={null} onClosed={() => {}} />);
 
     expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});
+
+/**
+ * Group roots are listed beside sessions, so the row has to say which it is
+ * and the click has to carry that through — a group id sent as a session would
+ * write the wrong row, or no row at all.
+ */
+describe('group roots in the relink list', () => {
+  test('marks the group row and reports its kind on click', async () => {
+    const calls: Array<[string, string, string]> = [];
+    render(
+      <ArrivalReportView
+        report={{
+          ...REPORT,
+          needsRelink: [
+            { kind: 'session', sessionId: 's1', name: 'api', workingDir: '/Users/will/Work/api' },
+            { kind: 'group', sessionId: 'g1', name: 'Work', workingDir: '/Users/will/Work' },
+          ],
+        }}
+        onClose={() => {}}
+        onDismiss={() => {}}
+        onSignIn={() => {}}
+        onRelink={(id, dir, kind) => { calls.push([id, dir, kind]); }}
+      />
+    );
+
+    // Only the group is marked; a session row saying "(group)" would be worse
+    // than no marking at all.
+    expect(screen.getAllByText('(group)')).toHaveLength(1);
+
+    const buttons = screen.getAllByText('Set Folder…');
+    await act(async () => { fireEvent.click(buttons[1]); });
+
+    expect(calls).toEqual([['g1', '/Users/will/Work', 'group']]);
+  });
+
+  test('names the mixed list without calling a group a session', () => {
+    render(
+      <ArrivalReportView
+        report={{
+          ...REPORT,
+          needsRelink: [
+            { kind: 'session', sessionId: 's1', name: 'api', workingDir: '/a' },
+            { kind: 'group', sessionId: 'g1', name: 'Work', workingDir: '/b' },
+          ],
+        }}
+        onClose={() => {}}
+        onDismiss={() => {}}
+        onSignIn={() => {}}
+        onRelink={() => {}}
+      />
+    );
+
+    expect(screen.getByText('2 items need their folder')).toBeTruthy();
+  });
+
+  test('a list that is all groups says so', () => {
+    render(
+      <ArrivalReportView
+        report={{
+          ...REPORT,
+          needsRelink: [{ kind: 'group', sessionId: 'g1', name: 'Work', workingDir: '/b' }],
+        }}
+        onClose={() => {}}
+        onDismiss={() => {}}
+        onSignIn={() => {}}
+        onRelink={() => {}}
+      />
+    );
+
+    expect(screen.getByText('1 group needs its folder')).toBeTruthy();
   });
 });

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -84,7 +84,7 @@ interface ElectronAPI {
   handoffRestore: (phrase: string) => Promise<PortableImportResult>;
   arrivalRead: () => Promise<ArrivalReport | null>;
   arrivalDismiss: () => Promise<void>;
-  arrivalResolveRelink: (sessionId: string, workingDir: string) => Promise<ArrivalReport | null>;
+  arrivalResolveRelink: (sessionId: string, workingDir: string, kind?: 'session' | 'group') => Promise<ArrivalReport | null>;
   resumeAccountLogin: (accountId: string) => Promise<{ account: ClaudeAccount; ptyId: string }>;
   handoffDecline: (handoffId: string) => Promise<void>;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -583,6 +583,13 @@ export interface TransferBundleCounts {
 
 /** A session that arrived but cannot start until somebody says where it lives. */
 export interface ArrivalRelinkItem {
+  /**
+   * A group's directory is where its next session would start, so it goes
+   * missing quietly — nothing fails until someone creates a session in it.
+   * Only sessions bear on `resumable`.
+   */
+  kind: 'session' | 'group';
+  /** The session or group id, per `kind`. */
   sessionId: string;
   name: string;
   /** The directory as it was remapped, i.e. where we looked and did not find it. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -587,8 +587,11 @@ export interface ArrivalRelinkItem {
    * A group's directory is where its next session would start, so it goes
    * missing quietly — nothing fails until someone creates a session in it.
    * Only sessions bear on `resumable`.
+   *
+   * Optional because reports persisted before this existed carry no kind, and
+   * every one of those was a session. Readers default accordingly.
    */
-  kind: 'session' | 'group';
+  kind?: 'session' | 'group';
   /** The session or group id, per `kind`. */
   sessionId: string;
   name: string;


### PR DESCRIPTION
Closes #258

Groups were already remapped on import (`bundle-import.ts`), but nothing recorded which ones landed on a directory this machine does not have. `needsRelink` was sessions only, so the report could read clean while every group pointed at a filesystem that is not here — which is what happened on the Mac -> Windows handoff that found this: 3 sessions all resolved, 14 groups on `/Users/will/...`, report silent.

A group root fails nothing until someone creates a session under it, and then it throws `Working directory does not exist` at `pty-manager.ts:297`. That is the failure #199 named as load-bearing — "a session whose directory is missing must land in a visible needs-relink state rather than erroring at launch time" — reached through groups instead of sessions.

**What changes.** `restoreGroups` collects group ids whose remapped directory is absent, carried on `ImportOutcome.groupsNeedingRelink`. `ArrivalRelinkItem` gains `kind: 'session' | 'group'`, and the report lists both. Rows are marked `(group)`, and the heading names the kind when the list is all one thing rather than being uniformly vague. `resolveRelink` takes a kind and writes the group row instead of the session row.

A group with **no** directory at all is not reported — that is a plain folder in the sidebar, not a broken root.

**The bit that needed care: `resumable`.** It was `sessions - needsRelink.length`, and the list now carries non-sessions, so counting the length would report conversations as unrecoverable that came back fine. It now counts session items only, in `buildArrivalReport` and in `resolveRelink`, which have to agree or the number changes when a row is struck off.

Items written before `kind` existed carry none and were all sessions, so an absent kind counts as a session rather than being dropped. There is a test for that specifically.

**A vacuous test I wrote and removed.** My first `resumable` test went through the full restore, where the fixture has one session and one group. Correct code gives `max(0, 1-1) = 0`; broken gives `max(0, 1-2) = 0`. The clamp hid the bug and the control passed. Replaced with a direct `buildArrivalReport` test using 4 sessions and 2 group items, where the two answers are 3 and 1 — and confirmed it fails against the old derivation.

**Controls, each verified to fail.** Never flagging a group root: 2 tests fail. Counting groups in `resumable`: the new derivation test fails. `resolveRelink` writing a session for a group: the group-relink test fails. Hardcoding the click's kind to `'session'`: the renderer test fails.

**Verification.** `tsc --noEmit` clean. Full suite on Windows: **1502 pass / 6 fail** — the same 6 that fail on a clean tree, tracked in #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CRgFEZ7jErTVJ8SHii9Ee
