### PR TITLE
Make the suite pass on Windows, and run it there

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,8 @@ concurrency:
 
 jobs:
   test:
-    # Windows is a shipped platform, and until this ran there nothing stood
-    # between a Windows-only regression and a user: six tests failed there for
-    # months while this gate was green. Path handling is where it goes wrong —
-    # POSIX literals, `/tmp`, `$VAR` in a shell command — and none of it is
-    # visible from Linux.
+    # Windows is a shipped platform, and its failures — path separators, 8.3
+    # short paths, POSIX-only shell syntax — are invisible from Linux.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,18 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Windows is a shipped platform, and until this ran there nothing stood
+    # between a Windows-only regression and a user: six tests failed there for
+    # months while this gate was green. Path handling is where it goes wrong —
+    # POSIX literals, `/tmp`, `$VAR` in a shell command — and none of it is
+    # visible from Linux.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    # Windows runners are markedly slower at install and native-free spawns.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/relay/src/config.test.ts
+++ b/relay/src/config.test.ts
@@ -19,10 +19,9 @@ describe('handoff storage limits', () => {
   });
 
   test('put bundles beside the database, which is what the volume holds', () => {
-    // "Beside the database" as two independent facts. The old assertion was a
-    // POSIX literal, and `path.resolve('/data/relay.db')` is `C:\data\relay.db`
-    // on Windows — so it failed there for a reason the relay, which only ever
-    // runs in a Linux container, does not actually have.
+    // Stated as two independent facts rather than one path literal: the
+    // config resolves the db path, so a literal only holds on the platform
+    // that shaped it.
     const dbPath = path.join(os.tmpdir(), 'relay-config-test', 'relay.db');
     const { config } = loadConfig({ ...BASE, DB_PATH: dbPath });
     expect(path.dirname(config.handoffDir)).toBe(path.dirname(dbPath));

--- a/relay/src/config.test.ts
+++ b/relay/src/config.test.ts
@@ -4,6 +4,8 @@
  * worth being able to see.
  */
 import { describe, expect, test } from 'bun:test';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { ConfigError, loadConfig } from './config';
 
 const BASE = { NODE_ENV: 'test', PUBLIC_URL: 'http://relay.test' };
@@ -17,8 +19,14 @@ describe('handoff storage limits', () => {
   });
 
   test('put bundles beside the database, which is what the volume holds', () => {
-    const { config } = loadConfig({ ...BASE, DB_PATH: '/data/relay.db' });
-    expect(config.handoffDir).toBe('/data/handoffs');
+    // "Beside the database" as two independent facts. The old assertion was a
+    // POSIX literal, and `path.resolve('/data/relay.db')` is `C:\data\relay.db`
+    // on Windows — so it failed there for a reason the relay, which only ever
+    // runs in a Linux container, does not actually have.
+    const dbPath = path.join(os.tmpdir(), 'relay-config-test', 'relay.db');
+    const { config } = loadConfig({ ...BASE, DB_PATH: dbPath });
+    expect(path.dirname(config.handoffDir)).toBe(path.dirname(dbPath));
+    expect(path.basename(config.handoffDir)).toBe('handoffs');
     expect(loadConfig({ ...BASE, HANDOFF_DIR: '/elsewhere' }).config.handoffDir).toBe('/elsewhere');
   });
 

--- a/src/main/__tests__/conversation-transcript.test.ts
+++ b/src/main/__tests__/conversation-transcript.test.ts
@@ -44,12 +44,20 @@ function writeTranscript(dir: string, slug: string, uuid: string, body: string):
   return file;
 }
 
-/** Every file under `root`, relative — used to prove nothing was written. */
+/**
+ * Every file under `root`, relative — used to prove nothing was written.
+ * Separators are normalised because these paths are only ever compared against
+ * literals in this file; `path.relative` hands back backslashes on Windows,
+ * which would fail the comparison without anything being wrong.
+ */
 function tree(root: string): string[] {
   if (!fs.existsSync(root)) return [];
   const out: string[] = [];
   for (const entry of fs.readdirSync(root, { withFileTypes: true, recursive: true }) as fs.Dirent[]) {
-    if (entry.isFile()) out.push(path.relative(root, path.join(entry.parentPath ?? root, entry.name)));
+    if (entry.isFile()) {
+      const rel = path.relative(root, path.join(entry.parentPath ?? root, entry.name));
+      out.push(rel.split(path.sep).join('/'));
+    }
   }
   return out.sort();
 }

--- a/src/main/api/routes/__tests__/sessions.test.ts
+++ b/src/main/api/routes/__tests__/sessions.test.ts
@@ -72,11 +72,7 @@ function freshDb(): Database {
   return d;
 }
 
-/**
- * The default has to be a directory that really exists: /start refuses to
- * launch a session whose folder is gone, and a POSIX-only literal makes that
- * guard fire on Windows for a reason the test never meant to exercise.
- */
+/** /start refuses a session whose folder is gone, so this has to exist. */
 const PRESENT_DIR = os.tmpdir();
 
 function insertSession(id: string, workingDir = PRESENT_DIR): void {

--- a/src/main/api/routes/__tests__/sessions.test.ts
+++ b/src/main/api/routes/__tests__/sessions.test.ts
@@ -8,6 +8,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { randomUUID } from 'node:crypto';
+import * as os from 'node:os';
 import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import express from 'express';
@@ -71,7 +72,14 @@ function freshDb(): Database {
   return d;
 }
 
-function insertSession(id: string, workingDir = '/tmp'): void {
+/**
+ * The default has to be a directory that really exists: /start refuses to
+ * launch a session whose folder is gone, and a POSIX-only literal makes that
+ * guard fire on Windows for a reason the test never meant to exercise.
+ */
+const PRESENT_DIR = os.tmpdir();
+
+function insertSession(id: string, workingDir = PRESENT_DIR): void {
   db.prepare(`
     INSERT INTO sessions (id, group_id, name, working_dir, state, shell_type, "order", created_at, last_activity_at)
     VALUES (?, 'g1', 'test', ?, 'idle', 'claude', 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
@@ -259,7 +267,7 @@ describe('POST /sessions/:id/start', () => {
 
   test('a session whose folder is present still starts', async () => {
     const id = randomUUID();
-    insertSession(id, '/tmp');
+    insertSession(id, PRESENT_DIR);
     const spawned: string[] = [];
     patchable.getSession = () => undefined;
     patchable.createSession = (startedId: string) => { spawned.push(startedId); };
@@ -276,7 +284,7 @@ describe('POST /sessions/:id/start', () => {
 
   test('a spawn failure reports what actually went wrong', async () => {
     const id = randomUUID();
-    insertSession(id, '/tmp');
+    insertSession(id, PRESENT_DIR);
     patchable.getSession = () => undefined;
     patchable.createSession = () => { throw new Error('Shell not found: /bin/nope'); };
 

--- a/src/main/arena/__tests__/engine.test.ts
+++ b/src/main/arena/__tests__/engine.test.ts
@@ -92,9 +92,8 @@ const FAKE_PROVIDERS: Record<string, any> = {
   keyed: {
     id: 'keyed',
     arena: {
-      // Contestants run through the user's shell, and `$VAR` is POSIX syntax
-      // that cmd.exe leaves as literal text — so reading the variable through
-      // node keeps this about env merging rather than about which shell ran it.
+      // Read through node, not `$VAR`: what is under test is that the vault's
+      // env reaches the child, not which shell expands a variable.
       buildCommand: () => `node -e "console.log('key=' + (process.env.FAKE_PROVIDER_KEY || ''))"`,
       createParser: textParser,
     },
@@ -298,8 +297,11 @@ describe('ArenaEngine', () => {
       const updates = await settled;
       expect(updates[updates.length - 1].status).toBe('done');
       const text = updates.map((u) => u.chunk).join('');
-      // realpath: the shell resolves symlinked tmpdirs (/tmp → /private/tmp).
-      expect(text).toContain(fs.realpathSync(dir));
+      // realpath because the shell resolves symlinked tmpdirs (/tmp →
+      // /private/tmp); `.native` because on Windows os.tmpdir() can hand back
+      // an 8.3 short path (C:\Users\RUNNER~1\...) where the shell prints the
+      // long one, and only the OS call expands it.
+      expect(text).toContain(fs.realpathSync.native(dir));
     } finally {
       fs.rmdirSync(dir);
     }

--- a/src/main/arena/__tests__/engine.test.ts
+++ b/src/main/arena/__tests__/engine.test.ts
@@ -92,7 +92,10 @@ const FAKE_PROVIDERS: Record<string, any> = {
   keyed: {
     id: 'keyed',
     arena: {
-      buildCommand: () => 'echo "key=$FAKE_PROVIDER_KEY"',
+      // Contestants run through the user's shell, and `$VAR` is POSIX syntax
+      // that cmd.exe leaves as literal text — so reading the variable through
+      // node keeps this about env merging rather than about which shell ran it.
+      buildCommand: () => `node -e "console.log('key=' + (process.env.FAKE_PROVIDER_KEY || ''))"`,
       createParser: textParser,
     },
   },


### PR DESCRIPTION
Closes #260

The suite now passes on Windows — **1508 pass / 0 fail** for the app and **308 / 0** for the relay — and `test.yml` runs on `windows-latest` alongside `ubuntu-latest` so it stays that way.

**The headline is that no product code changed.** All six failures were POSIX assumptions in *test* code. Windows users were never broken by any of them; the gate was. That is a better outcome than the issue guessed, and worth saying plainly rather than dressing six test fixes up as six bug fixes.

| test | assumption |
|---|---|
| `ensureTranscriptInConfigDir` (x2) | the `tree()` helper compared `path.relative` output against `/`-joined literals; Windows hands back `\` |
| `ArenaEngine > vault env is merged` | the fake contestant ran `echo "key=$FAKE_PROVIDER_KEY"` — `$VAR` is POSIX syntax that cmd.exe leaves as literal text, so the value read back empty |
| `POST /sessions/:id/start` (x2) | fixtures used `/tmp` as "a folder that is present". It is not present on Windows, so `/start`'s parked-session guard correctly returned 409 where the test wanted 200 and 500 |
| `handoff storage limits` | asserted `handoffDir === '/data/handoffs'`, but `path.resolve('/data/relay.db')` is `C:\data\relay.db` on Windows |

**On the relay one specifically.** The relay only ever runs in a Linux container, so its production behaviour was never in question. Rather than rebuild the implementation's own `path.join(dirname, 'handoffs')` in the expectation — which would assert the code against itself — the contract is now stated as two independent facts: the handoff dir's parent is the database's directory, and its name is `handoffs`. Either half breaking still fails the test.

The arena fix reads the variable through `node -e` instead of shell interpolation, which keeps that test about **env merging** rather than about which shell ran it — the thing it was actually written to prove.

**The workflow.** A matrix over `[ubuntu-latest, windows-latest]` with `fail-fast: false`, so a Windows failure never hides a Linux one or vice versa. `timeout-minutes` goes 15 → 25 because Windows runners are markedly slower at install.

This renames the check from `test` to `test (ubuntu-latest)` / `test (windows-latest)`. Verified safe first: the `development` ruleset carries only a `pull_request` rule, and classic branch protection reports no required status check contexts, so nothing requires the old name. If required checks are added later, both names need listing.

Fixing these without the job would only have reset the clock — which is the whole point of the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CRgFEZ7jErTVJ8SHii9Ee
