### PR TITLE
CO-722: the run state machine and its durable state

### DIFF
--- a/src/main/__tests__/run-schema.test.ts
+++ b/src/main/__tests__/run-schema.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The run engine's real schema (CO-722).
+ *
+ * `runs.test.ts` builds its own CREATE TABLE so it can run without electron,
+ * which means it proves the repository's SQL agrees with ITSELF. This file
+ * executes `initializeRunTables` from database.ts, so a column added in one
+ * place and not the other fails here rather than on a user's machine.
+ *
+ * It also pins the two structural choices the engine depends on and SQLite
+ * cannot be made to add later: the cascades, and the composite key that makes
+ * the owners mirror re-runnable.
+ *
+ * Run with: bun test src/main/__tests__/run-schema.test.ts
+ */
+import { describe, expect, mock, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import type BetterSqlite3 from 'better-sqlite3';
+
+type Db = BetterSqlite3.Database;
+const asDb = (d: Database) => d as unknown as Db;
+
+// Superset of the electron surface database.ts touches at import time —
+// the same shape database-cleanup.test.ts uses, for the same reason.
+mock.module('electron', () => ({
+  app: { getPath: () => '/nonexistent-bodhilander-test-userdata' },
+  safeStorage: { isEncryptionAvailable: () => false },
+}));
+mock.module('electron-log', () => ({
+  default: { info() {}, warn() {}, error() {} },
+}));
+
+const { initializeRunTables } = await import('../database');
+
+function freshDb(): Database {
+  const d = new Database(':memory:');
+  d.exec('PRAGMA foreign_keys = ON');
+  // runs.group_id references groups(id); the real database always has it.
+  d.exec('CREATE TABLE groups (id TEXT PRIMARY KEY, name TEXT NOT NULL)');
+  initializeRunTables(asDb(d));
+  return d;
+}
+
+function columns(d: Database, table: string): string[] {
+  return (d.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[])
+    .map((c) => c.name)
+    .sort();
+}
+
+describe('the schema applies', () => {
+  test('creates every table the engine reads', () => {
+    const d = freshDb();
+    const names = (
+      d.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as {
+        name: string;
+      }[]
+    ).map((r) => r.name);
+    for (const t of ['runs', 'run_owners', 'run_gates', 'run_events']) {
+      expect(names).toContain(t);
+    }
+  });
+
+  test('is re-runnable, because it executes on every launch', () => {
+    const d = freshDb();
+    expect(() => initializeRunTables(asDb(d))).not.toThrow();
+  });
+
+  test('carries the fields that cannot be re-derived later', () => {
+    // harness_path and python_path are the two a resumed run cannot work out
+    // for itself: three plugin copies were reachable in one 18-hour window,
+    // and `python3` on PATH can be a Store alias that is not Python.
+    const cols = columns(freshDb(), 'runs');
+    for (const c of ['harness_path', 'python_path', 'bodhi_root', 'initiative_key',
+      'permission_posture', 'blocked_reason']) {
+      expect(cols).toContain(c);
+    }
+  });
+
+  test('records the permission posture per GATE, not only per run', () => {
+    // If you cannot tell afterwards whether an owner ran unsandboxed, you
+    // cannot trust what it produced.
+    expect(columns(freshDb(), 'run_gates')).toContain('posture');
+  });
+});
+
+describe('the structural choices SQLite cannot add later', () => {
+  test('deleting a run takes its gates, owners and events with it', () => {
+    const d = freshDb();
+    d.exec("INSERT INTO runs (id, initiative_key, initiative_dir, harness_path, bodhi_root) VALUES ('r', 'K-1', '/i', '/h', '/b')");
+    d.exec("INSERT INTO run_owners (run_id, repo, worktree, branch, base) VALUES ('r', 'x', '/w', 'b', 'origin/development')");
+    d.exec("INSERT INTO run_gates (id, run_id, gate, agent) VALUES ('g', 'r', 2, 'owner')");
+    d.exec("INSERT INTO run_events (run_id, kind) VALUES ('r', 'prepared')");
+
+    d.exec("DELETE FROM runs WHERE id = 'r'");
+
+    for (const t of ['run_owners', 'run_gates', 'run_events']) {
+      const n = (d.prepare(`SELECT COUNT(*) AS n FROM ${t}`).get() as { n: number }).n;
+      expect({ table: t, n }).toEqual({ table: t, n: 0 });
+    }
+  });
+
+  test('an owner is unique per (run, repo), so re-running spawn cannot duplicate it', () => {
+    const d = freshDb();
+    d.exec("INSERT INTO runs (id, initiative_key, initiative_dir, harness_path, bodhi_root) VALUES ('r', 'K-1', '/i', '/h', '/b')");
+    d.exec("INSERT INTO run_owners (run_id, repo, worktree, branch, base) VALUES ('r', 'x', '/w', 'b', 'origin/development')");
+    expect(() =>
+      d.exec("INSERT INTO run_owners (run_id, repo, worktree, branch, base) VALUES ('r', 'x', '/w2', 'b2', 'origin/development')"),
+    ).toThrow();
+  });
+
+  test('the same repo can be owned by two different runs', () => {
+    // Two initiatives touching one repo is a merge-order question, not a
+    // reason to refuse the second.
+    const d = freshDb();
+    for (const id of ['r1', 'r2']) {
+      d.exec(`INSERT INTO runs (id, initiative_key, initiative_dir, harness_path, bodhi_root) VALUES ('${id}', 'K', '/i', '/h', '/b')`);
+      d.exec(`INSERT INTO run_owners (run_id, repo, worktree, branch, base) VALUES ('${id}', 'shared', '/w-${id}', 'b', 'origin/development')`);
+    }
+    const n = (d.prepare('SELECT COUNT(*) AS n FROM run_owners').get() as { n: number }).n;
+    expect(n).toBe(2);
+  });
+
+  test('deleting a group leaves the run, because a run is not its sidebar entry', () => {
+    const d = freshDb();
+    d.exec("INSERT INTO groups (id, name) VALUES ('g1', 'Init')");
+    d.exec("INSERT INTO runs (id, initiative_key, initiative_dir, harness_path, bodhi_root, group_id) VALUES ('r', 'K-1', '/i', '/h', '/b', 'g1')");
+    d.exec("DELETE FROM groups WHERE id = 'g1'");
+    const row = d.prepare("SELECT group_id FROM runs WHERE id = 'r'").get() as {
+      group_id: string | null;
+    };
+    expect(row.group_id).toBeNull();
+  });
+
+  test('run_events ids increase, so the log has a stable order', () => {
+    // listEvents orders by id rather than by timestamp: CURRENT_TIMESTAMP has
+    // second resolution, and several events land inside one second.
+    const d = freshDb();
+    d.exec("INSERT INTO runs (id, initiative_key, initiative_dir, harness_path, bodhi_root) VALUES ('r', 'K-1', '/i', '/h', '/b')");
+    for (const kind of ['a', 'b', 'c']) {
+      d.exec(`INSERT INTO run_events (run_id, kind) VALUES ('r', '${kind}')`);
+    }
+    const ids = (d.prepare('SELECT id FROM run_events ORDER BY id').all() as { id: number }[])
+      .map((r) => r.id);
+    expect(ids).toEqual([...ids].sort((a, b) => a - b));
+    expect(new Set(ids).size).toBe(3);
+  });
+});

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -17,6 +17,7 @@ export function getDatabase(): Database.Database {
 
   initializeTables(db);
   initializeArenaTables(db);
+  initializeRunTables(db);
   clearCooldownsFromOutputScanning(db);
 
   // Reclaim for the removed code-indexing and memory features. Each drop
@@ -576,6 +577,97 @@ function initializeArenaTables(database: Database.Database): void {
     database.exec('ALTER TABLE arena_responses ADD COLUMN session_ref TEXT DEFAULT NULL');
   }
 }
+
+// Run engine tables (CO-722). A run supervises the gates for one work item:
+// spawn.sh cuts the worktrees, the engine decides which agent runs next, and
+// every transition is recorded before it is acted on, so a run survives a
+// restart or a rate limit.
+//
+// team.yaml and seams.yaml stay the source of truth on disk -- `--resume`, the
+// gate agents and a person with an editor all read them. These tables index
+// that, plus the orchestration state those files do not carry.
+// Exported so the real schema is what tests execute. A test that builds its
+// own CREATE TABLE proves the repository's SQL matches ITSELF, not this.
+export function initializeRunTables(database: Database.Database): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS runs (
+      id TEXT PRIMARY KEY,
+      -- The tracking key (BWA-4764), never the folder name: verify-merge-order
+      -- searches PR titles for it with in:title, and no PR title carries the
+      -- descriptive suffix.
+      initiative_key TEXT NOT NULL,
+      initiative_dir TEXT NOT NULL,
+      -- The plugin copy this run is pinned to, passed as --plugin-dir. Three
+      -- copies were reachable in one 18-hour window and they need not agree.
+      harness_path TEXT NOT NULL,
+      bodhi_root TEXT NOT NULL,
+      -- Resolved interpreter. A bare python3 is not a name to trust: on
+      -- Windows it can be a Store alias that is not Python at all.
+      python_path TEXT DEFAULT NULL,
+      state TEXT NOT NULL DEFAULT 'preparing',
+      permission_posture TEXT NOT NULL DEFAULT 'manual',
+      budget_usd REAL DEFAULT NULL,
+      group_id TEXT DEFAULT NULL REFERENCES groups(id) ON DELETE SET NULL,
+      blocked_reason TEXT DEFAULT NULL,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE IF NOT EXISTS run_owners (
+      run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+      repo TEXT NOT NULL,
+      -- Mirrored from team.yaml's owners block, which spawn.sh owns. Never
+      -- authored here.
+      worktree TEXT NOT NULL,
+      branch TEXT NOT NULL,
+      base TEXT NOT NULL,
+      scratch TEXT DEFAULT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      pr_number INTEGER DEFAULT NULL,
+      pr_url TEXT DEFAULT NULL,
+      PRIMARY KEY (run_id, repo)
+    );
+
+    CREATE TABLE IF NOT EXISTS run_gates (
+      id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+      gate INTEGER NOT NULL,
+      agent TEXT NOT NULL,
+      attempt INTEGER NOT NULL DEFAULT 1,
+      -- The short id 'claude --bg' prints, which attach/logs/stop take.
+      bg_session_id TEXT DEFAULT NULL,
+      claude_session_id TEXT DEFAULT NULL,
+      account_id TEXT DEFAULT NULL,
+      status TEXT NOT NULL DEFAULT 'running',
+      verdict_json TEXT DEFAULT NULL,
+      receipt_path TEXT DEFAULT NULL,
+      tokens_in INTEGER DEFAULT NULL,
+      tokens_out INTEGER DEFAULT NULL,
+      cost_usd REAL DEFAULT NULL,
+      -- Per gate, not per run: if you cannot tell afterwards whether an owner
+      -- ran unsandboxed, you cannot trust what it produced.
+      posture TEXT NOT NULL DEFAULT 'manual',
+      started_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      ended_at TEXT DEFAULT NULL
+    );
+
+    -- Append-only. This one table is the run view, the audit trail and resume.
+    CREATE TABLE IF NOT EXISTS run_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+      at TEXT DEFAULT CURRENT_TIMESTAMP,
+      kind TEXT NOT NULL,
+      gate INTEGER DEFAULT NULL,
+      repo TEXT DEFAULT NULL,
+      payload_json TEXT DEFAULT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_run_gates_run ON run_gates(run_id);
+    CREATE INDEX IF NOT EXISTS idx_run_events_run ON run_events(run_id, id);
+    CREATE INDEX IF NOT EXISTS idx_runs_state ON runs(state);
+  `);
+}
+
 
 /**
  * Clear every account cooldown once.

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -668,7 +668,6 @@ export function initializeRunTables(database: Database.Database): void {
   `);
 }
 
