### PR TITLE
Cut v3.5.1-beta.14 so the handoff follow-up fixes ship

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodhilander",
-  "version": "3.5.1-beta.13",
+  "version": "3.5.1-beta.14",
   "description": "Cross-platform Claude Code session manager",
   "homepage": "https://github.com/Software-Development-LLC/Bodhilander",
   "author": {


### PR DESCRIPTION
Closes #262

Bumps `package.json` to `3.5.1-beta.14`. Nothing else changes.

Carries the two fixes that landed after `beta.13` was cut at `2de2d8b`, both found by running the machine handoff for real rather than by reading the code:

- #257 — the account-delete confirmation now counts the conversations it destroys. It previously said "Sessions themselves are kept" while `fs.rmSync` took the whole config directory, transcripts included.
- #258 — group roots whose folder is not on this machine are listed in the arrival report with their own **Set Folder…**. They were invisible before, so a restore could report a clean bill while every group pointed at a filesystem that does not exist here.

Same release mechanics as #246, #251 and #256, and the same one that actually bites: **no `--tags`.** The local tag `npm version` created has been deleted, and `git ls-remote --tags origin v3.5.1-beta.14` returns nothing, so `release.yml` cuts the tag itself rather than finding one and skipping the build.

No merge hold needed — `beta.13` finished, and no release run is in flight to race on the beta channel manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CRgFEZ7jErTVJ8SHii9Ee
