### PR TITLE
CO-722: build a gate command line from the pinned harness

### DIFF
--- a/src/main/run-engine/__tests__/agent-definition.test.ts
+++ b/src/main/run-engine/__tests__/agent-definition.test.ts
@@ -110,3 +110,34 @@ describe('against the agents the plugin actually ships', () => {
     expect(parsed.tools).toContain('Edit');
   });
 });
+
+describe('shapes a Windows checkout or a future plugin can produce', () => {
+  test('a UTF-8 BOM does not hide the front matter', () => {
+    // An editor on a Windows checkout can add one, and the failure would be
+    // "no front matter" reported about a file that plainly has it.
+    const { tools } = parseAgentFile('reviewer', '﻿' + REAL);
+    expect(tools).toEqual(['Read', 'Bash', 'Grep', 'Glob', 'TodoWrite']);
+  });
+
+  test('a scoped grant keeps its own commas', () => {
+    // `Bash(git add:*, git commit:*)` is ONE entry. Splitting it naively
+    // yields two names that match nothing, and --tools would then grant
+    // neither -- a capability lost silently, which the agent file did give.
+    const scoped = [
+      '---',
+      'tools: Read, Bash(git add:*, git commit:*), Glob',
+      '---',
+      '',
+      'body',
+      '',
+    ].join('\n');
+    expect(parseAgentFile('x', scoped).tools)
+      .toEqual(['Read', 'Bash(git add:*, git commit:*)', 'Glob']);
+  });
+
+  test('an unbalanced paren does not swallow the rest of the list', () => {
+    // Malformed input should degrade, not consume every later entry.
+    const bad = ['---', 'tools: Read, Bash(oops, Glob', '---', '', 'body', ''].join('\n');
+    expect(parseAgentFile('x', bad).tools.length).toBeGreaterThan(1);
+  });
+});

--- a/src/main/run-engine/__tests__/agent-definition.test.ts
+++ b/src/main/run-engine/__tests__/agent-definition.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Agent definition tests (CO-722).
+ *
+ * The grant this parser returns becomes `--tools` on a real gate, so the
+ * cases that matter are the ones where it must REFUSE. A parser that shrugs
+ * and returns a default hands the caller a reviewer that can rewrite the
+ * branch it is reviewing — the exact failure the plugin's own CI check exists
+ * to prevent, undone one layer down.
+ *
+ * Run with: bun test src/main/run-engine
+ */
+import { describe, expect, test } from 'bun:test';
+import { AgentParseError, parseAgentFile } from '../agent-definition';
+
+const REAL = `---
+name: reviewer
+description: Adversarial review of a branch.
+tools: Read, Bash, Grep, Glob, TodoWrite
+---
+
+# Reviewer
+
+Walk the path a person takes.
+`;
+
+describe('reading a real agent', () => {
+  test('takes the declared tools verbatim, in order', () => {
+    expect(parseAgentFile('reviewer', REAL).tools)
+      .toEqual(['Read', 'Bash', 'Grep', 'Glob', 'TodoWrite']);
+  });
+
+  test('the body is everything after the front matter', () => {
+    const { body } = parseAgentFile('reviewer', REAL);
+    expect(body.startsWith('# Reviewer')).toBe(true);
+    expect(body).toContain('Walk the path a person takes.');
+    // The front matter must not leak into a system prompt.
+    expect(body).not.toContain('tools:');
+    expect(body).not.toContain('---');
+  });
+
+  test('keeps the name it was asked for', () => {
+    expect(parseAgentFile('bodhi:reviewer', REAL).name).toBe('bodhi:reviewer');
+  });
+
+  test('reads CRLF files, which is what a Windows checkout has', () => {
+    const { tools, body } = parseAgentFile('reviewer', REAL.replace(/\n/g, '\r\n'));
+    expect(tools).toEqual(['Read', 'Bash', 'Grep', 'Glob', 'TodoWrite']);
+    expect(body).toContain('Walk the path');
+  });
+
+  test('tolerates spacing around the list', () => {
+    const spaced = REAL.replace('tools: Read, Bash', 'tools:   Read ,Bash');
+    expect(parseAgentFile('reviewer', spaced).tools.slice(0, 2)).toEqual(['Read', 'Bash']);
+  });
+});
+
+describe('it refuses rather than defaulting', () => {
+  test('no front matter at all', () => {
+    expect(() => parseAgentFile('x', '# Just a heading\n')).toThrow(AgentParseError);
+  });
+
+  test('front matter with no tools: line', () => {
+    // The plugin's CI says it plainly: a missing tools: line silently grants
+    // everything, including Skill and Agent. Inheriting that default here
+    // would undo that check for every gate this engine spawns.
+    const noTools = '---\nname: x\ndescription: y\n---\n\nbody\n';
+    expect(() => parseAgentFile('x', noTools)).toThrow(/declares no tools/);
+  });
+
+  test('an empty tools: list', () => {
+    expect(() => parseAgentFile('x', '---\ntools:\n---\n\nbody\n')).toThrow(AgentParseError);
+  });
+
+  test('front matter but no role', () => {
+    // An empty --append-system-prompt would run the gate as a generic
+    // assistant while the run history claims a reviewer looked at it.
+    expect(() => parseAgentFile('x', '---\ntools: Read\n---\n')).toThrow(/no role/);
+  });
+
+  test('the error names the agent, so a failed run says which one', () => {
+    expect(() => parseAgentFile('bodhi:verifier', '# no front matter'))
+      .toThrow(/bodhi:verifier/);
+  });
+});
+
+describe('against the agents the plugin actually ships', () => {
+  // Shapes taken from the real files, so a change to their front-matter
+  // convention fails here rather than at spawn time.
+  const shipped: Record<string, string> = {
+    reviewer: 'tools: Read, Bash, Grep, Glob, TodoWrite',
+    verifier: 'tools: Read, Bash, Grep, Glob, TodoWrite',
+    scribe: 'tools: Read, Write, Edit, Bash, Grep, Glob, TodoWrite',
+  };
+
+  test('the reading gates carry no Write and no Edit', () => {
+    for (const agent of ['reviewer', 'verifier']) {
+      const parsed = parseAgentFile(agent, `---\n${shipped[agent]}\n---\n\nbody\n`);
+      expect({ agent, write: parsed.tools.includes('Write') })
+        .toEqual({ agent, write: false });
+      expect({ agent, edit: parsed.tools.includes('Edit') })
+        .toEqual({ agent, edit: false });
+    }
+  });
+
+  test('scribe does carry them, because it writes the PR body', () => {
+    // CONTROL: without this, a parser dropping every tool would satisfy the
+    // assertion above while granting nothing to anyone.
+    const parsed = parseAgentFile('scribe', `---\n${shipped.scribe}\n---\n\nbody\n`);
+    expect(parsed.tools).toContain('Write');
+    expect(parsed.tools).toContain('Edit');
+  });
+});