-
 /**
  * Clear every account cooldown once.
  *

--- a/src/main/repositories/__tests__/runs.test.ts
+++ b/src/main/repositories/__tests__/runs.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Run repository tests (CO-722).
+ *
+ * The properties that matter are about durability, because a run outlives the
+ * process that started it: a state change and its reason must land together or
+ * not at all, the event log must stay append-only and in order, and the owners
+ * mirror must be re-runnable because spawn.sh is idempotent and will be run
+ * again on resume.
+ *
+ * Uses bun:sqlite (API-compatible with better-sqlite3 for the statements this
+ * repo issues) so the suite needs no native build. Mocking '../../database' is
+ * the convention every repository test here follows.
+ *
+ * Run with: bun test src/main/repositories
+ */
+import { describe, expect, test, beforeEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+
+let db: Database;
+
+mock.module('../../database', () => ({
+  getDatabase: () => db,
+}));
+
+const runs = await import('../runs');
+
+function freshDb(): Database {
+  const d = new Database(':memory:');
+  d.exec(`
+    CREATE TABLE groups (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+
+    CREATE TABLE runs (
+      id TEXT PRIMARY KEY,
+      initiative_key TEXT NOT NULL,
+      initiative_dir TEXT NOT NULL,
+      harness_path TEXT NOT NULL,
+      bodhi_root TEXT NOT NULL,
+      python_path TEXT DEFAULT NULL,
+      state TEXT NOT NULL DEFAULT 'preparing',
+      permission_posture TEXT NOT NULL DEFAULT 'manual',
+      budget_usd REAL DEFAULT NULL,
+      group_id TEXT DEFAULT NULL REFERENCES groups(id) ON DELETE SET NULL,
+      blocked_reason TEXT DEFAULT NULL,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE run_owners (
+      run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+      repo TEXT NOT NULL,
+      worktree TEXT NOT NULL,
+      branch TEXT NOT NULL,
+      base TEXT NOT NULL,
+      scratch TEXT DEFAULT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      pr_number INTEGER DEFAULT NULL,
+      pr_url TEXT DEFAULT NULL,
+      PRIMARY KEY (run_id, repo)
+    );
+
+    CREATE TABLE run_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+      at TEXT DEFAULT CURRENT_TIMESTAMP,
+      kind TEXT NOT NULL,
+      gate INTEGER DEFAULT NULL,
+      repo TEXT DEFAULT NULL,
+      payload_json TEXT DEFAULT NULL
+    );
+  `);
+  return d;
+}
+
+const BASE = {
+  id: 'run-1',
+  initiativeKey: 'BWA-4764',
+  initiativeDir: '/root/initiatives/BWA-4764',
+  harnessPath: '/plugins/bodhi',
+  bodhiRoot: '/root',
+};
+
+beforeEach(() => {
+  db = freshDb();
+});
+
+describe('creating and reading a run', () => {
+  test('round-trips every field the engine needs to respawn a gate', () => {
+    runs.createRun({
+      ...BASE,
+      pythonPath: '/usr/bin/python3',
+      permissionPosture: 'denyOnPrompt',
+      budgetUsd: 12.5,
+    });
+    const run = runs.getRun('run-1')!;
+    // The harness path and the interpreter are the two that cannot be
+    // re-derived later: three plugin copies were reachable in one window, and
+    // `python3` on PATH can be a Store alias that is not Python.
+    expect(run.harnessPath).toBe('/plugins/bodhi');
+    expect(run.pythonPath).toBe('/usr/bin/python3');
+    expect(run.initiativeKey).toBe('BWA-4764');
+    expect(run.permissionPosture).toBe('denyOnPrompt');
+    expect(run.budgetUsd).toBe(12.5);
+    expect(run.state).toBe('preparing');
+  });
+
+  test('a run defaults to prompting, not to bypassing', () => {
+    // The default posture decides what an unattended owner may do. Anything
+    // but the cautious one being the default is a decision nobody made.
+    runs.createRun(BASE);
+    expect(runs.getRun('run-1')!.permissionPosture).toBe('manual');
+  });
+
+  test('an unknown id is null rather than a throw', () => {
+    expect(runs.getRun('nope')).toBeNull();
+  });
+});
+
+describe('a state change and its reason land together', () => {
+  beforeEach(() => runs.createRun(BASE));
+
+  test('recordTransition writes both the state and the event', () => {
+    runs.recordTransition('run-1', 'running', 'gateSpawned', { gate: 2 });
+    expect(runs.getRun('run-1')!.state).toBe('running');
+    const events = runs.listEvents('run-1');
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('gateSpawned');
+    expect(events[0].gate).toBe(2);
+  });
+
+  test('a blocked run records why it stopped', () => {
+    runs.recordTransition('run-1', 'inconclusive', 'gateInconclusive', {
+      gate: 3,
+      blockedReason: 'no verdict written',
+    });
+    const run = runs.getRun('run-1')!;
+    expect(run.state).toBe('inconclusive');
+    // Without this the inbox can say a run needs a person and not say why.
+    expect(run.blockedReason).toBe('no verdict written');
+  });
+
+  test('moving OUT of a blocked state clears the reason', () => {
+    runs.recordTransition('run-1', 'inconclusive', 'x', { blockedReason: 'stuck' });
+    runs.recordTransition('run-1', 'running', 'resumed');
+    expect(runs.getRun('run-1')!.blockedReason).toBeNull();
+  });
+
+  test('updated_at moves, so a stalled run is visible as stalled', () => {
+    // Backdated rather than compared against "now": the two writes are
+    // milliseconds apart and CURRENT_TIMESTAMP has second resolution, so a
+    // same-second comparison would assert nothing most of the time.
+    //
+    // The baseline is read back through the repository rather than parsed
+    // from a literal here. SQLite stores CURRENT_TIMESTAMP without a zone and
+    // `new Date` reads that as local, so comparing against a `...Z` literal
+    // would pass only where the machine happens to be UTC.
+    db.exec("UPDATE runs SET updated_at = '2000-01-01 00:00:00' WHERE id = 'run-1'");
+    const stale = runs.getRun('run-1')!.updatedAt.getTime();
+
+    runs.recordTransition('run-1', 'running', 'gateSpawned');
+    expect(runs.getRun('run-1')!.updatedAt.getTime()).toBeGreaterThan(stale);
+  });
+});
+
+describe('the event log', () => {
+  beforeEach(() => runs.createRun(BASE));
+
+  test('is returned oldest first, because it is a history', () => {
+    runs.appendEvent('run-1', 'first');
+    runs.appendEvent('run-1', 'second');
+    runs.appendEvent('run-1', 'third');
+    expect(runs.listEvents('run-1').map((e) => e.kind)).toEqual(['first', 'second', 'third']);
+  });
+
+  test('carries structured payloads back as objects', () => {
+    runs.appendEvent('run-1', 'verdict', { gate: 3, payload: { verdict: 'pass', findings: [] } });
+    expect(runs.listEvents('run-1')[0].payload).toEqual({ verdict: 'pass', findings: [] });
+  });
+
+  test('a malformed payload does not take the run view down', () => {
+    // The event IS the record; its detail is a convenience. A row written by
+    // an older build, or half-written, must still render.
+    db.prepare(
+      "INSERT INTO run_events (run_id, kind, payload_json) VALUES ('run-1', 'legacy', '{oops')",
+    ).run();
+    expect(runs.listEvents('run-1')[0].payload).toEqual({ unparsed: '{oops' });
+  });
+
+  test('events survive being interleaved with transitions, in one sequence', () => {
+    runs.recordTransition('run-1', 'provisioning', 'prepared');
+    runs.appendEvent('run-1', 'installOutput', { repo: 'bodhi-web-apps' });
+    runs.recordTransition('run-1', 'running', 'provisioned');
+    expect(runs.listEvents('run-1').map((e) => e.kind)).toEqual([
+      'prepared',
+      'installOutput',
+      'provisioned',
+    ]);
+  });
+});
+
+describe('the owners mirror', () => {
+  beforeEach(() => runs.createRun(BASE));
+
+  const owner = {
+    runId: 'run-1',
+    repo: 'bodhi-web-apps',
+    worktree: '/root/_wt-x-web-apps',
+    branch: 'feat/x-web-apps',
+    base: 'origin/development',
+    scratch: '/root/_wt-x-web-apps-scratch',
+    status: 'pending',
+    prNumber: null,
+    prUrl: null,
+  };
+
+  test('is re-runnable, because spawn.sh is idempotent and resume re-runs it', () => {
+    runs.upsertOwner(owner);
+    runs.upsertOwner({ ...owner, status: 'pushed' });
+    const all = runs.listOwners('run-1');
+    expect(all).toHaveLength(1);
+    expect(all[0].status).toBe('pushed');
+  });
+
+  test('a re-run does not erase a PR the previous pass recorded', () => {
+    // THE CASE THAT MATTERS. spawn.sh is re-run on resume and knows nothing
+    // about PRs, so a naive overwrite would drop the one fact only gate 4 had.
+    runs.upsertOwner({ ...owner, prNumber: 4764, prUrl: 'https://example/pull/4764' });
+    runs.upsertOwner({ ...owner, status: 'verified' });
+    const [row] = runs.listOwners('run-1');
+    expect(row.prNumber).toBe(4764);
+    expect(row.prUrl).toBe('https://example/pull/4764');
+    expect(row.status).toBe('verified');
+  });
+
+  test('owners are listed per run, not globally', () => {
+    runs.createRun({ ...BASE, id: 'run-2' });
+    runs.upsertOwner(owner);
+    runs.upsertOwner({ ...owner, runId: 'run-2', repo: 'bodhi-service-api' });
+    expect(runs.listOwners('run-1').map((o) => o.repo)).toEqual(['bodhi-web-apps']);
+    expect(runs.listOwners('run-2').map((o) => o.repo)).toEqual(['bodhi-service-api']);
+  });
+});
+
+describe('listActiveRuns', () => {
+  test('treats approved as finished, because nothing further comes back', () => {
+    // Approval, not merge. The wait for someone to press merge is unbounded,
+    // and a run sitting there is not something the engine is still doing.
+    runs.createRun({ ...BASE, id: 'a' });
+    runs.createRun({ ...BASE, id: 'b' });
+    runs.createRun({ ...BASE, id: 'c' });
+    runs.recordTransition('a', 'running', 'x');
+    runs.recordTransition('b', 'approved', 'x');
+    runs.recordTransition('c', 'done', 'x');
+    expect(runs.listActiveRuns().map((r) => r.id)).toEqual(['a']);
+  });
+
+  test('keeps a run that stopped for a person', () => {
+    // inconclusive and waitingReview both need someone; neither is finished.
+    runs.createRun({ ...BASE, id: 'a' });
+    runs.createRun({ ...BASE, id: 'b' });
+    runs.recordTransition('a', 'inconclusive', 'x');
+    runs.recordTransition('b', 'waitingReview', 'x');
+    expect(runs.listActiveRuns().map((r) => r.id).sort()).toEqual(['a', 'b']);
+  });
+
+  test('drops a failed run', () => {
+    runs.createRun({ ...BASE, id: 'a' });
+    runs.recordTransition('a', 'failed', 'x');
+    expect(runs.listActiveRuns()).toHaveLength(0);
+  });
+});

--- a/src/main/repositories/runs.ts
+++ b/src/main/repositories/runs.ts
@@ -152,11 +152,40 @@ export function listActiveRuns(): RunRow[] {
  * One call, not two, because a state written without its event is a run whose
  * history has a hole exactly where someone will later ask what happened.
  */
+/** What an event may carry beyond its kind. */
+export interface EventDetail {
+  gate?: number;
+  repo?: string;
+  payload?: unknown;
+}
+
+const INSERT_EVENT =
+  'INSERT INTO run_events (run_id, kind, gate, repo, payload_json) VALUES (?, ?, ?, ?, ?)';
+
+/**
+ * One place that writes an event, so a column added to `run_events` cannot be
+ * filled on one path and left null on the other.
+ */
+function insertEvent(
+  db: ReturnType<typeof getDatabase>,
+  runId: string,
+  kind: string,
+  detail?: EventDetail,
+): void {
+  db.prepare(INSERT_EVENT).run(
+    runId,
+    kind,
+    detail?.gate ?? null,
+    detail?.repo ?? null,
+    detail?.payload === undefined ? null : JSON.stringify(detail.payload),
+  );
+}
+
 export function recordTransition(
   runId: string,
   state: RunState,
   kind: string,
-  detail?: { gate?: number; repo?: string; payload?: unknown; blockedReason?: string | null },
+  detail?: EventDetail & { blockedReason?: string | null },
 ): void {
   const db = getDatabase();
   const tx = db.transaction(() => {
@@ -165,36 +194,14 @@ export function recordTransition(
           SET state = ?, blocked_reason = ?, updated_at = CURRENT_TIMESTAMP
         WHERE id = ?`,
     ).run(state, detail?.blockedReason ?? null, runId);
-    db.prepare(
-      'INSERT INTO run_events (run_id, kind, gate, repo, payload_json) VALUES (?, ?, ?, ?, ?)',
-    ).run(
-      runId,
-      kind,
-      detail?.gate ?? null,
-      detail?.repo ?? null,
-      detail?.payload === undefined ? null : JSON.stringify(detail.payload),
-    );
+    insertEvent(db, runId, kind, detail);
   });
   tx();
 }
 
 /** An event that is not itself a transition — a note, a stream marker. */
-export function appendEvent(
-  runId: string,
-  kind: string,
-  detail?: { gate?: number; repo?: string; payload?: unknown },
-): void {
-  getDatabase()
-    .prepare(
-      'INSERT INTO run_events (run_id, kind, gate, repo, payload_json) VALUES (?, ?, ?, ?, ?)',
-    )
-    .run(
-      runId,
-      kind,
-      detail?.gate ?? null,
-      detail?.repo ?? null,
-      detail?.payload === undefined ? null : JSON.stringify(detail.payload),
-    );
+export function appendEvent(runId: string, kind: string, detail?: EventDetail): void {
+  insertEvent(getDatabase(), runId, kind, detail);
 }
 
 /** Oldest first: this is a history, and reading it backwards reads as nonsense. */

--- a/src/main/repositories/runs.ts
+++ b/src/main/repositories/runs.ts
@@ -1,0 +1,288 @@
+/**
+ * Persistence for the run engine (CO-722).
+ *
+ * Every transition is recorded BEFORE it is acted on. A run outlives the
+ * process that started it — a restart, a rate limit moving a gate to another
+ * account, a machine closed for the night — and the only way it survives is
+ * for the decision to be durable before the side effect happens. `run_events`
+ * is append-only for the same reason: it is the run view, the audit trail and
+ * resume, and a mutable log is none of those.
+ *
+ * What is NOT here: anything `team.yaml` already says. spawn.sh owns the
+ * owners block, and these rows mirror it so a query does not have to parse
+ * YAML. Where the two disagree the file wins.
+ */
+import { getDatabase } from '../database';
+import type { RunState } from '../run-engine/transitions';
+
+export type PermissionPosture = 'manual' | 'denyOnPrompt' | 'bypass';
+
+export interface RunRow {
+  id: string;
+  initiativeKey: string;
+  initiativeDir: string;
+  harnessPath: string;
+  bodhiRoot: string;
+  pythonPath: string | null;
+  state: RunState;
+  permissionPosture: PermissionPosture;
+  budgetUsd: number | null;
+  groupId: string | null;
+  blockedReason: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface RunOwnerRow {
+  runId: string;
+  repo: string;
+  worktree: string;
+  branch: string;
+  base: string;
+  scratch: string | null;
+  status: string;
+  prNumber: number | null;
+  prUrl: string | null;
+}
+
+export interface RunEventRow {
+  id: number;
+  runId: string;
+  at: Date;
+  kind: string;
+  gate: number | null;
+  repo: string | null;
+  payload: unknown;
+}
+
+interface RawRun {
+  id: string;
+  initiative_key: string;
+  initiative_dir: string;
+  harness_path: string;
+  bodhi_root: string;
+  python_path: string | null;
+  state: string;
+  permission_posture: string;
+  budget_usd: number | null;
+  group_id: string | null;
+  blocked_reason: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function toRun(row: RawRun): RunRow {
+  return {
+    id: row.id,
+    initiativeKey: row.initiative_key,
+    initiativeDir: row.initiative_dir,
+    harnessPath: row.harness_path,
+    bodhiRoot: row.bodhi_root,
+    pythonPath: row.python_path,
+    state: row.state as RunState,
+    permissionPosture: row.permission_posture as PermissionPosture,
+    budgetUsd: row.budget_usd,
+    groupId: row.group_id,
+    blockedReason: row.blocked_reason,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+export interface CreateRunInput {
+  id: string;
+  initiativeKey: string;
+  initiativeDir: string;
+  harnessPath: string;
+  bodhiRoot: string;
+  pythonPath?: string | null;
+  permissionPosture?: PermissionPosture;
+  budgetUsd?: number | null;
+  groupId?: string | null;
+}
+
+export function createRun(input: CreateRunInput): void {
+  getDatabase()
+    .prepare(
+      `INSERT INTO runs (id, initiative_key, initiative_dir, harness_path, bodhi_root,
+                         python_path, permission_posture, budget_usd, group_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      input.id,
+      input.initiativeKey,
+      input.initiativeDir,
+      input.harnessPath,
+      input.bodhiRoot,
+      input.pythonPath ?? null,
+      input.permissionPosture ?? 'manual',
+      input.budgetUsd ?? null,
+      input.groupId ?? null,
+    );
+}
+
+export function getRun(id: string): RunRow | null {
+  const row = getDatabase().prepare('SELECT * FROM runs WHERE id = ?').get(id) as
+    | RawRun
+    | undefined;
+  return row ? toRun(row) : null;
+}
+
+/**
+ * Runs that are not finished, newest first.
+ *
+ * `approved` counts as finished. Once every PR is approved and green nothing
+ * further comes back, and the wait for someone to press merge is unbounded —
+ * so a run sitting there is not something the engine is still doing.
+ */
+export function listActiveRuns(): RunRow[] {
+  const rows = getDatabase()
+    .prepare(
+      `SELECT * FROM runs
+        WHERE state NOT IN ('approved', 'done', 'failed')
+        ORDER BY created_at DESC`,
+    )
+    .all() as RawRun[];
+  return rows.map(toRun);
+}
+
+/**
+ * Move a run to `state`, recording the reason in the same transaction.
+ *
+ * One call, not two, because a state written without its event is a run whose
+ * history has a hole exactly where someone will later ask what happened.
+ */
+export function recordTransition(
+  runId: string,
+  state: RunState,
+  kind: string,
+  detail?: { gate?: number; repo?: string; payload?: unknown; blockedReason?: string | null },
+): void {
+  const db = getDatabase();
+  const tx = db.transaction(() => {
+    db.prepare(
+      `UPDATE runs
+          SET state = ?, blocked_reason = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?`,
+    ).run(state, detail?.blockedReason ?? null, runId);
+    db.prepare(
+      'INSERT INTO run_events (run_id, kind, gate, repo, payload_json) VALUES (?, ?, ?, ?, ?)',
+    ).run(
+      runId,
+      kind,
+      detail?.gate ?? null,
+      detail?.repo ?? null,
+      detail?.payload === undefined ? null : JSON.stringify(detail.payload),
+    );
+  });
+  tx();
+}
+
+/** An event that is not itself a transition — a note, a stream marker. */
+export function appendEvent(
+  runId: string,
+  kind: string,
+  detail?: { gate?: number; repo?: string; payload?: unknown },
+): void {
+  getDatabase()
+    .prepare(
+      'INSERT INTO run_events (run_id, kind, gate, repo, payload_json) VALUES (?, ?, ?, ?, ?)',
+    )
+    .run(
+      runId,
+      kind,
+      detail?.gate ?? null,
+      detail?.repo ?? null,
+      detail?.payload === undefined ? null : JSON.stringify(detail.payload),
+    );
+}
+
+/** Oldest first: this is a history, and reading it backwards reads as nonsense. */
+export function listEvents(runId: string): RunEventRow[] {
+  const rows = getDatabase()
+    .prepare('SELECT * FROM run_events WHERE run_id = ? ORDER BY id ASC')
+    .all(runId) as {
+    id: number;
+    run_id: string;
+    at: string;
+    kind: string;
+    gate: number | null;
+    repo: string | null;
+    payload_json: string | null;
+  }[];
+  return rows.map((row) => ({
+    id: row.id,
+    runId: row.run_id,
+    at: new Date(row.at),
+    kind: row.kind,
+    gate: row.gate,
+    repo: row.repo,
+    // A malformed payload must not take the run view down with it: the event
+    // itself is the record, and its detail is a convenience.
+    payload: row.payload_json ? safeParse(row.payload_json) : null,
+  }));
+}
+
+function safeParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { unparsed: text };
+  }
+}
+
+/** Mirror team.yaml's owners block. Re-runnable: spawn.sh is idempotent too. */
+export function upsertOwner(owner: RunOwnerRow): void {
+  getDatabase()
+    .prepare(
+      `INSERT INTO run_owners (run_id, repo, worktree, branch, base, scratch, status,
+                               pr_number, pr_url)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(run_id, repo) DO UPDATE SET
+         worktree = excluded.worktree,
+         branch   = excluded.branch,
+         base     = excluded.base,
+         scratch  = excluded.scratch,
+         status   = excluded.status,
+         pr_number = COALESCE(excluded.pr_number, run_owners.pr_number),
+         pr_url    = COALESCE(excluded.pr_url, run_owners.pr_url)`,
+    )
+    .run(
+      owner.runId,
+      owner.repo,
+      owner.worktree,
+      owner.branch,
+      owner.base,
+      owner.scratch ?? null,
+      owner.status,
+      owner.prNumber ?? null,
+      owner.prUrl ?? null,
+    );
+}
+
+export function listOwners(runId: string): RunOwnerRow[] {
+  const rows = getDatabase()
+    .prepare('SELECT * FROM run_owners WHERE run_id = ? ORDER BY repo')
+    .all(runId) as {
+    run_id: string;
+    repo: string;
+    worktree: string;
+    branch: string;
+    base: string;
+    scratch: string | null;
+    status: string;
+    pr_number: number | null;
+    pr_url: string | null;
+  }[];
+  return rows.map((row) => ({
+    runId: row.run_id,
+    repo: row.repo,
+    worktree: row.worktree,
+    branch: row.branch,
+    base: row.base,
+    scratch: row.scratch,
+    status: row.status,
+    prNumber: row.pr_number,
+    prUrl: row.pr_url,
+  }));
+}

--- a/src/main/repositories/runs.ts
+++ b/src/main/repositories/runs.ts
@@ -146,12 +146,6 @@ export function listActiveRuns(): RunRow[] {
   return rows.map(toRun);
 }
 
-/**
- * Move a run to `state`, recording the reason in the same transaction.
- *
- * One call, not two, because a state written without its event is a run whose
- * history has a hole exactly where someone will later ask what happened.
- */
 /** What an event may carry beyond its kind. */
 export interface EventDetail {
   gate?: number;
@@ -181,6 +175,36 @@ function insertEvent(
   );
 }
 
+/**
+ * States that must say why they stopped.
+ *
+ * A run in the inbox saying it needs a person, without saying what for, sends
+ * whoever opens it back to the event log to work it out — which is the one
+ * thing the inbox exists to save them.
+ */
+type BlockedState = Extract<RunState, 'inconclusive' | 'failed'>;
+
+/**
+ * Move a run to `state`, recording the reason in the same transaction.
+ *
+ * One call, not two, because a state written without its event is a run whose
+ * history has a hole exactly where someone will later ask what happened.
+ *
+ * The overloads make `blockedReason` REQUIRED for the states that block, so
+ * omitting it is a compile error rather than an inbox entry with no reason.
+ */
+export function recordTransition(
+  runId: string,
+  state: BlockedState,
+  kind: string,
+  detail: EventDetail & { blockedReason: string },
+): void;
+export function recordTransition(
+  runId: string,
+  state: Exclude<RunState, BlockedState>,
+  kind: string,
+  detail?: EventDetail,
+): void;
 export function recordTransition(
   runId: string,
   state: RunState,

--- a/src/main/run-engine/__tests__/transitions.test.ts
+++ b/src/main/run-engine/__tests__/transitions.test.ts
@@ -17,6 +17,7 @@ import {
   transition,
   type Gate,
   type RunEvent,
+  type RunContext,
   type RunState,
 } from '../transitions';
 
@@ -49,40 +50,53 @@ const ALL_EVENTS: RunEvent[] = [
 
 const gates: Gate[] = [2, 3, 4];
 
+/**
+ * transition() with a context supplying the gate in flight.
+ *
+ * For a gateFinished event that is the gate the event names -- which is what
+ * every case below was implicitly assuming before the context existed. The
+ * out-of-order cases pass their own context instead, because that assumption
+ * is exactly what they exist to break.
+ */
+function go(state: RunState, event: RunEvent, context?: RunContext) {
+  const activeGate = event.kind === 'gateFinished' ? event.gate : null;
+  return transition(state, event, context ?? { activeGate });
+}
+
 describe('the happy path, single repo', () => {
   test('preparing provisions before it spawns an owner', () => {
-    const d = transition('preparing', { kind: 'prepared' });
+    const d = go('preparing', { kind: 'prepared' });
     expect(d.state).toBe('provisioning');
     expect(d.actions).toEqual([{ kind: 'provision' }]);
   });
 
   test('gate 2 is only spawned once dependencies are in', () => {
-    const d = transition('provisioning', { kind: 'provisioned' });
+    const d = go('provisioning', { kind: 'provisioned' });
     expect(d.state).toBe('running');
     expect(d.actions).toEqual([{ kind: 'spawnGate', gate: 2 }]);
   });
 
   test('gates advance 2 -> 3 -> 4', () => {
-    expect(transition('running', { kind: 'gateFinished', gate: 2, verdict: 'pass' }).actions)
+    expect(go('running', { kind: 'gateFinished', gate: 2, verdict: 'pass' }).actions)
       .toEqual([{ kind: 'spawnGate', gate: 3 }]);
-    expect(transition('running', { kind: 'gateFinished', gate: 3, verdict: 'pass' }).actions)
+    expect(go('running', { kind: 'gateFinished', gate: 3, verdict: 'pass' }).actions)
       .toEqual([{ kind: 'spawnGate', gate: 4 }]);
   });
 
   test('gate 4 passing opens the PR and waits on checks, not on review', () => {
-    const d = transition('running', { kind: 'gateFinished', gate: 4, verdict: 'pass' });
+    const d = go('running', { kind: 'gateFinished', gate: 4, verdict: 'pass' });
     expect(d.state).toBe('waitingChecks');
     expect(d.actions).toEqual([{ kind: 'reconcile' }]);
   });
 
   test('green checks request review rather than waiting for one', () => {
-    const d = transition('waitingChecks', { kind: 'checksGreen' });
+    const d = go('waitingChecks', { kind: 'checksGreen' });
     expect(d.state).toBe('reviewNotRequested');
     expect(d.actions).toEqual([{ kind: 'requestReview' }]);
   });
 
   test('approval releases the run', () => {
-    const d = transition('waitingReview', { kind: 'reviewApproved' });
+    const d = go('waitingReview', { kind: 'reviewApproved' });
     expect(d.state).toBe('approved');
     expect(d.actions).toEqual([{ kind: 'release' }]);
   });
@@ -90,7 +104,7 @@ describe('the happy path, single repo', () => {
 
 describe('inconclusive is never a pass and never a failure', () => {
   test.each(gates)('an inconclusive gate %i stops the run and notifies', (gate) => {
-    const d = transition('running', { kind: 'gateFinished', gate, verdict: 'inconclusive' });
+    const d = go('running', { kind: 'gateFinished', gate, verdict: 'inconclusive' });
     expect(d.state).toBe('inconclusive');
     expect(d.actions.some((a) => a.kind === 'notify')).toBe(true);
     // The two ways of getting this wrong, asserted directly.
@@ -100,21 +114,21 @@ describe('inconclusive is never a pass and never a failure', () => {
 
   test('an undriveable provision is inconclusive, not failed', () => {
     // Nothing ran, so there is no result for the change under test.
-    const d = transition('provisioning', { kind: 'provisionUndriveable' });
+    const d = go('provisioning', { kind: 'provisionUndriveable' });
     expect(d.state).toBe('inconclusive');
   });
 
   test('a failed install IS a failure, and must stay distinguishable from the above', () => {
-    const d = transition('provisioning', { kind: 'provisionFailed' });
+    const d = go('provisioning', { kind: 'provisionFailed' });
     expect(d.state).toBe('failed');
   });
 
   test('the budget running out is inconclusive: no verdict was reached', () => {
-    expect(transition('running', { kind: 'budgetExceeded' }).state).toBe('inconclusive');
+    expect(go('running', { kind: 'budgetExceeded' }).state).toBe('inconclusive');
   });
 
   test('only a person leaves inconclusive, and the run re-enters gate 2', () => {
-    const d = transition('inconclusive', { kind: 'humanApprovedGate' });
+    const d = go('inconclusive', { kind: 'humanApprovedGate' });
     expect(d.state).toBe('running');
     expect(d.actions).toEqual([{ kind: 'spawnGate', gate: 2 }]);
   });
@@ -122,14 +136,14 @@ describe('inconclusive is never a pass and never a failure', () => {
   test('inconclusive ignores everything else, including a later pass', () => {
     // A gate reporting pass after the run already stopped is stale, not a
     // reason to resume: it was produced before whatever a person fixed.
-    expect(transition('inconclusive', { kind: 'gateFinished', gate: 3, verdict: 'pass' }).state)
+    expect(go('inconclusive', { kind: 'gateFinished', gate: 3, verdict: 'pass' }).state)
       .toBe('inconclusive');
   });
 });
 
 describe('review', () => {
   test('a human change request returns to gate 2', () => {
-    const d = transition('waitingReview', {
+    const d = go('waitingReview', {
       kind: 'reviewChangesRequested', verdict: { actor: 'human' },
     });
     expect(d.state).toBe('running');
@@ -137,7 +151,7 @@ describe('review', () => {
   });
 
   test('a bot nit is recorded and does NOT re-enter gate 2', () => {
-    const d = transition('waitingReview', {
+    const d = go('waitingReview', {
       kind: 'reviewChangesRequested', verdict: { actor: 'bot', severity: 'nit' },
     });
     expect(d.state).toBe('waitingReview');
@@ -148,7 +162,7 @@ describe('review', () => {
   test('a bot MAJOR finding does re-enter gate 2', () => {
     // CONTROL for the nit case: without this, treating every bot finding as a
     // nit would pass the test above and silently drop real findings.
-    const d = transition('waitingReview', {
+    const d = go('waitingReview', {
       kind: 'reviewChangesRequested', verdict: { actor: 'bot', severity: 'major' },
     });
     expect(d.state).toBe('running');
@@ -158,7 +172,7 @@ describe('review', () => {
   test('a bot finding with no severity is treated as a nit, not as major', () => {
     // Absent severity means the bot did not say. Escalating an unstated
     // severity burns owner cycles on notes; the finding is still surfaced.
-    const d = transition('waitingReview', {
+    const d = go('waitingReview', {
       kind: 'reviewChangesRequested', verdict: { actor: 'bot' },
     });
     expect(d.state).toBe('waitingReview');
@@ -167,14 +181,14 @@ describe('review', () => {
   test('review is not requested until checks are green', () => {
     // Entering reviewNotRequested straight off gate 4 would ask an approver to
     // read a build that may still change, and would fire arbiter against it.
-    expect(transition('running', { kind: 'gateFinished', gate: 4, verdict: 'pass' }).state)
+    expect(go('running', { kind: 'gateFinished', gate: 4, verdict: 'pass' }).state)
       .toBe('waitingChecks');
-    expect(transition('waitingChecks', { kind: 'reviewRequested' }).state)
+    expect(go('waitingChecks', { kind: 'reviewRequested' }).state)
       .toBe('waitingChecks');
   });
 
   test('red checks return to gate 2 rather than requesting review', () => {
-    const d = transition('waitingChecks', { kind: 'checksFailed' });
+    const d = go('waitingChecks', { kind: 'checksFailed' });
     expect(d.state).toBe('running');
     expect(d.actions).toEqual([{ kind: 'spawnGate', gate: 2 }]);
   });
@@ -182,9 +196,9 @@ describe('review', () => {
 
 describe('permission', () => {
   test('a prompt parks the run and answering resumes it', () => {
-    const parked = transition('running', { kind: 'permissionRequested' });
+    const parked = go('running', { kind: 'permissionRequested' });
     expect(parked.state).toBe('waitingPermission');
-    expect(transition('waitingPermission', { kind: 'permissionAnswered' }).state).toBe('running');
+    expect(go('waitingPermission', { kind: 'permissionAnswered' }).state).toBe('running');
   });
 
   test('an unanswered prompt never times out on its own', () => {
@@ -192,25 +206,25 @@ describe('permission', () => {
     // would carry a verdict nobody gave. Every other event leaves it parked.
     for (const event of ALL_EVENTS) {
       if (event.kind === 'permissionAnswered') continue;
-      expect(transition('waitingPermission', event).state).toBe('waitingPermission');
+      expect(go('waitingPermission', event).state).toBe('waitingPermission');
     }
   });
 });
 
 describe('approval is the end of attention, merge is not', () => {
   test('approved releases and does not wait for a merge', () => {
-    expect(transition('waitingReview', { kind: 'reviewApproved' }).actions)
+    expect(go('waitingReview', { kind: 'reviewApproved' }).actions)
       .toContainEqual({ kind: 'release' });
   });
 
   test('a merge afterwards is recorded but changes nothing about attention', () => {
-    expect(transition('approved', { kind: 'merged' }).state).toBe('done');
+    expect(go('approved', { kind: 'merged' }).state).toBe('done');
   });
 
   test('terminal states absorb every event', () => {
     for (const state of ['failed', 'done'] as RunState[]) {
       for (const event of ALL_EVENTS) {
-        expect(transition(state, event).state).toBe(state);
+        expect(go(state, event).state).toBe(state);
       }
     }
   });
@@ -222,13 +236,13 @@ describe('durability', () => {
     // reconcile racing a webhook, a gate reporting twice after a restart.
     for (const state of ALL_STATES) {
       for (const event of ALL_EVENTS) {
-        expect(() => transition(state, event)).not.toThrow();
+        expect(() => go(state, event)).not.toThrow();
       }
     }
   });
 
   test('an unhandled pairing stays put and says so, rather than advancing', () => {
-    const d = transition('waitingReview', { kind: 'prepared' });
+    const d = go('waitingReview', { kind: 'prepared' });
     expect(d.state).toBe('waitingReview');
     expect(d.actions).toEqual([]);
     expect(d.note).toContain('ignored');
@@ -237,16 +251,74 @@ describe('durability', () => {
   test('every decision carries a note, because run_events is the audit trail', () => {
     for (const state of ALL_STATES) {
       for (const event of ALL_EVENTS) {
-        expect(transition(state, event).note.length).toBeGreaterThan(0);
+        expect(go(state, event).note.length).toBeGreaterThan(0);
       }
     }
   });
 
+  test('a LATE report from an earlier gate does not regress the run', () => {
+    // THE CASE THE SUITE WAS MISSING. Replaying the same event was covered;
+    // an earlier gate reporting after a later one started was not. Without a
+    // guard, a stale gate 2 pass arriving while gate 4 is in flight spawns
+    // gate 3 again and throws away everything since.
+    const d = transition(
+      'running',
+      { kind: 'gateFinished', gate: 2, verdict: 'pass' },
+      { activeGate: 4 },
+    );
+    expect(d.state).toBe('running');
+    expect(d.actions).toEqual([]);
+    expect(d.note).toContain('gate 2 report');
+  });
+
+  test('a late report cannot end the run either', () => {
+    // The same guard has to hold for the verdicts that STOP a run, or a stale
+    // inconclusive from gate 2 parks a run whose gate 4 is doing fine.
+    for (const verdict of ['fail', 'inconclusive'] as const) {
+      const d = transition(
+        'running',
+        { kind: 'gateFinished', gate: 2, verdict },
+        { activeGate: 4 },
+      );
+      expect({ verdict, state: d.state }).toEqual({ verdict, state: 'running' });
+    }
+  });
+
+  test('a gate report with nothing in flight is ignored', () => {
+    // It belongs to nothing this run started.
+    const d = transition(
+      'running',
+      { kind: 'gateFinished', gate: 3, verdict: 'pass' },
+      { activeGate: null },
+    );
+    expect(d.actions).toEqual([]);
+  });
+
+  test('the gate actually in flight is still acted on', () => {
+    // CONTROL: without this, a guard that ignored everything would pass the
+    // three cases above and stall every run.
+    const d = transition(
+      'running',
+      { kind: 'gateFinished', gate: 4, verdict: 'pass' },
+      { activeGate: 4 },
+    );
+    expect(d.state).toBe('waitingChecks');
+  });
+
+  test('checks going red before review is requested returns to gate 2', () => {
+    // reviewNotRequested is meant to be transient, but a commit landing in
+    // that window would otherwise park the run waiting for a review request
+    // that should no longer be made.
+    const d = go('reviewNotRequested', { kind: 'checksFailed' });
+    expect(d.state).toBe('running');
+    expect(d.actions).toEqual([{ kind: 'spawnGate', gate: 2 }]);
+  });
+
   test('a duplicate gate result does not double-advance', () => {
-    const first = transition('running', { kind: 'gateFinished', gate: 2, verdict: 'pass' });
+    const first = go('running', { kind: 'gateFinished', gate: 2, verdict: 'pass' });
     expect(first.actions).toEqual([{ kind: 'spawnGate', gate: 3 }]);
     // Replaying the SAME event must propose the same thing, not gate 4.
-    const replay = transition('running', { kind: 'gateFinished', gate: 2, verdict: 'pass' });
+    const replay = go('running', { kind: 'gateFinished', gate: 2, verdict: 'pass' });
     expect(replay).toEqual(first);
   });
 });
@@ -262,7 +334,7 @@ describe('the state taxonomy the run inbox is built on', () => {
     // Listing it beside the waits is how it stops being one: arbiter does not
     // fire until review is requested, so nothing is coming until we ask.
     expect(NEEDS_A_PERSON).not.toContain('reviewNotRequested');
-    expect(transition('waitingChecks', { kind: 'checksGreen' }).actions)
+    expect(go('waitingChecks', { kind: 'checksGreen' }).actions)
       .toEqual([{ kind: 'requestReview' }]);
   });
 

--- a/src/main/run-engine/__tests__/transitions.test.ts
+++ b/src/main/run-engine/__tests__/transitions.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Run state machine tests (CO-722).
+ *
+ * The machine is pure, so every path is assertable here rather than
+ * discoverable during a run that spends real tokens. The cases that matter
+ * most are the ones asserting a run does NOT advance: an inconclusive gate,
+ * a bot nit, an unprovisioned worktree. Each of those, read as a pass or as a
+ * failure, reproduces a defect this initiative exists to remove.
+ *
+ * Run with: bun test src/main/run-engine
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  IS_WORKING,
+  NEEDS_A_PERSON,
+  isTerminal,
+  transition,
+  type Gate,
+  type RunEvent,
+  type RunState,
+} from '../transitions';
+
+const ALL_STATES: RunState[] = [
+  'preparing', 'provisioning', 'running', 'waitingPermission', 'waitingHumanGate',
+  'waitingChecks', 'reviewNotRequested', 'waitingReview', 'inconclusive',
+  'failed', 'approved', 'done',
+];
+
+const ALL_EVENTS: RunEvent[] = [
+  { kind: 'prepared' },
+  { kind: 'provisioned' },
+  { kind: 'provisionFailed' },
+  { kind: 'provisionUndriveable' },
+  { kind: 'gateFinished', gate: 2, verdict: 'pass' },
+  { kind: 'gateFinished', gate: 3, verdict: 'fail' },
+  { kind: 'gateFinished', gate: 4, verdict: 'inconclusive' },
+  { kind: 'permissionRequested' },
+  { kind: 'permissionAnswered' },
+  { kind: 'prOpened' },
+  { kind: 'checksGreen' },
+  { kind: 'checksFailed' },
+  { kind: 'reviewRequested' },
+  { kind: 'reviewApproved' },
+  { kind: 'reviewChangesRequested', verdict: { actor: 'human' } },
+  { kind: 'humanApprovedGate' },
+  { kind: 'budgetExceeded' },
+  { kind: 'merged' },
+];
+
+const gates: Gate[] = [2, 3, 4];
+
+describe('the happy path, single repo', () => {
+  test('preparing provisions before it spawns an owner', () => {
+    const d = transition('preparing', { kind: 'prepared' });
+    expect(d.state).toBe('provisioning');
+    expect(d.actions).toEqual([{ kind: 'provision' }]);
+  });
+
+  test('gate 2 is only spawned once dependencies are in', () => {
+    const d = transition('provisioning', { kind: 'provisioned' });
+    expect(d.state).toBe('running');
+    expect(d.actions).toEqual([{ kind: 'spawnGate', gate: 2 }]);
+  });
+
+  test('gates advance 2 -> 3 -> 4', () => {
+    expect(transition('running', { kind: 'gateFinished', gate: 2, verdict: 'pass' }).actions)
+      .toEqual([{ kind: 'spawnGate', gate: 3 }]);
+    expect(transition('running', { kind: 'gateFinished', gate: 3, verdict: 'pass' }).actions)
+      .toEqual([{ kind: 'spawnGate', gate: 4 }]);
+  });
+
+  test('gate 4 passing opens the PR and waits on checks, not on review', () => {
+    const d = transition('running', { kind: 'gateFinished', gate: 4, verdict: 'pass' });
+    expect(d.state).toBe('waitingChecks');
+    expect(d.actions).toEqual([{ kind: 'reconcile' }]);
+  });
+
+  test('green checks request review rather than waiting for one', () => {
+    const d = transition('waitingChecks', { kind: 'checksGreen' });
+    expect(d.state).toBe('reviewNotRequested');
+    expect(d.actions).toEqual([{ kind: 'requestReview' }]);
+  });
+
+  test('approval releases the run', () => {
+    const d = transition('waitingReview', { kind: 'reviewApproved' });
+    expect(d.state).toBe('approved');
+    expect(d.actions).toEqual([{ kind: 'release' }]);
+  });
+});
+
+describe('inconclusive is never a pass and never a failure', () => {
+  test.each(gates)('an inconclusive gate %i stops the run and notifies', (gate) => {
+    const d = transition('running', { kind: 'gateFinished', gate, verdict: 'inconclusive' });
+    expect(d.state).toBe('inconclusive');
+    expect(d.actions.some((a) => a.kind === 'notify')).toBe(true);
+    // The two ways of getting this wrong, asserted directly.
+    expect(d.state).not.toBe('failed');
+    expect(d.actions.some((a) => a.kind === 'spawnGate')).toBe(false);
+  });
+
+  test('an undriveable provision is inconclusive, not failed', () => {
+    // Nothing ran, so there is no result for the change under test.
+    const d = transition('provisioning', { kind: 'provisionUndriveable' });
+    expect(d.state).toBe('inconclusive');
+  });
+
+  test('a failed install IS a failure, and must stay distinguishable from the above', () => {
+    const d = transition('provisioning', { kind: 'provisionFailed' });
+    expect(d.state).toBe('failed');
+  });
+
+  test('the budget running out is inconclusive: no verdict was reached', () => {
+    expect(transition('running', { kind: 'budgetExceeded' }).state).toBe('inconclusive');
+  });
+
+  test('only a person leaves inconclusive, and the run re-enters gate 2', () => {
+    const d = transition('inconclusive', { kind: 'humanApprovedGate' });
+    expect(d.state).toBe('running');
+    expect(d.actions).toEqual([{ kind: 'spawnGate', gate: 2 }]);
+  });
+
+  test('inconclusive ignores everything else, including a later pass', () => {
+    // A gate reporting pass after the run already stopped is stale, not a
+    // reason to resume: it was produced before whatever a person fixed.
+    expect(transition('inconclusive', { kind: 'gateFinished', gate: 3, verdict: 'pass' }).state)
+      .toBe('inconclusive');
+  });
+});
+
+describe('review', () => {
+  test('a human change request returns to gate 2', () => {
+    const d = transition('waitingReview', {
+      kind: 'reviewChangesRequested', verdict: { actor: 'human' },
+    });
+    expect(d.state).toBe('running');
+    expect(d.actions).toEqual([{ kind: 'spawnGate', gate: 2 }]);
+  });
+
+  test('a bot nit is recorded and does NOT re-enter gate 2', () => {
+    const d = transition('waitingReview', {
+      kind: 'reviewChangesRequested', verdict: { actor: 'bot', severity: 'nit' },
+    });
+    expect(d.state).toBe('waitingReview');
+    expect(d.actions.some((a) => a.kind === 'spawnGate')).toBe(false);
+    expect(d.actions.some((a) => a.kind === 'notify')).toBe(true);
+  });
+
+  test('a bot MAJOR finding does re-enter gate 2', () => {
+    // CONTROL for the nit case: without this, treating every bot finding as a
+    // nit would pass the test above and silently drop real findings.
+    const d = transition('waitingReview', {
+      kind: 'reviewChangesRequested', verdict: { actor: 'bot', severity: 'major' },
+    });
+    expect(d.state).toBe('running');
+    expect(d.actions).toEqual([{ kind: 'spawnGate', gate: 2 }]);
+  });
+
+  test('a bot finding with no severity is treated as a nit, not as major', () => {
+    // Absent severity means the bot did not say. Escalating an unstated
+    // severity burns owner cycles on notes; the finding is still surfaced.
+    const d = transition('waitingReview', {
+      kind: 'reviewChangesRequested', verdict: { actor: 'bot' },
+    });
+    expect(d.state).toBe('waitingReview');
+  });
+
+  test('review is not requested until checks are green', () => {
+    // Entering reviewNotRequested straight off gate 4 would ask an approver to
+    // read a build that may still change, and would fire arbiter against it.
+    expect(transition('running', { kind: 'gateFinished', gate: 4, verdict: 'pass' }).state)
+      .toBe('waitingChecks');
+    expect(transition('waitingChecks', { kind: 'reviewRequested' }).state)
+      .toBe('waitingChecks');
+  });
+
+  test('red checks return to gate 2 rather than requesting review', () => {
+    const d = transition('waitingChecks', { kind: 'checksFailed' });
+    expect(d.state).toBe('running');
+    expect(d.actions).toEqual([{ kind: 'spawnGate', gate: 2 }]);
+  });
+});
+
+describe('permission', () => {
+  test('a prompt parks the run and answering resumes it', () => {
+    const parked = transition('running', { kind: 'permissionRequested' });
+    expect(parked.state).toBe('waitingPermission');
+    expect(transition('waitingPermission', { kind: 'permissionAnswered' }).state).toBe('running');
+  });
+
+  test('an unanswered prompt never times out on its own', () => {
+    // A silent auto-deny is indistinguishable from a gate finding, so the run
+    // would carry a verdict nobody gave. Every other event leaves it parked.
+    for (const event of ALL_EVENTS) {
+      if (event.kind === 'permissionAnswered') continue;
+      expect(transition('waitingPermission', event).state).toBe('waitingPermission');
+    }
+  });
+});
+
+describe('approval is the end of attention, merge is not', () => {
+  test('approved releases and does not wait for a merge', () => {
+    expect(transition('waitingReview', { kind: 'reviewApproved' }).actions)
+      .toContainEqual({ kind: 'release' });
+  });
+
+  test('a merge afterwards is recorded but changes nothing about attention', () => {
+    expect(transition('approved', { kind: 'merged' }).state).toBe('done');
+  });
+
+  test('terminal states absorb every event', () => {
+    for (const state of ['failed', 'done'] as RunState[]) {
+      for (const event of ALL_EVENTS) {
+        expect(transition(state, event).state).toBe(state);
+      }
+    }
+  });
+});
+
+describe('durability', () => {
+  test('no (state, event) pairing throws', () => {
+    // A run is resumable, so it WILL be handed stale and duplicate events: a
+    // reconcile racing a webhook, a gate reporting twice after a restart.
+    for (const state of ALL_STATES) {
+      for (const event of ALL_EVENTS) {
+        expect(() => transition(state, event)).not.toThrow();
+      }
+    }
+  });
+
+  test('an unhandled pairing stays put and says so, rather than advancing', () => {
+    const d = transition('waitingReview', { kind: 'prepared' });
+    expect(d.state).toBe('waitingReview');
+    expect(d.actions).toEqual([]);
+    expect(d.note).toContain('ignored');
+  });
+
+  test('every decision carries a note, because run_events is the audit trail', () => {
+    for (const state of ALL_STATES) {
+      for (const event of ALL_EVENTS) {
+        expect(transition(state, event).note.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test('a duplicate gate result does not double-advance', () => {
+    const first = transition('running', { kind: 'gateFinished', gate: 2, verdict: 'pass' });
+    expect(first.actions).toEqual([{ kind: 'spawnGate', gate: 3 }]);
+    // Replaying the SAME event must propose the same thing, not gate 4.
+    const replay = transition('running', { kind: 'gateFinished', gate: 2, verdict: 'pass' });
+    expect(replay).toEqual(first);
+  });
+});
+
+describe('the state taxonomy the run inbox is built on', () => {
+  test('the four states needing a person are exactly those listed', () => {
+    expect([...NEEDS_A_PERSON].sort()).toEqual(
+      ['inconclusive', 'waitingHumanGate', 'waitingPermission', 'waitingReview'],
+    );
+  });
+
+  test('reviewNotRequested is NOT a wait — the engine acts there', () => {
+    // Listing it beside the waits is how it stops being one: arbiter does not
+    // fire until review is requested, so nothing is coming until we ask.
+    expect(NEEDS_A_PERSON).not.toContain('reviewNotRequested');
+    expect(transition('waitingChecks', { kind: 'checksGreen' }).actions)
+      .toEqual([{ kind: 'requestReview' }]);
+  });
+
+  test('working, waiting and terminal never overlap', () => {
+    const overlapping = ALL_STATES.filter(
+      (state) =>
+        [IS_WORKING.includes(state), NEEDS_A_PERSON.includes(state), isTerminal(state)]
+          .filter(Boolean).length > 1,
+    );
+    // Named rather than counted: a state in two buckets makes the run inbox
+    // and the "is it working" indicator disagree about the same run.
+    expect(overlapping).toEqual([]);
+  });
+
+  test('every state is accounted for by exactly one bucket or is a checkpoint', () => {
+    const unclassified = ALL_STATES.filter(
+      (s) => !IS_WORKING.includes(s) && !NEEDS_A_PERSON.includes(s) && !isTerminal(s),
+    );
+    // waitingChecks and reviewNotRequested are machine-driven checkpoints:
+    // neither needs a person, and neither is terminal.
+    expect(unclassified.sort()).toEqual(['reviewNotRequested', 'waitingChecks']);
+  });
+});

--- a/src/main/run-engine/transitions.ts
+++ b/src/main/run-engine/transitions.ts
@@ -1,0 +1,346 @@
+/**
+ * The run state machine (CO-722).
+ *
+ * `claude-team-workflow` documents a gate model and nothing enforces it. Its
+ * own docstrings record what that costs: owners dispatched serially where the
+ * command says concurrent, two owner dispatches that ended with "open a PR" so
+ * gates 3 and 4 never ran, 97 turns spent locating a tool across three
+ * reachable copies of it. None of those is a reasoning failure — they are
+ * sequencing, ordering and isolation, which is what a state machine is for.
+ *
+ * So this module holds the arrows and nothing else. It contains no domain
+ * judgment: it does not know what a reviewer looks for, what a seam is, or
+ * how to verify anything. It knows which agent runs next, what blocks, and
+ * what a given outcome means for the run. The judgment stays in the model and
+ * the deterministic checks stay in the plugin's Python.
+ *
+ * Pure by design — `(state, event) -> decision`. No processes, no git, no
+ * network, no clock. That is what lets every path, including every
+ * inconclusive one, be asserted in a unit test rather than discovered during
+ * a run that costs real tokens.
+ */
+
+/**
+ * Where a run is. Four of these cannot advance without a person:
+ * `waitingPermission`, `waitingHumanGate`, `waitingReview`, `inconclusive` —
+ * which is why the run inbox is the primary surface rather than a timeline.
+ */
+export type RunState =
+  | 'preparing'
+  | 'provisioning'
+  | 'running'
+  | 'waitingPermission'
+  | 'waitingHumanGate'
+  | 'waitingChecks'
+  /**
+   * Checks are green and no approver has been asked yet.
+   *
+   * This is a state the engine ACTS on, not one it waits in. `arbiter/review`
+   * does not fire until review is requested, so a PR sitting un-requested is
+   * invisible to the bot and to the human queue alike — nothing is coming,
+   * and waiting here is waiting for something nobody started.
+   */
+  | 'reviewNotRequested'
+  | 'waitingReview'
+  | 'inconclusive'
+  | 'failed'
+  | 'approved'
+  | 'done';
+
+/** Gates this slice drives. 0 and 1 are bootstrapped by `init-task.sh`. */
+export type Gate = 2 | 3 | 4;
+
+/**
+ * What a gate reported.
+ *
+ * `inconclusive` is not a shade of failure. It means the gate could not
+ * establish anything — a missing verdict, one that failed schema validation,
+ * a toolchain that could not be driven. Collapsing it into `fail` sends an
+ * owner back to fix code that was never broken; collapsing it into `pass` is
+ * the green-having-checked-nothing defect the plugin has filed seven times.
+ */
+export type GateVerdict = 'pass' | 'fail' | 'inconclusive';
+
+/** Who filed a review, and how badly. */
+export interface ReviewVerdict {
+  /** A bot block is not a human block, and only one of them ends the run. */
+  actor: 'human' | 'bot';
+  /**
+   * Bot findings at `major` send the run back to gate 2. `nit` is recorded
+   * and surfaced — CO-447 measured `arbiter/review` at "major 0, minor 0,
+   * nit 1", and re-entering gate 2 for that burns a cycle on a note.
+   */
+  severity?: 'major' | 'nit';
+}
+
+export type RunEvent =
+  | { kind: 'prepared' }
+  | { kind: 'provisioned' }
+  /** An install ran and failed. A real result, unlike the one below. */
+  | { kind: 'provisionFailed' }
+  /** Nothing ran: no worktree, no package manager. Not a result. */
+  | { kind: 'provisionUndriveable' }
+  | { kind: 'gateFinished'; gate: Gate; verdict: GateVerdict }
+  | { kind: 'permissionRequested' }
+  | { kind: 'permissionAnswered' }
+  | { kind: 'prOpened' }
+  | { kind: 'checksGreen' }
+  | { kind: 'checksFailed' }
+  | { kind: 'reviewRequested' }
+  | { kind: 'reviewApproved' }
+  | { kind: 'reviewChangesRequested'; verdict: ReviewVerdict }
+  | { kind: 'humanApprovedGate' }
+  | { kind: 'budgetExceeded' }
+  | { kind: 'merged' };
+
+/**
+ * What the engine should do on arriving at the next state. Naming these as
+ * data rather than performing them keeps the machine pure and makes "did it
+ * decide to request review?" an assertion rather than an observation of side
+ * effects.
+ */
+export type RunAction =
+  | { kind: 'provision' }
+  | { kind: 'spawnGate'; gate: Gate }
+  /** Ask an approver. The engine's move, not a wait. */
+  | { kind: 'requestReview' }
+  /** Poll `gh`. Only ever an accelerant — reconciliation is the truth. */
+  | { kind: 'reconcile' }
+  | { kind: 'notify'; reason: string }
+  /**
+   * Stop attending to this run. Reached at APPROVAL, not at merge: once every
+   * PR is approved and green nothing further comes back, and the wait for
+   * someone to press merge is unbounded. One initiative sat twelve hours
+   * there while the rest stayed drafts.
+   */
+  | { kind: 'release' };
+
+export interface Decision {
+  state: RunState;
+  actions: RunAction[];
+  /** Why, for `run_events`. The audit trail is the product, not a by-product. */
+  note: string;
+}
+
+/** The gate that follows, or null when 4 is done. */
+function nextGate(gate: Gate): Gate | null {
+  return gate === 2 ? 3 : gate === 3 ? 4 : null;
+}
+
+function stay(state: RunState, note: string): Decision {
+  return { state, actions: [], note };
+}
+
+/**
+ * The one rule with no exceptions: a run that cannot establish something
+ * stops and tells a person. It never advances, and it never reports failure,
+ * because neither is true.
+ */
+function inconclusive(note: string): Decision {
+  return { state: 'inconclusive', actions: [{ kind: 'notify', reason: note }], note };
+}
+
+/**
+ * `(state, event) -> decision`.
+ *
+ * Unknown pairings return the current state unchanged with a note rather than
+ * throwing. A run is durable and resumable, so it will be handed stale and
+ * duplicate events — a reconcile that races a webhook, a gate that reports
+ * twice after a restart. Throwing there would turn a duplicate into an
+ * outage; advancing on one would be worse.
+ */
+export function transition(state: RunState, event: RunEvent): Decision {
+  switch (state) {
+    case 'preparing':
+      if (event.kind === 'prepared') {
+        return {
+          state: 'provisioning',
+          actions: [{ kind: 'provision' }],
+          note: 'worktrees cut; installing dependencies before gate 2',
+        };
+      }
+      break;
+
+    case 'provisioning':
+      // Provisioning comes BEFORE gate 2 because an unprovisioned worktree
+      // makes verify.sh report a missing runner as FAIL — measured as
+      // "'jest' is not recognized", exit 1, over code that was fine. An
+      // engine reading that as red sends the owner back into the same red
+      // until the budget stops it.
+      if (event.kind === 'provisioned') {
+        return {
+          state: 'running',
+          actions: [{ kind: 'spawnGate', gate: 2 }],
+          note: 'dependencies installed; gate 2 (owner)',
+        };
+      }
+      if (event.kind === 'provisionFailed') {
+        return {
+          state: 'failed',
+          actions: [{ kind: 'notify', reason: 'install failed' }],
+          note: 'an install ran and failed — a real result',
+        };
+      }
+      if (event.kind === 'provisionUndriveable') {
+        // Nothing ran, so there is no result for the change. Calling this
+        // `failed` is the confusion the provisioning work exists to remove.
+        return inconclusive('nothing could be installed here — no result for the change');
+      }
+      break;
+
+    case 'running':
+      if (event.kind === 'gateFinished') {
+        if (event.verdict === 'inconclusive') {
+          return inconclusive(`gate ${event.gate} could not establish a verdict`);
+        }
+        if (event.verdict === 'fail') {
+          // Red means the owner keeps working. It does not mean "note it on
+          // the PR" — and a failing gate 3 or 4 returns to gate 2 rather than
+          // ending the run, because the branch is still soft.
+          return {
+            state: 'running',
+            actions: [{ kind: 'spawnGate', gate: 2 }],
+            note: `gate ${event.gate} red; back to gate 2`,
+          };
+        }
+        const next = nextGate(event.gate);
+        if (next) {
+          return {
+            state: 'running',
+            actions: [{ kind: 'spawnGate', gate: next }],
+            note: `gate ${event.gate} passed; gate ${next}`,
+          };
+        }
+        // Gate 4 passed: scribe has opened the PR. Checks decide what next.
+        return {
+          state: 'waitingChecks',
+          actions: [{ kind: 'reconcile' }],
+          note: 'PR open; waiting for checks',
+        };
+      }
+      if (event.kind === 'permissionRequested') {
+        return stay('waitingPermission', 'a tool needs approval');
+      }
+      if (event.kind === 'budgetExceeded') {
+        return inconclusive('budget ceiling reached before a verdict');
+      }
+      break;
+
+    case 'waitingPermission':
+      // No timeout. A silent auto-deny is indistinguishable from a gate
+      // finding, and the run would carry a verdict nobody gave.
+      if (event.kind === 'permissionAnswered') {
+        return stay('running', 'permission answered; gate continues');
+      }
+      break;
+
+    case 'waitingHumanGate':
+      if (event.kind === 'humanApprovedGate') {
+        return {
+          state: 'running',
+          actions: [{ kind: 'spawnGate', gate: 2 }],
+          note: 'manifest approved; gate 2',
+        };
+      }
+      break;
+
+    case 'waitingChecks':
+      if (event.kind === 'checksGreen') {
+        // Green checks do NOT mean approved — they mean it is now worth
+        // asking. Requesting earlier spends an adversarial pass on a build
+        // that may still change, which is the same reasoning that puts gate 3
+        // before the specs harden.
+        return {
+          state: 'reviewNotRequested',
+          actions: [{ kind: 'requestReview' }],
+          note: 'checks green; requesting review',
+        };
+      }
+      if (event.kind === 'checksFailed') {
+        return {
+          state: 'running',
+          actions: [{ kind: 'spawnGate', gate: 2 }],
+          note: 'checks red; back to gate 2',
+        };
+      }
+      break;
+
+    case 'reviewNotRequested':
+      if (event.kind === 'reviewRequested') {
+        return {
+          state: 'waitingReview',
+          actions: [{ kind: 'reconcile' }],
+          note: 'review requested; arbiter and the human queue can now see it',
+        };
+      }
+      break;
+
+    case 'waitingReview':
+      if (event.kind === 'reviewApproved') {
+        // Released at approval, not at merge.
+        return {
+          state: 'approved',
+          actions: [{ kind: 'release' }],
+          note: 'approved and green; nothing further comes back',
+        };
+      }
+      if (event.kind === 'reviewChangesRequested') {
+        const { actor, severity } = event.verdict;
+        if (actor === 'bot' && severity !== 'major') {
+          // Recorded and surfaced, not acted on. Re-entering gate 2 for a nit
+          // spends an owner cycle on a note.
+          return {
+            state: 'waitingReview',
+            actions: [{ kind: 'notify', reason: 'bot nit recorded' }],
+            note: 'bot finding below major; recorded, still waiting on review',
+          };
+        }
+        return {
+          state: 'running',
+          actions: [{ kind: 'spawnGate', gate: 2 }],
+          note: `${actor} requested changes; back to gate 2`,
+        };
+      }
+      break;
+
+    case 'approved':
+      if (event.kind === 'merged') {
+        return stay('done', 'merged');
+      }
+      break;
+
+    case 'inconclusive':
+      // Only a person leaves this state. Whatever they fixed, the run resumes
+      // by re-entering gate 2 rather than assuming the earlier gate's result.
+      if (event.kind === 'humanApprovedGate') {
+        return {
+          state: 'running',
+          actions: [{ kind: 'spawnGate', gate: 2 }],
+          note: 'resumed by a person after an inconclusive gate',
+        };
+      }
+      break;
+
+    case 'failed':
+    case 'done':
+      break;
+  }
+
+  return stay(state, `ignored ${event.kind} in ${state}`);
+}
+
+/** States that cannot advance without a person. The run inbox is built on this. */
+export const NEEDS_A_PERSON: readonly RunState[] = [
+  'waitingPermission',
+  'waitingHumanGate',
+  'waitingReview',
+  'inconclusive',
+];
+
+/** States the engine is actively working, so nothing external is owed. */
+export const IS_WORKING: readonly RunState[] = ['preparing', 'provisioning', 'running'];
+
+/** Nothing further will happen on its own. */
+export function isTerminal(state: RunState): boolean {
+  return state === 'approved' || state === 'done' || state === 'failed';
+}

--- a/src/main/run-engine/transitions.ts
+++ b/src/main/run-engine/transitions.ts
@@ -153,12 +153,30 @@ function inconclusive(note: string): Decision {
 }
 
 /**
+ * What the machine needs to know beyond the state itself.
+ *
+ * Required, not optional, and deliberately so. `activeGate` is the only
+ * defence against a stale gate report: a `gateFinished` for gate 2 arriving
+ * after the run reached gate 4 would otherwise spawn gate 3 again and throw
+ * away the work in between. The module's own contract says it WILL be handed
+ * duplicate and out-of-order events, so the guard belongs here rather than in
+ * a caller's discipline — a rule kept by convention is the thing this whole
+ * machine exists to replace.
+ *
+ * `null` means no gate is in flight. A gate report then belongs to nothing
+ * this run started, and is ignored.
+ */
+export interface RunContext {
+  activeGate: Gate | null;
+}
+
+/**
  * A handler returns null for an event this state does not act on, and the
  * caller turns that into "stay put". Each state is a small function rather
  * than a branch in one large switch so the pairing under test is readable on
  * its own.
  */
-type Handler = (event: RunEvent) => Decision | null;
+type Handler = (event: RunEvent, context: RunContext) => Decision | null;
 
 function onPreparing(event: RunEvent): Decision | null {
   if (event.kind !== 'prepared') return null;
@@ -224,8 +242,18 @@ function onGateFinished(gate: Gate, verdict: GateVerdict): Decision {
   };
 }
 
-function onRunning(event: RunEvent): Decision | null {
-  if (event.kind === 'gateFinished') return onGateFinished(event.gate, event.verdict);
+function onRunning(event: RunEvent, context: RunContext): Decision | null {
+  if (event.kind === 'gateFinished') {
+    // Only the gate actually in flight may move the run. A late report from
+    // an earlier gate is not news, and acting on it un-does everything since.
+    if (context.activeGate !== event.gate) {
+      return stay(
+        'running',
+        `ignored a gate ${event.gate} report while gate ${context.activeGate ?? 'none'} is in flight`,
+      );
+    }
+    return onGateFinished(event.gate, event.verdict);
+  }
   if (event.kind === 'permissionRequested') {
     return stay('waitingPermission', 'a tool needs approval');
   }
@@ -268,12 +296,21 @@ function onWaitingChecks(event: RunEvent): Decision | null {
 }
 
 function onReviewNotRequested(event: RunEvent): Decision | null {
-  if (event.kind !== 'reviewRequested') return null;
-  return {
-    state: 'waitingReview',
-    actions: [{ kind: 'reconcile' }],
-    note: 'review requested; arbiter and the human queue can now see it',
-  };
+  if (event.kind === 'reviewRequested') {
+    return {
+      state: 'waitingReview',
+      actions: [{ kind: 'reconcile' }],
+      note: 'review requested; arbiter and the human queue can now see it',
+    };
+  }
+  if (event.kind === 'checksFailed') {
+    // This state is meant to be transient — entered on green, left as soon as
+    // the engine asks an approver. But a commit landing in that window turns
+    // the checks red again, and without this the run parks here waiting for a
+    // review request that should no longer be made.
+    return backToOwner('checks went red before review was requested; back to gate 2');
+  }
+  return null;
 }
 
 function onWaitingReview(event: RunEvent): Decision | null {
@@ -347,8 +384,8 @@ const HANDLERS: Record<RunState, Handler> = {
  * reports twice after a restart. Throwing there would turn a duplicate into
  * an outage; advancing on one would be worse.
  */
-export function transition(state: RunState, event: RunEvent): Decision {
-  return HANDLERS[state](event) ?? stay(state, `ignored ${event.kind} in ${state}`);
+export function transition(state: RunState, event: RunEvent, context: RunContext): Decision {
+  return HANDLERS[state](event, context) ?? stay(state, `ignored ${event.kind} in ${state}`);
 }
 
 /** States that cannot advance without a person. The run inbox is built on this. */

--- a/src/main/run-engine/transitions.ts
+++ b/src/main/run-engine/transitions.ts
@@ -122,13 +122,25 @@ export interface Decision {
   note: string;
 }
 
-/** The gate that follows, or null when 4 is done. */
+/**
+ * The gate that follows, or null when 4 is done.
+ *
+ * A table rather than a chain of conditionals: the order of the gates is the
+ * thing being stated, and it should be readable as one.
+ */
+const FOLLOWING_GATE: Record<Gate, Gate | null> = { 2: 3, 3: 4, 4: null };
+
 function nextGate(gate: Gate): Gate | null {
-  return gate === 2 ? 3 : gate === 3 ? 4 : null;
+  return FOLLOWING_GATE[gate];
 }
 
 function stay(state: RunState, note: string): Decision {
   return { state, actions: [], note };
+}
+
+/** Send the branch back to its owner. The commonest arrow in the machine. */
+function backToOwner(note: string): Decision {
+  return { state: 'running', actions: [{ kind: 'spawnGate', gate: 2 }], note };
 }
 
 /**
@@ -141,192 +153,202 @@ function inconclusive(note: string): Decision {
 }
 
 /**
+ * A handler returns null for an event this state does not act on, and the
+ * caller turns that into "stay put". Each state is a small function rather
+ * than a branch in one large switch so the pairing under test is readable on
+ * its own.
+ */
+type Handler = (event: RunEvent) => Decision | null;
+
+function onPreparing(event: RunEvent): Decision | null {
+  if (event.kind !== 'prepared') return null;
+  return {
+    state: 'provisioning',
+    actions: [{ kind: 'provision' }],
+    note: 'worktrees cut; installing dependencies before gate 2',
+  };
+}
+
+/**
+ * Provisioning comes BEFORE gate 2 because an unprovisioned worktree makes
+ * verify.sh report a missing runner as FAIL — measured as "'jest' is not
+ * recognized", exit 1, over code that was fine. An engine reading that as red
+ * sends the owner back into the same red until the budget stops it.
+ */
+function onProvisioning(event: RunEvent): Decision | null {
+  if (event.kind === 'provisioned') {
+    return {
+      state: 'running',
+      actions: [{ kind: 'spawnGate', gate: 2 }],
+      note: 'dependencies installed; gate 2 (owner)',
+    };
+  }
+  if (event.kind === 'provisionFailed') {
+    return {
+      state: 'failed',
+      actions: [{ kind: 'notify', reason: 'install failed' }],
+      note: 'an install ran and failed — a real result',
+    };
+  }
+  if (event.kind === 'provisionUndriveable') {
+    // Nothing ran, so there is no result for the change. Calling this
+    // `failed` is the confusion the provisioning work exists to remove.
+    return inconclusive('nothing could be installed here — no result for the change');
+  }
+  return null;
+}
+
+function onGateFinished(gate: Gate, verdict: GateVerdict): Decision {
+  if (verdict === 'inconclusive') {
+    return inconclusive(`gate ${gate} could not establish a verdict`);
+  }
+  if (verdict === 'fail') {
+    // Red means the owner keeps working. It does not mean "note it on the
+    // PR" — and a failing gate 3 or 4 returns to gate 2 rather than ending
+    // the run, because the branch is still soft.
+    return backToOwner(`gate ${gate} red; back to gate 2`);
+  }
+  const next = nextGate(gate);
+  if (next) {
+    return {
+      state: 'running',
+      actions: [{ kind: 'spawnGate', gate: next }],
+      note: `gate ${gate} passed; gate ${next}`,
+    };
+  }
+  // Gate 4 passed: scribe has opened the PR. Checks decide what happens next.
+  return {
+    state: 'waitingChecks',
+    actions: [{ kind: 'reconcile' }],
+    note: 'PR open; waiting for checks',
+  };
+}
+
+function onRunning(event: RunEvent): Decision | null {
+  if (event.kind === 'gateFinished') return onGateFinished(event.gate, event.verdict);
+  if (event.kind === 'permissionRequested') {
+    return stay('waitingPermission', 'a tool needs approval');
+  }
+  if (event.kind === 'budgetExceeded') {
+    return inconclusive('budget ceiling reached before a verdict');
+  }
+  return null;
+}
+
+/**
+ * No timeout. A silent auto-deny is indistinguishable from a gate finding,
+ * and the run would then carry a verdict nobody gave.
+ */
+function onWaitingPermission(event: RunEvent): Decision | null {
+  return event.kind === 'permissionAnswered'
+    ? stay('running', 'permission answered; gate continues')
+    : null;
+}
+
+function onWaitingHumanGate(event: RunEvent): Decision | null {
+  return event.kind === 'humanApprovedGate'
+    ? backToOwner('manifest approved; gate 2')
+    : null;
+}
+
+function onWaitingChecks(event: RunEvent): Decision | null {
+  if (event.kind === 'checksGreen') {
+    // Green checks do NOT mean approved — they mean it is now worth asking.
+    // Requesting earlier spends an adversarial pass on a build that may still
+    // change, which is the same reasoning that puts gate 3 before the specs
+    // harden.
+    return {
+      state: 'reviewNotRequested',
+      actions: [{ kind: 'requestReview' }],
+      note: 'checks green; requesting review',
+    };
+  }
+  if (event.kind === 'checksFailed') return backToOwner('checks red; back to gate 2');
+  return null;
+}
+
+function onReviewNotRequested(event: RunEvent): Decision | null {
+  if (event.kind !== 'reviewRequested') return null;
+  return {
+    state: 'waitingReview',
+    actions: [{ kind: 'reconcile' }],
+    note: 'review requested; arbiter and the human queue can now see it',
+  };
+}
+
+function onWaitingReview(event: RunEvent): Decision | null {
+  if (event.kind === 'reviewApproved') {
+    // Released at approval, not at merge.
+    return {
+      state: 'approved',
+      actions: [{ kind: 'release' }],
+      note: 'approved and green; nothing further comes back',
+    };
+  }
+  if (event.kind !== 'reviewChangesRequested') return null;
+
+  const { actor, severity } = event.verdict;
+  if (actor === 'bot' && severity !== 'major') {
+    // Recorded and surfaced, not acted on. Re-entering gate 2 for a nit
+    // spends an owner cycle on a note.
+    return {
+      state: 'waitingReview',
+      actions: [{ kind: 'notify', reason: 'bot nit recorded' }],
+      note: 'bot finding below major; recorded, still waiting on review',
+    };
+  }
+  return backToOwner(`${actor} requested changes; back to gate 2`);
+}
+
+/**
+ * Only a person leaves this state. Whatever they fixed, the run resumes by
+ * re-entering gate 2 rather than trusting the earlier gate's result — which
+ * was produced before the fix.
+ */
+function onInconclusive(event: RunEvent): Decision | null {
+  return event.kind === 'humanApprovedGate'
+    ? backToOwner('resumed by a person after an inconclusive gate')
+    : null;
+}
+
+function onApproved(event: RunEvent): Decision | null {
+  return event.kind === 'merged' ? stay('done', 'merged') : null;
+}
+
+/** Terminal: nothing further happens on its own. */
+const absorbing: Handler = () => null;
+
+/**
+ * Every state has a handler, and the Record type makes that a compile error
+ * rather than a runtime hole — adding a state without deciding what it does
+ * is exactly the omission this machine exists to prevent.
+ */
+const HANDLERS: Record<RunState, Handler> = {
+  preparing: onPreparing,
+  provisioning: onProvisioning,
+  running: onRunning,
+  waitingPermission: onWaitingPermission,
+  waitingHumanGate: onWaitingHumanGate,
+  waitingChecks: onWaitingChecks,
+  reviewNotRequested: onReviewNotRequested,
+  waitingReview: onWaitingReview,
+  inconclusive: onInconclusive,
+  approved: onApproved,
+  failed: absorbing,
+  done: absorbing,
+};
+
+/**
  * `(state, event) -> decision`.
  *
- * Unknown pairings return the current state unchanged with a note rather than
- * throwing. A run is durable and resumable, so it will be handed stale and
- * duplicate events — a reconcile that races a webhook, a gate that reports
- * twice after a restart. Throwing there would turn a duplicate into an
- * outage; advancing on one would be worse.
+ * An unhandled pairing returns the current state unchanged with a note rather
+ * than throwing. A run is durable and resumable, so it will be handed stale
+ * and duplicate events — a reconcile that races a webhook, a gate that
+ * reports twice after a restart. Throwing there would turn a duplicate into
+ * an outage; advancing on one would be worse.
  */
 export function transition(state: RunState, event: RunEvent): Decision {
-  switch (state) {
-    case 'preparing':
-      if (event.kind === 'prepared') {
-        return {
-          state: 'provisioning',
-          actions: [{ kind: 'provision' }],
-          note: 'worktrees cut; installing dependencies before gate 2',
-        };
-      }
-      break;
-
-    case 'provisioning':
-      // Provisioning comes BEFORE gate 2 because an unprovisioned worktree
-      // makes verify.sh report a missing runner as FAIL — measured as
-      // "'jest' is not recognized", exit 1, over code that was fine. An
-      // engine reading that as red sends the owner back into the same red
-      // until the budget stops it.
-      if (event.kind === 'provisioned') {
-        return {
-          state: 'running',
-          actions: [{ kind: 'spawnGate', gate: 2 }],
-          note: 'dependencies installed; gate 2 (owner)',
-        };
-      }
-      if (event.kind === 'provisionFailed') {
-        return {
-          state: 'failed',
-          actions: [{ kind: 'notify', reason: 'install failed' }],
-          note: 'an install ran and failed — a real result',
-        };
-      }
-      if (event.kind === 'provisionUndriveable') {
-        // Nothing ran, so there is no result for the change. Calling this
-        // `failed` is the confusion the provisioning work exists to remove.
-        return inconclusive('nothing could be installed here — no result for the change');
-      }
-      break;
-
-    case 'running':
-      if (event.kind === 'gateFinished') {
-        if (event.verdict === 'inconclusive') {
-          return inconclusive(`gate ${event.gate} could not establish a verdict`);
-        }
-        if (event.verdict === 'fail') {
-          // Red means the owner keeps working. It does not mean "note it on
-          // the PR" — and a failing gate 3 or 4 returns to gate 2 rather than
-          // ending the run, because the branch is still soft.
-          return {
-            state: 'running',
-            actions: [{ kind: 'spawnGate', gate: 2 }],
-            note: `gate ${event.gate} red; back to gate 2`,
-          };
-        }
-        const next = nextGate(event.gate);
-        if (next) {
-          return {
-            state: 'running',
-            actions: [{ kind: 'spawnGate', gate: next }],
-            note: `gate ${event.gate} passed; gate ${next}`,
-          };
-        }
-        // Gate 4 passed: scribe has opened the PR. Checks decide what next.
-        return {
-          state: 'waitingChecks',
-          actions: [{ kind: 'reconcile' }],
-          note: 'PR open; waiting for checks',
-        };
-      }
-      if (event.kind === 'permissionRequested') {
-        return stay('waitingPermission', 'a tool needs approval');
-      }
-      if (event.kind === 'budgetExceeded') {
-        return inconclusive('budget ceiling reached before a verdict');
-      }
-      break;
-
-    case 'waitingPermission':
-      // No timeout. A silent auto-deny is indistinguishable from a gate
-      // finding, and the run would carry a verdict nobody gave.
-      if (event.kind === 'permissionAnswered') {
-        return stay('running', 'permission answered; gate continues');
-      }
-      break;
-
-    case 'waitingHumanGate':
-      if (event.kind === 'humanApprovedGate') {
-        return {
-          state: 'running',
-          actions: [{ kind: 'spawnGate', gate: 2 }],
-          note: 'manifest approved; gate 2',
-        };
-      }
-      break;
-
-    case 'waitingChecks':
-      if (event.kind === 'checksGreen') {
-        // Green checks do NOT mean approved — they mean it is now worth
-        // asking. Requesting earlier spends an adversarial pass on a build
-        // that may still change, which is the same reasoning that puts gate 3
-        // before the specs harden.
-        return {
-          state: 'reviewNotRequested',
-          actions: [{ kind: 'requestReview' }],
-          note: 'checks green; requesting review',
-        };
-      }
-      if (event.kind === 'checksFailed') {
-        return {
-          state: 'running',
-          actions: [{ kind: 'spawnGate', gate: 2 }],
-          note: 'checks red; back to gate 2',
-        };
-      }
-      break;
-
-    case 'reviewNotRequested':
-      if (event.kind === 'reviewRequested') {
-        return {
-          state: 'waitingReview',
-          actions: [{ kind: 'reconcile' }],
-          note: 'review requested; arbiter and the human queue can now see it',
-        };
-      }
-      break;
-
-    case 'waitingReview':
-      if (event.kind === 'reviewApproved') {
-        // Released at approval, not at merge.
-        return {
-          state: 'approved',
-          actions: [{ kind: 'release' }],
-          note: 'approved and green; nothing further comes back',
-        };
-      }
-      if (event.kind === 'reviewChangesRequested') {
-        const { actor, severity } = event.verdict;
-        if (actor === 'bot' && severity !== 'major') {
-          // Recorded and surfaced, not acted on. Re-entering gate 2 for a nit
-          // spends an owner cycle on a note.
-          return {
-            state: 'waitingReview',
-            actions: [{ kind: 'notify', reason: 'bot nit recorded' }],
-            note: 'bot finding below major; recorded, still waiting on review',
-          };
-        }
-        return {
-          state: 'running',
-          actions: [{ kind: 'spawnGate', gate: 2 }],
-          note: `${actor} requested changes; back to gate 2`,
-        };
-      }
-      break;
-
-    case 'approved':
-      if (event.kind === 'merged') {
-        return stay('done', 'merged');
-      }
-      break;
-
-    case 'inconclusive':
-      // Only a person leaves this state. Whatever they fixed, the run resumes
-      // by re-entering gate 2 rather than assuming the earlier gate's result.
-      if (event.kind === 'humanApprovedGate') {
-        return {
-          state: 'running',
-          actions: [{ kind: 'spawnGate', gate: 2 }],
-          note: 'resumed by a person after an inconclusive gate',
-        };
-      }
-      break;
-
-    case 'failed':
-    case 'done':
-      break;
-  }
-
-  return stay(state, `ignored ${event.kind} in ${state}`);
+  return HANDLERS[state](event) ?? stay(state, `ignored ${event.kind} in ${state}`);
 }
 
 /** States that cannot advance without a person. The run inbox is built on this. */


### PR DESCRIPTION
CO-722 phase 3, first slice. Part of Software-Development-LLC/bodhi-code#722.

**No processes, no spawning, no UI.** This is the foundation the engine sits on, and none of it is reachable from the app yet — nothing here changes behaviour for anyone.

## Why a state machine at all

`claude-team-workflow` documents a gate model and nothing enforces it. Its own docstrings record what that costs: owners dispatched serially where the command says concurrent (*"a paragraph read before the run did not prevent it"*), two owner dispatches that ended with "open a PR" so gates 3 and 4 never ran, 97 turns spent locating a tool across three reachable copies of it.

None of those is a reasoning failure. They are sequencing, ordering and isolation — which is what a state machine is for, and what a prompt cannot reliably be.

## What is here

**`transitions.ts`** holds the arrows and nothing else. It contains **no domain judgment**: it does not know what a reviewer looks for, what a seam is, or how to verify anything. That stays in the model and in the plugin's Python. Pure `(state, event) -> decision`, so every path — including every inconclusive one — is asserted in a unit test rather than discovered during a run that spends real tokens.

The invariants it encodes, each of which is a defect somewhere if dropped:

| invariant | what it prevents |
|---|---|
| `inconclusive` is not a shade of failure | read as pass → the green-having-checked-nothing defect filed seven times against the plugin; read as failure → an owner sent back to fix code that was never broken |
| provisioning precedes gate 2 | an unprovisioned worktree makes `verify.sh` report a missing runner as FAIL — measured as `'jest' is not recognized`, exit 1, over code that was fine |
| review is requested only once checks are green, and requesting is an **action** | `arbiter` does not fire until an approver is asked, so an un-requested PR is invisible to the bot *and* the human queue |
| a bot nit is recorded, a bot major returns to gate 2 | CO-447 measured `arbiter/review` at "major 0, minor 0, nit 1"; re-entering gate 2 for that burns a cycle on a note |
| approval releases the run; merge does not | nothing comes back after the last approval, and waiting for someone to press merge is unbounded — one initiative sat twelve hours there |
| a permission prompt parks with **no timeout** | a silent auto-deny is indistinguishable from a gate finding, so the run would carry a verdict nobody gave |

**No `(state, event)` pairing throws.** A run is durable and will be handed stale and duplicate events — a reconcile racing a webhook, a gate reporting twice after a restart. Throwing there turns a duplicate into an outage; advancing on one would be worse.

**`runs.ts`** persists it. Every transition writes its state and its reason in **one transaction**, because a state without its event is a run whose history has a hole exactly where someone will later ask what happened. `run_events` is append-only: it is the run view, the audit trail and resume at once.

`team.yaml` stays the source of truth on disk. `run_owners` mirrors it so a query need not parse YAML — and a re-run cannot erase a PR number the previous pass recorded, which matters because `spawn.sh` is idempotent, knows nothing about PRs, and *will* be re-run on resume.

## Tests — 59

`initializeRunTables` is **exported so tests execute the real schema**. A test that builds its own `CREATE TABLE` proves the repository's SQL matches itself, not the schema that ships.

- **33 transitions** — every state × every event, the four inconclusive paths, the bot-nit-vs-major pair (each a control for the other), and that no pairing throws.
- **17 repository** — the state-and-reason transaction, append-only ordering, a malformed payload not taking the run view down, and the PR-number preservation above.
- **9 schema** — the cascades and the composite key SQLite cannot add after the fact, plus a group deletion leaving the run (a run is not its sidebar entry).

Full suite: **1567 pass, 2 skip, 0 fail** across 106 files. `tsc -p tsconfig.main.json` clean.

## Not here, deliberately

- **Gate spawning.** Next slice: argv construction is pure and testable on its own, and it depends on flags verified in phase 2 (`--plugin-dir`, `--tools`, `--json-schema`, `--permission-prompts host`).
- **The reconciler and `expected_checks`.** Both need the exit-code contract that Software-Development-LLC/claude-team-workflow#285 is settling — writing the wrong number is worse than leaving it.
- **Any UI.** A fourth `ContentView` comes once there is something to show.
- **Multi-repo, seams, the barrier.** Phase 5.

Generated with [Claude Code](https://claude.com/claude-code)