--- a/src/main/run-engine/__tests__/gate-command.test.ts
+++ b/src/main/run-engine/__tests__/gate-command.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Gate command tests (CO-722).
+ *
+ * A dropped or mistaken flag here is not a crash — it is a reviewer that can
+ * rewrite the branch it is reviewing, or a gate that inherits a stranger's
+ * settings and reaches a different verdict while reporting honestly. Nothing
+ * downstream notices either. So the assertions are about the argv itself.
+ *
+ * Every expectation traces to a measurement against Claude Code 2.1.263, not
+ * to documentation. Where a measurement contradicted the design, the test
+ * names the contradiction.
+ *
+ * Run with: bun test src/main/run-engine
+ */
+import { describe, expect, test } from 'bun:test';
+import { buildGateCommand, type GateSpec, type RunSpawnContext } from '../gate-command';
+import type { AgentDefinition } from '../agent-definition';
+
+const CONTEXT: RunSpawnContext = {
+  harnessPath: '/plugins/bodhi',
+  bodhiRoot: '/root',
+  cwd: '/root/_wt-k-1-web-apps',
+  pythonPath: '/usr/bin/python3',
+  posture: 'manual',
+  sessionId: '11111111-2222-3333-4444-555555555555',
+  receiptPath: '/root/initiatives/K-1/gates/3-reviewer.json',
+  permissionPromptTool: 'mcp__bodhilander__approve',
+  systemPromptPath: '/tmp/run-1/gate-3-role.md',
+};
+
+const REVIEWER_AGENT: AgentDefinition = {
+  name: 'bodhi:reviewer',
+  tools: ['Read', 'Bash', 'Grep', 'Glob'],
+  body: 'You are the reviewer. Walk the path a person takes.',
+};
+
+const OWNER_AGENT: AgentDefinition = {
+  name: 'bodhi:staff:bwa-lead',
+  tools: ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob'],
+  body: 'You are the owner for bodhi-web-apps.',
+};
+
+const REVIEWER: GateSpec = {
+  gate: 3,
+  agent: REVIEWER_AGENT,
+  mode: 'print',
+  schema: { type: 'object', properties: { verdict: { type: 'string' } } },
+};
+
+const OWNER: GateSpec = { gate: 2, agent: OWNER_AGENT, mode: 'background' };
+
+/** The value following `flag`, or undefined. */
+function valueOf(argv: string[], flag: string): string | undefined {
+  const i = argv.indexOf(flag);
+  return i === -1 ? undefined : argv[i + 1];
+}
+
+describe('what every gate gets', () => {
+  test('the harness is pinned, so a gate cannot pick up another copy', () => {
+    // Three copies were reachable in one 18-hour window, and two agents on the
+    // same initiative could reach opposite verdicts while both reported
+    // honestly. --plugin-dir makes that structurally impossible.
+    const { argv } = buildGateCommand(REVIEWER, CONTEXT, 'go');
+    expect(valueOf(argv, '--plugin-dir')).toBe('/plugins/bodhi');
+  });
+
+  test('a background gate names the agent plugin-qualified', () => {
+    // The qualified form cannot be shadowed by another plugin shipping the
+    // same role. An unresolvable name fails loudly and lists the
+    // alternatives, rather than falling back to a full grant.
+    expect(valueOf(buildGateCommand(OWNER, CONTEXT, 'go').argv, '--agent'))
+      .toBe('bodhi:staff:bwa-lead');
+  });
+
+  test('settings are NOT inherited from the machine', () => {
+    // Two machines must not reach different verdicts on the same branch.
+    const { argv } = buildGateCommand(REVIEWER, CONTEXT, 'go');
+    expect(argv).toContain('--setting-sources');
+    expect(valueOf(argv, '--setting-sources')).toBe('');
+    expect(argv).toContain('--strict-mcp-config');
+  });
+
+  test('the gate runs in the owner worktree, never the shared checkout', () => {
+    expect(buildGateCommand(REVIEWER, CONTEXT, 'go').cwd).toBe('/root/_wt-k-1-web-apps');
+  });
+
+  test('the session is named up front so it can be resumed after it exits', () => {
+    const { argv } = buildGateCommand(REVIEWER, CONTEXT, 'go');
+    expect(valueOf(argv, '--session-id')).toBe(CONTEXT.sessionId);
+  });
+
+  test('a budget ceiling is a flag, not a document', () => {
+    const { argv } = buildGateCommand(REVIEWER, { ...CONTEXT, budgetUsd: 7.5 }, 'go');
+    expect(valueOf(argv, '--max-budget-usd')).toBe('7.5');
+  });
+
+  test('no budget means no flag, rather than a zero that would stop everything', () => {
+    const { argv } = buildGateCommand(REVIEWER, { ...CONTEXT, budgetUsd: null }, 'go');
+    expect(argv).not.toContain('--max-budget-usd');
+  });
+});
+
+describe('the tool grant comes from the plugin, not from here', () => {
+  test('--allowedTools is NEVER emitted', () => {
+    // MEASURED: with --allowedTools "Read,Grep,Glob" --permission-mode manual,
+    // Bash ran to completion with permission_denials: []. It is a
+    // pre-approval list, not a capability set. Emitting it would look like a
+    // restriction and be none.
+    for (const spec of [REVIEWER, OWNER]) {
+      const { argv } = buildGateCommand(spec, CONTEXT, 'go');
+      expect(argv).not.toContain('--allowedTools');
+      expect(argv).not.toContain('--allowed-tools');
+    }
+  });
+
+  test('a reading gate passes --tools, and it is the AGENT\'S list verbatim', () => {
+    // --tools is the flag that actually restricts, and print mode must send
+    // it because --agent (which would carry the grant itself) suppresses
+    // structured_output. The list is never composed here: it is whatever the
+    // agent file declared, so it cannot drift from the file it came from.
+    const { argv } = buildGateCommand(REVIEWER, CONTEXT, 'go');
+    expect(valueOf(argv, '--tools')).toBe(REVIEWER_AGENT.tools.join(','));
+  });
+
+  test('a reading gate gets no Write and no Edit', () => {
+    // The property all of this exists for: a reviewer that can rewrite the
+    // branch it is reviewing is the failure the plugin's own CI check names.
+    const granted = valueOf(buildGateCommand(REVIEWER, CONTEXT, 'go').argv, '--tools')!
+      .split(',');
+    expect(granted).not.toContain('Write');
+    expect(granted).not.toContain('Edit');
+  });
+
+  test('an owner DOES get them, so the reviewer case is not vacuous', () => {
+    // CONTROL: if the grant were being dropped rather than forwarded, the
+    // assertion above would pass while proving nothing.
+    expect(OWNER_AGENT.tools).toContain('Write');
+    expect(OWNER_AGENT.tools).toContain('Edit');
+  });
+
+  test('a background gate lets the plugin resolve the grant, so sends no --tools', () => {
+    // It can afford to: its verdict is a receipt file, not structured output,
+    // so it keeps --agent and with it the plugin's own composition and hooks.
+    expect(buildGateCommand(OWNER, CONTEXT, 'go').argv).not.toContain('--tools');
+  });
+});
+
+describe('permission posture', () => {
+  test('manual routes prompts to the host, which is how the app becomes the surface', () => {
+    const { argv } = buildGateCommand(REVIEWER, CONTEXT, 'go');
+    expect(valueOf(argv, '--permission-mode')).toBe('manual');
+    expect(valueOf(argv, '--permission-prompts')).toBe('host');
+    expect(valueOf(argv, '--permission-prompt-tool')).toBe('mcp__bodhilander__approve');
+  });
+
+  test('denyOnPrompt fails CLOSED and asks nobody', () => {
+    const { argv } = buildGateCommand(REVIEWER, { ...CONTEXT, posture: 'denyOnPrompt' }, 'go');
+    expect(valueOf(argv, '--permission-prompts')).toBe('none');
+    expect(argv).not.toContain('--permission-prompt-tool');
+    expect(argv).not.toContain('--dangerously-skip-permissions');
+  });
+
+  test('bypass is the only posture that skips checks, and only when asked for', () => {
+    const { argv } = buildGateCommand(REVIEWER, { ...CONTEXT, posture: 'bypass' }, 'go');
+    expect(argv).toContain('--dangerously-skip-permissions');
+  });
+
+  test('no other posture skips permission checks', () => {
+    // CONTROL. Without this, a posture that fell through to bypass would pass
+    // its own test and silently unsandbox every gate.
+    for (const posture of ['manual', 'denyOnPrompt'] as const) {
+      const { argv } = buildGateCommand(REVIEWER, { ...CONTEXT, posture }, 'go');
+      expect({ posture, skips: argv.includes('--dangerously-skip-permissions') })
+        .toEqual({ posture, skips: false });
+    }
+  });
+
+  test('manual without a handler still asks the host rather than silently allowing', () => {
+    const { argv } = buildGateCommand(
+      REVIEWER, { ...CONTEXT, permissionPromptTool: null }, 'go',
+    );
+    expect(valueOf(argv, '--permission-prompts')).toBe('host');
+    expect(argv).not.toContain('--dangerously-skip-permissions');
+  });
+});
+
+describe('print mode: the reading gates', () => {
+  test('asks for a schema-validated verdict', () => {
+    const { argv } = buildGateCommand(REVIEWER, CONTEXT, 'go');
+    expect(argv).toContain('--print');
+    expect(valueOf(argv, '--output-format')).toBe('json');
+    expect(valueOf(argv, '--json-schema')).toBe(JSON.stringify(REVIEWER.schema));
+  });
+
+  test('the prompt goes on STDIN, never in argv', () => {
+    // MEASURED: a variadic option swallows a trailing positional --
+    // `--tools a,b,c '<prompt>'` failed with "Input must be provided either
+    // through stdin or as a prompt argument". stdin removes the ordering
+    // hazard entirely, and keeps the prompt text out of the command line.
+    const prompt = 'review the branch and say whether an operator can do the job';
+    const cmd = buildGateCommand(REVIEWER, CONTEXT, prompt);
+    expect(cmd.stdin).toBe(prompt);
+    expect(cmd.argv).not.toContain(prompt);
+  });
+
+  test('carries the agent BODY, not --agent, which suppresses structured_output', () => {
+    // MEASURED: --agent + --json-schema returns subtype success, is_error
+    // false, exit 0 and NO structured_output -- even when the agent completes
+    // the task. A reading gate exists to produce a verdict, so it takes the
+    // route that returns one.
+    const { argv } = buildGateCommand(REVIEWER, CONTEXT, 'go');
+    expect(valueOf(argv, '--append-system-prompt-file')).toBe(CONTEXT.systemPromptPath);
+    expect(argv).not.toContain('--agent');
+
+    // A PATH, never the text. reviewer.md's body is 37,429 characters, and
+    // inline it exceeds Windows' 32,767-character command line -- measured as
+    // `ENAMETOOLONG: uv_spawn`, before the process starts.
+    expect(argv).not.toContain('--append-system-prompt');
+    expect(argv).not.toContain(REVIEWER_AGENT.body);
+    for (const arg of argv) expect(arg.length).toBeLessThan(4096);
+  });
+
+  test('never carries --bg, because --bg and --print conflict', () => {
+    // MEASURED: "--bg and --print conflict: --print never starts the
+    // interactive session that `claude agents` attaches to".
+    expect(buildGateCommand(REVIEWER, CONTEXT, 'go').argv).not.toContain('--bg');
+  });
+
+  test('a gate with no schema still runs, it just returns unvalidated text', () => {
+    const { argv } = buildGateCommand({ ...REVIEWER, schema: undefined }, CONTEXT, 'go');
+    expect(argv).not.toContain('--json-schema');
+    expect(argv).toContain('--print');
+  });
+});
+
+describe('background mode: the owner', () => {
+  test('is attachable, which is what makes a stuck owner recoverable', () => {
+    const { argv } = buildGateCommand(OWNER, CONTEXT, 'go');
+    expect(argv).toContain('--bg');
+    expect(argv).not.toContain('--print');
+  });
+
+  test('the prompt is the LAST argument, after a non-variadic flag', () => {
+    // The ordering hazard in the other direction: --bg takes the prompt as a
+    // positional, so whatever precedes it must take exactly one value or the
+    // prompt is consumed as that value.
+    const prompt = 'implement the issue in this worktree, push, and stop';
+    const { argv, stdin } = buildGateCommand(OWNER, CONTEXT, prompt);
+    expect(argv[argv.length - 1]).toBe(prompt);
+    expect(argv[argv.length - 3]).toBe('--session-id');
+    expect(stdin).toBeNull();
+  });
+
+  test('carries no --json-schema, which needs --print', () => {
+    const { argv } = buildGateCommand(
+      { ...OWNER, schema: { type: 'object' } }, CONTEXT, 'go',
+    );
+    expect(argv).not.toContain('--json-schema');
+    expect(argv).not.toContain('--output-format');
+  });
+});
+
+describe('the child environment', () => {
+  test('passes the resolved interpreter, so the wrappers do not trust the name', () => {
+    // The plugin's wrappers probe BODHI_PYTHON ahead of PATH. On Windows
+    // `python3` can be a Store alias that is not Python at all.
+    expect(buildGateCommand(REVIEWER, CONTEXT, 'go').env.BODHI_PYTHON)
+      .toBe('/usr/bin/python3');
+  });
+
+  test('forces UTF-8, or every em-dash the plugin prints becomes a replacement char', () => {
+    const { env } = buildGateCommand(REVIEWER, CONTEXT, 'go');
+    expect(env.PYTHONUTF8).toBe('1');
+    expect(env.PYTHONIOENCODING).toBe('utf-8');
+  });
+
+  test('names where the receipt goes, which is load-bearing for a --bg gate', () => {
+    // A background gate cannot return a schema-validated verdict, and
+    // `claude logs` yields raw TUI ANSI rather than events. The receipt file
+    // is the only structured thing it can leave behind.
+    expect(buildGateCommand(OWNER, CONTEXT, 'go').env.BODHI_GATE_RECEIPT)
+      .toBe(CONTEXT.receiptPath);
+  });
+
+  test('omits BODHI_PYTHON when none was resolved, rather than passing empty', () => {
+    // An empty value would be honoured ahead of PATH and resolve to nothing.
+    const { env } = buildGateCommand(REVIEWER, { ...CONTEXT, pythonPath: null }, 'go');
+    expect('BODHI_PYTHON' in env).toBe(false);
+  });
+
+  test('always names the workspace root', () => {
+    expect(buildGateCommand(REVIEWER, CONTEXT, 'go').env.BODHI_ROOT).toBe('/root');
+  });
+});

--- a/src/main/run-engine/__tests__/gate-command.test.ts
+++ b/src/main/run-engine/__tests__/gate-command.test.ts
@@ -13,7 +13,12 @@
  * Run with: bun test src/main/run-engine
  */
 import { describe, expect, test } from 'bun:test';
-import { buildGateCommand, type GateSpec, type RunSpawnContext } from '../gate-command';
+import {
+  buildGateCommand,
+  GateCommandError,
+  type GateSpec,
+  type RunSpawnContext,
+} from '../gate-command';
 import type { AgentDefinition } from '../agent-definition';
 
 const CONTEXT: RunSpawnContext = {
@@ -142,6 +147,35 @@ describe('the tool grant comes from the plugin, not from here', () => {
     // It can afford to: its verdict is a receipt file, not structured output,
     // so it keeps --agent and with it the plugin's own composition and hooks.
     expect(buildGateCommand(OWNER, CONTEXT, 'go').argv).not.toContain('--tools');
+  });
+});
+
+describe('a reading gate refuses to run without its role', () => {
+  test('print mode with no systemPromptPath throws', () => {
+    // THE FAILURE. Skipping the flag would still emit --tools and
+    // --json-schema, so the gate runs with the right restrictions, returns a
+    // SCHEMA-VALID verdict from a generic assistant, and is recorded as
+    // bodhi:reviewer. A verdict that looks right and came from nobody is
+    // worse than none, because nothing downstream can tell.
+    for (const missing of [null, undefined, '']) {
+      expect(() =>
+        buildGateCommand(REVIEWER, { ...CONTEXT, systemPromptPath: missing }, 'go'),
+      ).toThrow(GateCommandError);
+    }
+  });
+
+  test('the refusal names the gate and the agent it would have impersonated', () => {
+    expect(() =>
+      buildGateCommand(REVIEWER, { ...CONTEXT, systemPromptPath: null }, 'go'),
+    ).toThrow(/gate 3.*bodhi:reviewer/s);
+  });
+
+  test('a BACKGROUND gate does not need one, because --agent carries the role', () => {
+    // CONTROL: without this, a guard that refused unconditionally would pass
+    // the cases above and stop every owner from ever starting.
+    expect(() =>
+      buildGateCommand(OWNER, { ...CONTEXT, systemPromptPath: null }, 'go'),
+    ).not.toThrow();
   });
 });
 

--- a/src/main/run-engine/agent-definition.ts
+++ b/src/main/run-engine/agent-definition.ts
@@ -1,0 +1,77 @@
+/**
+ * Reading a gate agent out of the pinned harness (CO-722).
+ *
+ * The plugin owns what an agent IS — its role, its rules, and the tool grant
+ * in its front matter, which the plugin's own CI asserts is present:
+ *
+ *   "A missing `tools:` line silently grants an agent everything — including
+ *    Skill and Agent. Not a lint preference: it is the difference between a
+ *    reviewer that can only read and one that can rewrite the branch it is
+ *    reviewing."
+ *
+ * So Bodhilander reads that file rather than restating any of it. Nothing here
+ * knows what a reviewer looks for; it knows how to find the two fields the
+ * command line needs.
+ *
+ * WHY NOT JUST `--agent`. Because `--agent` and `--json-schema` do not
+ * compose: measured against 2.1.263, a run with `--agent bodhi:reviewer` and a
+ * schema returns `subtype: success`, `is_error: false`, exit 0, and NO
+ * `structured_output` — even when the agent completes the task. Passing the
+ * same agent's body via `--append-system-prompt` with its own `tools:` returns
+ * the validated object and the same restricted tool set. The reading gates
+ * need a verdict, so they take that route; the owner gate keeps `--agent`,
+ * which it can because its verdict comes from a receipt file.
+ */
+
+export interface AgentDefinition {
+  /** Plugin-qualified name, for the modes that resolve it themselves. */
+  name: string;
+  /** The grant, exactly as the agent file declares it. Never composed here. */
+  tools: readonly string[];
+  /** Everything after the front matter: the role itself. */
+  body: string;
+}
+
+export class AgentParseError extends Error {}
+
+const FRONT_MATTER = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+/**
+ * Parse an agent's markdown.
+ *
+ * Throws rather than defaulting. An agent whose `tools:` cannot be read must
+ * not fall back to "everything" — that is the exact failure the plugin's CI
+ * check exists to prevent, and inheriting it here would undo that check for
+ * every gate this engine spawns.
+ */
+export function parseAgentFile(name: string, text: string): AgentDefinition {
+  const match = FRONT_MATTER.exec(text);
+  if (!match) {
+    throw new AgentParseError(`${name}: no front matter, so no declared tools`);
+  }
+
+  const toolsLine = match[1]
+    .split(/\r?\n/)
+    .find((line) => /^tools:\s*/.test(line));
+  if (!toolsLine) {
+    throw new AgentParseError(
+      `${name}: front matter declares no tools:, and defaulting would grant everything`,
+    );
+  }
+
+  const tools = toolsLine
+    .replace(/^tools:\s*/, '')
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+  if (tools.length === 0) {
+    throw new AgentParseError(`${name}: tools: is empty`);
+  }
+
+  const body = text.slice(match[0].length).trim();
+  if (!body) {
+    throw new AgentParseError(`${name}: front matter only, no role`);
+  }
+
+  return { name, tools, body };
+}

--- a/src/main/run-engine/agent-definition.ts
+++ b/src/main/run-engine/agent-definition.ts
@@ -37,6 +37,37 @@ export class AgentParseError extends Error {}
 const FRONT_MATTER = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 
 /**
+ * Split a `tools:` list on commas that separate entries.
+ *
+ * Not a plain `.split(',')`. A scoped grant carries its own commas inside
+ * parentheses — `Bash(git add:*, git commit:*)` — and splitting naively turns
+ * one correct entry into two malformed ones. Those would then be passed to
+ * `--tools`, where a name that matches nothing grants nothing, so a gate would
+ * quietly lose a capability its agent file had given it.
+ *
+ * None of the shipped agents uses that syntax yet. This is here so that
+ * adopting it is a change in the plugin alone.
+ */
+function splitTools(list: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of list) {
+    if (ch === '(') depth += 1;
+    else if (ch === ')') depth = Math.max(0, depth - 1);
+
+    if (ch === ',' && depth === 0) {
+      out.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  out.push(current);
+  return out.map((t) => t.trim()).filter(Boolean);
+}
+
+/**
  * Parse an agent's markdown.
  *
  * Throws rather than defaulting. An agent whose `tools:` cannot be read must
@@ -45,7 +76,10 @@ const FRONT_MATTER = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
  * every gate this engine spawns.
  */
 export function parseAgentFile(name: string, text: string): AgentDefinition {
-  const match = FRONT_MATTER.exec(text);
+  // A UTF-8 BOM ahead of `---` would make the front matter unfindable, and
+  // this reads files from a Windows checkout where an editor can add one. The
+  // failure would be "no front matter" on a file that plainly has it.
+  const match = FRONT_MATTER.exec(text.replace(/^﻿/, ''));
   if (!match) {
     throw new AgentParseError(`${name}: no front matter, so no declared tools`);
   }
@@ -59,11 +93,7 @@ export function parseAgentFile(name: string, text: string): AgentDefinition {
     );
   }
 
-  const tools = toolsLine
-    .replace(/^tools:\s*/, '')
-    .split(',')
-    .map((t) => t.trim())
-    .filter(Boolean);
+  const tools = splitTools(toolsLine.replace(/^tools:\s*/, ''));
   if (tools.length === 0) {
     throw new AgentParseError(`${name}: tools: is empty`);
   }

--- a/src/main/run-engine/gate-command.ts
+++ b/src/main/run-engine/gate-command.ts
@@ -1,0 +1,206 @@
+/**
+ * Turning a gate into the exact `claude` command line (CO-722).
+ *
+ * Pure: it builds an argv, an env and a cwd, and runs nothing. That is what
+ * makes "does a reviewer get Write?" a snapshot assertion instead of something
+ * you find out by reading a diff an agent should never have been able to
+ * produce.
+ *
+ * Every flag here was verified against Claude Code 2.1.263 rather than taken
+ * from documentation, and three of those measurements contradicted what the
+ * design assumed:
+ *
+ * - `--allowedTools` does NOT restrict anything. With
+ *   `--allowedTools "Read,Grep,Glob" --permission-mode manual`, Bash ran to
+ *   completion with `permission_denials: []`. It is a pre-approval list. This
+ *   module never emits it, and a test asserts that.
+ * - `--bg` and `--print` conflict outright, so a gate cannot be both
+ *   attachable and verdict-shaped. Owners get `--bg`; the reading gates get
+ *   `-p`.
+ * - a variadic option swallows a trailing positional, so a prompt placed
+ *   after one is consumed as a value. Print mode therefore passes the prompt
+ *   on **stdin**, which also keeps it out of argv entirely.
+ *
+ * The two modes also differ in how the agent reaches the CLI, and that is a
+ * measurement rather than a preference. `--agent` and `--json-schema` do NOT
+ * compose: a run with `--agent bodhi:reviewer` and a schema returns
+ * `subtype: success`, `is_error: false`, exit 0 and **no**
+ * `structured_output` — even when the agent completes the task. So:
+ *
+ * - the reading gates pass the agent's own body via
+ *   `--append-system-prompt-FILE` and its own `tools:` via `--tools`, which
+ *   returns the validated object and the same restricted set (`Bash, Glob,
+ *   Grep, Read` — no Write, no Edit). The file matters: reviewer.md's body is
+ *   37,429 characters and passing it inline exceeds Windows' 32,767-character
+ *   command line, failing with `ENAMETOOLONG` before the process starts;
+ * - the owner gate keeps `--agent`, which it can afford because its verdict
+ *   comes from a receipt file, and which keeps the plugin's own composition,
+ *   hooks and grant intact. An unresolvable name there fails loudly and lists
+ *   the alternatives rather than falling back to a full grant.
+ *
+ * Neither path RESTATES a grant. Both read it from the agent file in the
+ * pinned harness, because a copy of it here could drift from the file it
+ * copies — and domain knowledge is the one thing this engine may not hold.
+ *
+ * That a verdict can simply be ABSENT, with every success signal set, is why
+ * "no verdict is inconclusive, never a pass" is load-bearing rather than
+ * defensive.
+ */
+import type { Gate } from './transitions';
+import type { AgentDefinition } from './agent-definition';
+import type { PermissionPosture } from '../repositories/runs';
+
+/** How a gate is invoked. The two are mutually exclusive — see the header. */
+export type GateMode = 'background' | 'print';
+
+export interface GateSpec {
+  gate: Gate;
+  /** Read from the pinned harness. Never composed here. */
+  agent: AgentDefinition;
+  mode: GateMode;
+  /** Verdict shape. Print mode only: `--json-schema` needs `--print`. */
+  schema?: object;
+}
+
+export interface RunSpawnContext {
+  harnessPath: string;
+  bodhiRoot: string;
+  /** Where the gate works. An owner's worktree, never the shared checkout. */
+  cwd: string;
+  /**
+   * The resolved interpreter, passed to the plugin's wrappers as
+   * `BODHI_PYTHON`. They probe it rather than trusting the name `python3`,
+   * which on Windows can be a Store alias that is not Python.
+   */
+  pythonPath?: string | null;
+  posture: PermissionPosture;
+  budgetUsd?: number | null;
+  /** Named up front so the conversation can be resumed after it exits. */
+  sessionId: string;
+  /** Where the gate writes its receipt. Load-bearing for `--bg`. */
+  receiptPath?: string | null;
+  /**
+   * File holding the agent's body, for print mode.
+   *
+   * A PATH, never the text. The bodies are real: reviewer.md is 37,429
+   * characters, and passing that inline exceeds Windows' 32,767-character
+   * command line — `ENAMETOOLONG: uv_spawn`, before the process starts.
+   * The caller writes the file; this module only names it.
+   */
+  systemPromptPath?: string | null;
+  /** MCP tool answering permission prompts, for the `manual` posture. */
+  permissionPromptTool?: string | null;
+  mcpConfigPath?: string | null;
+}
+
+export interface GateCommand {
+  argv: string[];
+  /** Print mode delivers the prompt here. Null when it is a positional. */
+  stdin: string | null;
+  cwd: string;
+  env: Record<string, string>;
+}
+
+/**
+ * Permission flags for a posture.
+ *
+ * `manual` is the default and needs somewhere to ask: `--permission-prompts
+ * host` routes a prompt to the handler named by `--permission-prompt-tool`,
+ * which is how Bodhilander becomes the surface. Measured working end to end —
+ * a handler received the tool name and full input, its deny was honoured and
+ * the write never happened, and its allow round-tripped.
+ *
+ * Only genuinely gated actions ever arrive: `echo` is auto-classified safe and
+ * never prompts, so routine work does not spam the surface.
+ */
+function permissionFlags(context: RunSpawnContext): string[] {
+  switch (context.posture) {
+    case 'bypass':
+      return ['--dangerously-skip-permissions'];
+    case 'denyOnPrompt':
+      // Fails closed: anything that would prompt is denied, nobody is asked.
+      return ['--permission-mode', 'manual', '--permission-prompts', 'none'];
+    case 'manual':
+    default: {
+      const flags = ['--permission-mode', 'manual', '--permission-prompts', 'host'];
+      if (context.permissionPromptTool) {
+        flags.push('--permission-prompt-tool', context.permissionPromptTool);
+      }
+      return flags;
+    }
+  }
+}
+
+/**
+ * Env for the child.
+ *
+ * `PYTHONUTF8`/`PYTHONIOENCODING` are not cosmetic: without them every em-dash
+ * the plugin prints arrives as a replacement character on Windows, and those
+ * lines end up in receipts and in the run view.
+ */
+function gateEnv(context: RunSpawnContext): Record<string, string> {
+  const env: Record<string, string> = {
+    BODHI_ROOT: context.bodhiRoot,
+    PYTHONUTF8: '1',
+    PYTHONIOENCODING: 'utf-8',
+  };
+  if (context.pythonPath) env.BODHI_PYTHON = context.pythonPath;
+  if (context.receiptPath) env.BODHI_GATE_RECEIPT = context.receiptPath;
+  return env;
+}
+
+/**
+ * The exact command for one gate.
+ *
+ * `--setting-sources ""` is deliberate: a gate must not inherit whatever
+ * settings happen to exist on the machine it runs on, or two machines reach
+ * different verdicts on the same branch and both report honestly.
+ */
+export function buildGateCommand(
+  spec: GateSpec,
+  context: RunSpawnContext,
+  prompt: string,
+): GateCommand {
+  const argv: string[] = [];
+
+  // Pinned first: the harness and the agent decide what this even is. Three
+  // plugin copies were reachable in one 18-hour window and need not agree.
+  argv.push('--plugin-dir', context.harnessPath);
+  argv.push('--setting-sources', '');
+  argv.push('--strict-mcp-config');
+  if (context.mcpConfigPath) argv.push('--mcp-config', context.mcpConfigPath);
+  argv.push(...permissionFlags(context));
+  if (context.budgetUsd != null) {
+    // The plugin documents its budget as "a ceiling, not a target" and nothing
+    // enforced it. Here it is a flag.
+    argv.push('--max-budget-usd', String(context.budgetUsd));
+  }
+
+  if (spec.mode === 'print') {
+    // The agent's own body and grant, rather than --agent: that flag
+    // suppresses structured_output, and a reading gate exists to produce a
+    // verdict. Both values come from the agent file in the pinned harness.
+    if (context.systemPromptPath) {
+      argv.push('--append-system-prompt-file', context.systemPromptPath);
+    }
+    argv.push('--tools', spec.agent.tools.join(','));
+    argv.push('--print', '--output-format', 'json');
+    if (spec.schema) argv.push('--json-schema', JSON.stringify(spec.schema));
+    // Last, and non-variadic on purpose — see the header. Nothing positional
+    // follows in print mode anyway, because the prompt goes on stdin.
+    argv.push('--session-id', context.sessionId);
+    return { argv, stdin: prompt, cwd: context.cwd, env: gateEnv(context) };
+  }
+
+  // Background mode takes the prompt as a POSITIONAL, so the flag immediately
+  // before it must not be variadic or the prompt is swallowed as its value.
+  // `--session-id` takes exactly one argument, which is why it goes last.
+  // --agent here, because a background gate cannot return structured output
+  // anyway (its verdict is the receipt file) and letting the plugin resolve
+  // the agent keeps its composition, hooks and grant intact.
+  argv.push('--agent', spec.agent.name);
+  argv.push('--bg');
+  argv.push('--session-id', context.sessionId);
+  argv.push(prompt);
+  return { argv, stdin: null, cwd: context.cwd, env: gateEnv(context) };
+}

--- a/src/main/run-engine/gate-command.ts
+++ b/src/main/run-engine/gate-command.ts
@@ -50,6 +50,8 @@ import type { Gate } from './transitions';
 import type { AgentDefinition } from './agent-definition';
 import type { PermissionPosture } from '../repositories/runs';
 
+export class GateCommandError extends Error {}
+
 /** How a gate is invoked. The two are mutually exclusive — see the header. */
 export type GateMode = 'background' | 'print';
 
@@ -177,12 +179,23 @@ export function buildGateCommand(
   }
 
   if (spec.mode === 'print') {
+    // Refuse rather than build a command with no role. Skipping the flag
+    // would still emit --tools and --json-schema, so the gate would run with
+    // the right restrictions, produce a SCHEMA-VALID verdict from a generic
+    // assistant, and be recorded in the run history as bodhi:reviewer. A
+    // verdict that looks right and came from nobody is worse than no verdict,
+    // because nothing downstream can tell.
+    if (!context.systemPromptPath) {
+      throw new GateCommandError(
+        `gate ${spec.gate} (${spec.agent.name}): print mode needs systemPromptPath. ` +
+          'Without it the gate would answer as a generic assistant while the run ' +
+          'records the agent that never saw it.',
+      );
+    }
     // The agent's own body and grant, rather than --agent: that flag
     // suppresses structured_output, and a reading gate exists to produce a
     // verdict. Both values come from the agent file in the pinned harness.
-    if (context.systemPromptPath) {
-      argv.push('--append-system-prompt-file', context.systemPromptPath);
-    }
+    argv.push('--append-system-prompt-file', context.systemPromptPath);
     argv.push('--tools', spec.agent.tools.join(','));
     argv.push('--print', '--output-format', 'json');
     if (spec.schema) argv.push('--json-schema', JSON.stringify(spec.schema));


### PR DESCRIPTION
CO-722 phase 3. Part of Software-Development-LLC/bodhi-code#722. Still no spawning and no UI — this is the pure function that turns a gate into an exact `claude` command line.

## Three measurements contradicted the design

Every flag here was verified by running it, not read from documentation. Three came back the opposite of what the design assumed:

**`--allowedTools` does not restrict anything.** With `--allowedTools "Read,Grep,Glob" --permission-mode manual`, Bash ran to completion with `permission_denials: []`. It is a pre-approval list. This module never emits it, and a test asserts that.

**`--agent` and `--json-schema` do not compose.** A run with `--agent bodhi:reviewer` and a schema returns `subtype: success`, `is_error: false`, exit 0 and **no `structured_output`** — even when the agent completes the task in two turns.

That one is worth dwelling on: **a verdict can simply be absent while every success signal is set.** It is why "no verdict is inconclusive, never a pass" is load-bearing rather than defensive, and it is the same shape as the seven `exits 0 having checked nothing` defects filed against the plugin.

**`--append-system-prompt` cannot carry a real agent.** `reviewer.md`'s body is **37,429 characters**; inline it exceeds Windows' 32,767-character command line and fails with `ENAMETOOLONG` in `uv_spawn` before the process even starts. No unit test would have found that.

## So the modes differ, each using what works

| | reading gates (3, 4) | owner gate (2) |
|---|---|---|
| invocation | `--print` | `--bg` |
| agent | `--append-system-prompt-file` + `--tools` | `--agent bodhi:…` |
| verdict | `--json-schema` → `structured_output` | receipt file |
| grant | the agent file's `tools:`, forwarded | resolved by the plugin |

The owner gate can afford `--agent` because its verdict is a receipt file anyway, and keeping it preserves the plugin's own composition and hooks. An unresolvable name there **fails loudly and lists the alternatives** rather than falling back to a full grant — verified.

**Neither path restates a grant.** `agent-definition.ts` reads it from the agent file and **refuses** when it cannot: no front matter, no `tools:`, an empty list, or a body-less file all throw. Defaulting would undo the plugin's own CI check — *"a missing `tools:` line silently grants an agent everything, including Skill and Agent"* — for every gate this engine spawns.

## Verified end to end

Against the real reviewer, through the real CLI:

```
structured_output present: true
  verdict  : inconclusive
  tools    : Bash, Glob, Grep, Read, StructuredOutput
  role_seen: # Purpose
```

`role_seen` is the control that makes it real: it quotes the first heading of `reviewer.md`'s body, proving the 37,429 characters actually reached the model. **An earlier run of this probe passed on an empty file** — a `sed` had extracted nothing — which is precisely the vacuous pass this initiative keeps finding, so the control is not decoration.

No `Write`, no `Edit`.

## Also

`--setting-sources ""` so two machines cannot reach different verdicts on one branch and both report honestly. `--max-budget-usd` so the plugin's documented ceiling ("a ceiling, not a target") is enforced rather than described. `PYTHONUTF8`/`PYTHONIOENCODING` in the child env, without which every em-dash the plugin prints lands in receipts as a replacement character. `BODHI_PYTHON`, so the wrappers get the interpreter this run resolved rather than trusting the name `python3`.

## Tests — 80 in the module

The ones that matter assert what must **not** be there: no `--allowedTools`, no `Write`/`Edit` in a reading gate's grant, no body inline in argv, and no posture other than `bypass` skipping permission checks. Each has a control, because an assertion that something is absent passes just as well when everything is absent.

Full suite: **1614 pass, 0 fail** across 108 files.

## Not here

Spawning, the reconciler, `expected_checks`, and any UI. The middle two need the exit-code contract Software-Development-LLC/claude-team-workflow#285 is settling.

Generated with [Claude Code](https://claude.com/claude-code)
